### PR TITLE
lua: don't accept a table as a return value from match - v1

### DIFF
--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -219,39 +219,9 @@ static int DetectLuaRunMatch(
 
             if (script_ret == 1.0)
                 match = 1;
-
-        /* script returns a table */
-        } else if (lua_type(tlua->luastate, 1) == LUA_TTABLE) {
-            lua_pushnil(tlua->luastate);
-            const char *k, *v;
-            while (lua_next(tlua->luastate, -2)) {
-                v = lua_tostring(tlua->luastate, -1);
-                lua_pop(tlua->luastate, 1);
-                k = lua_tostring(tlua->luastate, -1);
-
-                if (!k || !v)
-                    continue;
-
-                SCLogDebug("k='%s', v='%s'", k, v);
-
-                if (strcmp(k, "retval") == 0) {
-                    int val;
-                    if (StringParseInt32(&val, 10, 0, (const char *)v) < 0) {
-                        SCLogError("Invalid value "
-                                   "for \"retval\" from LUA return table: '%s'",
-                                v);
-                        match = 0;
-                    }
-                    else if (val == 1) {
-                        match = 1;
-                    }
-                } else {
-                    /* set flow var? */
-                }
-            }
-
-            /* pop the table */
-            lua_pop(tlua->luastate, 1);
+        } else {
+            SCLogDebug("Unsupported datatype returned from Lua script");
+            abort();
         }
     }
 


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/6941

Remove the half finished support for accepting a table returned from a
Lua rule's match function. This is not documented, not tested, and not
really implemented.
