### PR TITLE
detect/entropy: Clarify when entropy is logged

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -737,10 +737,11 @@ Logging
 ~~~~~~~
 
 When the ``entropy`` rule keyword is provided and the rule is evaluated, the
-`calculated entropy` value is logged within the ``metadata`` section of an
-output log. If the alert matched, it will be included there; here's an example
-that shows the calculated entropy value with the buffer on which the value was
-computed::
+`calculated entropy` value is associated with the flow even if the calculated
+entropy value didn't result in a match or alert. Subsequent logging of event
+types that include the flow, including alerts, will contain the ``entropy`` value in
+the ``metadata`` section of an output log. The follow is an example that shows
+the calculated entropy value with the buffer on which the value was computed::
 
      "metadata": {
         "entropy": {


### PR DESCRIPTION
Clarify when entropy values are logged and associated with non-alert log records.


Describe changes:
- Clarify when entropy values are logged.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
