### PR TITLE
Fw cleanups/v2

### DIFF
--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -80,6 +80,7 @@ void DetectConfigRegister(void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_CONFIG].RegisterTests = DetectConfigRegisterTests;
 #endif
+    sigmatch_table[DETECT_CONFIG].flags = SIGMATCH_SUPPORT_FIREWALL;
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -16,6 +16,7 @@
  */
 
 #include "suricata-common.h"
+#include "suricata.h"
 
 #include "detect.h"
 #include "detect-engine-alert.h"
@@ -409,13 +410,12 @@ static inline void FlowApplySignatureActions(
 static inline void PacketAlertFinalizeProcessQueue(
         const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p)
 {
-    const bool have_fw_rules = (de_ctx->flags & DE_HAS_FIREWALL) != 0;
+    const bool have_fw_rules = EngineModeIsFirewall();
 
     if (det_ctx->alert_queue_size > 1) {
         /* sort the alert queue before thresholding and appending to Packet */
         qsort(det_ctx->alert_queue, det_ctx->alert_queue_size, sizeof(PacketAlert),
-                (de_ctx->flags & DE_HAS_FIREWALL) ? AlertQueueSortHelperFirewall
-                                                  : AlertQueueSortHelper);
+                have_fw_rules ? AlertQueueSortHelperFirewall : AlertQueueSortHelper);
     }
 
     bool dropped = false;

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -2266,7 +2266,7 @@ int SigGroupBuild(DetectEngineCtx *de_ctx)
         VarNameStoreActivate();
     }
 
-    if (de_ctx->flags & DE_HAS_FIREWALL) {
+    if (EngineModeIsFirewall()) {
         FirewallAnalyzer(de_ctx);
     }
     return 0;

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -300,7 +300,6 @@ static int LoadFirewallRuleFiles(DetectEngineCtx *de_ctx)
         int32_t skipped_sigs = 0;
 
         SCLogNotice("fw: rule file full path \"%s\"", de_ctx->firewall_rule_file_exclusive);
-        de_ctx->flags |= DE_HAS_FIREWALL;
 
         int ret = DetectLoadSigFile(de_ctx, de_ctx->firewall_rule_file_exclusive, &good_sigs,
                 &bad_sigs, &skipped_sigs, true);
@@ -360,8 +359,6 @@ static int LoadFirewallRuleFiles(DetectEngineCtx *de_ctx)
             de_ctx->sig_stat.good_sigs_total += good_sigs;
         }
     }
-    de_ctx->flags |= DE_HAS_FIREWALL;
-
     return 0;
 }
 

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -323,14 +323,14 @@ static int LoadFirewallRuleFiles(DetectEngineCtx *de_ctx)
         return 0;
     }
 
-    SCConfNode *default_fw_rule_path = SCConfGetNode("firewall-rule-path");
+    SCConfNode *default_fw_rule_path = SCConfGetNode("firewall.rule-path");
     if (default_fw_rule_path == NULL) {
-        SCLogNotice("fw: firewall-rule-path not defined, skip loading firewall rules");
+        SCLogNotice("fw: firewall.rule-path not defined, skip loading firewall rules");
         return 0;
     }
-    SCConfNode *rule_files = SCConfGetNode("firewall-rule-files");
+    SCConfNode *rule_files = SCConfGetNode("firewall.rule-files");
     if (rule_files == NULL) {
-        SCLogNotice("fw: firewall-rule-files not defined, skip loading firewall rules");
+        SCLogNotice("fw: firewall.rule-files not defined, skip loading firewall rules");
         return 0;
     }
 
@@ -340,7 +340,7 @@ static int LoadFirewallRuleFiles(DetectEngineCtx *de_ctx)
         int32_t bad_sigs = 0;
         int32_t skipped_sigs = 0;
 
-        char *sfile = DetectLoadCompleteSigPathWithKey(de_ctx, "firewall-rule-path", file->val);
+        char *sfile = DetectLoadCompleteSigPathWithKey(de_ctx, "firewall.rule-path", file->val);
         SCLogNotice("fw: rule file full path \"%s\"", sfile);
 
         int ret = DetectLoadSigFile(de_ctx, sfile, &good_sigs, &bad_sigs, &skipped_sigs, true);

