### PR TITLE
Smtp inspection fix/v2

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -171,6 +171,10 @@ Major changes
     -         cpu: [0, 1]
     +     worker-cpu-set:
     +       cpu: [0, 1]
+- All applayer protocols except FTP and HTTP now trigger inspection upon completion
+  of a request/response in the respective direction. This means that earlier a
+  content that matched just because it fell in the inspection chunk without wholly
+  belonging to any one request/response may not match any longer.
 
 Removals
 ~~~~~~~~


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7783

Restores behavior from the past rejected PR https://github.com/OISF/suricata/pull/13319/commits/b4c51d3e66c54a9fbe12964515ab3836f6a8118c as that was correct.

Previous PR: https://github.com/OISF/suricata/pull/13505

Changes since v1:
- fixed commit message
- added upgrade note

NOTE: Requires upgrading of at least one internal test.