### PR TITLE
json/schema: link file.name to email.attachment - v3

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1348,6 +1348,11 @@
                     "minItems": 1,
                     "items": {
                         "type": "string"
+                    },
+                    "suricata": {
+                        "keywords": [
+                            "file.name"
+                        ]
                     }
                 },
                 "body_md5": {


### PR DESCRIPTION
As a Suricata keyword.

Ticket: #7683

previous PR https://github.com/OISF/suricata/pull/13360

Following @catenacyber comment there.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7683

Describe changes:
- Try to follow Philippe's suggestion on how to indicate that file.name is a keyword that refers to email.attachment