### PR TITLE
Mpm queue 7678 v2.1

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -567,6 +567,7 @@ noinst_HEADERS = \
 	util-memrchr.h \
 	util-misc.h \
 	util-mpm-ac-ks.h \
+	util-mpm-ac-queue.h \
 	util-mpm-ac.h \
 	util-mpm-hs-cache.h \
 	util-mpm-hs-core.h \
@@ -1149,6 +1150,7 @@ libsuricata_c_a_SOURCES = \
 	util-misc.c \
 	util-mpm-ac-ks-small.c \
 	util-mpm-ac-ks.c \
+	util-mpm-ac-queue.c \
 	util-mpm-ac.c \
 	util-mpm-hs-cache.c \
 	util-mpm-hs-core.c \

--- a/src/util-mpm-ac-ks.c
+++ b/src/util-mpm-ac-ks.c
@@ -401,7 +401,7 @@ static void SCACTileCreateGotoTable(MpmCtx *mpm_ctx)
     }
 }
 
-static inline int SCACTileStateQueueIsEmpty(StateQueue *q)
+static inline int SCACStateQueueIsEmpty(StateQueue *q)
 {
     if (q->top == q->bot)
         return 1;
@@ -409,7 +409,7 @@ static inline int SCACTileStateQueueIsEmpty(StateQueue *q)
         return 0;
 }
 
-static inline void SCACTileEnqueue(StateQueue *q, int32_t state)
+static inline void SCACEnqueue(StateQueue *q, int32_t state)
 {
     int i = 0;
 
@@ -430,7 +430,7 @@ static inline void SCACTileEnqueue(StateQueue *q, int32_t state)
     }
 }
 
-static inline int32_t SCACTileDequeue(StateQueue *q)
+static inline int32_t SCACDequeue(StateQueue *q)
 {
     if (q->bot == STATE_QUEUE_CONTAINER_SIZE)
         q->bot = 0;
@@ -505,8 +505,10 @@ static void SCACTileCreateFailureTable(MpmCtx *mpm_ctx)
     int32_t state = 0;
     int32_t r_state = 0;
 
-    StateQueue q;
-    memset(&q, 0, sizeof(StateQueue));
+    StateQueue *q = SCCalloc(1, sizeof(StateQueue));
+    if (q == NULL) {
+        FatalError("Error allocating memory");
+    }
 
     /* Allocate space for the failure table.  A failure entry in the table for
      * every state(SCACTileCtx->state_count) */
@@ -521,19 +523,19 @@ static void SCACTileCreateFailureTable(MpmCtx *mpm_ctx)
     for (aa = 0; aa < ctx->alphabet_size; aa++) {
         int32_t temp_state = ctx->goto_table[0][aa];
         if (temp_state != 0) {
-            SCACTileEnqueue(&q, temp_state);
+            SCACEnqueue(q, temp_state);
             ctx->failure_table[temp_state] = 0;
         }
     }
 
-    while (!SCACTileStateQueueIsEmpty(&q)) {
+    while (!SCACStateQueueIsEmpty(q)) {
         /* pick up every state from the queue and add failure transitions */
-        r_state = SCACTileDequeue(&q);
+        r_state = SCACDequeue(q);
         for (aa = 0; aa < ctx->alphabet_size; aa++) {
             int32_t temp_state = ctx->goto_table[r_state][aa];
             if (temp_state == SC_AC_TILE_FAIL)
                 continue;
-            SCACTileEnqueue(&q, temp_state);
+            SCACEnqueue(q, temp_state);
             state = ctx->failure_table[r_state];
 
             while(ctx->goto_table[state][aa] == SC_AC_TILE_FAIL)
@@ -543,6 +545,7 @@ static void SCACTileCreateFailureTable(MpmCtx *mpm_ctx)
                                      mpm_ctx);
         }
     }
+    SCFree(q);
 }
 
 /*
@@ -676,28 +679,31 @@ static inline void SCACTileCreateDeltaTable(MpmCtx *mpm_ctx)
         ctx->alphabet_storage = 256; /* Change? */
     }
 
-    StateQueue q;
-    memset(&q, 0, sizeof(StateQueue));
+    StateQueue *q = SCCalloc(1, sizeof(StateQueue));
+    if (q == NULL) {
+        FatalError("Error allocating memory");
+    }
 
     for (aa = 0; aa < ctx->alphabet_size; aa++) {
         int temp_state = ctx->goto_table[0][aa];
         if (temp_state != 0)
-            SCACTileEnqueue(&q, temp_state);
+            SCACEnqueue(q, temp_state);
     }
 
