### PR TITLE
doc/userguide: break out package installation - v1

### DIFF
--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -17,6 +17,7 @@ EXTRA_DIST = \
 	upgrade.rst \
 	initscripts.rst \
 	install.rst \
+	install \
 	licenses \
 	lua \
 	make-sense-alerts.rst \

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -164,210 +164,39 @@ and will present you with a ready-to-run (configured and set-up) Suricata.
 Binary packages
 ---------------
 
-Ubuntu from Personal Package Archives (PPA)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. toctree::
+   :maxdepth: 1
 
-For Ubuntu, OISF maintains a PPA ``suricata-stable`` that always contains the
-latest stable release.
+   install/ubuntu
+   install/debian
+   install/rpm
+   install/other
 
-.. note:: The following instructions require ``sudo`` to be installed.
+Suricata is available on various distributions as binary
+packages. These offer a convenient way to install and manage Suricata
+without compiling from source.
 
-Setup to install the latest stable Suricata::
+For Ubuntu systems:
 
-    sudo apt-get install software-properties-common
-    sudo add-apt-repository ppa:oisf/suricata-stable
-    sudo apt-get update
+    See :doc:`install/ubuntu` for detailed instructions on
+    installing from PPA repositories.
 
-Then, you can install the latest stable with::
+For Debian systems:
 
-    sudo apt-get install suricata
+    See :doc:`install/debian` for detailed instructions on
+    installing from official repositories and backports.
 
-After installing you can proceed to the :ref:`Basic setup`.
+For RPM-based distributions (CentOS, AlmaLinux, RockyLinux, Fedora, etc):
 
-`OISF launchpad: suricata-stable <https://launchpad.net/~oisf/+archive/suricata-stable>`_.
+    See :doc:`install/rpm` for detailed instructions on
+    installing from COPR repositories.
 
