### PR TITLE
util/mtu: Avoid excessive ioctls for MTU

### DIFF
--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -127,13 +127,16 @@ int GetIfaceMaxPacketSize(LiveDevice *ld)
     if ((dev == NULL) || strlen(dev) == 0)
         return 0;
 
-    int mtu = GetIfaceMTU(dev);
-    switch (mtu) {
-        case 0:
-        case -1:
-            return 0;
+    int mtu = ld->mtu;
+    if (ld->mtu == 0) {
+        mtu = GetIfaceMTU(dev);
+        switch (mtu) {
+            case 0:
+            case -1:
+                return 0;
+        }
+        ld->mtu = mtu;
     }
-    ld->mtu = mtu;
     int ll_header = GetIfaceMaxHWHeaderLength(dev);
     return ll_header + mtu;
 }


### PR DESCRIPTION
Issue: 7643

Use the cached livedev MTU value when available.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7643

Describe changes:
- Only fetch the MTU if the cached version is unset. This avoids excessive IOCTL (one for each receive thread) and logs

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
