### PR TITLE
Replace strtoul 7212 v3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,7 @@
     AC_FUNC_STRTOD
 
     AC_CHECK_FUNCS([memmem memset memchr memrchr memmove])
-    AC_CHECK_FUNCS([strcasecmp strchr strrchr strdup strndup strncasecmp strtol strtoul strstr strpbrk strtoull strtoumax])
+    AC_CHECK_FUNCS([strcasecmp strchr strrchr strdup strndup strncasecmp strtol strstr strpbrk strtoull strtoumax])
     AC_CHECK_FUNCS([strerror])
     AC_CHECK_FUNCS([gethostname inet_ntoa uname])
     AC_CHECK_FUNCS([gettimeofday clock_gettime utime strptime tzset localtime_r])

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -129,7 +129,7 @@ int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData 
         extbytes = ByteExtractStringUint64(&val, data->base,
                                            data->nbytes, (const char *)ptr);
         if (extbytes <= 0) {
-            /* strtoull() return 0 if there is no numeric value in data string */
+            /* ByteExtractStringUint64() set val to 0 if there is no numeric value in data string */
             if (val == 0) {
                 SCLogDebug("No Numeric value");
                 return 0;

--- a/src/detect-gid.c
+++ b/src/detect-gid.c
@@ -33,6 +33,7 @@
 #include "decode-events.h"
 
 #include "detect-gid.h"
+#include "util-byte.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 
@@ -71,21 +72,13 @@ void DetectGidRegister (void)
  */
 static int DetectGidSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
-    unsigned long gid = 0;
-    char *endptr = NULL;
-    errno = 0;
-    gid = strtoul(rawstr, &endptr, 10);
-    if (errno == ERANGE || endptr == NULL || *endptr != '\0') {
-        SCLogError("invalid character as arg "
-                   "to gid keyword");
-        goto error;
-    }
-    if (gid >= UINT_MAX) {
-        SCLogError("gid value to high, max %u", UINT_MAX);
+    uint32_t gid = 0;
+    if (ByteExtractStringUint32(&gid, 10, strlen(rawstr), rawstr) <= 0) {
+        SCLogError("invalid input as arg to gid keyword");
         goto error;
     }
 
-    s->gid = (uint32_t)gid;
+    s->gid = gid;
 
     return 0;
 

--- a/src/detect-rev.c
+++ b/src/detect-rev.c
@@ -25,11 +25,18 @@
 
 #include "suricata-common.h"
 #include "detect.h"
+#include "detect-engine.h"
+#include "detect-parse.h"
 #include "detect-rev.h"
+#include "util-byte.h"
 #include "util-debug.h"
 #include "util-error.h"
+#include "util-unittest.h"
 
 static int DetectRevSetup (DetectEngineCtx *, Signature *, const char *);
+#ifdef UNITTESTS
+static void DetectRevRegisterTests(void);
+#endif
 
 void DetectRevRegister (void)
 {
@@ -37,21 +44,16 @@ void DetectRevRegister (void)
     sigmatch_table[DETECT_REV].desc = "set version of the rule";
     sigmatch_table[DETECT_REV].url = "/rules/meta.html#rev-revision";
     sigmatch_table[DETECT_REV].Setup = DetectRevSetup;
+#ifdef UNITTESTS
+    sigmatch_table[DETECT_REV].RegisterTests = DetectRevRegisterTests;
+#endif
 }
 
 static int DetectRevSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
-    unsigned long rev = 0;
-    char *endptr = NULL;
-    errno = 0;
-    rev = strtoul(rawstr, &endptr, 10);
-    if (errno == ERANGE || endptr == NULL || *endptr != '\0') {
-        SCLogError("invalid character as arg "
-                   "to rev keyword");
-        goto error;
-    }
-    if (rev >= UINT_MAX) {
-        SCLogError("rev value to high, max %u", UINT_MAX);
+    uint32_t rev = 0;
+    if (ByteExtractStringUint32(&rev, 10, strlen(rawstr), rawstr) <= 0) {
+        SCLogError("invalid input as arg to rev keyword");
         goto error;
     }
     if (rev == 0) {
@@ -63,10 +65,85 @@ static int DetectRevSetup (DetectEngineCtx *de_ctx, Signature *s, const char *ra
         goto error;
     }
 
-    s->rev = (uint32_t)rev;
-
+    s->rev = rev;
     return 0;
 
- error:
+error:
     return -1;
- }
+}
+
+#ifdef UNITTESTS
+/**
+ * \test RevTestParse01 is a test for a valid rev value
+ */
+static int RevTestParse01(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    Signature *s =
+            DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> any any (sid:1; rev:1;)");
+
+    FAIL_IF_NULL(s);
+    FAIL_IF(s->rev != 1);
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+/**
+ * \test RevTestParse02 is a test for an invalid rev value
+ */
+static int RevTestParse02(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    FAIL_IF_NOT_NULL(
+            DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> any any (sid:1; rev:a;)"));
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+/**
+ * \test RevTestParse03 is a test for a rev containing of a single quote.
+ */
+static int RevTestParse03(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    FAIL_IF_NOT_NULL(DetectEngineAppendSig(
+            de_ctx, "alert tcp any any -> any any (content:\"ABC\"; rev:\";)"));
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+/**
+ * \test RevTestParse04 is a test for a rev value of 0
+ */
+static int RevTestParse04(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    FAIL_IF_NOT_NULL(DetectEngineAppendSig(
+            de_ctx, "alert tcp any any -> any any (content:\"ABC\"; rev:0;)"));
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+/**
+ * \brief this function registers unit tests for Rev
+ */
+static void DetectRevRegisterTests(void)
+{
+    UtRegisterTest("RevTestParse01", RevTestParse01);
+    UtRegisterTest("RevTestParse02", RevTestParse02);
+    UtRegisterTest("RevTestParse03", RevTestParse03);
+    UtRegisterTest("RevTestParse04", RevTestParse04);
+}
+#endif /* UNITTESTS */

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -28,6 +28,7 @@
 #include "detect-engine.h"
 #include "detect-parse.h"
 #include "detect-sid.h"
+#include "util-byte.h"
 #include "util-debug.h"
 #include "util-error.h"
 #include "util-unittest.h"
@@ -52,17 +53,9 @@ void DetectSidRegister (void)
 
 static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, const char *sidstr)
 {
-    unsigned long id = 0;
-    char *endptr = NULL;
-    errno = 0;
-    id = strtoul(sidstr, &endptr, 10);
-    if (errno == ERANGE || endptr == NULL || *endptr != '\0') {
-        SCLogError("invalid character as arg "
-                   "to sid keyword");
-        goto error;
-    }
-    if (id >= UINT_MAX) {
-        SCLogError("sid value too high, max %u", UINT_MAX);
+    uint32_t id = 0;
+    if (ByteExtractStringUint32(&id, 10, strlen(sidstr), sidstr) <= 0) {
+        SCLogError("invalid input as arg to sid keyword");
         goto error;
     }
     if (id == 0) {
@@ -74,7 +67,7 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, const char *si
         goto error;
     }
 
-    s->id = (uint32_t)id;
+    s->id = id;
     return 0;
 
  error:

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -68,6 +68,7 @@
 #include "util-radix6-tree.h"
 #include "util-host-os-info.h"
 #include "util-cidr.h"
+#include "util-coredump-config.h"
 #include "util-unittest-helper.h"
 #include "util-time.h"
 #include "util-rule-vars.h"
@@ -218,6 +219,7 @@ static void RegisterUnittests(void)
     SCProtoNameRegisterTests();
     UtilCIDRTests();
     OutputJsonStatsRegisterTests();
+    CoredumpConfigRegisterTests();
 }
 #endif
 

--- a/src/util-coredump-config.c
+++ b/src/util-coredump-config.c
@@ -32,6 +32,7 @@
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #endif
+#include "util-byte.h"
 #include "util-debug.h"
 
 #ifdef OS_WIN32
@@ -43,6 +44,10 @@ int32_t CoredumpLoadConfig(void) {
     /* todo: use the registry to get/set dump configuration */
     SCLogInfo("Configuring core dump is not yet supported on Windows.");
     return 0;
+}
+
+void CoredumpConfigRegisterTests(void)
+{
 }
 
 #else
@@ -91,6 +96,9 @@ int32_t CoredumpLoadConfig (void)
 {
 #ifdef HAVE_SYS_RESOURCE_H
     /* get core dump configuration settings for suricata */
+    int ret = 0;
+    uint64_t max_dump64 = 0;
+    uint32_t max_dump32 = 0;
     const char *dump_size_config = NULL;
     size_t rlim_size = sizeof(rlim_t);
 
@@ -116,18 +124,25 @@ int32_t CoredumpLoadConfig (void)
             SCLogInfo ("Unexpected type for rlim_t");
             return 0;
         }
-        errno = 0;
         if (rlim_size == 8) {
-            max_dump = (rlim_t) strtoull (dump_size_config, NULL, 10);
+            ret = ByteExtractStringUint64(
+                    &max_dump64, 10, strlen(dump_size_config), dump_size_config);
         }
         else if (rlim_size == 4) {
-            max_dump = (rlim_t) strtoul (dump_size_config, NULL, 10);
+            ret = ByteExtractStringUint32(
+                    &max_dump32, 10, strlen(dump_size_config), dump_size_config);
         }
-        if ((errno == ERANGE) || (errno != 0 && max_dump == 0)) {
+        if (ret <= 0) {
             SCLogInfo ("Illegal core dump size: %s.", dump_size_config);
             return 0;
         }
-        SCLogInfo ("Max dump is %"PRIu64, (uint64_t) max_dump);
+
+        max_dump = rlim_size == 8 ? (rlim_t)max_dump64 : (rlim_t)max_dump32;
+        if (max_dump == 0) {
+            SCLogInfo("Max dump is 0, disable core dumping.");
+        } else {
+            SCLogInfo("Max dump is %" PRIu64, (uint64_t)max_dump);
+        }
     }
 
     CoredumpEnable();
@@ -236,6 +251,174 @@ int32_t CoredumpLoadConfig (void)
     SCLogInfo("Couldn't set coredump size to %s.", dump_size_config);
 #endif /* HAVE_SYS_RESOURCE_H */
     return 0;
+}
+
+#if defined UNITTESTS && defined HAVE_SYS_RESOURCE_H
+#include "conf-yaml-loader.h"
+
+static void ResetCoredumpConfig(void)
+{
+    unlimited = false;
+    max_dump = 0;
+}
+
+/**
+ * \test CoredumpConfigTest01 is a test for the coredump configuration
+ *        with unlimited coredump size.
+ */
+static int CoredumpConfigTest01(void)
+{
+    char config[] = "\
+%YAML 1.1\n\
+---\n\
+coredump:\n\
+  max-dump: unlimited\n\
+";
+
+    int ret = 0;
+    ResetCoredumpConfig();
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    SCConfYamlLoadString(config, strlen(config));
+    ret = CoredumpLoadConfig();
+    FAIL_IF(errno != EPERM && ret != 1);
+
+    FAIL_IF(unlimited != true);
+    FAIL_IF(max_dump != 0);
+
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+    PASS;
+}
+
+/**
+ * \test CoredumpConfigTest02 is a test for the coredump configuration
+ *        with a specific coredump size.
+ */
+static int CoredumpConfigTest02(void)
+{
+    char config[] = "\
+%YAML 1.1\n\
+---\n\
+coredump:\n\
+  max-dump: 1000000\n\
+";
+
+    int ret = 0;
+    ResetCoredumpConfig();
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    SCConfYamlLoadString(config, strlen(config));
+    ret = CoredumpLoadConfig();
+    FAIL_IF(errno != EPERM && ret != 1);
+
+    FAIL_IF(unlimited != false);
+    FAIL_IF(max_dump != 1000000);
+
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+    PASS;
+}
+
+/**
+ * \test CoredumpConfigTest03 is a test for the coredump configuration
+ *        with an invalid coredump size.
+ */
+static int CoredumpConfigTest03(void)
+{
+    char config[] = "\
+%YAML 1.1\n\
+---\n\
+coredump:\n\
+  max-dump: -1000000\n\
+";
+
+    ResetCoredumpConfig();
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    SCConfYamlLoadString(config, strlen(config));
+    FAIL_IF(CoredumpLoadConfig() != 0);
+
+    FAIL_IF(unlimited != false);
+    FAIL_IF(max_dump != 0);
+
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+    PASS;
+}
+
+/**
+ * \test CoredumpConfigTest04 is a test for the coredump configuration
+ *        with a non-numeric coredump size.
+ */
+static int CoredumpConfigTest04(void)
+{
+    char config[] = "\
+%YAML 1.1\n\
+---\n\
+coredump:\n\
+  max-dump: a\n\
+";
+
+    ResetCoredumpConfig();
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    SCConfYamlLoadString(config, strlen(config));
+    FAIL_IF(CoredumpLoadConfig() != 0);
+
+    FAIL_IF(unlimited != false);
+    FAIL_IF(max_dump != 0);
+
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+    PASS;
+}
+
+/**
+ * \test CoredumpConfigTest05 is a test for the coredump configuration
+ *        with a zero coredump size.
+ */
+static int CoredumpConfigTest05(void)
+{
+    char config[] = "\
+%YAML 1.1\n\
+---\n\
+coredump:\n\
+  max-dump: 0\n\
+";
+
+    int ret = 0;
+    ResetCoredumpConfig();
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    SCConfYamlLoadString(config, strlen(config));
+    ret = CoredumpLoadConfig();
+    /* should return 1 because zero coredump size is allowed. */
+    FAIL_IF(errno != EPERM && ret != 1);
+
+    FAIL_IF(unlimited != false);
+    FAIL_IF(max_dump != 0);
+
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+    PASS;
+}
+#endif /* UNITTESTS */
+
+void CoredumpConfigRegisterTests(void)
+{
+#if defined UNITTESTS && defined HAVE_SYS_RESOURCE_H
+    UtRegisterTest("CoredumpConfigTest01", CoredumpConfigTest01);
+    UtRegisterTest("CoredumpConfigTest02", CoredumpConfigTest02);
+    UtRegisterTest("CoredumpConfigTest03", CoredumpConfigTest03);
+    UtRegisterTest("CoredumpConfigTest04", CoredumpConfigTest04);
+    UtRegisterTest("CoredumpConfigTest05", CoredumpConfigTest05);
+#endif /* UNITTESTS */
 }
 
 #endif /* OS_WIN32 */

--- a/src/util-coredump-config.h
+++ b/src/util-coredump-config.h
@@ -29,4 +29,6 @@
 int32_t CoredumpLoadConfig(void);
 void CoredumpEnable(void);
 
+void CoredumpConfigRegisterTests(void);
+
 #endif /* SURICATA_COREDUMP_CONFIG_H */


### PR DESCRIPTION
Replaces: #13407

Changes since v2:
- Split commits to improve clarity and maintainability.
- Removed unsafe pointer casts and replaced them with explicit intermediate variables.
- Fixed outdated comment in `detect-byte-extract.c` to better reflect the current parsing logic.
- Removed the unused `strtoul` check from `AC_CHECK_FUNCS` in configure.ac.

Changes since v1:
- Allowed `max-dump` to be set to 0, and correctly apply a core dump limit of 0.
- Updated the unit test to reflect this change. (The `errno != EPERM` check was added to skip the test gracefully in non-root CI environments.)
- Fixed the English grammar issues.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7212

Describe changes:
- Replaced all direct usages of `strtoul`/`strtoull` across the codebase with the standardized ByteExtractString* helpers to improve consistency and error handling.
- Also added and updated unit tests to ensure correctness.

Notes:

The ticket mentions adding suricata-verify tests, but the code I modified does not appear to involve parsing or behavior that can be validated through PCAP-based testing.
Therefore, I focused on unit testing to validate the changes.
If this understanding is incorrect, I’d be happy to adjust the approach accordingly.
