### PR TITLE
detect/dataset: skip adding localstatedir if fullpath is provided

### DIFF
--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -340,13 +340,16 @@ static int SetupSavePath(const DetectEngineCtx *de_ctx,
     // data dir
     const char *dir = ConfigGetDataDirectory();
     BUG_ON(dir == NULL); // should not be able to fail
-    char path[PATH_MAX];
-    if (snprintf(path, sizeof(path), "%s/%s", dir, save) >= (int)sizeof(path)) // TODO windows path
-        return -1;
+    if (!PathIsAbsolute(save)) {
+        char path[PATH_MAX];
+        if (snprintf(path, sizeof(path), "%s/%s", dir, save) >=
+                (int)sizeof(path)) // TODO windows path
+            return -1;
 
-    /* TODO check if location exists and is writable */
+        /* TODO check if location exists and is writable */
 
-    strlcpy(save, path, save_size);
+        strlcpy(save, path, save_size);
+    }
 
     return 0;
 }


### PR DESCRIPTION
When the option to set a full path is enabled and a full path is provided, skip adding the prefix (based on localstatedir) to the directory since it would be unexpected and unwanted by a user.

Ticket: 7083

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7083

Describe changes:
- When a user enables the option to provide a full path for a dataset, the prefix (based on localstatedir) should not be added since it doesn't make much sense to add that prefix on a provided full path
- This commit adds a check to skip the prefix addition in that case

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2553
SU_REPO=
SU_BRANCH=