--- a/src/detect.h
+++ b/src/detect.h
@@ -327,8 +327,7 @@ typedef struct DetectPort_ {
 #define FILE_SIG_NEED_SIZE          0x80
 
 /* Detection Engine flags */
-#define DE_QUIET           0x01     /**< DE is quiet (esp for unittests) */
-#define DE_HAS_FIREWALL    0x02     /**< firewall rules loaded, default policies active */
+#define DE_QUIET 0x01 /**< DE is quiet (esp for unittests) */
 
 typedef struct IPOnlyCIDRItem_ {
     /* address data for this item */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -600,20 +600,18 @@ static void PrintUsage(const char *progname)
     printf("%s %s\n", PROG_NAME, PROG_VER);
 #endif
     printf("USAGE: %s [OPTIONS] [BPF FILTER]\n\n", progname);
+
+    printf("\n  General:\n");
+    printf("\t-v                                   : be more verbose (use multiple times to "
+           "increase verbosity)\n");
     printf("\t-c <path>                            : path to configuration file\n");
-    printf("\t-T                                   : test configuration file (use with -c)\n");
-    printf("\t-i <dev or ip>                       : run in pcap live mode\n");
-    printf("\t-F <bpf filter file>                 : bpf filter file\n");
-    printf("\t-r <path>                            : run in pcap file/offline mode\n");
-#ifdef NFQ
-    printf("\t-q <qid[:qid]>                       : run in inline nfqueue mode (use colon to specify a range of queues)\n");
-#endif /* NFQ */
-#ifdef IPFW
-    printf("\t-d <divert port>                     : run in inline ipfw divert mode\n");
-#endif /* IPFW */
-    printf("\t-s <path>                            : path to signature file loaded in addition to suricata.yaml settings (optional)\n");
-    printf("\t-S <path>                            : path to signature file loaded exclusively (optional)\n");
     printf("\t-l <dir>                             : default log directory\n");
+    printf("\t--include <path>                     : additional configuration file\n");
+    printf("\t--set name=value                     : set a configuration value\n");
+    printf("\t--pidfile <file>                     : write pid to this file\n");
+    printf("\t-T                                   : test configuration file (use with -c)\n");
+    printf("\t--init-errors-fatal                  : enable fatal failure on signature init "
+           "error\n");
 #ifndef OS_WIN32
     printf("\t-D                                   : run as daemon\n");
 #else
@@ -621,48 +619,35 @@ static void PrintUsage(const char *progname)
     printf("\t--service-remove                     : remove service\n");
     printf("\t--service-change-params              : change service startup parameters\n");
 #endif /* OS_WIN32 */
-    printf("\t-k [all|none]                        : force checksum check (all) or disabled it (none)\n");
-    printf("\t-V                                   : display Suricata version\n");
-    printf("\t-v                                   : be more verbose (use multiple times to increase verbosity)\n");
-#ifdef UNITTESTS
-    printf("\t-u                                   : run the unittests and exit\n");
-    printf("\t-U, --unittest-filter=REGEX          : filter unittests with a regex\n");
-    printf("\t--list-unittests                     : list unit tests\n");
-    printf("\t--fatal-unittests                    : enable fatal failure on unittest error\n");
-    printf("\t--unittests-coverage                 : display unittest coverage report\n");
-#endif /* UNITTESTS */
-    printf("\t--firewall                           : enable firewall mode\n");
-    printf("\t--firewall-rules-exclusive=<path>    : path to firewall rule file loaded "
-           "exclusively\n");
-    printf("\t--list-app-layer-protos              : list supported app layer protocols\n");
-    printf("\t--list-app-layer-hooks               : list supported app layer hooks for use in "
-           "rules\n");
-    printf("\t--list-keywords[=all|csv|<kword>]    : list keywords implemented by the engine\n");
-    printf("\t--list-runmodes                      : list supported runmodes\n");
+#ifdef HAVE_LIBCAP_NG
+    printf("\t--user <user>                        : run suricata as this user after init\n");
+    printf("\t--group <group>                      : run suricata as this group after init\n");
+#endif /* HAVE_LIBCAP_NG */
+#ifdef BUILD_UNIX_SOCKET
+    printf("\t--unix-socket[=<file>]               : use unix socket to control suricata work\n");
+#endif
     printf("\t--runmode <runmode_id>               : specific runmode modification the engine should run.  The argument\n"
            "\t                                       supplied should be the id for the runmode obtained by running\n"
            "\t                                       --list-runmodes\n");
-    printf("\t--engine-analysis                    : print reports on analysis of different sections in the engine and exit.\n"
-           "\t                                       Please have a look at the conf parameter engine-analysis on what reports\n"
-           "\t                                       can be printed\n");
-    printf("\t--pidfile <file>                     : write pid to this file\n");
-    printf("\t--init-errors-fatal                  : enable fatal failure on signature init error\n");
-    printf("\t--disable-detection                  : disable detection engine\n");
-    printf("\t--dump-config                        : show the running configuration\n");
-    printf("\t--dump-features                      : display provided features\n");
-    printf("\t--build-info                         : display build information\n");
-    printf("\t--pcap[=<dev>]                       : run in pcap mode, no value select interfaces from suricata.yaml\n");
-    printf("\t--pcap-file-continuous               : when running in pcap mode with a directory, continue checking directory for pcaps until interrupted\n");
-    printf("\t--pcap-file-delete                   : when running in replay mode (-r with directory or file), will delete pcap files that have been processed when done\n");
-    printf("\t--pcap-file-recursive                : will descend into subdirectories when running in replay mode (-r)\n");
-    printf("\t--pcap-file-buffer-size              : set read buffer size (setvbuf)\n");
+
+    printf("\n  Capture and IPS:\n");
+
+    printf("\t-F <bpf filter file>                 : bpf filter file\n");
+    printf("\t-k [all|none]                        : force checksum check (all) or disabled it "
+           "(none)\n");
+    printf("\t-i <dev or ip>                       : run in pcap live mode\n");
+    printf("\t--pcap[=<dev>]                       : run in pcap mode, no value select interfaces "
+           "from suricata.yaml\n");
 #ifdef HAVE_PCAP_SET_BUFF
     printf("\t--pcap-buffer-size                   : size of the pcap buffer value from 0 - %i\n",INT_MAX);
 #endif /* HAVE_SET_PCAP_BUFF */
-#ifdef HAVE_DPDK
-    printf("\t--dpdk                               : run in dpdk mode, uses interfaces from "
-           "suricata.yaml\n");
-#endif
+#ifdef NFQ
+    printf("\t-q <qid[:qid]>                       : run in inline nfqueue mode (use colon to "
+           "specify a range of queues)\n");
+#endif /* NFQ */
+#ifdef IPFW
+    printf("\t-d <divert port>                     : run in inline ipfw divert mode\n");
+#endif /* IPFW */
 #ifdef HAVE_AF_PACKET
     printf("\t--af-packet[=<dev>]                  : run in af-packet mode, no value select interfaces from suricata.yaml\n");
 #endif
@@ -679,17 +664,12 @@ static void PrintUsage(const char *progname)
     printf("\t--pfring-cluster-id <id>             : pfring cluster id \n");
     printf("\t--pfring-cluster-type <type>         : pfring cluster type for PF_RING 4.1.2 and later cluster_round_robin|cluster_flow\n");
 #endif /* HAVE_PFRING */
-    printf("\t--simulate-ips                       : force engine into IPS mode. Useful for QA\n");
-#ifdef HAVE_LIBCAP_NG
-    printf("\t--user <user>                        : run suricata as this user after init\n");
-    printf("\t--group <group>                      : run suricata as this group after init\n");
-#endif /* HAVE_LIBCAP_NG */
-    printf("\t--erf-in <path>                      : process an ERF file\n");
+#ifdef HAVE_DPDK
+    printf("\t--dpdk                               : run in dpdk mode, uses interfaces from "
+           "suricata.yaml\n");
+#endif
 #ifdef HAVE_DAG
     printf("\t--dag <dagX:Y>                       : process ERF records from DAG interface X, stream Y\n");
-#endif
-#ifdef BUILD_UNIX_SOCKET
-    printf("\t--unix-socket[=<file>]               : use unix socket to control suricata work\n");
 #endif
 #ifdef WINDIVERT
     printf("\t--windivert <filter>                 : run in inline WinDivert mode\n");
@@ -698,12 +678,60 @@ static void PrintUsage(const char *progname)
 #ifdef HAVE_LIBNET11
     printf("\t--reject-dev <dev>                   : send reject packets from this interface\n");
 #endif
-    printf("\t--include <path>                     : additional configuration file\n");
-    printf("\t--set name=value                     : set a configuration value\n");
+
+    printf("\n  Capture Files:\n");
+    printf("\t-r <path>                            : run in pcap file/offline mode\n");
+    printf("\t--pcap-file-continuous               : when running in pcap mode with a directory, "
+           "continue checking directory for pcaps until interrupted\n");
+    printf("\t--pcap-file-delete                   : when running in replay mode (-r with "
+           "directory or file), will delete pcap files that have been processed when done\n");
+    printf("\t--pcap-file-recursive                : will descend into subdirectories when running "
+           "in replay mode (-r)\n");
+    printf("\t--pcap-file-buffer-size              : set read buffer size (setvbuf)\n");
+    printf("\t--erf-in <path>                      : process an ERF file\n");
+
+    printf("\n  Detection:\n");
+    printf("\t-s <path>                            : path to signature file loaded in addition to "
+           "suricata.yaml settings (optional)\n");
+    printf("\t-S <path>                            : path to signature file loaded exclusively "
+           "(optional)\n");
+    printf("\t--disable-detection                  : disable detection engine\n");
+    printf("\t--engine-analysis                    : print reports on analysis of different "
+           "sections in the engine and exit.\n"
+           "\t                                       Please have a look at the conf parameter "
+           "engine-analysis on what reports\n"
+           "\t                                       can be printed\n");
+
+    printf("\n  Firewall:\n");
+    printf("\t--firewall                           : enable firewall mode\n");
+    printf("\t--firewall-rules-exclusive=<path>    : path to firewall rule file loaded "
+           "exclusively\n");
+
+    printf("\n  Info:\n");
+    printf("\t-V                                   : display Suricata version\n");
+    printf("\t--list-keywords[=all|csv|<kword>]    : list keywords implemented by the engine\n");
+    printf("\t--list-runmodes                      : list supported runmodes\n");
+    printf("\t--list-app-layer-protos              : list supported app layer protocols\n");
+    printf("\t--list-app-layer-hooks               : list supported app layer hooks for use in "
+           "rules\n");
+    printf("\t--dump-config                        : show the running configuration\n");
+    printf("\t--dump-features                      : display provided features\n");
+    printf("\t--build-info                         : display build information\n");
+
+    printf("\n  Testing:\n");
+    printf("\t--simulate-ips                       : force engine into IPS mode. Useful for QA\n");
+#ifdef UNITTESTS
+    printf("\t-u                                   : run the unittests and exit\n");
+    printf("\t-U=REGEX, --unittest-filter=REGEX    : filter unittests with a pcre compatible "
+           "regex\n");
+    printf("\t--list-unittests                     : list unit tests\n");
+    printf("\t--fatal-unittests                    : enable fatal failure on unittest error\n");
+    printf("\t--unittests-coverage                 : display unittest coverage report\n");
+#endif /* UNITTESTS */
     printf("\n");
-    printf("\nTo run the engine with default configuration on "
-            "interface eth0 with signature file \"signatures.rules\", run the "
-            "command as:\n\n%s -c suricata.yaml -s signatures.rules -i eth0 \n\n",
+    printf("\nTo run " PROG_NAME " with default configuration on "
+           "interface eth0 with signature file \"signatures.rules\", run the "
+           "command as:\n\n%s -c suricata.yaml -s signatures.rules -i eth0 \n\n",
             progname);
 }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -232,16 +232,28 @@ int EngineModeIsUnknown(void)
     return (g_engine_mode == ENGINE_MODE_UNKNOWN);
 }
 
+bool EngineModeIsFirewall(void)
+{
+    DEBUG_VALIDATE_BUG_ON(g_engine_mode == ENGINE_MODE_UNKNOWN);
+    return (g_engine_mode == ENGINE_MODE_FIREWALL);
+}
+
+/* this returns true for firewall mode as well */
 int EngineModeIsIPS(void)
 {
     DEBUG_VALIDATE_BUG_ON(g_engine_mode == ENGINE_MODE_UNKNOWN);
-    return (g_engine_mode == ENGINE_MODE_IPS);
+    return (g_engine_mode >= ENGINE_MODE_IPS);
 }
 
 int EngineModeIsIDS(void)
 {
     DEBUG_VALIDATE_BUG_ON(g_engine_mode == ENGINE_MODE_UNKNOWN);
     return (g_engine_mode == ENGINE_MODE_IDS);
+}
+
+void EngineModeSetFirewall(void)
+{
+    g_engine_mode = ENGINE_MODE_FIREWALL;
 }
 
 void EngineModeSetIPS(void)
@@ -619,6 +631,7 @@ static void PrintUsage(const char *progname)
     printf("\t--fatal-unittests                    : enable fatal failure on unittest error\n");
     printf("\t--unittests-coverage                 : display unittest coverage report\n");
 #endif /* UNITTESTS */
+    printf("\t--firewall                           : enable firewall mode\n");
     printf("\t--firewall-rules-exclusive=<path>    : path to firewall rule file loaded "
            "exclusively\n");
     printf("\t--list-app-layer-protos              : list supported app layer protocols\n");
@@ -1336,6 +1349,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
     int conf_test = 0;
     int engine_analysis = 0;
     int ret = TM_ECODE_OK;
+    int is_firewall = 0;
 
 #ifdef UNITTESTS
     coverage_unittests = 0;
@@ -1420,6 +1434,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
 
         {"qa-skip-prefilter", 0, &g_skip_prefilter, 1 },
 
+        {"firewall", 0, &is_firewall, 1 },
         {"firewall-rules-exclusive", required_argument, 0, 0},
 
         {"include", required_argument, 0, 0},
@@ -1833,6 +1848,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
                 }
                 suri->firewall_rule_file = optarg;
                 suri->firewall_rule_file_exclusive = true;
