### PR TITLE
Doc krb 6566 v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -6,11 +6,13 @@ on:
       # Don't run this workflow if only files under doc/ have been
       # modified.
       - "doc/**"
+      - "etc/schema.json"
   pull_request:
     paths-ignore:
       # Don't run this workflow if only files under doc/ have been
       # modified.
       - "doc/**"
+      - "etc/schema.json"
   workflow_dispatch:
     inputs:
       SU_REPO:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths-ignore:
       - "doc/**"
+      - "etc/schema.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,11 +5,13 @@ on:
     branches: [ master ]
     paths-ignore:
       - "doc/**"
+      - "etc/schema.json"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
     paths-ignore:
       - "doc/**"
+      - "etc/schema.json"
   schedule:
     - cron: '18 21 * * 1'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     paths:
       # Something has to change in doc/ for thos workflow to be run.
       - "doc/**"
+      - "etc/schema.json"
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -8,9 +8,11 @@ on:
       - 'master-*'
     paths-ignore:
       - "doc/**"
+      - "etc/schema.json"
   pull_request:
     paths-ignore:
       - "doc/**"
+      - "etc/schema.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths-ignore:
       - "doc/**"
+      - "etc/schema.json"
   pull_request:
     paths-ignore:
       - "doc/**"
+      - "etc/schema.json"
 
 permissions:
   contents: read #  to fetch code (actions/checkout)

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths-ignore:
       - "doc/**"
+      - "etc/schema.json"
   pull_request:
     paths-ignore:
       - "doc/**"
+      - "etc/schema.json"
 
 permissions: read-all
 

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -1124,6 +1124,37 @@ Example of TFTP logging:
       "mode": "octet"
    }
 
+Event type: KRB5
+----------------
+
+KRB5 Fields
+~~~~~~~~~~~
+
+* "cname" (string): The client PrincipalName
+* "encryption" (string): Encryption used (only in AS-REP and TGS-REP)
+* "error_code" (string): Error code, if request has failed
+* "failed_request" (string): The request type for which the response had an error_code
+* "msg_type" (string): The message type: AS-REQ, AS-REP, etc...
+* "realm" (string): The server Realm
+* "sname" (string): The server PrincipalName
+* "ticket_encryption" (string): Encryption used for ticket
+* "ticket_weak_encryption" (boolean): Whether the encryption used for ticket is a weak cipher
+* "weak_encryption" (boolean): Whether the encryption used in AS-REP or TGS-REP is a weak cipher
+
+Examples of KRB5 logging:
+
+Pipe open::
+
+    "krb5": {
+      "msg_type": "KRB_TGS_REP",
+      "cname": "robin",
+      "realm": "CYLERA.LAB",
+      "sname": "ldap/dc01",
+      "encryption": "aes256-cts-hmac-sha1-96",
+      "weak_encryption": false,
+      "ticket_encryption": "aes256-cts-hmac-sha1-96",
+      "ticket_weak_encryption": false
+    }
 
 Event type: SMB
 ---------------

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -1345,6 +1345,74 @@ DCERPC BIND/BINDACK::
       "call_id": 2
     }
 
+NTLMSSP fields
+~~~~~~~~~~~~~~
+
+* "domain" (string): the Windows domain.
+* "user" (string): the user.
+* "host" (string): the host.
+* "version" (string): the client version.
+
+Example::
+
+    "ntlmssp": {
+      "domain": "VNET3",
+      "user": "administrator",
+      "host": "BLU",
+      "version": "60.230 build 13699 rev 188"
+    }
+
+More complete example::
+
+  "smb": {
+    "id": 3,
+    "dialect": "NT LM 0.12",
+    "command": "SMB1_COMMAND_SESSION_SETUP_ANDX",
+    "status": "STATUS_SUCCESS",
+    "status_code": "0x0",
+    "session_id": 2048,
+    "tree_id": 0,
+    "ntlmssp": {
+      "domain": "VNET3",
+      "user": "administrator",
+      "host": "BLU",
+      "version": "60.230 build 13699 rev 188"
+    },
+    "request": {
+      "native_os": "Unix",
+      "native_lm": "Samba 3.9.0-SVN-build-11572"
+    },
+    "response": {
+      "native_os": "Windows (TM) Code Name \"Longhorn\" Ultimate 5231",
+      "native_lm": "Windows (TM) Code Name \"Longhorn\" Ultimate 6.0"
+    }
+  }
+
+Kerberos fields
+~~~~~~~~~~~~~~~
+
+* "kerberos.realm" (string): the Kerberos Realm.
+* "kerberos.snames (array of strings): snames.
+
+Example::
+
+  "smb": {
+    "dialect": "2.10",
+    "command": "SMB2_COMMAND_SESSION_SETUP",
+    "status": "STATUS_SUCCESS",
+    "status_code": "0x0",
+    "session_id": 35184439197745,
+    "tree_id": 0,
+    "kerberos": {
+      "realm": "CONTOSO.LOCAL",
+      "snames": [
+        "cifs",
+        "DC1.contoso.local"
+      ]
+    }
+  }
+
+
 Event type: BITTORRENT-DHT
 --------------------------
 
@@ -1567,74 +1635,6 @@ Sample error responses::
       "msg": "Malformed Packet"
     }
   }
