### PR TITLE
detect/analyzer: Extend analyzer with ICMP icode

### DIFF
--- a/rust/src/detect/tojson/mod.rs
+++ b/rust/src/detect/tojson/mod.rs
@@ -74,6 +74,13 @@ where
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn SCDetectU8ToJson(
+    js: &mut JsonBuilder, du: &DetectUintData<u8>,
+) -> bool {
+    return detect_uint_to_json(js, du).is_ok();
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn SCDetectU16ToJson(
     js: &mut JsonBuilder, du: &DetectUintData<u16>,
 ) -> bool {

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -935,6 +935,13 @@ static void DumpMatches(RuleAnalyzer *ctx, SCJsonBuilder *js, const SigMatchData
                 SCJbClose(js);
                 break;
             }
+            case DETECT_ICODE: {
+                const DetectIcmpIdData *cd = (const DetectU8Data *)smd->ctx;
+                SCJbOpenObject(js, "code");
+                SCDetectU8ToJson(js, cd);
+                SCJbClose(js);
+                break;
+            }
             case DETECT_ICMP_ID: {
                 const DetectIcmpIdData *cd = (const DetectIcmpIdData *)smd->ctx;
                 SCJbOpenObject(js, "id");


### PR DESCRIPTION
Extend engine analysis output with ICMP `icode` information.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6359

Describe changes:
- Add utilitity function to JSONify U8 types
- Add `icode` value to analyzer output

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2572
SU_REPO=
SU_BRANCH=
