### PR TITLE
Datajson coverity fixes

### DIFF
--- a/src/datasets-context-json.c
+++ b/src/datasets-context-json.c
@@ -716,12 +716,10 @@ Dataset *DatajsonGet(const char *name, enum DatasetTypes type, const char *load,
     DatasetUnlock();
     return set;
 out_err:
-    if (set) {
-        if (set->hash) {
-            THashShutdown(set->hash);
-        }
-        SCFree(set);
+    if (set->hash) {
+        THashShutdown(set->hash);
     }
+    SCFree(set);
     DatasetUnlock();
     return NULL;
 }

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -443,9 +443,6 @@ int DatasetGetOrCreate(const char *name, enum DatasetTypes type, const char *sav
     return 0;
 out_err:
     if (set) {
-        if (set->hash) {
-            THashShutdown(set->hash);
-        }
         SCFree(set);
     }
     return -1;

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -520,12 +520,10 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, 
     DatasetUnlock();
     return set;
 out_err:
-    if (set) {
-        if (set->hash) {
-            THashShutdown(set->hash);
-        }
-        SCFree(set);
+    if (set->hash) {
+        THashShutdown(set->hash);
     }
+    SCFree(set);
     DatasetUnlock();
     return NULL;
 }


### PR DESCRIPTION
Fixes a set of issues found by Coverity on dataset with JSON code.

There is one reported issue that I did not fix because lock is handled by DatasetLock and DatasetUnlock:

```
*** CID 1649393:         Concurrent data access violations  (MISSING_LOCK)
/src/datasets.c: 95             in DatasetAppendSet()
89         }
90
91         SCLogDebug(
92                 "set %p/%s type %u save %s load %s", set, set->name,
set->type, set->save, set->load);
93
94         set->next = sets;
 >>>     CID 1649393:         Concurrent data access violations
(MISSING_LOCK)
 >>>     Accessing "sets" without holding lock "sets_lock". Elsewhere,
"sets" is written to with "sets_lock" held 2 out of 3 times.
95         sets = set;
96
97         /* hash size accounting */
98         DatasetUpdateHashsize(set->name, set->hash->config.hash_size);
99         return 0;
100     }
```


## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- fix some Coverity found problems