### PR TITLE
doc/lua: document request_host lua lib - v1

### DIFF
--- a/doc/userguide/lua/libs/http.rst
+++ b/doc/userguide/lua/libs/http.rst
@@ -194,4 +194,14 @@ Example::
   http_response_body = tx:response_body()
   print(http_response_body)
 
+``request_host()``
+^^^^^^^^^^^^^^^^^^
+
+Get the HTTP request host.
+
+Example::
+
+  local tx = http.get_tx()
+  http_host = tx:request_host()
+  print(http_host)
 


### PR DESCRIPTION
Seems that we missed bringing this one, when documenting HTTP lua lib functions.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none

Describe changes:
- as per https://github.com/OISF/suricata/pull/13368/files/500281929a16d3fc22768d42e1eebbff993c1392..dc3b830d8900f16f612b6146ae6d70dc694fc018#r2127440048, add seemingly missing HTTP request_host function to lua libs docs
