### PR TITLE
hs-cache: adjust printing directive to match uint64_t v1

### DIFF
--- a/src/util-mpm-hs-cache.c
+++ b/src/util-mpm-hs-cache.c
@@ -42,8 +42,8 @@ static const char *HSCacheConstructFPath(const char *folder_path, uint64_t hs_db
 
     char hash_file_path_suffix[] = "_v1.hs";
     char filename[PATH_MAX];
-    uint64_t r =
-            snprintf(filename, sizeof(filename), "%020lu%s", hs_db_hash, hash_file_path_suffix);
+    uint64_t r = snprintf(
+            filename, sizeof(filename), "%020" PRIu64 "%s", hs_db_hash, hash_file_path_suffix);
     if (r != (uint64_t)(20 + strlen(hash_file_path_suffix)))
         return NULL;
 


### PR DESCRIPTION
## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues


MacOS warning was reported by Mr. Julien.
Report:
```
util-mpm-hs-cache.c:46:62: warning: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
   46 |             snprintf(filename, sizeof(filename), "%020lu%s", hs_db_hash, hash_file_path_suffix);
      |                                                   ~~~~~~     ^~~~~~~~~~
      |                                                   %020llu
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
   57 |   __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
      |                                                              ^~~~~~~~~~~
1 warning generated.
```

Describe changes:
-  changed %lu to %PRIu64