### PR TITLE
wip: move plugin initialization - v1

### DIFF
--- a/examples/plugins/c-custom-loggers/custom-logger.c
+++ b/examples/plugins/c-custom-loggers/custom-logger.c
@@ -79,14 +79,12 @@ static int CustomFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     return 0;
 }
 
-#if 0
 static int CustomDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state,
         void *tx, uint64_t tx_id)
 {
     SCLogNotice("We have a DNS transaction");
     return 0;
 }
-#endif
 
 static TmEcode ThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
@@ -106,15 +104,8 @@ static void Init(void)
             CustomPacketLoggerCondition, NULL, ThreadInit, ThreadDeinit);
     SCOutputRegisterFlowLogger(
             "custom-flow-logger", CustomFlowLogger, NULL, ThreadInit, ThreadDeinit);
-
-    /* Register a custom DNS transaction logger.
-     *
-     * Currently disabled due to https://redmine.openinfosecfoundation.org/issues/7236.
-     */
-#if 0
-    OutputRegisterTxLogger(LOGGER_USER, "custom-dns-logger", ALPROTO_DNS, CustomDnsLogger, NULL, -1,
-            -1, NULL, ThreadInit, ThreadDeinit);
-#endif
+    SCOutputRegisterTxLogger(LOGGER_USER, "custom-dns-logger", ALPROTO_DNS, CustomDnsLogger, NULL,
+            -1, -1, NULL, ThreadInit, ThreadDeinit);
 }
 
 const SCPlugin PluginRegistration = {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2793,6 +2793,9 @@ int PostConfLoadedSetup(SCInstance *suri)
     }
 
     RegisterAllModules();
+
+    SCInitPlugins();
+
     AppLayerHtpNeedFileInspection();
 
     StorageFinalize();

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -22,7 +22,6 @@
 
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args);
 SCCapturePlugin *SCPluginFindCaptureByName(const char *name);
-
-bool RegisterPlugin(SCPlugin *, void *);
+void SCInitPlugins(void);
 
 #endif /* SURICATA_UTIL_PLUGIN_H */


### PR DESCRIPTION
First attempt at fixing custom tx logger plugins (https://redmine.openinfosecfoundation.org/issues/7236).

The root of the issue is that the plugin `Init()` method is called very early in the loading Suricata, too early for a TX logger to be registered.

This delays the `Init()` method of plugins to be called later on where a custom TX logger can be registered.

However, this breaks application layer plugins.