-    while (!SCACTileStateQueueIsEmpty(&q)) {
-        r_state = SCACTileDequeue(&q);
+    while (!SCACStateQueueIsEmpty(q)) {
+        r_state = SCACDequeue(q);
 
         for (aa = 0; aa < ctx->alphabet_size; aa++) {
             int temp_state = ctx->goto_table[r_state][aa];
             if (temp_state != SC_AC_TILE_FAIL) {
-                SCACTileEnqueue(&q, temp_state);
+                SCACEnqueue(q, temp_state);
             } else {
                 int f_state = ctx->failure_table[r_state];
                 ctx->goto_table[r_state][aa] = ctx->goto_table[f_state][aa];
             }
         }
     }
+    SCFree(q);
 }
 
 static void SCACTileClubOutputStatePresenceWithDeltaTable(MpmCtx *mpm_ctx)

--- a/src/util-mpm-ac-ks.c
+++ b/src/util-mpm-ac-ks.c
@@ -81,6 +81,7 @@
 #include "util-memcpy.h"
 #include "util-validate.h"
 #include "util-mpm-ac-ks.h"
+#include "util-mpm-ac-queue.h"
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 
@@ -146,17 +147,6 @@ static void SCACTileDestroyInitCtx(MpmCtx *mpm_ctx);
 
 /* a placeholder to denote a failure transition in the goto table */
 #define SC_AC_TILE_FAIL (-1)
-
-#define STATE_QUEUE_CONTAINER_SIZE 65536
-
-/**
- * \brief Helper structure used by AC during state table creation
- */
-typedef struct StateQueue_ {
-    int32_t store[STATE_QUEUE_CONTAINER_SIZE];
-    int top;
-    int bot;
-} StateQueue;
 
 /**
  * \internal
@@ -401,48 +391,6 @@ static void SCACTileCreateGotoTable(MpmCtx *mpm_ctx)
     }
 }
 
-static inline int SCACStateQueueIsEmpty(StateQueue *q)
-{
-    if (q->top == q->bot)
-        return 1;
-    else
-        return 0;
-}
-
-static inline void SCACEnqueue(StateQueue *q, int32_t state)
-{
-    int i = 0;
-
-    /*if we already have this */
-    for (i = q->bot; i < q->top; i++) {
-        if (q->store[i] == state)
-            return;
-    }
-
-    q->store[q->top++] = state;
-
-    if (q->top == STATE_QUEUE_CONTAINER_SIZE)
-        q->top = 0;
-
-    if (q->top == q->bot) {
-        FatalError("Just ran out of space in the queue.  "
-                   "Fatal Error.  Exiting.  Please file a bug report on this");
-    }
-}
-
-static inline int32_t SCACDequeue(StateQueue *q)
-{
-    if (q->bot == STATE_QUEUE_CONTAINER_SIZE)
-        q->bot = 0;
-
-    if (q->bot == q->top) {
-        FatalError("StateQueue behaving weirdly.  "
-                   "Fatal Error.  Exiting.  Please file a bug report on this");
-    }
-
-    return q->store[q->bot++];
-}
-
 /**
  * \internal
  * \brief Club the output data from 2 states and store it in the 1st state.
@@ -505,10 +453,7 @@ static void SCACTileCreateFailureTable(MpmCtx *mpm_ctx)
     int32_t state = 0;
     int32_t r_state = 0;
 
-    StateQueue *q = SCCalloc(1, sizeof(StateQueue));
-    if (q == NULL) {
-        FatalError("Error allocating memory");
-    }
+    StateQueue *q = SCACStateQueueAlloc();
 
     /* Allocate space for the failure table.  A failure entry in the table for
      * every state(SCACTileCtx->state_count) */
@@ -545,7 +490,7 @@ static void SCACTileCreateFailureTable(MpmCtx *mpm_ctx)
                                      mpm_ctx);
         }
     }
-    SCFree(q);
+    SCACStateQueueFree(q);
 }
 
 /*
@@ -679,10 +624,7 @@ static inline void SCACTileCreateDeltaTable(MpmCtx *mpm_ctx)
         ctx->alphabet_storage = 256; /* Change? */
     }
 