+                suri->is_firewall = true;
             } else {
                 int r = ExceptionSimulationCommandLineParser(
                         (long_opts[option_index]).name, optarg);
@@ -2056,6 +2072,10 @@ TmEcode SCParseCommandLine(int argc, char **argv)
             PrintUsage(argv[0]);
             return TM_ECODE_FAILED;
         }
+    }
+
+    if (is_firewall) {
+        suri->is_firewall = true;
     }
 
     if (suri->disabled_detect && (suri->sig_file != NULL || suri->firewall_rule_file != NULL)) {
@@ -2662,6 +2682,21 @@ static void SetupUserMode(SCInstance *suri)
  */
 int PostConfLoadedSetup(SCInstance *suri)
 {
+    int cnf_firewall_enabled = 0;
+    if (SCConfGetBool("firewall.enabled", &cnf_firewall_enabled) == 1) {
+        if (cnf_firewall_enabled == 1) {
+            suri->is_firewall = true;
+        } else {
+            if (suri->is_firewall) {
+                FatalError("firewall mode enabled through commandline, but disabled in config");
+            }
+        }
+    }
+    if (suri->is_firewall) {
+        SCLogWarning("firewall mode is EXPERIMENTAL and subject to change");
+        EngineModeSetFirewall();
+    }
+
     /* load the pattern matchers */
     MpmTableSetup();
     SpmTableSetup();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1359,6 +1359,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
 
     // clang-format off
     struct option long_opts[] = {
+        {"help", 0, 0, 0},
         {"dump-config", 0, &dump_config, 1},
         {"dump-features", 0, &dump_features, 1},
         {"pfring", optional_argument, 0, 0},
@@ -1451,8 +1452,11 @@ TmEcode SCParseCommandLine(int argc, char **argv)
     while ((opt = getopt_long(argc, argv, short_opts, long_opts, &option_index)) != -1) {
         switch (opt) {
         case 0:
-            if (strcmp((long_opts[option_index]).name , "pfring") == 0 ||
-                strcmp((long_opts[option_index]).name , "pfring-int") == 0) {
+            if (strcmp((long_opts[option_index]).name, "help") == 0) {
+                suri->run_mode = RUNMODE_PRINT_USAGE;
+                return TM_ECODE_OK;
+            } else if (strcmp((long_opts[option_index]).name, "pfring") == 0 ||
+                       strcmp((long_opts[option_index]).name, "pfring-int") == 0) {
 #ifdef HAVE_PFRING
                 /* TODO: Which plugin? */
                 suri->run_mode = RUNMODE_PLUGIN;
@@ -1469,8 +1473,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
                            "to pass --enable-pfring to configure when building.");
                 return TM_ECODE_FAILED;
 #endif /* HAVE_PFRING */
-            }
-            else if(strcmp((long_opts[option_index]).name , "pfring-cluster-id") == 0){
+            } else if (strcmp((long_opts[option_index]).name, "pfring-cluster-id") == 0) {
 #ifdef HAVE_PFRING
                 if (SCConfSetFinal("pfring.cluster-id", optarg) != 1) {
                     SCLogError("failed to set pfring.cluster-id");
@@ -1481,8 +1484,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
                            "to pass --enable-pfring to configure when building.");
                 return TM_ECODE_FAILED;
 #endif /* HAVE_PFRING */
-            }
-            else if(strcmp((long_opts[option_index]).name , "pfring-cluster-type") == 0){
+            } else if (strcmp((long_opts[option_index]).name, "pfring-cluster-type") == 0) {
 #ifdef HAVE_PFRING
                 if (SCConfSetFinal("pfring.cluster-type", optarg) != 1) {
                     SCLogError("failed to set pfring.cluster-type");
@@ -1493,12 +1495,10 @@ TmEcode SCParseCommandLine(int argc, char **argv)
                            "to pass --enable-pfring to configure when building.");
                 return TM_ECODE_FAILED;
 #endif /* HAVE_PFRING */
-            }
-            else if (strcmp((long_opts[option_index]).name , "capture-plugin") == 0){
+            } else if (strcmp((long_opts[option_index]).name, "capture-plugin") == 0) {
                 suri->run_mode = RUNMODE_PLUGIN;
                 suri->capture_plugin_name = optarg;
-            }
-            else if (strcmp((long_opts[option_index]).name , "capture-plugin-args") == 0){
+            } else if (strcmp((long_opts[option_index]).name, "capture-plugin-args") == 0) {
                 suri->capture_plugin_args = optarg;
             } else if (strcmp((long_opts[option_index]).name, "dpdk") == 0) {
                 if (ParseCommandLineDpdk(suri, optarg) != TM_ECODE_OK) {

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -106,12 +106,17 @@ enum {
 enum EngineMode {
     ENGINE_MODE_UNKNOWN,
     ENGINE_MODE_IDS,
+    /* order matters, we need to be able to do IPS is true for >= ENGINE_MODE_IPS */
     ENGINE_MODE_IPS,
+    ENGINE_MODE_FIREWALL,
 };
 
+/* superset of IPS mode */
+void EngineModeSetFirewall(void);
 void EngineModeSetIPS(void);
 void EngineModeSetIDS(void);
 int EngineModeIsUnknown(void);
+bool EngineModeIsFirewall(void);
 int EngineModeIsIPS(void);
 int EngineModeIsIDS(void);
 
@@ -136,6 +141,8 @@ typedef struct SCInstance_ {
     char *regex_arg;
     char *firewall_rule_file;
     bool firewall_rule_file_exclusive;
+    /* is firewall mode enabled */
+    bool is_firewall;
 
     char *keyword_info;
     char *runmode_custom_mode;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -2302,26 +2302,26 @@ rule-files:
   - suricata.rules
 
 ##
-## Suricata as a Firewall options (experimental)
-##
-
-# Firewall rule file are in their own path and are not managed
-# by Suricata-Update.
-#firewall-rule-path: /etc/suricata/firewall/
-
-# List of files with firewall rules. Order matters, files are loaded
-# in order and rules are applied in that order (per state, see docs)
-#firewall-rule-files:
-#  - firewall.rules
-
-
-##
 ## Auxiliary configuration files.
 ##
 
 classification-file: @e_sysconfdir@classification.config
 reference-config-file: @e_sysconfdir@reference.config
 # threshold-file: @e_sysconfdir@threshold.config
+
+##
+## Suricata as a Firewall options (experimental)
+##
+firewall:
+  # Firewall rule file are in their own path and are not managed
+  # by Suricata-Update.
+  #rule-path: /etc/suricata/firewall/
+
+  # List of files with firewall rules. Order matters, files are loaded
+  # in order and rules are applied in that order (per state, see docs)
+  #rule-files:
+  #  - firewall.rules
+
 
 ##
 ## Include other configs

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -2313,6 +2313,9 @@ reference-config-file: @e_sysconfdir@reference.config
 ## Suricata as a Firewall options (experimental)
 ##
 firewall:
+  # toggle to enable firewall mode
+  #enabled: no
+
   # Firewall rule file are in their own path and are not managed
   # by Suricata-Update.
   #rule-path: /etc/suricata/firewall/


### PR DESCRIPTION
Misc cleanups:
- firewall object in yaml
- `--firewall` commandline option and `firewall.enabled` yaml option
- config keyword supports firewall
- nicer `suricata -h` layout
- `--help` addition
- make firewall mode a global setting, not a per detect engine

Includes changes to address review in #13424