### PR TITLE
Bindgen more 7667 v10.2

### DIFF
--- a/examples/plugins/altemplate/src/template.rs
+++ b/examples/plugins/altemplate/src/template.rs
@@ -28,8 +28,7 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 use suricata::applayer::{
     state_get_tx_iterator, AppLayerEvent, AppLayerParserConfParserEnabled,
-    AppLayerParserRegisterLogger, AppLayerParserStateIssetFlag,
-    AppLayerProtoDetectConfProtoDetectionEnabled, AppLayerRegisterParser,
+    AppLayerParserRegisterLogger, AppLayerParserStateIssetFlag, AppLayerRegisterParser,
     AppLayerRegisterProtocolDetection, AppLayerResult, AppLayerStateData, AppLayerTxData,
     RustParser, State, StreamSlice, Transaction, APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS,
     APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
@@ -39,7 +38,7 @@ use suricata::core::{ALPROTO_UNKNOWN, IPPROTO_TCP};
 use suricata::{
     build_slice, cast_pointer, export_state_data_get, export_tx_data_get, SCLogError, SCLogNotice,
 };
-use suricata_sys::sys::{AppProto, Flow};
+use suricata_sys::sys::{AppProto, Flow, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 
 static mut TEMPLATE_MAX_TX: usize = 256;
 
@@ -297,7 +296,7 @@ unsafe extern "C" fn template_state_tx_free(state: *mut c_void, tx_id: u64) {
 }
 
 unsafe extern "C" fn template_parse_request(
-    _flow: *const Flow, state: *mut c_void, pstate: *mut c_void, stream_slice: StreamSlice,
+    _flow: *mut Flow, state: *mut c_void, pstate: *mut c_void, stream_slice: StreamSlice,
     _data: *const c_void,
 ) -> AppLayerResult {
     let eof = AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TS) > 0;
@@ -321,7 +320,7 @@ unsafe extern "C" fn template_parse_request(
 }
 
 unsafe extern "C" fn template_parse_response(
-    _flow: *const Flow, state: *mut c_void, pstate: *mut c_void, stream_slice: StreamSlice,
+    _flow: *mut Flow, state: *mut c_void, pstate: *mut c_void, stream_slice: StreamSlice,
     _data: *const c_void,
 ) -> AppLayerResult {
     let _eof = AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TC) > 0;
@@ -409,7 +408,7 @@ pub(super) unsafe extern "C" fn template_register_parser() {
 
     let ip_proto_str = CString::new("tcp").unwrap();
 
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_TEMPLATE = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -120,6 +120,7 @@ exclude = [
     "SRepCatGetByShortname",
     "SIGMATCH_NOOPT",
     "SIGMATCH_INFO_STICKY_BUFFER",
+    "FtpCommand",
 ]
 
 # Types of items that we'll generate. If empty, then all types of item are emitted.

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -479,7 +479,7 @@ impl AppLayerGetFileState {
     }
 }
 
-pub type ParseFn      = unsafe extern "C" fn (flow: *const Flow,
+pub type ParseFn      = unsafe extern "C" fn (flow: *mut Flow,
                                        state: *mut c_void,
                                        pstate: *mut c_void,
                                        stream_slice: StreamSlice,
@@ -518,32 +518,6 @@ extern "C" {
     pub fn AppLayerRegisterParser(parser: *const RustParser, alproto: AppProto) -> c_int;
 }
 
-
-// Defined in app-layer-detect-proto.h
-/// cbindgen:ignore
-extern "C" {
-    pub fn AppLayerForceProtocolChange(f: *const Flow, new_proto: AppProto);
-    pub fn AppLayerProtoDetectPPRegister(ipproto: u8, portstr: *const c_char, alproto: AppProto,
-                                         min_depth: u16, max_depth: u16, dir: u8,
-                                         pparser1: ProbeFn, pparser2: ProbeFn);
-    pub fn AppLayerProtoDetectPPParseConfPorts(ipproto_name: *const c_char, ipproto: u8,
-                                               alproto_name: *const c_char, alproto: AppProto,
-                                               min_depth: u16, max_depth: u16,
-                                               pparser_ts: ProbeFn, pparser_tc: ProbeFn) -> i32;
-    pub fn AppLayerProtoDetectPMRegisterPatternCI(ipproto: u8, alproto: AppProto,
-                                                pattern: *const c_char, depth: u16,
-                                                offset: u16, direction: u8) -> c_int;
-    pub fn AppLayerProtoDetectPMRegisterPatternCS(ipproto: u8, alproto: AppProto,
-                                                  pattern: *const c_char, depth: u16,
-                                                  offset: u16, direction: u8) -> c_int;
-    pub fn AppLayerProtoDetectPMRegisterPatternCSwPP(ipproto: u8, alproto: AppProto,
-                                                     pattern: *const c_char, depth: u16,
-                                                     offset: u16, direction: u8, ppfn: ProbeFn,
-                                                     pp_min_depth: u16, pp_max_depth: u16) -> c_int;
-    pub fn AppLayerProtoDetectConfProtoDetectionEnabled(ipproto: *const c_char, proto: *const c_char) -> c_int;
-    pub fn AppLayerProtoDetectConfProtoDetectionEnabledDefault(ipproto: *const c_char, proto: *const c_char, default: bool) -> c_int;
-    pub fn AppLayerRequestProtocolTLSUpgrade(flow: *const Flow) -> bool;
-}
 
 // Defined in app-layer-parser.h
 pub const APP_LAYER_PARSER_NO_INSPECTION : u16 = BIT_U16!(1);

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -68,11 +68,6 @@ macro_rules!BIT_U64 {
     ($x:expr) => (1 << $x);
 }
 
-// Defined in app-layer-protos.h
-/// cbindgen:ignore
-extern "C" {
-    pub fn StringToAppProto(proto_name: *const u8) -> AppProto;
-}
 
 /// cbindgen:ignore
 extern "C" {

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 
 use crate::applayer::{self, *};
 use crate::core::{ALPROTO_UNKNOWN, IPPROTO_UDP};
@@ -224,7 +224,7 @@ unsafe extern "C" fn dhcp_state_get_tx_count(state: *mut std::os::raw::c_void) -
 }
 
 unsafe extern "C" fn dhcp_parse(
-    _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    _flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, DHCPState);
@@ -296,7 +296,7 @@ pub unsafe extern "C" fn SCRegisterDhcpParser() {
 
     let ip_proto_str = CString::new("udp").unwrap();
 
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_DHCP = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/rust/src/ftp/ftp.rs
+++ b/rust/src/ftp/ftp.rs
@@ -35,7 +35,6 @@ pub struct DetectFtpReplyReceivedData {
     pub received: bool,
 }
 
-/// cbindgen:ignore
 #[repr(C)]
 pub struct FtpCommand {
     command_name: CString,

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -29,7 +29,7 @@ use crate::ike::ikev1::{handle_ikev1, IkeV1Header, Ikev1Container};
 use crate::ike::ikev2::{handle_ikev2, Ikev2Container};
 use crate::ike::parser::*;
 use nom7::Err;
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 use std;
 use std::collections::HashSet;
 use std::ffi::CString;
@@ -315,7 +315,7 @@ unsafe extern "C" fn ike_state_tx_free(state: *mut std::os::raw::c_void, tx_id: 
 }
 
 unsafe extern "C" fn ike_parse_request(
-    _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    _flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, IKEState);
@@ -323,7 +323,7 @@ unsafe extern "C" fn ike_parse_request(
 }
 
 unsafe extern "C" fn ike_parse_response(
-    _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    _flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, IKEState);
@@ -403,7 +403,7 @@ pub unsafe extern "C" fn SCRegisterIkeParser() {
 
     let ip_proto_str = CString::new("udp").unwrap();
 
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_IKE = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -32,7 +32,7 @@ use nom7::number::streaming::be_u32;
 use nom7::{Err, IResult};
 use std;
 use std::ffi::CString;
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 
 #[derive(AppLayerEvent)]
 pub enum KRB5Event {
@@ -449,7 +449,7 @@ unsafe extern "C" fn krb5_probing_parser_tcp(
 }
 
 unsafe extern "C" fn krb5_parse_request(
-    flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let buf = stream_slice.as_slice();
@@ -461,7 +461,7 @@ unsafe extern "C" fn krb5_parse_request(
 }
 
 unsafe extern "C" fn krb5_parse_response(
-    flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let buf = stream_slice.as_slice();
@@ -473,7 +473,7 @@ unsafe extern "C" fn krb5_parse_response(
 }
 
 unsafe extern "C" fn krb5_parse_request_tcp(
-    flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, KRB5State);
@@ -531,7 +531,7 @@ unsafe extern "C" fn krb5_parse_request_tcp(
 }
 
 unsafe extern "C" fn krb5_parse_response_tcp(
-    flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, KRB5State);
@@ -631,7 +631,7 @@ pub unsafe extern "C" fn SCRegisterKrb5Parser() {
     };
     // register UDP parser
     let ip_proto_str = CString::new("udp").unwrap();
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         // store the allocated ID for the probe function
         ALPROTO_KRB5 = alproto;
@@ -649,7 +649,7 @@ pub unsafe extern "C" fn SCRegisterKrb5Parser() {
     parser.parse_ts = krb5_parse_request_tcp;
     parser.parse_tc = krb5_parse_response_tcp;
     let ip_proto_str = CString::new("tcp").unwrap();
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         // store the allocated ID for the probe function
         ALPROTO_KRB5 = alproto;

--- a/rust/src/mdns/mdns.rs
+++ b/rust/src/mdns/mdns.rs
@@ -26,7 +26,7 @@ use crate::dns::dns;
 use crate::flow::Flow;
 
 use suricata_sys::sys::DetectEngineThreadCtx;
-use suricata_sys::sys::{AppProto, AppProtoEnum};
+use suricata_sys::sys::{AppProto, AppProtoEnum, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 
 pub(super) static mut ALPROTO_MDNS: AppProto = ALPROTO_UNKNOWN;
 
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn SCRegisterMdnsParser() {
     };
 
     let ip_proto_str = CString::new("udp").unwrap();
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_MDNS = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/rust/src/modbus/modbus.rs
+++ b/rust/src/modbus/modbus.rs
@@ -25,7 +25,7 @@ use sawp::error::ErrorKind as SawpErrorKind;
 use sawp::parser::{Direction, Parse};
 use sawp::probe::{Probe, Status};
 use sawp_modbus::{self, AccessType, ErrorFlags, Flags, Message};
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, SCAppLayerProtoDetectConfProtoDetectionEnabledDefault};
 
 pub const REQUEST_FLOOD: usize = 500; // Default unreplied Modbus requests are considered a flood
 pub const MODBUS_PARSER: sawp_modbus::Modbus = sawp_modbus::Modbus { probe_strict: true };
@@ -336,7 +336,7 @@ unsafe extern "C" fn modbus_state_tx_free(state: *mut std::os::raw::c_void, tx_i
 }
 
 unsafe extern "C" fn modbus_parse_request(
-    flow: *const Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let buf = stream_slice.as_slice();
@@ -353,7 +353,7 @@ unsafe extern "C" fn modbus_parse_request(
 }
 
 unsafe extern "C" fn modbus_parse_response(
-    flow: *const Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let buf = stream_slice.as_slice();
@@ -439,7 +439,7 @@ pub unsafe extern "C" fn SCRegisterModbusParser() {
     };
 
     let ip_proto_str = CString::new("tcp").unwrap();
-    if AppLayerProtoDetectConfProtoDetectionEnabledDefault(
+    if SCAppLayerProtoDetectConfProtoDetectionEnabledDefault(
         ip_proto_str.as_ptr(),
         parser.name,
         false,

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -30,7 +30,7 @@ use nom7::Err;
 use std;
 use std::collections::VecDeque;
 use std::ffi::CString;
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 
 // Used as a special pseudo packet identifier to denote the first CONNECT
 // packet in a connection. Note that there is no risk of collision with a
@@ -679,7 +679,7 @@ unsafe extern "C" fn mqtt_state_tx_free(state: *mut std::os::raw::c_void, tx_id:
 }
 
 unsafe extern "C" fn mqtt_parse_request(
-    flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, MQTTState);
@@ -687,7 +687,7 @@ unsafe extern "C" fn mqtt_parse_request(
 }
 
 unsafe extern "C" fn mqtt_parse_response(
-    flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, MQTTState);
@@ -785,7 +785,7 @@ pub unsafe extern "C" fn SCMqttRegisterParser() {
 
     let ip_proto_str = CString::new("tcp").unwrap();
 
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_MQTT = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -28,7 +28,7 @@ use std;
 use std::ffi::CString;
 
 use nom7::Err;
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 
 #[derive(AppLayerEvent)]
 pub enum NTPEvent {
@@ -177,7 +177,7 @@ extern "C" fn ntp_state_free(state: *mut std::os::raw::c_void) {
 }
 
 unsafe extern "C" fn ntp_parse_request(
-    _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    _flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, NTPState);
@@ -188,7 +188,7 @@ unsafe extern "C" fn ntp_parse_request(
 }
 
 unsafe extern "C" fn ntp_parse_response(
-    _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    _flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, NTPState);
@@ -291,7 +291,7 @@ pub unsafe extern "C" fn SCRegisterNtpParser() {
     };
 
     let ip_proto_str = CString::new("udp").unwrap();
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         // store the allocated ID for the probe function
         ALPROTO_NTP = alproto;

--- a/rust/src/quic/quic.rs
+++ b/rust/src/quic/quic.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 use std::collections::VecDeque;
 use std::ffi::CString;
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 use tls_parser::TlsExtensionType;
 
 static mut ALPROTO_QUIC: AppProto = ALPROTO_UNKNOWN;
@@ -464,7 +464,7 @@ unsafe extern "C" fn quic_probing_parser(
 }
 
 unsafe extern "C" fn quic_parse_tc(
-    _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    _flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, QuicState);
@@ -478,7 +478,7 @@ unsafe extern "C" fn quic_parse_tc(
 }
 
 unsafe extern "C" fn quic_parse_ts(
-    _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    _flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, QuicState);
@@ -579,7 +579,7 @@ pub unsafe extern "C" fn SCRegisterQuicParser() {
 
     let ip_proto_str = CString::new("udp").unwrap();
 
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_QUIC = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -25,7 +25,7 @@ use crate::flow::Flow;
 use crate::rdp::parser::*;
 use crate::direction::Direction;
 use nom7::Err;
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 use std;
 use std::collections::VecDeque;
 use tls_parser::{parse_tls_plaintext, TlsMessage, TlsMessageHandshake, TlsRecordType};
@@ -441,7 +441,7 @@ fn probe_tls_handshake(input: &[u8]) -> bool {
 //
 
 unsafe extern "C" fn rdp_parse_ts(
-    flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice,
     _data: *const std::os::raw::c_void
 ) -> AppLayerResult {
@@ -452,7 +452,7 @@ unsafe extern "C" fn rdp_parse_ts(
 }
 
 unsafe extern "C" fn rdp_parse_tc(
-    flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice,
     _data: *const std::os::raw::c_void
 ) -> AppLayerResult {
@@ -510,7 +510,7 @@ pub unsafe extern "C" fn SCRegisterRdpParser() {
 
     let ip_proto_str = std::ffi::CString::new("tcp").unwrap();
 
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_RDP = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -34,7 +34,8 @@ use nom7::{Err, IResult};
 use nom7::error::{ErrorKind, make_error};
 use suricata_sys::sys::{
     AppProto, AppProtoNewProtoFromString, EveJsonTxLoggerRegistrationData,
-    SCOutputJsonLogDirection, SCOutputEvePreRegisterLogger, SCSigTablePreRegister,
+    SCAppLayerProtoDetectConfProtoDetectionEnabled, SCOutputEvePreRegisterLogger,
+    SCOutputJsonLogDirection, SCSigTablePreRegister,
 };
 
 #[derive(AppLayerEvent)]
@@ -270,7 +271,7 @@ extern "C" fn snmp_state_free(state: *mut std::os::raw::c_void) {
     snmp_state.free();
 }
 
-unsafe extern "C" fn snmp_parse_request(_flow: *const Flow,
+unsafe extern "C" fn snmp_parse_request(_flow: *mut Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        stream_slice: StreamSlice,
@@ -280,7 +281,7 @@ unsafe extern "C" fn snmp_parse_request(_flow: *const Flow,
     state.parse(stream_slice.as_slice(), Direction::ToServer).into()
 }
 
-unsafe extern "C" fn snmp_parse_response(_flow: *const Flow,
+unsafe extern "C" fn snmp_parse_response(_flow: *mut Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        stream_slice: StreamSlice,
@@ -421,7 +422,7 @@ pub unsafe extern "C" fn SCRegisterSnmpParser() {
     };
     SCOutputEvePreRegisterLogger(reg_data);
     SCSigTablePreRegister(Some(detect_snmp_register));
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         // port 161
         _ = AppLayerRegisterProtocolDetection(&parser, 1);
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -24,7 +24,7 @@ use crate::frames::Frame;
 use nom7::Err;
 use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, Ordering};
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -454,7 +454,7 @@ extern "C" fn ssh_state_tx_free(_state: *mut std::os::raw::c_void, _tx_id: u64) 
 }
 
 unsafe extern "C" fn ssh_parse_request(
-    flow: *const Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = &mut cast_pointer!(state, SSHState);
@@ -469,7 +469,7 @@ unsafe extern "C" fn ssh_parse_request(
 }
 
 unsafe extern "C" fn ssh_parse_response(
-    flow: *const Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
+    flow: *mut Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = &mut cast_pointer!(state, SSHState);
@@ -572,7 +572,7 @@ pub unsafe extern "C" fn SCRegisterSshParser() {
 
     let ip_proto_str = CString::new("tcp").unwrap();
 
-    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_SSH = alproto;
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {

--- a/rust/src/telnet/telnet.rs
+++ b/rust/src/telnet/telnet.rs
@@ -22,7 +22,7 @@ use crate::flow::Flow;
 use crate::frames::*;
 use std::ffi::CString;
 use nom7::IResult;
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, SCAppLayerProtoDetectConfProtoDetectionEnabled};
 use super::parser;
 
 static mut ALPROTO_TELNET: AppProto = ALPROTO_UNKNOWN;
@@ -415,7 +415,7 @@ unsafe extern "C" fn telnet_state_tx_free(
 }
 
 unsafe extern "C" fn telnet_parse_request(
-    flow: *const Flow,
+    flow: *mut Flow,
     state: *mut std::os::raw::c_void,
     pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice,
@@ -442,7 +442,7 @@ unsafe extern "C" fn telnet_parse_request(
 }
 
 unsafe extern "C" fn telnet_parse_response(
-    flow: *const Flow,
+    flow: *mut Flow,
     state: *mut std::os::raw::c_void,
     pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice,
@@ -539,7 +539,7 @@ pub unsafe extern "C" fn SCRegisterTelnetParser() {
 
     let ip_proto_str = CString::new("tcp").unwrap();
 
-    if AppLayerProtoDetectConfProtoDetectionEnabled(
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(
         ip_proto_str.as_ptr(),
         parser.name,
     ) != 0

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -624,3 +624,68 @@ extern "C" {
 extern "C" {
     pub fn SCConfGetValueNode(node: *const SCConfNode) -> *const ::std::os::raw::c_char;
 }
+pub type ProbingParserFPtr = ::std::option::Option<
+    unsafe extern "C" fn(
+        f: *const Flow,
+        flags: u8,
+        input: *const u8,
+        input_len: u32,
+        rdir: *mut u8,
+    ) -> AppProto,
+>;
+extern "C" {
+    #[doc = " PP registration"]
+    pub fn SCAppLayerProtoDetectPPRegister(
+        ipproto: u8, portstr: *const ::std::os::raw::c_char, alproto: AppProto, min_depth: u16,
+        max_depth: u16, direction: u8, ProbingParser1: ProbingParserFPtr,
+        ProbingParser2: ProbingParserFPtr,
+    );
+}
+extern "C" {
+    #[doc = "  \\retval bool 0 if no config was found, 1 if config was found"]
+    pub fn SCAppLayerProtoDetectPPParseConfPorts(
+        ipproto_name: *const ::std::os::raw::c_char, ipproto: u8,
+        alproto_name: *const ::std::os::raw::c_char, alproto: AppProto, min_depth: u16,
+        max_depth: u16, ProbingParserTs: ProbingParserFPtr, ProbingParserTc: ProbingParserFPtr,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " \\brief Registers a case-sensitive pattern for protocol detection."]
+    pub fn SCAppLayerProtoDetectPMRegisterPatternCS(
+        ipproto: u8, alproto: AppProto, pattern: *const ::std::os::raw::c_char, depth: u16,
+        offset: u16, direction: u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SCAppLayerProtoDetectPMRegisterPatternCSwPP(
+        ipproto: u8, alproto: AppProto, pattern: *const ::std::os::raw::c_char, depth: u16,
+        offset: u16, direction: u8, PPFunc: ProbingParserFPtr, pp_min_depth: u16,
+        pp_max_depth: u16,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " \\brief Registers a case-insensitive pattern for protocol detection."]
+    pub fn SCAppLayerProtoDetectPMRegisterPatternCI(
+        ipproto: u8, alproto: AppProto, pattern: *const ::std::os::raw::c_char, depth: u16,
+        offset: u16, direction: u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SCAppLayerRequestProtocolTLSUpgrade(f: *mut Flow) -> bool;
+}
+extern "C" {
+    pub fn SCAppLayerForceProtocolChange(f: *mut Flow, new_proto: AppProto);
+}
+extern "C" {
+    #[doc = " \\brief Given a protocol name, checks if proto detection is enabled in\n        the conf file.\n\n \\param alproto Name of the app layer protocol.\n\n \\retval 1 If enabled.\n \\retval 0 If disabled."]
+    pub fn SCAppLayerProtoDetectConfProtoDetectionEnabled(
+        ipproto: *const ::std::os::raw::c_char, alproto: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " \\brief Given a protocol name, checks if proto detection is enabled in\n        the conf file.\n\n \\param alproto Name of the app layer protocol.\n \\param default_enabled enable by default if not in the configuration file\n\n \\retval 1 If enabled.\n \\retval 0 If disabled."]
+    pub fn SCAppLayerProtoDetectConfProtoDetectionEnabledDefault(
+        ipproto: *const ::std::os::raw::c_char, alproto: *const ::std::os::raw::c_char,
+        default_enabled: bool,
+    ) -> ::std::os::raw::c_int;
+}

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1524,13 +1524,9 @@ int AppLayerProtoDetectPrepareState(void)
  *
  *  \param direction STREAM_TOSERVER or STREAM_TOCLIENT for dp or sp
  */
-void AppLayerProtoDetectPPRegister(uint8_t ipproto,
-                                   const char *portstr,
-                                   AppProto alproto,
-                                   uint16_t min_depth, uint16_t max_depth,
-                                   uint8_t direction,
-                                   ProbingParserFPtr ProbingParser1,
-                                   ProbingParserFPtr ProbingParser2)
+void SCAppLayerProtoDetectPPRegister(uint8_t ipproto, const char *portstr, AppProto alproto,
+        uint16_t min_depth, uint16_t max_depth, uint8_t direction, ProbingParserFPtr ProbingParser1,
+        ProbingParserFPtr ProbingParser2)
 {
     SCEnter();
 
@@ -1564,13 +1560,9 @@ void AppLayerProtoDetectPPRegister(uint8_t ipproto,
     SCReturn;
 }
 
-int AppLayerProtoDetectPPParseConfPorts(const char *ipproto_name,
-                                         uint8_t ipproto,
-                                         const char *alproto_name,
-                                         AppProto alproto,
-                                         uint16_t min_depth, uint16_t max_depth,
-                                         ProbingParserFPtr ProbingParserTs,
-                                         ProbingParserFPtr ProbingParserTc)
+int SCAppLayerProtoDetectPPParseConfPorts(const char *ipproto_name, uint8_t ipproto,
+        const char *alproto_name, AppProto alproto, uint16_t min_depth, uint16_t max_depth,
+        ProbingParserFPtr ProbingParserTs, ProbingParserFPtr ProbingParserTc)
 {
     SCEnter();
 
@@ -1608,12 +1600,9 @@ int AppLayerProtoDetectPPParseConfPorts(const char *ipproto_name,
         port_node = SCConfNodeLookupChild(node, "toserver");
 
     if (port_node != NULL && port_node->val != NULL) {
-        AppLayerProtoDetectPPRegister(ipproto,
-                                      port_node->val,
-                                      alproto,
-                                      min_depth, max_depth,
-                                      STREAM_TOSERVER, /* to indicate dp */
-                                      ProbingParserTs, ProbingParserTc);
+        SCAppLayerProtoDetectPPRegister(ipproto, port_node->val, alproto, min_depth, max_depth,
+                STREAM_TOSERVER, /* to indicate dp */
+                ProbingParserTs, ProbingParserTc);
     }
 
     /* detect by source port of flow */
@@ -1622,13 +1611,9 @@ int AppLayerProtoDetectPPParseConfPorts(const char *ipproto_name,
         port_node = SCConfNodeLookupChild(node, "toclient");
 
     if (port_node != NULL && port_node->val != NULL) {
-        AppLayerProtoDetectPPRegister(ipproto,
-                                      port_node->val,
-                                      alproto,
-                                      min_depth, max_depth,
-                                      STREAM_TOCLIENT, /* to indicate sp */
-                                      ProbingParserTc, ProbingParserTs);
-
+        SCAppLayerProtoDetectPPRegister(ipproto, port_node->val, alproto, min_depth, max_depth,
+                STREAM_TOCLIENT, /* to indicate sp */
+                ProbingParserTc, ProbingParserTs);
     }
 
     config = 1;
@@ -1638,10 +1623,8 @@ int AppLayerProtoDetectPPParseConfPorts(const char *ipproto_name,
 
 /***** PM registration *****/
 
-int AppLayerProtoDetectPMRegisterPatternCS(uint8_t ipproto, AppProto alproto,
-                                           const char *pattern,
-                                           uint16_t depth, uint16_t offset,
-                                           uint8_t direction)
+int SCAppLayerProtoDetectPMRegisterPatternCS(uint8_t ipproto, AppProto alproto, const char *pattern,
+        uint16_t depth, uint16_t offset, uint8_t direction)
 {
     SCEnter();
     int r = AppLayerProtoDetectPMRegisterPattern(ipproto, alproto,
@@ -1651,11 +1634,9 @@ int AppLayerProtoDetectPMRegisterPatternCS(uint8_t ipproto, AppProto alproto,
     SCReturnInt(r);
 }
 
-int AppLayerProtoDetectPMRegisterPatternCSwPP(uint8_t ipproto, AppProto alproto,
-        const char *pattern, uint16_t depth, uint16_t offset,
-        uint8_t direction,
-        ProbingParserFPtr PPFunc,
-        uint16_t pp_min_depth, uint16_t pp_max_depth)
+int SCAppLayerProtoDetectPMRegisterPatternCSwPP(uint8_t ipproto, AppProto alproto,
+        const char *pattern, uint16_t depth, uint16_t offset, uint8_t direction,
+        ProbingParserFPtr PPFunc, uint16_t pp_min_depth, uint16_t pp_max_depth)
 {
     SCEnter();
     int r = AppLayerProtoDetectPMRegisterPattern(ipproto, alproto,
@@ -1665,10 +1646,8 @@ int AppLayerProtoDetectPMRegisterPatternCSwPP(uint8_t ipproto, AppProto alproto,
     SCReturnInt(r);
 }
 
-int AppLayerProtoDetectPMRegisterPatternCI(uint8_t ipproto, AppProto alproto,
-                                           const char *pattern,
-                                           uint16_t depth, uint16_t offset,
-                                           uint8_t direction)
+int SCAppLayerProtoDetectPMRegisterPatternCI(uint8_t ipproto, AppProto alproto, const char *pattern,
+        uint16_t depth, uint16_t offset, uint8_t direction)
 {
     SCEnter();
     int r = AppLayerProtoDetectPMRegisterPattern(ipproto, alproto,
@@ -1851,7 +1830,7 @@ bool AppLayerRequestProtocolChange(Flow *f, uint16_t dp, AppProto expect_proto)
  *
  *  \param f flow to act on
  */
-bool AppLayerRequestProtocolTLSUpgrade(Flow *f)
+bool SCAppLayerRequestProtocolTLSUpgrade(Flow *f)
 {
     return AppLayerRequestProtocolChange(f, 443, ALPROTO_TLS);
 }
@@ -1862,7 +1841,7 @@ bool AppLayerRequestProtocolTLSUpgrade(Flow *f)
  *  \param f flow to act on
  *  \param new_proto new app-layer protocol
  */
-void AppLayerForceProtocolChange(Flow *f, AppProto new_proto)
+void SCAppLayerForceProtocolChange(Flow *f, AppProto new_proto)
 {
     if (new_proto != f->alproto) {
         f->alproto_orig = f->alproto;
@@ -1882,7 +1861,6 @@ void AppLayerProtoDetectReset(Flow *f)
     FLOW_RESET_PE_DONE(f, STREAM_TOCLIENT);
     f->probing_parser_toserver_alproto_masks = 0;
     f->probing_parser_toclient_alproto_masks = 0;
-
     // Does not free the structures for the parser
     // keeps f->alstate for new state creation
     f->alparser = NULL;
@@ -1891,7 +1869,7 @@ void AppLayerProtoDetectReset(Flow *f)
     f->alproto_tc = ALPROTO_UNKNOWN;
 }
 
-int AppLayerProtoDetectConfProtoDetectionEnabledDefault(
+int SCAppLayerProtoDetectConfProtoDetectionEnabledDefault(
         const char *ipproto, const char *alproto, bool default_enabled)
 {
     SCEnter();
@@ -1961,9 +1939,9 @@ int AppLayerProtoDetectConfProtoDetectionEnabledDefault(
     SCReturnInt(enabled);
 }
 
-int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto, const char *alproto)
+int SCAppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto, const char *alproto)
 {
-    return AppLayerProtoDetectConfProtoDetectionEnabledDefault(ipproto, alproto, true);
+    return SCAppLayerProtoDetectConfProtoDetectionEnabledDefault(ipproto, alproto, true);
 }
 
 AppLayerProtoDetectThreadCtx *AppLayerProtoDetectGetCtxThread(void)
@@ -2178,9 +2156,11 @@ static int AppLayerProtoDetectTest01(void)
     AppLayerProtoDetectSetup();
 
     const char *buf = "HTTP";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(
+            IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
     buf = "GET";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOSERVER);
+    SCAppLayerProtoDetectPMRegisterPatternCS(
+            IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOSERVER);
 
     AppLayerProtoDetectPrepareState();
     FAIL_IF(alpd_ctx.ctx_ipp[FLOW_PROTO_TCP].ctx_pm[0].max_pat_id != 1);
@@ -2197,9 +2177,10 @@ static int AppLayerProtoDetectTest02(void)
     AppLayerProtoDetectSetup();
 
     const char *buf = "HTTP";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(
+            IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
     buf = "ftp";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_FTP, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_FTP, buf, 4, 0, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
     FAIL_IF(alpd_ctx.ctx_ipp[FLOW_PROTO_TCP].ctx_pm[0].max_pat_id != 0);
@@ -2230,9 +2211,10 @@ static int AppLayerProtoDetectTest03(void)
 
 
     const char *buf = "HTTP";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(
+            IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
     buf = "220 ";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_FTP, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_FTP, buf, 4, 0, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
     /* AppLayerProtoDetectGetCtxThread() should be called post AppLayerProtoDetectPrepareState(), since
@@ -2274,7 +2256,8 @@ static int AppLayerProtoDetectTest04(void)
     f.protomap = FlowGetProtoMapping(IPPROTO_TCP);
 
     const char *buf = "200 ";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_HTTP1, buf, 13, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(
+            IPPROTO_TCP, ALPROTO_HTTP1, buf, 13, 0, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
     /* AppLayerProtoDetectGetCtxThread() should be called post AppLayerProtoDetectPrepareState(), since
@@ -2314,9 +2297,10 @@ static int AppLayerProtoDetectTest05(void)
     f.protomap = FlowGetProtoMapping(IPPROTO_TCP);
 
     const char *buf = "HTTP";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(
+            IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
     buf = "220 ";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_FTP, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_FTP, buf, 4, 0, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
     /* AppLayerProtoDetectGetCtxThread() should be called post AppLayerProtoDetectPrepareState(), since
@@ -2358,9 +2342,10 @@ static int AppLayerProtoDetectTest06(void)
     f.protomap = FlowGetProtoMapping(IPPROTO_TCP);
 
     const char *buf = "HTTP";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(
+            IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
     buf = "220 ";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_FTP, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_FTP, buf, 4, 0, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
     /* AppLayerProtoDetectGetCtxThread() should be called post AppLayerProtoDetectPrepareState(), since
@@ -2401,7 +2386,8 @@ static int AppLayerProtoDetectTest07(void)
     memset(pm_results, 0, sizeof(pm_results));
 
     const char *buf = "HTTP";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(
+            IPPROTO_TCP, ALPROTO_HTTP1, buf, 4, 0, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
     /* AppLayerProtoDetectGetCtxThread() should be called post AppLayerProtoDetectPrepareState(), since
@@ -2458,7 +2444,7 @@ static int AppLayerProtoDetectTest08(void)
     f.protomap = FlowGetProtoMapping(IPPROTO_TCP);
 
     const char *buf = "|ff|SMB";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_SMB, buf, 8, 4, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_SMB, buf, 8, 4, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
     /* AppLayerProtoDetectGetCtxThread() should be called post AppLayerProtoDetectPrepareState(), since
@@ -2513,7 +2499,7 @@ static int AppLayerProtoDetectTest09(void)
     f.protomap = FlowGetProtoMapping(IPPROTO_TCP);
 
     const char *buf = "|fe|SMB";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_SMB, buf, 8, 4, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_SMB, buf, 8, 4, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
     /* AppLayerProtoDetectGetCtxThread() should be called post AppLayerProtoDetectPrepareState(), since
@@ -2563,7 +2549,8 @@ static int AppLayerProtoDetectTest10(void)
     f.protomap = FlowGetProtoMapping(IPPROTO_TCP);
 
     const char *buf = "|05 00|";
-    AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_DCERPC, buf, 4, 0, STREAM_TOCLIENT);
+    SCAppLayerProtoDetectPMRegisterPatternCS(
+            IPPROTO_TCP, ALPROTO_DCERPC, buf, 4, 0, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
     /* AppLayerProtoDetectGetCtxThread() should be called post AppLayerProtoDetectPrepareState(), since
@@ -2607,21 +2594,21 @@ static int AppLayerProtoDetectTest11(void)
     memset(&f, 0x00, sizeof(f));
     f.protomap = FlowGetProtoMapping(IPPROTO_TCP);
 
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_TCP, ALPROTO_HTTP1, "HTTP", 4, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_TCP, ALPROTO_HTTP1, "GET", 3, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_TCP, ALPROTO_HTTP1, "PUT", 3, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_TCP, ALPROTO_HTTP1, "POST", 4, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_TCP, ALPROTO_HTTP1, "TRACE", 5, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_TCP, ALPROTO_HTTP1, "OPTIONS", 7, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_TCP, ALPROTO_HTTP1, "CONNECT", 7, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_TCP, ALPROTO_HTTP1, "HTTP", 4, 0, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
@@ -2674,7 +2661,7 @@ static int AppLayerProtoDetectTest12(void)
 
     int r = 0;
 
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_TCP, ALPROTO_HTTP1, "HTTP", 4, 0, STREAM_TOSERVER);
     if (alpd_ctx.ctx_ipp[FLOW_PROTO_TCP].ctx_pm[0].head == NULL ||
         alpd_ctx.ctx_ipp[FLOW_PROTO_TCP].ctx_pm[0].map != NULL)
@@ -2732,21 +2719,21 @@ static int AppLayerProtoDetectTest13(void)
     memset(&f, 0x00, sizeof(f));
     f.protomap = FlowGetProtoMapping(IPPROTO_TCP);
 
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "HTTP", 4, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "GET", 3, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "PUT", 3, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "POST", 4, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "TRACE", 5, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "OPTIONS", 7, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "CONNECT", 7, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "HTTP", 4, 0, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
@@ -2803,21 +2790,21 @@ static int AppLayerProtoDetectTest14(void)
     memset(&f, 0x00, sizeof(f));
     f.protomap = FlowGetProtoMapping(IPPROTO_UDP);
 
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "HTTP", 4, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "GET", 3, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "PUT", 3, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "POST", 4, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "TRACE", 5, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "OPTIONS", 7, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "CONNECT", 7, 0, STREAM_TOSERVER);
-    AppLayerProtoDetectPMRegisterPatternCS(
+    SCAppLayerProtoDetectPMRegisterPatternCS(
             IPPROTO_UDP, ALPROTO_HTTP1, "HTTP", 4, 0, STREAM_TOCLIENT);
 
     AppLayerProtoDetectPrepareState();
@@ -2960,9 +2947,8 @@ static int AppLayerProtoDetectPPTestData(AppLayerProtoDetectProbingParser *pp,
     return result;
 }
 
-static uint16_t ProbingParserDummyForTesting(Flow *f, uint8_t direction,
-                                             const uint8_t *input,
-                                             uint32_t input_len, uint8_t *rdir)
+static uint16_t ProbingParserDummyForTesting(
+        const Flow *f, uint8_t direction, const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     return 0;
 }
@@ -2974,137 +2960,57 @@ static int AppLayerProtoDetectTest15(void)
 
     int result = 0;
 
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP, "80", ALPROTO_HTTP1, 5, 8, STREAM_TOSERVER,
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "80", ALPROTO_HTTP1, 5, 8, STREAM_TOSERVER,
             ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "80",
-                                  ALPROTO_SMB,
-                                  5, 6,
-                                  STREAM_TOSERVER,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "80",
-                                  ALPROTO_FTP,
-                                  7, 10,
-                                  STREAM_TOSERVER,
-                                  ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "80", ALPROTO_SMB, 5, 6, STREAM_TOSERVER,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "80", ALPROTO_FTP, 7, 10, STREAM_TOSERVER,
+            ProbingParserDummyForTesting, NULL);
 
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "81",
-                                  ALPROTO_DCERPC,
-                                  9, 10,
-                                  STREAM_TOSERVER,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "81",
-                                  ALPROTO_FTP,
-                                  7, 15,
-                                  STREAM_TOSERVER,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "0",
-                                  ALPROTO_SMTP,
-                                  12, 0,
-                                  STREAM_TOSERVER,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "0",
-                                  ALPROTO_TLS,
-                                  12, 18,
-                                  STREAM_TOSERVER,
-                                  ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "81", ALPROTO_DCERPC, 9, 10, STREAM_TOSERVER,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "81", ALPROTO_FTP, 7, 15, STREAM_TOSERVER,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "0", ALPROTO_SMTP, 12, 0, STREAM_TOSERVER,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "0", ALPROTO_TLS, 12, 18, STREAM_TOSERVER,
+            ProbingParserDummyForTesting, NULL);
 
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "85",
-                                  ALPROTO_DCERPC,
-                                  9, 10,
-                                  STREAM_TOSERVER,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "85",
-                                  ALPROTO_FTP,
-                                  7, 15,
-                                  STREAM_TOSERVER,
-                                  ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "85", ALPROTO_DCERPC, 9, 10, STREAM_TOSERVER,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "85", ALPROTO_FTP, 7, 15, STREAM_TOSERVER,
+            ProbingParserDummyForTesting, NULL);
     result = 1;
 
-    AppLayerProtoDetectPPRegister(IPPROTO_UDP,
-                                  "85",
-                                  ALPROTO_IMAP,
-                                  12, 23,
-                                  STREAM_TOSERVER,
-                                  ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_UDP, "85", ALPROTO_IMAP, 12, 23, STREAM_TOSERVER,
+            ProbingParserDummyForTesting, NULL);
 
     /* toclient */
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "0",
-                                  ALPROTO_JABBER,
-                                  12, 23,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "0",
-                                  ALPROTO_IRC,
-                                  12, 14,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
-
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "85",
-                                  ALPROTO_DCERPC,
-                                  9, 10,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "81",
-                                  ALPROTO_FTP,
-                                  7, 15,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "0",
-                                  ALPROTO_TLS,
-                                  12, 18,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP, "80", ALPROTO_HTTP1, 5, 8, STREAM_TOCLIENT,
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "0", ALPROTO_JABBER, 12, 23, STREAM_TOCLIENT,
             ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "81",
-                                  ALPROTO_DCERPC,
-                                  9, 10,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "90",
-                                  ALPROTO_FTP,
-                                  7, 15,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "80",
-                                  ALPROTO_SMB,
-                                  5, 6,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_UDP,
-                                  "85",
-                                  ALPROTO_IMAP,
-                                  12, 23,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "0",
-                                  ALPROTO_SMTP,
-                                  12, 17,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
-    AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                  "80",
-                                  ALPROTO_FTP,
-                                  7, 10,
-                                  STREAM_TOCLIENT,
-                                  ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "0", ALPROTO_IRC, 12, 14, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
+
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "85", ALPROTO_DCERPC, 9, 10, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "81", ALPROTO_FTP, 7, 15, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "0", ALPROTO_TLS, 12, 18, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "80", ALPROTO_HTTP1, 5, 8, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "81", ALPROTO_DCERPC, 9, 10, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "90", ALPROTO_FTP, 7, 15, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "80", ALPROTO_SMB, 5, 6, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_UDP, "85", ALPROTO_IMAP, 12, 23, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "0", ALPROTO_SMTP, 12, 17, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
+    SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "80", ALPROTO_FTP, 7, 10, STREAM_TOCLIENT,
+            ProbingParserDummyForTesting, NULL);
 
     AppLayerProtoDetectPPTestDataElement element_ts_80[] = {
         { "http", ALPROTO_HTTP1, 80, 5, 8 },

--- a/src/app-layer-detect-proto.h
+++ b/src/app-layer-detect-proto.h
@@ -25,13 +25,14 @@
 #ifndef SURICATA_APP_LAYER_DETECT_PROTO__H
 #define SURICATA_APP_LAYER_DETECT_PROTO__H
 
-#include "flow.h"
+// only forward declaration for bindgen
+typedef struct Flow_ Flow;
 #include "app-layer-protos.h"
 
 typedef struct AppLayerProtoDetectThreadCtx_ AppLayerProtoDetectThreadCtx;
 
 typedef AppProto (*ProbingParserFPtr)(
-        Flow *f, uint8_t flags, const uint8_t *input, uint32_t input_len, uint8_t *rdir);
+        const Flow *f, uint8_t flags, const uint8_t *input, uint32_t input_len, uint8_t *rdir);
 
 /***** Protocol Retrieval *****/
 
@@ -62,45 +63,32 @@ int AppLayerProtoDetectPrepareState(void);
 
 /***** PP registration *****/
 
-void AppLayerProtoDetectPPRegister(uint8_t ipproto,
-                                   const char *portstr,
-                                   AppProto alproto,
-                                   uint16_t min_depth, uint16_t max_depth,
-                                   uint8_t direction,
-                                   ProbingParserFPtr ProbingParser1,
-                                   ProbingParserFPtr ProbingParser2);
+void SCAppLayerProtoDetectPPRegister(uint8_t ipproto, const char *portstr, AppProto alproto,
+        uint16_t min_depth, uint16_t max_depth, uint8_t direction, ProbingParserFPtr ProbingParser1,
+        ProbingParserFPtr ProbingParser2);
 /**
  *  \retval bool 0 if no config was found, 1 if config was found
  */
-int AppLayerProtoDetectPPParseConfPorts(const char *ipproto_name,
-                                         uint8_t ipproto,
-                                         const char *alproto_name,
-                                         AppProto alproto,
-                                         uint16_t min_depth, uint16_t max_depth,
-                                         ProbingParserFPtr ProbingParserTs,
-                                         ProbingParserFPtr ProbingParserTc);
+int SCAppLayerProtoDetectPPParseConfPorts(const char *ipproto_name, uint8_t ipproto,
+        const char *alproto_name, AppProto alproto, uint16_t min_depth, uint16_t max_depth,
+        ProbingParserFPtr ProbingParserTs, ProbingParserFPtr ProbingParserTc);
 
 /***** PM registration *****/
 
 /**
  * \brief Registers a case-sensitive pattern for protocol detection.
  */
-int AppLayerProtoDetectPMRegisterPatternCS(uint8_t ipproto, AppProto alproto,
-        const char *pattern, uint16_t depth, uint16_t offset,
-        uint8_t direction);
-int AppLayerProtoDetectPMRegisterPatternCSwPP(uint8_t ipproto, AppProto alproto,
-        const char *pattern, uint16_t depth, uint16_t offset,
-        uint8_t direction,
-        ProbingParserFPtr PPFunc,
-        uint16_t pp_min_depth, uint16_t pp_max_depth);
+int SCAppLayerProtoDetectPMRegisterPatternCS(uint8_t ipproto, AppProto alproto, const char *pattern,
+        uint16_t depth, uint16_t offset, uint8_t direction);
+int SCAppLayerProtoDetectPMRegisterPatternCSwPP(uint8_t ipproto, AppProto alproto,
+        const char *pattern, uint16_t depth, uint16_t offset, uint8_t direction,
+        ProbingParserFPtr PPFunc, uint16_t pp_min_depth, uint16_t pp_max_depth);
 
 /**
  * \brief Registers a case-insensitive pattern for protocol detection.
  */
-int AppLayerProtoDetectPMRegisterPatternCI(uint8_t ipproto, AppProto alproto,
-                                           const char *pattern,
-                                           uint16_t depth, uint16_t offset,
-                                           uint8_t direction);
+int SCAppLayerProtoDetectPMRegisterPatternCI(uint8_t ipproto, AppProto alproto, const char *pattern,
+        uint16_t depth, uint16_t offset, uint8_t direction);
 
 /***** Setup/General Registration *****/
 
@@ -119,9 +107,9 @@ int AppLayerProtoDetectSetup(void);
 void AppLayerProtoDetectReset(Flow *);
 
 bool AppLayerRequestProtocolChange(Flow *f, uint16_t dp, AppProto expect_proto);
-bool AppLayerRequestProtocolTLSUpgrade(Flow *f);
+bool SCAppLayerRequestProtocolTLSUpgrade(Flow *f);
 
-void AppLayerForceProtocolChange(Flow *f, AppProto new_proto);
+void SCAppLayerForceProtocolChange(Flow *f, AppProto new_proto);
 
 /**
  * \brief Cleans up the app layer protocol detection phase.
@@ -164,8 +152,7 @@ void AppLayerProtoDetectRegisterAlias(const char *proto_name, const char *proto_
  * \retval 1 If enabled.
  * \retval 0 If disabled.
  */
-int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
-                                                 const char *alproto);
+int SCAppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto, const char *alproto);
 
 /**
  * \brief Given a protocol name, checks if proto detection is enabled in
@@ -177,7 +164,7 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
  * \retval 1 If enabled.
  * \retval 0 If disabled.
  */
-int AppLayerProtoDetectConfProtoDetectionEnabledDefault(
+int SCAppLayerProtoDetectConfProtoDetectionEnabledDefault(
         const char *ipproto, const char *alproto, bool default_enabled);
 
 /**

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -262,9 +262,8 @@ static int DNP3ContainsBanner(const uint8_t *input, uint32_t len)
 /**
  * \brief DNP3 probing parser.
  */
-static uint16_t DNP3ProbingParser(Flow *f, uint8_t direction,
-        const uint8_t *input, uint32_t len,
-        uint8_t *rdir)
+static uint16_t DNP3ProbingParser(
+        const Flow *f, uint8_t direction, const uint8_t *input, uint32_t len, uint8_t *rdir)
 {
     const DNP3LinkHeader *const hdr = (const DNP3LinkHeader *)input;
     const bool toserver = (direction & STREAM_TOSERVER) != 0;
@@ -1533,18 +1532,16 @@ void RegisterDNP3Parsers(void)
 
     const char *proto_name = "dnp3";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabledDefault("tcp", proto_name, false)) {
+    if (SCAppLayerProtoDetectConfProtoDetectionEnabledDefault("tcp", proto_name, false)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_DNP3, proto_name);
 
         if (RunmodeIsUnittests()) {
-            AppLayerProtoDetectPPRegister(IPPROTO_TCP, DNP3_DEFAULT_PORT,
-                ALPROTO_DNP3, 0, sizeof(DNP3LinkHeader), STREAM_TOSERVER,
-                DNP3ProbingParser, DNP3ProbingParser);
+            SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, DNP3_DEFAULT_PORT, ALPROTO_DNP3, 0,
+                    sizeof(DNP3LinkHeader), STREAM_TOSERVER, DNP3ProbingParser, DNP3ProbingParser);
         }
         else {
-            if (!AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
-                    proto_name, ALPROTO_DNP3, 0, sizeof(DNP3LinkHeader),
-                    DNP3ProbingParser, DNP3ProbingParser)) {
+            if (!SCAppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP, proto_name, ALPROTO_DNP3,
+                        0, sizeof(DNP3LinkHeader), DNP3ProbingParser, DNP3ProbingParser)) {
                 return;
             }
         }

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1593,9 +1593,8 @@ void HTPFreeConfig(void)
 {
     SCEnter();
 
-    if (!AppLayerProtoDetectConfProtoDetectionEnabled("tcp", "http") ||
-        !AppLayerParserConfParserEnabled("tcp", "http"))
-    {
+    if (!SCAppLayerProtoDetectConfProtoDetectionEnabled("tcp", "http") ||
+            !AppLayerParserConfParserEnabled("tcp", "http")) {
         SCReturn;
     }
 
@@ -2590,7 +2589,7 @@ static int HTPRegisterPatternsForProtocolDetection(void)
              * 3 is subtracted from the length since the spacing is hex typed as |xx|
              * but the pattern matching should only be one char
             */
-            register_result = AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_HTTP1,
+            register_result = SCAppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_HTTP1,
                     method_buffer, (uint16_t)strlen(method_buffer) - 3, 0, STREAM_TOSERVER);
             if (register_result < 0) {
                 return -1;
@@ -2600,7 +2599,7 @@ static int HTPRegisterPatternsForProtocolDetection(void)
 
     /* Loop through all the http version patterns that are TO_CLIENT */
     for (versions_pos = 0; versions[versions_pos]; versions_pos++) {
-        register_result = AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_HTTP1,
+        register_result = SCAppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_HTTP1,
                 versions[versions_pos], (uint16_t)strlen(versions[versions_pos]), 0,
                 STREAM_TOCLIENT);
         if (register_result < 0) {
@@ -2622,7 +2621,7 @@ void RegisterHTPParsers(void)
     const char *proto_name = "http";
 
     /** HTTP */
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
+    if (SCAppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_HTTP1, proto_name);
         if (HTPRegisterPatternsForProtocolDetection() < 0)
             return;

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -41,10 +41,8 @@ static int HTTP2RegisterPatternsForProtocolDetection(void)
     /* Using the 24 bytes pattern makes AppLayerTest09 fail/leak
      * The complete pattern is "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
      */
-    if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_HTTP2,
-                                               "PRI * HTTP/2.0\r\n",
-                                               16, 0, STREAM_TOSERVER) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_HTTP2, "PRI * HTTP/2.0\r\n", 16, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
     return 0;
@@ -57,7 +55,7 @@ void RegisterHTTP2Parsers(void)
 {
     const char *proto_name = "http2";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabledDefault("tcp", proto_name, true)) {
+    if (SCAppLayerProtoDetectConfProtoDetectionEnabledDefault("tcp", proto_name, true)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_HTTP2, proto_name);
         if (HTTP2RegisterPatternsForProtocolDetection() < 0)
             return;

--- a/src/app-layer-imap.c
+++ b/src/app-layer-imap.c
@@ -28,37 +28,37 @@
 
 static int IMAPRegisterPatternsForProtocolDetection(void)
 {
-    if (AppLayerProtoDetectPMRegisterPatternCI(
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(
                 IPPROTO_TCP, ALPROTO_IMAP, "* OK ", 5, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
 
-    if (AppLayerProtoDetectPMRegisterPatternCI(
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(
                 IPPROTO_TCP, ALPROTO_IMAP, "* NO ", 5, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
 
-    if (AppLayerProtoDetectPMRegisterPatternCI(
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(
                 IPPROTO_TCP, ALPROTO_IMAP, "* BAD ", 6, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
 
-    if (AppLayerProtoDetectPMRegisterPatternCI(
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(
                 IPPROTO_TCP, ALPROTO_IMAP, "* LIST ", 7, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
 
-    if (AppLayerProtoDetectPMRegisterPatternCI(
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(
                 IPPROTO_TCP, ALPROTO_IMAP, "* ESEARCH ", 10, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
 
-    if (AppLayerProtoDetectPMRegisterPatternCI(
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(
                 IPPROTO_TCP, ALPROTO_IMAP, "* STATUS ", 9, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
 
-    if (AppLayerProtoDetectPMRegisterPatternCI(
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(
                 IPPROTO_TCP, ALPROTO_IMAP, "* FLAGS ", 8, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
@@ -73,7 +73,7 @@ static int IMAPRegisterPatternsForProtocolDetection(void)
      * AppLayerTest10 fails because it expects protocol detection to be completed with only 17 bytes
      * as input, and with this new pattern, we would need more bytes to finish protocol detection.
      */
-    if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_IMAP, " CAPABILITY",
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_IMAP, " CAPABILITY",
                 17 /*6 for max tag len + space + len(CAPABILITY)*/, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
@@ -85,7 +85,7 @@ void RegisterIMAPParsers(void)
 {
     const char *proto_name = "imap";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
+    if (SCAppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
         SCLogDebug("IMAP protocol detection is enabled.");
         AppLayerProtoDetectRegisterProtocol(ALPROTO_IMAP, proto_name);
         if (IMAPRegisterPatternsForProtocolDetection() < 0)

--- a/src/app-layer-nfs-tcp.c
+++ b/src/app-layer-nfs-tcp.c
@@ -49,7 +49,7 @@ void RegisterNFSTCPParsers(void)
 
     /* Check if NFSTCP TCP detection is enabled. If it does not exist in
      * the configuration file then it will be enabled by default. */
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
+    if (SCAppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
 
         SCNfsInit(&sfc);
         SCRegisterNfsParser();

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -65,30 +65,25 @@ AppProto AppLayerRegisterProtocolDetection(const struct AppLayerParser *p, int e
     if (RunmodeIsUnittests()) {
 
         SCLogDebug("Unittest mode, registering default configuration.");
-        AppLayerProtoDetectPPRegister(p->ip_proto, p->default_port,
-                alproto, p->min_depth, p->max_depth, STREAM_TOSERVER,
-                p->ProbeTS, p->ProbeTC);
+        SCAppLayerProtoDetectPPRegister(p->ip_proto, p->default_port, alproto, p->min_depth,
+                p->max_depth, STREAM_TOSERVER, p->ProbeTS, p->ProbeTC);
 
     }
     else {
 
-        if (!AppLayerProtoDetectPPParseConfPorts(ip_proto_str, p->ip_proto,
-                    p->name, alproto, p->min_depth, p->max_depth,
-                    p->ProbeTS, p->ProbeTC)) {
+        if (!SCAppLayerProtoDetectPPParseConfPorts(ip_proto_str, p->ip_proto, p->name, alproto,
+                    p->min_depth, p->max_depth, p->ProbeTS, p->ProbeTC)) {
             if (enable_default != 0) {
                 SCLogDebug("No %s app-layer configuration, enabling %s"
                         " detection %s detection on port %s.",
                         p->name, p->name, ip_proto_str, p->default_port);
-                AppLayerProtoDetectPPRegister(p->ip_proto,
-                        p->default_port, alproto,
-                        p->min_depth, p->max_depth, STREAM_TOSERVER,
-                        p->ProbeTS, p->ProbeTC);
+                SCAppLayerProtoDetectPPRegister(p->ip_proto, p->default_port, alproto, p->min_depth,
+                        p->max_depth, STREAM_TOSERVER, p->ProbeTS, p->ProbeTC);
             } else {
                 SCLogDebug("No %s app-layer configuration for detection port (%s).",
                         p->name, ip_proto_str);
             }
         }
-
     }
 
     return alproto;

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -60,14 +60,12 @@
 
 static int SSHRegisterPatternsForProtocolDetection(void)
 {
-    if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SSH,
-                                               "SSH-", 4, 0, STREAM_TOSERVER) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_SSH, "SSH-", 4, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SSH,
-                                               "SSH-", 4, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_SSH, "SSH-", 4, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
     return 0;
@@ -84,7 +82,7 @@ void RegisterSSHParsers(void)
 {
     const char *proto_name = "ssh";
 
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
+    if (SCAppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_SSH, proto_name);
         if (SSHRegisterPatternsForProtocolDetection() < 0)
             return;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2934,8 +2934,8 @@ static void SSLStateTransactionFree(void *state, uint64_t tx_id)
     /* do nothing */
 }
 
-static AppProto SSLProbingParser(Flow *f, uint8_t direction,
-        const uint8_t *input, uint32_t ilen, uint8_t *rdir)
+static AppProto SSLProbingParser(
+        const Flow *f, uint8_t direction, const uint8_t *input, uint32_t ilen, uint8_t *rdir)
 {
     /* probably a rst/fin sending an eof */
     if (ilen < 3)
@@ -3014,125 +3014,105 @@ static int SSLStateGetEventInfoById(
 
 static int SSLRegisterPatternsForProtocolDetection(void)
 {
-    if (AppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP, ALPROTO_TLS, "|01 00 02|", 5, 2,
+    if (SCAppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP, ALPROTO_TLS, "|01 00 02|", 5, 2,
                 STREAM_TOSERVER, SSLProbingParser, 0, 3) < 0) {
         return -1;
     }
 
     /** SSLv3 */
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|01 03 00|", 3, 0, STREAM_TOSERVER) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|01 03 00|", 3, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|16 03 00|", 3, 0, STREAM_TOSERVER) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|16 03 00|", 3, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
 
     /** TLSv1 */
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|01 03 01|", 3, 0, STREAM_TOSERVER) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|01 03 01|", 3, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|16 03 01|", 3, 0, STREAM_TOSERVER) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|16 03 01|", 3, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
 
     /** TLSv1.1 */
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|01 03 02|", 3, 0, STREAM_TOSERVER) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|01 03 02|", 3, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|16 03 02|", 3, 0, STREAM_TOSERVER) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|16 03 02|", 3, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
 
     /** TLSv1.2 */
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|01 03 03|", 3, 0, STREAM_TOSERVER) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|01 03 03|", 3, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|16 03 03|", 3, 0, STREAM_TOSERVER) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|16 03 03|", 3, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
 
     /***** toclient direction *****/
 
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|15 03 00|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|15 03 00|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|16 03 00|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|16 03 00|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|17 03 00|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|17 03 00|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
 
     /** TLSv1 */
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|15 03 01|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|15 03 01|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|16 03 01|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|16 03 01|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|17 03 01|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|17 03 01|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
 
     /** TLSv1.1 */
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|15 03 02|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|15 03 02|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|16 03 02|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|16 03 02|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|17 03 02|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|17 03 02|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
 
     /** TLSv1.2 */
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|15 03 03|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|15 03 03|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|16 03 03|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|16 03 03|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
-                                               "|17 03 03|", 3, 0, STREAM_TOCLIENT) < 0)
-    {
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(
+                IPPROTO_TCP, ALPROTO_TLS, "|17 03 03|", 3, 0, STREAM_TOCLIENT) < 0) {
         return -1;
     }
 
@@ -3141,12 +3121,12 @@ static int SSLRegisterPatternsForProtocolDetection(void)
      * Updated by Anoop Saldanha.  Disabled it for now.  We'll get back to
      * it after some tests */
 #if 0
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
                                                "|01 03 00|", 5, 2, STREAM_TOSERVER) < 0)
     {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
+    if (SCAppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_TLS,
                                                "|00 02|", 7, 5, STREAM_TOCLIENT) < 0)
     {
         return -1;
@@ -3216,32 +3196,22 @@ void RegisterSSLParsers(void)
     SC_ATOMIC_INIT(ssl_config.enable_ja3);
 
     /** SSLv2  and SSLv23*/
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
+    if (SCAppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
         AppLayerProtoDetectRegisterProtocol(ALPROTO_TLS, proto_name);
 
         if (SSLRegisterPatternsForProtocolDetection() < 0)
             return;
 
         if (RunmodeIsUnittests()) {
-            AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                          "443",
-                                          ALPROTO_TLS,
-                                          0, 3,
-                                          STREAM_TOSERVER,
-                                          SSLProbingParser, NULL);
+            SCAppLayerProtoDetectPPRegister(
+                    IPPROTO_TCP, "443", ALPROTO_TLS, 0, 3, STREAM_TOSERVER, SSLProbingParser, NULL);
         } else {
-            if (AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
-                                                    proto_name, ALPROTO_TLS,
-                                                    0, 3,
-                                                    SSLProbingParser, NULL) == 0) {
+            if (SCAppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP, proto_name, ALPROTO_TLS,
+                        0, 3, SSLProbingParser, NULL) == 0) {
                 SCLogConfig("no TLS config found, "
                             "enabling TLS detection on port 443.");
-                AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                              "443",
-                                              ALPROTO_TLS,
-                                              0, 3,
-                                              STREAM_TOSERVER,
-                                              SSLProbingParser, NULL);
+                SCAppLayerProtoDetectPPRegister(IPPROTO_TCP, "443", ALPROTO_TLS, 0, 3,
+                        STREAM_TOSERVER, SSLProbingParser, NULL);
             }
         }
     } else {

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -74,8 +74,8 @@ static int TFTPStateGetEventInfo(
  * \retval ALPROTO_TFTP if it looks like tftp, otherwise
  *     ALPROTO_UNKNOWN.
  */
-static AppProto TFTPProbingParser(Flow *f, uint8_t direction,
-        const uint8_t *input, uint32_t input_len, uint8_t *rdir)
+static AppProto TFTPProbingParser(
+        const Flow *f, uint8_t direction, const uint8_t *input, uint32_t input_len, uint8_t *rdir)
 {
     /* Very simple test - if there is input, this is tftp.
      * Also check if it's starting by a zero */
@@ -158,7 +158,7 @@ void RegisterTFTPParsers(void)
 
     /* Check if TFTP UDP detection is enabled. If it does not exist in
      * the configuration file then it will be enabled by default. */
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("udp", proto_name)) {
+    if (SCAppLayerProtoDetectConfProtoDetectionEnabled("udp", proto_name)) {
 
         SCLogDebug("TFTP UDP protocol detection enabled.");
 
@@ -166,23 +166,16 @@ void RegisterTFTPParsers(void)
 
         if (RunmodeIsUnittests()) {
             SCLogDebug("Unittest mode, registering default configuration.");
-            AppLayerProtoDetectPPRegister(IPPROTO_UDP, TFTP_DEFAULT_PORT,
-                                          ALPROTO_TFTP, 0, TFTP_MIN_FRAME_LEN,
-                                          STREAM_TOSERVER, TFTPProbingParser,
-                                          TFTPProbingParser);
+            SCAppLayerProtoDetectPPRegister(IPPROTO_UDP, TFTP_DEFAULT_PORT, ALPROTO_TFTP, 0,
+                    TFTP_MIN_FRAME_LEN, STREAM_TOSERVER, TFTPProbingParser, TFTPProbingParser);
         } else {
-            if (!AppLayerProtoDetectPPParseConfPorts("udp", IPPROTO_UDP,
-                                                     proto_name, ALPROTO_TFTP,
-                                                     0, TFTP_MIN_FRAME_LEN,
-                                                     TFTPProbingParser, TFTPProbingParser)) {
+            if (!SCAppLayerProtoDetectPPParseConfPorts("udp", IPPROTO_UDP, proto_name, ALPROTO_TFTP,
+                        0, TFTP_MIN_FRAME_LEN, TFTPProbingParser, TFTPProbingParser)) {
                 SCLogDebug("No tftp app-layer configuration, enabling tftp"
                            " detection UDP detection on port %s.",
                         TFTP_DEFAULT_PORT);
-                AppLayerProtoDetectPPRegister(IPPROTO_UDP,
-                                              TFTP_DEFAULT_PORT, ALPROTO_TFTP,
-                                              0, TFTP_MIN_FRAME_LEN,
-                                              STREAM_TOSERVER,TFTPProbingParser,
-                                              TFTPProbingParser);
+                SCAppLayerProtoDetectPPRegister(IPPROTO_UDP, TFTP_DEFAULT_PORT, ALPROTO_TFTP, 0,
+                        TFTP_MIN_FRAME_LEN, STREAM_TOSERVER, TFTPProbingParser, TFTPProbingParser);
             }
         }
         AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_TFTP);

--- a/src/bindgen.h
+++ b/src/bindgen.h
@@ -46,4 +46,6 @@
 
 #include "conf.h"
 
+#include "app-layer-detect-proto.h"
+
 #endif


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7667

Describe changes:
- Bindgen app-layer-detect-proto.h
- Remove some unneeded cbindgen:ignore

#13374 with unit tests compiling with probing parser using a const Flow now

Still to do afterwards (convert more keywords to rust and DetectHelperBufferMpmRegister)
- bindgen more extern definitions for other rust cases like `AppLayerRegisterParser` https://redmine.openinfosecfoundation.org/issues/7667

