### PR TITLE
windows: add UCRT build support and fix timezone compatibility

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2961,6 +2961,63 @@ jobs:
       - run: make install
       - run: suricata-update -V
 
+  windows-msys2-ucrt64-libpcap:
+    name: Windows MSYS2 UCRT64 (libpcap)
+    runs-on: windows-latest
+    needs: [prepare-deps, ubuntu-22-04-dist]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ucrt64
+          update: true
+          install: |
+            autoconf
+            automake
+            git
+            make
+            mingw-w64-ucrt-x86_64-cbindgen
+            mingw-w64-ucrt-x86_64-jansson
+            mingw-w64-ucrt-x86_64-libpcap
+            mingw-w64-ucrt-x86_64-libtool
+            mingw-w64-ucrt-x86_64-libyaml
+            mingw-w64-ucrt-x86_64-pcre2
+            mingw-w64-ucrt-x86_64-python-yaml
+            mingw-w64-ucrt-x86_64-rust
+            mingw-w64-ucrt-x86_64-toolchain
+            unzip
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: prep
+          path: prep
+      - name: Download suricata.tar.gz
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: dist
+      - run: tar xvf suricata-*.tar.gz --strip-components=1
+      - run: tar xf prep/suricata-verify.tar.gz
+      - name: Build
+        run: |
+          ./autogen.sh
+          CFLAGS="-ggdb -Werror" ./configure --enable-warnings --enable-unittests --enable-gccprotect --disable-gccmarch-native --disable-shared
+          make -j3
+      - name: Run
+        run: |
+          ./src/suricata --build-info
+          ./src/suricata -u -l .
+          python3 ./suricata-verify/run.py -q --debug-failed
+      - run: make install
+      - run: suricata-update -V
+
   windows-msys2-mingw64-windivert:
     name: Windows MSYS2 MINGW64 (WinDivert)
     runs-on: windows-latest

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2985,6 +2985,7 @@ jobs:
             make
             mingw-w64-ucrt-x86_64-cbindgen
             mingw-w64-ucrt-x86_64-jansson
+            mingw-w64-ucrt-x86_64-jq
             mingw-w64-ucrt-x86_64-libpcap
             mingw-w64-ucrt-x86_64-libtool
             mingw-w64-ucrt-x86_64-libyaml

--- a/src/util-strptime.c
+++ b/src/util-strptime.c
@@ -383,54 +383,58 @@ recurse:
 #endif
 				bp += 3;
 			} else {
-				ep = find_string(bp, &i,
-						 (const char * const *)tzname,
-						  NULL, 2);
-				if (ep != NULL) {
-					tm->tm_isdst = i;
+                            ep = find_string(bp, &i,
+#ifdef _WIN32
+                                    (const char *const *)_tzname,
+#else
+                                    (const char *const *)tzname,
+#endif
+                                    NULL, 2);
+                            if (ep != NULL) {
+                                tm->tm_isdst = i;
 #ifdef TM_GMTOFF
 					tm->TM_GMTOFF = -(timezone);
 #endif
 #ifdef TM_ZONE
 					tm->TM_ZONE = tzname[i];
 #endif
-				}
-				bp = ep;
-			}
-			continue;
+                            }
+                            bp = ep;
+                        }
+                        continue;
 
-		case 'z':
-			/*
-			 * We recognize all ISO 8601 formats:
-			 * Z	= Zulu time/UTC
-			 * [+-]hhmm
-			 * [+-]hh:mm
-			 * [+-]hh
-			 * We recognize all RFC-822/RFC-2822 formats:
-			 * UT|GMT
-			 *          North American : UTC offsets
-			 * E[DS]T = Eastern : -4 | -5
-			 * C[DS]T = Central : -5 | -6
-			 * M[DS]T = Mountain: -6 | -7
-			 * P[DS]T = Pacific : -7 | -8
-			 *          Military
-			 * [A-IL-M] = -1 ... -9 (J not used)
-			 * [N-Y]  = +1 ... +12
-			 */
-			while (isspace(*bp))
-				bp++;
+                case 'z':
+                    /*
+                     * We recognize all ISO 8601 formats:
+                     * Z	= Zulu time/UTC
+                     * [+-]hhmm
+                     * [+-]hh:mm
+                     * [+-]hh
+                     * We recognize all RFC-822/RFC-2822 formats:
+                     * UT|GMT
+                     *          North American : UTC offsets
+                     * E[DS]T = Eastern : -4 | -5
+                     * C[DS]T = Central : -5 | -6
+                     * M[DS]T = Mountain: -6 | -7
+                     * P[DS]T = Pacific : -7 | -8
+                     *          Military
+                     * [A-IL-M] = -1 ... -9 (J not used)
+                     * [N-Y]  = +1 ... +12
+                     */
+                    while (isspace(*bp))
+                        bp++;
 
-			switch (*bp++) {
-			case 'G':
-				if (*bp++ != 'M')
-					return NULL;
-				/*FALLTHROUGH*/
-			case 'U':
-				if (*bp++ != 'T')
-					return NULL;
-				/*FALLTHROUGH*/
-			case 'Z':
-				tm->tm_isdst = 0;
+                    switch (*bp++) {
+                        case 'G':
+                            if (*bp++ != 'M')
+                                return NULL;
+                            /*FALLTHROUGH*/
+                        case 'U':
+                            if (*bp++ != 'T')
+                                return NULL;
+                            /*FALLTHROUGH*/
+                        case 'Z':
+                            tm->tm_isdst = 0;
 #ifdef TM_GMTOFF
 				tm->TM_GMTOFF = 0;
 #endif
@@ -489,37 +493,37 @@ recurse:
 					continue;
 				}
 				return NULL;
-			}
-			offs = 0;
-			for (i = 0; i < 4; ) {
-				if (isdigit(*bp)) {
-					offs = offs * 10 + (*bp++ - '0');
-					i++;
-					continue;
-				}
-				if (i == 2 && *bp == ':') {
-					bp++;
-					continue;
-				}
-				break;
-			}
-			switch (i) {
-			case 2:
-				offs *= 100;
-				break;
-			case 4:
-				i = offs % 100;
-				if (i >= 60)
-					return NULL;
-				/* Convert minutes into decimal */
-				offs = (offs / 100) * 100 + (i * 50) / 30;
-				break;
-			default:
-				return NULL;
-			}
-			if (neg)
-				offs = -offs;
-			tm->tm_isdst = 0;	/* XXX */
+                    }
+                    offs = 0;
+                    for (i = 0; i < 4;) {
+                        if (isdigit(*bp)) {
+                            offs = offs * 10 + (*bp++ - '0');
+                            i++;
+                            continue;
+                        }
+                        if (i == 2 && *bp == ':') {
+                            bp++;
+                            continue;
+                        }
+                        break;
+                    }
+                    switch (i) {
+                        case 2:
+                            offs *= 100;
+                            break;
+                        case 4:
+                            i = offs % 100;
+                            if (i >= 60)
+                                return NULL;
+                            /* Convert minutes into decimal */
+                            offs = (offs / 100) * 100 + (i * 50) / 30;
+                            break;
+                        default:
+                            return NULL;
+                    }
+                    if (neg)
+                        offs = -offs;
+                    tm->tm_isdst = 0; /* XXX */
 #ifdef TM_GMTOFF
 			tm->TM_GMTOFF = offs;
 #endif


### PR DESCRIPTION
- add a windows ucrt build
- ucrt is more WIN32 compliant than the other builders, warning on `tzname` which is actually `_tzname` under win32