-    StateQueue *q = SCCalloc(1, sizeof(StateQueue));
-    if (q == NULL) {
-        FatalError("Error allocating memory");
-    }
+    StateQueue *q = SCACStateQueueAlloc();
 
     for (aa = 0; aa < ctx->alphabet_size; aa++) {
         int temp_state = ctx->goto_table[0][aa];
@@ -703,7 +645,7 @@ static inline void SCACTileCreateDeltaTable(MpmCtx *mpm_ctx)
             }
         }
     }
-    SCFree(q);
+    SCACStateQueueFree(q);
 }
 
 static void SCACTileClubOutputStatePresenceWithDeltaTable(MpmCtx *mpm_ctx)

--- a/src/util-mpm-ac-queue.c
+++ b/src/util-mpm-ac-queue.c
@@ -25,10 +25,16 @@ StateQueue *SCACStateQueueAlloc(void)
     if (q == NULL) {
         FatalError("Error allocating memory");
     }
+    q->store = SCCalloc(STATE_QUEUE_CONTAINER_SIZE, sizeof(int32_t));
+    if (q->store == NULL) {
+        FatalError("Error allocating memory");
+    }
+    q->size = STATE_QUEUE_CONTAINER_SIZE;
     return q;
 }
 
 void SCACStateQueueFree(StateQueue *q)
 {
+    SCFree(q->store);
     SCFree(q);
 }

--- a/src/util-mpm-ac-queue.c
+++ b/src/util-mpm-ac-queue.c
@@ -1,0 +1,34 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "util-debug.h"
+#include "util-mpm-ac-queue.h"
+
+StateQueue *SCACStateQueueAlloc(void)
+{
+    StateQueue *q = SCCalloc(1, sizeof(StateQueue));
+    if (q == NULL) {
+        FatalError("Error allocating memory");
+    }
+    return q;
+}
+
+void SCACStateQueueFree(StateQueue *q)
+{
+    SCFree(q);
+}

--- a/src/util-mpm-ac-queue.h
+++ b/src/util-mpm-ac-queue.h
@@ -1,0 +1,84 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Anoop Saldanha <anoopsaldanha@gmail.com>
+ *
+ */
+
+#ifndef SURICATA_UTIL_MPM_AC_QUEUE_H
+#define SURICATA_UTIL_MPM_AC_QUEUE_H
+
+#define STATE_QUEUE_CONTAINER_SIZE 65536
+
+/**
+ * \brief Helper structure used by AC during state table creation
+ */
+typedef struct StateQueue_ {
+    int32_t store[STATE_QUEUE_CONTAINER_SIZE];
+    int top;
+    int bot;
+} StateQueue;
+
+StateQueue *SCACStateQueueAlloc(void);
+void SCACStateQueueFree(StateQueue *q);
+
+static inline int SCACStateQueueIsEmpty(StateQueue *q)
+{
+    if (q->top == q->bot)
+        return 1;
+    else
+        return 0;
+}
+
+static inline void SCACEnqueue(StateQueue *q, int32_t state)
+{
+    int i = 0;
+
+    /*if we already have this */
+    for (i = q->bot; i < q->top; i++) {
+        if (q->store[i] == state)
+            return;
+    }
+
+    q->store[q->top++] = state;
+
+    if (q->top == STATE_QUEUE_CONTAINER_SIZE)
+        q->top = 0;
+
+    if (q->top == q->bot) {
+        FatalError("Just ran out of space in the queue.  "
+                   "Fatal Error.  Exiting.  Please file a bug report on this");
+    }
+}
+
+static inline int32_t SCACDequeue(StateQueue *q)
+{
+    if (q->bot == STATE_QUEUE_CONTAINER_SIZE)
+        q->bot = 0;
+
+    if (q->bot == q->top) {
+        FatalError("StateQueue behaving weirdly.  "
+                   "Fatal Error.  Exiting.  Please file a bug report on this");
+    }
+
+    return q->store[q->bot++];
+}
+
+#endif /* SURICATA_UTIL_MPM_AC_QUEUE_H */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7678

Describe changes:
- factorize code for mpm/ac (and its ks counterpart)
- make ks use heap instead of stack for big structure
- grow StateQueue store pointer on demand

Test is described in ticket https://redmine.openinfosecfoundation.org/issues/7678 and takes quite some time to run

#13459 with green CI and clean history