### PR TITLE
decode: Ipv6 tunnel flow bug & tunnel counters - v1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6064,6 +6064,12 @@
                         "ipv4": {
                             "type": "integer"
                         },
+                        "ipv4_in_ipv4": {
+                            "type": "integer"
+                        },
+                        "ipv6_in_ipv4": {
+                            "type": "integer"
+                        },
                         "ipv4_in_ipv6": {
                             "type": "integer"
                         },

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -591,6 +591,7 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             if (tp != NULL) {
                 PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
                 PacketEnqueueNoLock(&tv->decode_pq, tp);
+                StatsIncr(tv, dtv->counter_ipv6inipv4);
             }
             FlowSetupPacket(p);
             break;
@@ -601,6 +602,7 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             if (tp != NULL) {
                 PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
                 PacketEnqueueNoLock(&tv->decode_pq, tp);
+                StatsIncr(tv, dtv->counter_ipv4inipv4);
             }
             FlowSetupPacket(p);
             break;

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -34,6 +34,7 @@
 #include "decode-ipv6.h"
 #include "decode.h"
 #include "defrag.h"
+#include "flow-hash.h"
 #include "util-print.h"
 #include "util-validate.h"
 
@@ -54,6 +55,7 @@ static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, c
             PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV6);
             PacketEnqueueNoLock(&tv->decode_pq,tp);
             StatsIncr(tv, dtv->counter_ipv4inipv6);
+            FlowSetupPacket(p);
             return;
         }
     } else {
@@ -79,6 +81,7 @@ static int DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV6);
             PacketEnqueueNoLock(&tv->decode_pq,tp);
             StatsIncr(tv, dtv->counter_ipv6inipv6);
+            FlowSetupPacket(p);
         }
     } else {
         ENGINE_SET_EVENT(p, IPV6_IN_IPV6_WRONG_IP_VER);

--- a/src/decode.c
+++ b/src/decode.c
@@ -664,6 +664,8 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_vntag = StatsRegisterCounter("decoder.vntag", tv);
     dtv->counter_ieee8021ah = StatsRegisterCounter("decoder.ieee8021ah", tv);
     dtv->counter_teredo = StatsRegisterCounter("decoder.teredo", tv);
+    dtv->counter_ipv4inipv4 = StatsRegisterCounter("decoder.ipv4_in_ipv4", tv);
+    dtv->counter_ipv6inipv4 = StatsRegisterCounter("decoder.ipv6_in_ipv4", tv);
     dtv->counter_ipv4inipv6 = StatsRegisterCounter("decoder.ipv4_in_ipv6", tv);
     dtv->counter_ipv6inipv6 = StatsRegisterCounter("decoder.ipv6_in_ipv6", tv);
     dtv->counter_mpls = StatsRegisterCounter("decoder.mpls", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -1007,6 +1007,8 @@ typedef struct DecodeThreadVars_
     uint16_t counter_pppoe;
     uint16_t counter_teredo;
     uint16_t counter_mpls;
+    uint16_t counter_ipv4inipv4;
+    uint16_t counter_ipv6inipv4;
     uint16_t counter_ipv4inipv6;
     uint16_t counter_ipv6inipv6;
     uint16_t counter_erspan;


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes (including schema descriptions)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7752

Describe changes:
- add stats counters for ipv6/ipv4 over ipv4
- add flow to parent packet for tunneling over ipv6 (as found out missing with PR https://github.com/OISF/suricata-verify/pull/2546)

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2569
