### PR TITLE
pcap-log: fix memory leak on error paths after SCStrdup(prefix)

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -785,6 +785,7 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
         copy_comp->buffer = SCMalloc(copy_comp->buffer_size);
         if (copy_comp->buffer == NULL) {
             SCLogError("SCMalloc failed: %s", strerror(errno));
+            SCFree(copy->prefix);
             SCFree(copy->h);
             SCFree(copy);
             return NULL;
@@ -793,6 +794,7 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
         if (copy_comp->pcap_buf == NULL) {
             SCLogError("SCMalloc failed: %s", strerror(errno));
             SCFree(copy_comp->buffer);
+            SCFree(copy->prefix);
             SCFree(copy->h);
             SCFree(copy);
             return NULL;
@@ -803,6 +805,7 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
             SCLogError("SCFmemopen failed: %s", strerror(errno));
             SCFree(copy_comp->buffer);
             SCFree(copy_comp->pcap_buf);
+            SCFree(copy->prefix);
             SCFree(copy->h);
             SCFree(copy);
             return NULL;
@@ -817,6 +820,7 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
             fclose(copy_comp->pcap_buf_wrapper);
             SCFree(copy_comp->buffer);
             SCFree(copy_comp->pcap_buf);
+            SCFree(copy->prefix);
             SCFree(copy->h);
             SCFree(copy);
             return NULL;


### PR DESCRIPTION
When PcapLogDataCopy() fails after duplicating pl->prefix, the allocated 'prefix' string was not freed, leading to a leak.

Ticket: 7759

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7759

Describe changes:
- Fix memory leak: free `copy->prefix` on all early-return error paths
  in `PcapLogDataCopy()`.
  
Found with SVACE static analyzer