### PR TITLE
detect/bytetest: fix incorrect NULL check for offset pointer

### DIFF
--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -348,7 +348,7 @@ static DetectBytetestData *DetectBytetestParse(
         if (i == 2) {
             test_value = (char *) str_ptr;
             data_offset = SCStrdup((char *) str_ptr);
-            if (data_offset == NULL) {
+            if (offset == NULL) {
                 goto error;
             }
         } else {


### PR DESCRIPTION
DetectBytetestParse() checked data_offset for NULL instead of the caller-supplied offset pointer. When NULL was passed for offset, this led to a NULL-pointer dereference and a crash.

Replaced the condition with the correct `if (offset == NULL)`.

Bug 7767

Found with SVACE static analyzer


## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7767