-
-NTLMSSP fields
-~~~~~~~~~~~~~~
-
-* "domain" (string): the Windows domain.
-* "user" (string): the user.
-* "host" (string): the host.
-* "version" (string): the client version.
-
-Example::
-
-    "ntlmssp": {
-      "domain": "VNET3",
-      "user": "administrator",
-      "host": "BLU",
-      "version": "60.230 build 13699 rev 188"
-    }
-
-More complete example::
-
-  "smb": {
-    "id": 3,
-    "dialect": "NT LM 0.12",
-    "command": "SMB1_COMMAND_SESSION_SETUP_ANDX",
-    "status": "STATUS_SUCCESS",
-    "status_code": "0x0",
-    "session_id": 2048,
-    "tree_id": 0,
-    "ntlmssp": {
-      "domain": "VNET3",
-      "user": "administrator",
-      "host": "BLU",
-      "version": "60.230 build 13699 rev 188"
-    },
-    "request": {
-      "native_os": "Unix",
-      "native_lm": "Samba 3.9.0-SVN-build-11572"
-    },
-    "response": {
-      "native_os": "Windows (TM) Code Name \"Longhorn\" Ultimate 5231",
-      "native_lm": "Windows (TM) Code Name \"Longhorn\" Ultimate 6.0"
-    }
-  }
-
-Kerberos fields
-~~~~~~~~~~~~~~~
-
-* "kerberos.realm" (string): the Kerberos Realm.
-* "kerberos.snames (array of strings): snames.
-
-Example::
-
-  "smb": {
-    "dialect": "2.10",
-    "command": "SMB2_COMMAND_SESSION_SETUP",
-    "status": "STATUS_SUCCESS",
-    "status_code": "0x0",
-    "session_id": 35184439197745,
-    "tree_id": 0,
-    "kerberos": {
-      "realm": "CONTOSO.LOCAL",
-      "snames": [
-        "cifs",
-        "DC1.contoso.local"
-      ]
-    }
-  }
-
 
 Event type: SSH
 ----------------

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1123,7 +1123,7 @@
                     "desription":
                             "DNS fields grouped by type: alternative format, no direct keywords",
                     "suricata": {
-                        "keywords": false
+                        "no_keywords": true
                     }
                 },
                 "id": {
@@ -1258,7 +1258,7 @@
                     "type": "integer",
                     "description": "The version of this EVE DNS event",
                     "suricata": {
-                        "keywords": false
+                        "no_keywords": true
                     }
                 },
                 "z": {
@@ -1341,7 +1341,7 @@
                 }
             },
             "suricata": {
-                "keywords": false
+                "no_keywords": true
             }
         },
         "email": {
@@ -7049,7 +7049,7 @@
             },
             "optional": true,
             "suricata": {
-                "keywords": false
+                "no_keywords": true
             }
         },
         "stream": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2428,34 +2428,90 @@
             "additionalProperties": false,
             "properties": {
                 "cname": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The client PrincipalName",
+                    "suricata": {
+                        "keywords": [
+                            "krb5.cname"
+                        ]
+                    }
                 },
                 "encryption": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Encryption used (only in AS-REP and TGS-REP)",
+                    "suricata": {
+                        "$comment": "we should add a keyword about it",
+                        "keywords": []
+                    }
                 },
                 "error_code": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Error code, if request has failed",
+                    "suricata": {
+                        "keywords": [
+                            "krb5_err_code"
+                        ]
+                    }
                 },
                 "failed_request": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The request type for which the response had an error_code",
+                    "suricata": {
+                        "$comment": "we should add a keyword about it, but also maybe first improve the parsing",
+                        "keywords": []
+                    }
                 },
                 "msg_type": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The message type: AS-REQ, AS-REP, etc...",
+                    "suricata": {
+                        "keywords": [
+                            "krb5_msg_type"
+                        ]
+                    }
                 },
                 "realm": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The server Realm",
+                    "suricata": {
+                        "$comment": "we should add a keyword about it",
+                        "keywords": []
+                    }
                 },
                 "sname": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The server PrincipalName",
+                    "suricata": {
+                        "keywords": [
+                            "krb5.sname"
+                        ]
+                    }
                 },
                 "ticket_encryption": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Encryption used for ticket",
+                    "suricata": {
+                        "keywords": [
+                            "krb5.ticket_encryption"
+                        ]
+                    }
                 },
                 "ticket_weak_encryption": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Whether the encryption used for ticket is a weak cipher",
+                    "suricata": {
+                        "keywords": [
+                            "krb5.ticket_encryption"
+                        ]
+                    }
                 },
                 "weak_encryption": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Whether the encryption used in AS-REP or TGS-REP is a weak cipher",
+                    "suricata": {
+                        "$comment": "we should add a keyword about encryption and have an option for this",
+                        "keywords": []
+                    }
                 }
             },
             "optional": true


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6566

Describe changes:
- document krb5 fields in json schema
- fix doc about smb events which has some part in bittorrent
- document krb5 event in userguide
- ci : consider etc/schema.json like doc
- scripts: eve-parity fields-missing-keywords command

#13481 with last commit for script eve-parity

This PR will still run CI as it also modifies .github workflow files 

`python3 scripts/eve-parity.py fields-missing-keywords` shows the krb5 log fields missing keywords