### PR TITLE
suricatasc: reconnect on loss of connection - v3

### DIFF
--- a/rust/suricatactl/src/main.rs
+++ b/rust/suricatactl/src/main.rs
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
 // SPDX-License-Identifier: GPL-2.0-only
 
+// Allow these patterns as its a style we like.
+#![allow(clippy::needless_return)]
+#![allow(clippy::let_and_return)]
+#![allow(clippy::uninlined_format_args)]
+
 use clap::Parser;
 use clap::Subcommand;
 use tracing::Level;

--- a/rust/suricatasc/src/main.rs
+++ b/rust/suricatasc/src/main.rs
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
 // SPDX-License-Identifier: GPL-2.0-only
 
+// Allow these patterns as its a style we like.
+#![allow(clippy::needless_return)]
+#![allow(clippy::let_and_return)]
+#![allow(clippy::uninlined_format_args)]
+
 #[cfg(not(target_os = "windows"))]
 mod unix;
 


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/7746

If the connection is lost (for example, Suricata is restarted), try to
re-open the connect and re-execute the command.

This was the behavior of the Python implementation.
