### PR TITLE
detect/analyzer: Extend analyzer output with dsize value info

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -935,6 +935,13 @@ static void DumpMatches(RuleAnalyzer *ctx, SCJsonBuilder *js, const SigMatchData
                 SCJbClose(js);
                 break;
             }
+            case DETECT_DSIZE: {
+                const DetectU16Data *cd = (const DetectU16Data *)smd->ctx;
+                SCJbOpenObject(js, "dsize");
+                SCDetectU16ToJson(js, cd);
+                SCJbClose(js);
+                break;
+            }
             case DETECT_ICMP_ID: {
                 const DetectIcmpIdData *cd = (const DetectIcmpIdData *)smd->ctx;
                 SCJbOpenObject(js, "id");


### PR DESCRIPTION
Issue: 6357

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6357

Describe changes:
- Extend analyzer match output with `dsize` value information.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2573
SU_REPO=
SU_BRANCH=
