### PR TITLE
detect: Ensure byte* variable usages is for same buffers

### DIFF
--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -372,7 +372,7 @@ static void DetectByteExtractFree(DetectEngineCtx *de_ctx, void *ptr)
  *
  * \retval A pointer to the SigMatch if found, otherwise NULL.
  */
-SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, const Signature *s)
+SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, int sm_list, const Signature *s)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
         SigMatch *sm = s->init_data->buffers[x].head;
@@ -390,7 +390,8 @@ SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, const Signature *s)
     for (int list = 0; list < DETECT_SM_LIST_MAX; list++) {
         SigMatch *sm = s->init_data->smlists[list];
         while (sm != NULL) {
-            if (sm->type == DETECT_BYTE_EXTRACT) {
+            // Make sure that the linked buffers ore on the same list
+            if (sm->type == DETECT_BYTE_EXTRACT && (sm_list == -1 || sm_list == list)) {
                 const SCDetectByteExtractData *bed = (const SCDetectByteExtractData *)sm->ctx;
                 if (strcmp(bed->name, arg) == 0) {
                     return sm;

--- a/src/detect-byte-extract.h
+++ b/src/detect-byte-extract.h
@@ -26,7 +26,7 @@
 
 void DetectByteExtractRegister(void);
 
-SigMatch *DetectByteExtractRetrieveSMVar(const char *, const Signature *);
+SigMatch *DetectByteExtractRetrieveSMVar(const char *, int sm_list, const Signature *);
 int DetectByteExtractDoMatch(DetectEngineThreadCtx *, const SigMatchData *, const Signature *,
         const uint8_t *, uint32_t, uint64_t *, uint8_t);
 

--- a/src/detect-byte.c
+++ b/src/detect-byte.c
@@ -32,20 +32,22 @@
  *
  * \param arg The name of the variable being sought
  * \param s The signature to check for the variable
+ * \param sm_list The caller's matching buffer
  * \param index When found, the value of the slot within the byte vars
  *
  * \retval true A match for the variable was found.
  * \retval false
  */
-bool DetectByteRetrieveSMVar(const char *arg, const Signature *s, DetectByteIndexType *index)
+bool DetectByteRetrieveSMVar(
+        const char *arg, const Signature *s, int sm_list, DetectByteIndexType *index)
 {
-    SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(arg, s);
+    SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(arg, sm_list, s);
     if (bed_sm != NULL) {
         *index = ((SCDetectByteExtractData *)bed_sm->ctx)->local_id;
         return true;
     }
 
-    SigMatch *bmd_sm = DetectByteMathRetrieveSMVar(arg, s);
+    SigMatch *bmd_sm = DetectByteMathRetrieveSMVar(arg, sm_list, s);
     if (bmd_sm != NULL) {
         *index = ((DetectByteMathData *)bmd_sm->ctx)->local_id;
         return true;

--- a/src/detect-byte.h
+++ b/src/detect-byte.h
@@ -27,6 +27,6 @@
 
 typedef uint8_t DetectByteIndexType;
 
-bool DetectByteRetrieveSMVar(const char *, const Signature *, DetectByteIndexType *);
+bool DetectByteRetrieveSMVar(const char *, const Signature *, int sm_list, DetectByteIndexType *);
 
 #endif /* SURICATA_DETECT_BYTE_H */

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -544,7 +544,7 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (nbytes != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(nbytes, s, &index)) {
+        if (!DetectByteRetrieveSMVar(nbytes, s, sm_list, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in byte_jump - %s",
                     nbytes);
@@ -557,7 +557,7 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (offset != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(offset, s, &index)) {
+        if (!DetectByteRetrieveSMVar(offset, s, sm_list, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in byte_jump - %s",
                     offset);

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -359,7 +359,7 @@ static int DetectByteMathSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (nbytes != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(nbytes, s, &index)) {
+        if (!DetectByteRetrieveSMVar(nbytes, s, sm_list, &index)) {
             SCLogError("unknown byte_ keyword var seen in byte_math - %s", nbytes);
             goto error;
         }
@@ -371,7 +371,7 @@ static int DetectByteMathSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (rvalue != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(rvalue, s, &index)) {
+        if (!DetectByteRetrieveSMVar(rvalue, s, sm_list, &index)) {
             SCLogError("unknown byte_ keyword var seen in byte_math - %s", rvalue);
             goto error;
         }
@@ -441,7 +441,7 @@ static void DetectByteMathFree(DetectEngineCtx *de_ctx, void *ptr)
  *
  * \retval A pointer to the SigMatch if found, otherwise NULL.
  */
-SigMatch *DetectByteMathRetrieveSMVar(const char *arg, const Signature *s)
+SigMatch *DetectByteMathRetrieveSMVar(const char *arg, int sm_list, const Signature *s)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
         SigMatch *sm = s->init_data->buffers[x].head;
@@ -460,7 +460,8 @@ SigMatch *DetectByteMathRetrieveSMVar(const char *arg, const Signature *s)
     for (int list = 0; list < DETECT_SM_LIST_MAX; list++) {
         SigMatch *sm = s->init_data->smlists[list];
         while (sm != NULL) {
-            if (sm->type == DETECT_BYTEMATH) {
+            // Make sure that the linked buffers ore on the same list
+            if (sm->type == DETECT_BYTEMATH && (sm_list == -1 || sm_list == list)) {
                 const DetectByteMathData *bmd = (const DetectByteMathData *)sm->ctx;
                 if (strcmp(bmd->result, arg) == 0) {
                     SCLogDebug("Retrieved SM for \"%s\"", arg);

--- a/src/detect-bytemath.h
+++ b/src/detect-bytemath.h
@@ -26,7 +26,7 @@
 
 void DetectBytemathRegister(void);
 
-SigMatch *DetectByteMathRetrieveSMVar(const char *, const Signature *);
+SigMatch *DetectByteMathRetrieveSMVar(const char *, int sm_list, const Signature *);
 int DetectByteMathDoMatch(DetectEngineThreadCtx *, const DetectByteMathData *, const Signature *,
         const uint8_t *, const uint32_t, uint8_t, uint64_t, uint64_t *, uint8_t);
 

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -646,7 +646,7 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (value != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(value, s, &index)) {
+        if (!DetectByteRetrieveSMVar(value, s, sm_list, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in byte_test - %s",
                     value);
@@ -660,7 +660,7 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (offset != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(offset, s, &index)) {
+        if (!DetectByteRetrieveSMVar(offset, s, sm_list, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in byte_test - %s",
                     offset);
@@ -674,7 +674,7 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (nbytes != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(nbytes, s, &index)) {
+        if (!DetectByteRetrieveSMVar(nbytes, s, sm_list, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in byte_test - %s",
                     nbytes);

--- a/src/detect-depth.c
+++ b/src/detect-depth.c
@@ -106,7 +106,7 @@ static int DetectDepthSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(str, s, &index)) {
+        if (!DetectByteRetrieveSMVar(str, s, -1, &index)) {
             SCLogError("unknown byte_ keyword var "
                        "seen in depth - %s.",
                     str);

--- a/src/detect-distance.c
+++ b/src/detect-distance.c
@@ -108,7 +108,7 @@ static int DetectDistanceSetup (DetectEngineCtx *de_ctx, Signature *s,
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(str, s, &index)) {
+        if (!DetectByteRetrieveSMVar(str, s, -1, &index)) {
             SCLogError("unknown byte_ keyword var "
                        "seen in distance - %s",
                     str);

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -532,12 +532,15 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
 
         if (bjflags & DETECT_BYTEJUMP_OFFSET_VAR) {
             offset = det_ctx->byte_values[offset];
+            SCLogDebug("[BJ] using offset value %d", offset);
         }
 
         if (bjflags & DETECT_BYTEJUMP_NBYTES_VAR) {
             nbytes = det_ctx->byte_values[bjd->nbytes];
+            SCLogDebug("[BJ] using nbytes value %d [index %d]", nbytes, bjd->nbytes);
         } else {
             nbytes = bjd->nbytes;
+            SCLogDebug("[BJ] using nbytes value %d [index n/a]", nbytes);
         }
 
         /* if we have dce enabled we will have to use the endianness

--- a/src/detect-isdataat.c
+++ b/src/detect-isdataat.c
@@ -347,7 +347,7 @@ int DetectIsdataatSetup (DetectEngineCtx *de_ctx, Signature *s, const char *isda
 
     if (offset != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(offset, s, &index)) {
+        if (!DetectByteRetrieveSMVar(offset, s, -1, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in isdataat - %s\n",
                     offset);

--- a/src/detect-offset.c
+++ b/src/detect-offset.c
@@ -92,7 +92,7 @@ int DetectOffsetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *offset
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(str, s, &index)) {
+        if (!DetectByteRetrieveSMVar(str, s, -1, &index)) {
             SCLogError("unknown byte_ keyword var "
                        "seen in offset - %s.",
                     str);

--- a/src/detect-within.c
+++ b/src/detect-within.c
@@ -104,7 +104,7 @@ static int DetectWithinSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(str, s, &index)) {
+        if (!DetectByteRetrieveSMVar(str, s, -1, &index)) {
             SCLogError("unknown byte_ keyword var "
                        "seen in within - %s",
                     str);

--- a/src/util-lua-bytevarlib.c
+++ b/src/util-lua-bytevarlib.c
@@ -55,7 +55,7 @@ static int LuaBytevarMap(lua_State *L)
     }
 
     DetectByteIndexType idx;
-    if (!DetectByteRetrieveSMVar(name, s, &idx)) {
+    if (!DetectByteRetrieveSMVar(name, s, -1, &idx)) {
         luaL_error(L, "unknown byte_extract or byte_math variable: %s", name);
     }
 


### PR DESCRIPTION
Issue: 7549

Use the active buffer list to fetch SM variables to ensure that they are part of the same list so a variable created with bytemath or byteextract will have context when used with bytejump, e.g

Not needed for content modifiers.


Link to ticket: https://redmine.openinfosecfoundation.org/issues/7549

Describe changes:
- When retrieving variables, check for a match of the associated buffers.


### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2552
SU_REPO=
SU_BRANCH=
