### PR TITLE
pgsql: install rules - v1

### DIFF
--- a/rules/Makefile.am
+++ b/rules/Makefile.am
@@ -17,6 +17,7 @@ modbus-events.rules \
 mqtt-events.rules \
 nfs-events.rules \
 ntp-events.rules \
+pgsql-events.rules \
 pop3-events.rules \
 quic-events.rules \
 rfb-events.rules \


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none

Describe changes:
- as indicated by @catenacyber ([here](https://github.com/OISF/suricata/pull/13376#issuecomment-2945796066)), pgsql event rules file was missing in the Makefile

