### PR TITLE
lua: update to Lua 5.4.8 - v2

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1599,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "suricata-lua-sys"
-version = "0.1.0-alpha.9"
+version = "5.4.8000"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424e1aac0aa6f35ff10609bb8f36903e397efe7023279d434532c8bd0fa45aba"
+checksum = "903640726b3751bfe1e4d1a5dbf478c264100d3679c65e9b9ce870798a2d892a"
 dependencies = [
  "fs_extra",
 ]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -85,7 +85,7 @@ time = "~0.3.36"
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 suricata-sys = { path = "./sys", version = "@PACKAGE_VERSION@" }
 
-suricata-lua-sys = { version = "0.1.0-alpha.9" }
+suricata-lua-sys = { version = "5.4.8000" }
 
 htp = { package = "suricata-htp", path = "./htp", version = "2.0.0" }
 


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/7632

Also uses a proper Lua tagged version that is not a pre-release.
