### PR TITLE
wip: plugin initialization for loggers - v2

### DIFF
--- a/examples/plugins/altemplate/src/plugin.rs
+++ b/examples/plugins/altemplate/src/plugin.rs
@@ -40,6 +40,7 @@ extern "C" fn SCPluginRegister() -> *const SCPlugin {
         license: b"MIT\0".as_ptr() as *const libc::c_char,
         author: b"Philippe Antoine\0".as_ptr() as *const libc::c_char,
         Init: Some(altemplate_plugin_init),
+        RegisterLoggers: None,
     };
     Box::into_raw(Box::new(plugin))
 }

--- a/examples/plugins/c-custom-loggers/custom-logger.c
+++ b/examples/plugins/c-custom-loggers/custom-logger.c
@@ -79,14 +79,12 @@ static int CustomFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     return 0;
 }
 
-#if 0
 static int CustomDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state,
         void *tx, uint64_t tx_id)
 {
     SCLogNotice("We have a DNS transaction");
     return 0;
 }
-#endif
 
 static TmEcode ThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
@@ -102,19 +100,16 @@ static TmEcode ThreadDeinit(ThreadVars *tv, void *data)
 
 static void Init(void)
 {
+}
+
+static void RegisterLoggers(void)
+{
     SCOutputRegisterPacketLogger(LOGGER_USER, "custom-packet-logger", CustomPacketLogger,
             CustomPacketLoggerCondition, NULL, ThreadInit, ThreadDeinit);
     SCOutputRegisterFlowLogger(
             "custom-flow-logger", CustomFlowLogger, NULL, ThreadInit, ThreadDeinit);
-
-    /* Register a custom DNS transaction logger.
-     *
-     * Currently disabled due to https://redmine.openinfosecfoundation.org/issues/7236.
-     */
-#if 0
-    OutputRegisterTxLogger(LOGGER_USER, "custom-dns-logger", ALPROTO_DNS, CustomDnsLogger, NULL, -1,
-            -1, NULL, ThreadInit, ThreadDeinit);
-#endif
+    SCOutputRegisterTxLogger(LOGGER_USER, "custom-dns-logger", ALPROTO_DNS, CustomDnsLogger, NULL,
+            -1, -1, NULL, ThreadInit, ThreadDeinit);
 }
 
 const SCPlugin PluginRegistration = {
@@ -125,6 +120,7 @@ const SCPlugin PluginRegistration = {
     .author = "Firstname Lastname",
     .license = "GPLv2",
     .Init = Init,
+    .RegisterLoggers = RegisterLoggers,
 };
 
 const SCPlugin *SCPluginRegister(void)

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -72,6 +72,7 @@ pub struct SCPlugin_ {
     pub license: *const ::std::os::raw::c_char,
     pub author: *const ::std::os::raw::c_char,
     pub Init: ::std::option::Option<unsafe extern "C" fn()>,
+    pub RegisterLoggers: ::std::option::Option<unsafe extern "C" fn()>,
 }
 #[doc = " Structure to define a Suricata plugin."]
 pub type SCPlugin = SCPlugin_;

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -47,6 +47,7 @@ typedef struct SCPlugin_ {
     const char *license;
     const char *author;
     void (*Init)(void);
+    void (*RegisterLoggers)(void);
 } SCPlugin;
 
 typedef SCPlugin *(*SCPluginRegisterFunc)(void);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2793,6 +2793,9 @@ int PostConfLoadedSetup(SCInstance *suri)
     }
 
     RegisterAllModules();
+
+    SCInitPluginLoggers();
+
     AppLayerHtpNeedFileInspection();
 
     StorageFinalize();

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -49,7 +49,7 @@ static TAILQ_HEAD(, PluginListNode_) plugins = TAILQ_HEAD_INITIALIZER(plugins);
 
 static TAILQ_HEAD(, SCCapturePlugin_) capture_plugins = TAILQ_HEAD_INITIALIZER(capture_plugins);
 
-bool RegisterPlugin(SCPlugin *plugin, void *lib)
+static bool SCRegisterPlugin(SCPlugin *plugin, void *lib)
 {
     if (plugin->version != SC_API_VERSION) {
         SCLogError("Suricata and plugin versions differ: plugin has %" PRIx64
@@ -77,7 +77,29 @@ bool RegisterPlugin(SCPlugin *plugin, void *lib)
     return true;
 }
 
-static void InitPlugin(char *path)
+/**
+ * \brief Initialize registered plugins.
+ */
+void SCInitPlugins(void)
+{
+    PluginListNode *node = NULL;
+    TAILQ_FOREACH (node, &plugins, entries) {
+        SCLogNotice("Initializing %s", node->plugin->name);
+        (*node->plugin->Init)();
+    }
+}
+
+void SCInitPluginLoggers(void)
+{
+    PluginListNode *node = NULL;
+    TAILQ_FOREACH (node, &plugins, entries) {
+        if (node->plugin->RegisterLoggers) {
+            (*node->plugin->RegisterLoggers)();
+        }
+    }
+}
+
+static void SCLoadPlugin(char *path)
 {
     void *lib = dlopen(path, RTLD_NOW);
     if (lib == NULL) {
@@ -92,7 +114,7 @@ static void InitPlugin(char *path)
             return;
         }
 
-        if (!RegisterPlugin(plugin_register(), lib)) {
+        if (!SCRegisterPlugin(plugin_register(), lib)) {
             SCLogError("Plugin registration failed: %s", path);
             dlclose(lib);
             return;
@@ -125,12 +147,12 @@ void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_a
             while ((entry = readdir(dir)) != NULL) {
                 if (strstr(entry->d_name, ".so") != NULL) {
                     snprintf(path, sizeof(path), "%s/%s", plugin->val, entry->d_name);
-                    InitPlugin(path);
+                    SCLoadPlugin(path);
                 }
             }
             closedir(dir);
         } else {
-            InitPlugin(plugin->val);
+            SCLoadPlugin(plugin->val);
         }
     }
 

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -22,7 +22,7 @@
 
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args);
 SCCapturePlugin *SCPluginFindCaptureByName(const char *name);
-
-bool RegisterPlugin(SCPlugin *, void *);
+void SCInitPlugins(void);
+void SCInitPluginLoggers(void);
 
 #endif /* SURICATA_UTIL_PLUGIN_H */


### PR DESCRIPTION
As #13385 breaks application layer plugins, this is another try where the early `Init` method is left as-is.

Instead we add a new function to plugin registration, `RegisterLoggers`.  If set by the plugin, Suricata will call it in the lifecycle startup at a suitable time where Suricata is ready to have custom loggers registered.

Ticket: https://redmine.openinfosecfoundation.org/issues/7236