### PR TITLE
Akaki alice/detect mime email body md5 7587 v8

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -222,3 +222,28 @@ Example of a signature that would alert if a packet contains the MIME field ``re
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email received"; :example-rule-emphasis:`email.received; content:"from [65.201.218.30] (helo=COZOXORY.club)by 173-66-46-112.wash.fios.verizon.net with esmtpa (Exim 4.86)(envelope-from )id 71cF63a9for mirjam@abrakadabra.ch\; Mon, 29 Jul 2019 17:01:45 +0000";` sid:1;)
+
+email.body_md5
+--------------
+
+Matches the ``md5`` hash generated from an email body.
+This keyword only works if config option
+``app-layer.protocols.smtp.mime.body-md5`` is true.
+
+Syntax::
+
+ email.body_md5; content:"<content to match against>";
+
+``email.body_md5`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE field ``email.body_md5``.
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if the hash ``ed00c81b85fa455d60e19f1230977134``
+is generated from an email body:
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email body_md5"; :example-rule-emphasis:`email.body_md5; content:"ed00c81b85fa455d60e19f1230977134";` sid:1;)

--- a/rust/src/mime/detect.rs
+++ b/rust/src/mime/detect.rs
@@ -93,3 +93,12 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetDataArray(
     }
     return 0;
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectMimeEmailGetBodyMd5(
+    ctx: &MimeStateSMTP, buffer: *mut *const u8, buffer_len: *mut u32,
+) {
+    let hash = &ctx.md5_result;
+    *buffer = hash.as_ptr();
+    *buffer_len = hash.len() as u32;
+}

--- a/rust/src/mime/detect.rs
+++ b/rust/src/mime/detect.rs
@@ -27,8 +27,14 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetData(
     ctx: &MimeStateSMTP, buffer: *mut *const u8, buffer_len: *mut u32,
     hname: *const std::os::raw::c_char,
 ) -> u8 {
+    *buffer = ptr::null();
+    *buffer_len = 0;
+
     let c_str = CStr::from_ptr(hname); //unsafe
-    let str = c_str.to_str().unwrap_or("");
+    let Ok(str) = c_str.to_str() else {
+        SCLogDebug!("Received non-UTF8 string in SCDetectMimeEmailGetData");
+        return 0;
+    };
 
     for h in &ctx.headers[..ctx.main_headers_nb] {
         if mime::slice_equals_lowercase(&h.name, str.as_bytes()) {
@@ -37,10 +43,6 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetData(
             return 1;
         }
     }
-
-    *buffer = ptr::null();
-    *buffer_len = 0;
-
     return 0;
 }
 
@@ -69,8 +71,14 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetDataArray(
     ctx: &MimeStateSMTP, buffer: *mut *const u8, buffer_len: *mut u32,
     hname: *const std::os::raw::c_char, idx: u32,
 ) -> u8 {
+    *buffer = ptr::null();
+    *buffer_len = 0;
+
     let c_str = CStr::from_ptr(hname); //unsafe
-    let str = c_str.to_str().unwrap_or("");
+    let Ok(str) = c_str.to_str() else {
+        SCLogDebug!("Received non-UTF8 string in SCDetectMimeEmailGetDataArray");
+        return 0;
+    };
 
     let mut i = 0;
     for h in &ctx.headers[..ctx.main_headers_nb] {
@@ -83,9 +91,5 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetDataArray(
             i += 1;
         }
     }
-
-    *buffer = ptr::null();
-    *buffer_len = 0;
-
     return 0;
 }

--- a/rust/src/mime/smtp.rs
+++ b/rust/src/mime/smtp.rs
@@ -742,6 +742,11 @@ pub unsafe extern "C" fn SCMimeSmtpConfigBodyMd5(val: std::os::raw::c_int) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn MimeBodyMd5IsEnabled() -> bool {
+    MIME_SMTP_CONFIG_BODY_MD5
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn SCMimeSmtpConfigHeaderValueDepth(val: u32) {
     MIME_SMTP_CONFIG_HEADER_VALUE_DEPTH = val;
 }

--- a/rust/src/mime/smtp_log.rs
+++ b/rust/src/mime/smtp_log.rs
@@ -43,8 +43,7 @@ pub unsafe extern "C" fn SCMimeSmtpLogSubjectMd5(
 
 fn log_body_md5(js: &mut JsonBuilder, ctx: &MimeStateSMTP) -> Result<(), JsonError> {
     if ctx.md5_state == MimeSmtpMd5State::MimeSmtpMd5Completed {
-        let hash = format!("{:x}", ctx.md5_result);
-        js.set_string("body_md5", &hash)?;
+        js.set_string("body_md5", &ctx.md5_result)?;
     }
     return Ok(());
 }


### PR DESCRIPTION
Ticket: [#7587](https://redmine.openinfosecfoundation.org/issues/7587)

### Description:
- Implement ``email.body_md5``  keyword.

### Changes:
- Needed Rebase
- added comment about why we do not need to precise progress
- add `DetectBufferTypeRegisterValidateCallback("email.body_md5", DetectMd5ValidateCallback);`
- add check `MimeBodyMd5IsEnabled`

@jasonish what do you think about this keyword being dependent on a config option ?
Should we handle an additional `auto` value for `body-md5` in suricata.yaml ?
Do we need to do something for `requires` keyword ?

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2560
Previous PR: https://github.com/OISF/suricata/pull/13169