-Upgrading
-"""""""""
+For other distributions:
 
-To upgrade::
-
-    sudo apt-get update
-    sudo apt-get upgrade suricata
-
-Remove
-""""""
-
-To remove Suricata from your system::
-
-    sudo apt-get remove suricata
-
-
-
-Getting Debug or Pre-release Versions
-"""""""""""""""""""""""""""""""""""""
-
-.. note:: The following instructions require ``sudo`` to be installed.
-
-If you want Suricata with built-in (enabled) debugging, you can install the
-debug package::
-
-    sudo apt-get install suricata-dbg
-
-If you would like to help test the Release Candidate (RC) packages, the same procedures
-apply, just using another PPA: ``suricata-beta``::
-
-    sudo add-apt-repository ppa:oisf/suricata-beta
-    sudo apt-get update
-    sudo apt-get upgrade
-
-You can use both the suricata-stable and suricata-beta repositories together.
-Suricata will then always be the latest release, stable or beta.
-
-`OISF launchpad: suricata-beta <https://launchpad.net/~oisf/+archive/suricata-beta>`_.
-
-Daily Releases
-""""""""""""""
-
-.. note:: The following instructions require ``sudo`` to be installed.
-
-If you would like to help test the daily build packages from our latest git(dev)
-repository, the same procedures as above apply, just using another PPA,
-``suricata-daily``::
-
-    sudo add-apt-repository ppa:oisf/suricata-daily-allarch
-    sudo apt-get update
-    sudo apt-get upgrade
-
-.. note::
-
-    Please have in mind that this is packaged from our latest development git master
-    and is therefore potentially unstable.
-
-    We do our best to make others aware of continuing development and items
-    within the engine that are not yet complete or optimal. With this in mind,
-    please refer to `Suricata's issue tracker on Redmine 
-    <http://redmine.openinfosecfoundation.org/projects/suricata/issues>`_ 
-    for an up-to-date list of what we are working on, planned roadmap, 
-    and to report issues.
-
-`OISF launchpad: suricata-daily <https://launchpad.net/~oisf/+archive/suricata-daily>`_.
-
-Debian
-^^^^^^
-
-.. note:: The following instructions require ``sudo`` to be installed.
-
-In Debian 9 (stretch) and later do::
-
-    sudo apt-get install suricata
-
-In the "stable" version of Debian, Suricata is usually not available in the
-latest version. A more recent version is often available from Debian backports,
-if it can be built there.
-
-To use backports, the backports repository for the current stable
-distribution needs to be added to the system-wide sources list.
-For Debian 10 (buster), for instance, run the following as ``root``::
-
-    echo "deb http://http.debian.net/debian buster-backports main" > \
-        /etc/apt/sources.list.d/backports.list
-    apt-get update
-    apt-get install suricata -t buster-backports
-
-.. _RPM packages:
-
-CentOS, AlmaLinux, RockyLinux, Fedora, etc
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-RPMs are provided for the latest release of *Enterprise Linux*. This
-includes CentOS Linux and rebuilds such as AlmaLinux and RockyLinux.
-Additionally, RPMs are provided for the latest supported versions of Fedora.
-
-RPMs specifically for CentOS Stream are not provided, however the RPMs for their
-related version may work fine.
-
-Installing From Package Repositories
-""""""""""""""""""""""""""""""""""""
-
-CentOS, RHEL, AlmaLinux, RockyLinux, etc Version 8+
-'''''''''''''''''''''''''''''''''''''''''''''''''''
-
-.. note:: The following instructions require ``sudo`` to be installed.
-
-.. code-block:: none
-
-   sudo dnf install epel-release dnf-plugins-core
-   sudo dnf copr enable @oisf/suricata-7.0
-   sudo dnf install suricata
-
-CentOS 7
-''''''''
-
-.. code-block:: none
-
-   sudo yum install epel-release yum-plugin-copr
-   sudo yum copr enable @oisf/suricata-7.0
-   sudo yum install suricata
-
-Fedora
-''''''
-
-.. code-block:: none
-
-    sudo dnf install dnf-plugins-core
-    sudo dnf copr enable @oisf/suricata-7.0
-    sudo dnf install suricata
-
-Additional Notes for RPM Installations
-""""""""""""""""""""""""""""""""""""""
-
-- Suricata is pre-configured to run as the ``suricata`` user.
-- Command line parameters such as providing the interface names can be
-  configured in ``/etc/sysconfig/suricata``.
-- Users can run ``suricata-update`` without being root provided they
-  are added to the ``suricata`` group.
-- Directories:
-
-  - ``/etc/suricata``: Configuration directory
-  - ``/var/log/suricata``: Log directory
-  - ``/var/lib/suricata``: State directory rules, datasets.
-
-Starting Suricata On-Boot
-'''''''''''''''''''''''''
-
-The Suricata RPMs are configured to run from Systemd.
-
-.. note:: The following instructions require ``sudo`` to be installed.
-
-To start Suricata::
-
-  sudo systemctl start suricata
-
-To stop Suricata::
-
-  sudo systemctl stop suricata
-
-To have Suricata start on-boot::
-
-  sudo systemctl enable suricata
-
-To reload rules::
-
-  sudo systemctl reload suricata
+    See :doc:`install/other` for installation instructions
+    for Arch Linux and other distributions.
 
 .. _install-advanced:
-
-Arch Based
-^^^^^^^^^^
-
-The ArchLinux AUR contains Suricata and suricata-nfqueue packages, with commonly
-used configurations for compilation (may also be edited to your liking). You may
-use makepkg, yay (sample below), or other AUR helpers to compile and build
-Suricata packages.
-
-::
-
-    yay -S suricata
 
 Advanced Installation
 ---------------------

--- a/doc/userguide/install/debian.rst
+++ b/doc/userguide/install/debian.rst
@@ -1,0 +1,31 @@
+.. _install-binary-debian:
+
+Debian Package Installation
+===========================
+
+Suricata is available in the official Debian repositories for Debian 9
+(stretch) and later versions.
+
+.. note:: The following instructions require ``sudo`` to be installed.
+
+In Debian 9 (stretch) and later do::
+
+    sudo apt-get install suricata
+
+In the "stable" version of Debian, Suricata is usually not available in the
+latest version. A more recent version is often available from Debian backports,
+if it can be built there.
+
+To use backports, the backports repository for the current stable
+distribution needs to be added to the system-wide sources list.
+For Debian 10 (buster), for instance, run the following as ``root``::
+
+    echo "deb http://http.debian.net/debian buster-backports main" > \
+        /etc/apt/sources.list.d/backports.list
+    apt-get update
+    apt-get install suricata -t buster-backports
+
+After Installation
+------------------
+
+After installing you can proceed to the :ref:`Basic setup`.

--- a/doc/userguide/install/other.rst
+++ b/doc/userguide/install/other.rst
@@ -1,0 +1,26 @@
+.. _install-binary-other:
+
+Other Package Installations
+===========================
+
+Suricata can be found in the package managers for many other operating
+systems and distributions, but it is important to note that these are
+not created or supported by the OISF and the Suricata development
+team.
+
+Arch Based
+----------
+
+The ArchLinux AUR contains Suricata and suricata-nfqueue packages,
+with commonly used configurations for compilation (may also be edited
+to your liking). You may use makepkg, yay (sample below), or other AUR
+helpers to compile and build Suricata packages.
+
+::
+
+    yay -S suricata
+
+After Installation
+------------------
+
+After installing you can proceed to the :ref:`Basic setup`.

--- a/doc/userguide/install/rpm.rst
+++ b/doc/userguide/install/rpm.rst
@@ -19,20 +19,14 @@ CentOS, RHEL, AlmaLinux, RockyLinux, etc Version 8+
 
 .. note:: The following instructions require ``sudo`` to be installed.
 
+Enterprise Linux and Rebuilds
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 .. code-block:: none
 
    sudo dnf install epel-release dnf-plugins-core
-   sudo dnf copr enable @oisf/suricata-7.0
+   sudo dnf copr enable @oisf/suricata-8.0
    sudo dnf install suricata
-
-CentOS 7
-^^^^^^^^
-
-.. code-block:: none
-
-   sudo yum install epel-release yum-plugin-copr
-   sudo yum copr enable @oisf/suricata-7.0
-   sudo yum install suricata
 
 Fedora
 ^^^^^^
@@ -40,7 +34,7 @@ Fedora
 .. code-block:: none
 
     sudo dnf install dnf-plugins-core
-    sudo dnf copr enable @oisf/suricata-7.0
+    sudo dnf copr enable @oisf/suricata-8.0
     sudo dnf install suricata
 
 Additional Notes for RPM Installations

--- a/doc/userguide/install/rpm.rst
+++ b/doc/userguide/install/rpm.rst
@@ -1,0 +1,86 @@
+.. _install-binary-rpm:
+
+RPM Installation
+================
+
+Using the Fedora COPR system, the OISF provides Suricata packages for
+Fedora, Red Hat Enterprise Linux, and Enterprise Linux rebuilds.
+
+The benefit of using the OISF maintained COPR package repositories is
+that the OISF maintains packages for all non-EOL Suricata versions for
+each distribution version. For example, the OISF maintains Suricata 7
+and Suricata 8 packages for RHEL 9 and 10.
+
+Installing From Package Repositories
+------------------------------------
+
+CentOS, RHEL, AlmaLinux, RockyLinux, etc Version 8+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note:: The following instructions require ``sudo`` to be installed.
+
+.. code-block:: none
+
+   sudo dnf install epel-release dnf-plugins-core
+   sudo dnf copr enable @oisf/suricata-7.0
+   sudo dnf install suricata
+
+CentOS 7
+^^^^^^^^
+
+.. code-block:: none
+
+   sudo yum install epel-release yum-plugin-copr
+   sudo yum copr enable @oisf/suricata-7.0
+   sudo yum install suricata
+
+Fedora
+^^^^^^
+
+.. code-block:: none
+
+    sudo dnf install dnf-plugins-core
+    sudo dnf copr enable @oisf/suricata-7.0
+    sudo dnf install suricata
+
+Additional Notes for RPM Installations
+--------------------------------------
+
+- Suricata is pre-configured to run as the ``suricata`` user.
+- Command line parameters such as providing the interface names can be
+  configured in ``/etc/sysconfig/suricata``.
+- Users can run ``suricata-update`` without being root provided they
+  are added to the ``suricata`` group.
+- Directories:
+
+  - ``/etc/suricata``: Configuration directory
+  - ``/var/log/suricata``: Log directory
+  - ``/var/lib/suricata``: State directory rules, datasets.
+
+Starting Suricata On-Boot
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Suricata RPMs are configured to run from Systemd.
+
+.. note:: The following instructions require ``sudo`` to be installed.
+
+To start Suricata::
+
+  sudo systemctl start suricata
+
+To stop Suricata::
+
+  sudo systemctl stop suricata
+
+To have Suricata start on-boot::
+
+  sudo systemctl enable suricata
+
+To reload rules::
+
+  sudo systemctl reload suricata
+
+After Installation
+------------------
+
+After installing you can proceed to the :ref:`Basic setup`.

--- a/doc/userguide/install/ubuntu.rst
+++ b/doc/userguide/install/ubuntu.rst
@@ -1,0 +1,92 @@
+.. _install-binary-ubuntu:
+
+Ubuntu Package Installation
+===========================
+
+For Ubuntu, the OISF maintains a Personal Package Archive (PPA)
+``suricata-stable`` that always contains the latest stable release.
+
+.. note:: The following instructions require ``sudo`` to be installed.
+
+Setup to install the latest stable Suricata::
+
+    sudo apt-get install software-properties-common
+    sudo add-apt-repository ppa:oisf/suricata-stable
+    sudo apt-get update
+
+Then, you can install the latest stable with::
+
+    sudo apt-get install suricata
+
+After installing you can proceed to the :ref:`Basic setup`.
+
+`OISF launchpad: suricata-stable <https://launchpad.net/~oisf/+archive/suricata-stable>`_.
+
+Upgrading
+^^^^^^^^^
+
+To upgrade::
+
+    sudo apt-get update
+    sudo apt-get upgrade suricata
+
+Remove
+^^^^^^
+
+To remove Suricata from your system::
+
+    sudo apt-get remove suricata
+
+Getting Debug or Pre-release Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note:: The following instructions require ``sudo`` to be installed.
+
+If you want Suricata with built-in (enabled) debugging, you can install the
+debug package::
+
+    sudo apt-get install suricata-dbg
+
+If you would like to help test the Release Candidate (RC) packages, the same procedures
+apply, just using another PPA: ``suricata-beta``::
+
+    sudo add-apt-repository ppa:oisf/suricata-beta
+    sudo apt-get update
+    sudo apt-get upgrade
+
+You can use both the suricata-stable and suricata-beta repositories together.
+Suricata will then always be the latest release, stable or beta.
+
+`OISF launchpad: suricata-beta <https://launchpad.net/~oisf/+archive/suricata-beta>`_.
+
+Daily Releases
+^^^^^^^^^^^^^^
+
+.. note:: The following instructions require ``sudo`` to be installed.
+
+If you would like to help test the daily build packages from our latest git(dev)
+repository, the same procedures as above apply, just using another PPA,
+``suricata-daily``::
+
+    sudo add-apt-repository ppa:oisf/suricata-daily-allarch
+    sudo apt-get update
+    sudo apt-get upgrade
+
+.. note::
+
+    Please have in mind that this is packaged from our latest development git master
+    and is therefore potentially unstable.
+
+    We do our best to make others aware of continuing development and items
+    within the engine that are not yet complete or optimal. With this in mind,
+    please refer to `Suricata's issue tracker on Redmine 
+    <http://redmine.openinfosecfoundation.org/projects/suricata/issues>`_ 
+    for an up-to-date list of what we are working on, planned roadmap, 
+    and to report issues.
+
+`OISF launchpad: suricata-daily <https://launchpad.net/~oisf/+archive/suricata-daily>`_.
+
+After Installation
+------------------
+
+After installing you can proceed to the :ref:`Basic setup`.


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/7749
Ticket: https://redmine.openinfosecfoundation.org/issues/6252
Ticket: https://redmine.openinfosecfoundation.org/issues/6069

Break out RPM, Debian, and Ubuntu package installation into their own
pages.

Also break out other distributions like "Arch" into an "Other" section
with a note about how those packages are not supported by the OISF.
