### PR TITLE
detect/var: Restrict var usage to single buffer

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -171,6 +171,9 @@ Major changes
     -         cpu: [0, 1]
     +     worker-cpu-set:
     +       cpu: [0, 1]
+-  When using the `byte` keywords like ``byte_extract``, ``byte_math``, etc with
+  variables, the variables must be associated with the same buffer or the rule
+  won't load.
 
 Removals
 ~~~~~~~~

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -442,17 +442,20 @@ static void DetectByteMathFree(DetectEngineCtx *de_ctx, void *ptr)
  */
 SigMatch *DetectByteMathRetrieveSMVar(const char *arg, int sm_list, const Signature *s)
 {
+    bool any = sm_list == -1;
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        SigMatch *sm = s->init_data->buffers[x].head;
-        while (sm != NULL) {
-            if (sm->type == DETECT_BYTEMATH) {
-                const DetectByteMathData *bmd = (const DetectByteMathData *)sm->ctx;
-                if (strcmp(bmd->result, arg) == 0) {
-                    SCLogDebug("Retrieved SM for \"%s\"", arg);
-                    return sm;
+        if (any || (uint32_t)sm_list == s->init_data->buffers[x].id) {
+            SigMatch *sm = s->init_data->buffers[x].head;
+            while (sm != NULL) {
+                if (sm->type == DETECT_BYTEMATH) {
+                    const DetectByteMathData *bmd = (const DetectByteMathData *)sm->ctx;
+                    if (strcmp(bmd->result, arg) == 0) {
+                        SCLogDebug("Retrieved SM for \"%s\"", arg);
+                        return sm;
+                    }
                 }
+                sm = sm->next;
             }
-            sm = sm->next;
         }
     }
 
@@ -460,7 +463,7 @@ SigMatch *DetectByteMathRetrieveSMVar(const char *arg, int sm_list, const Signat
         SigMatch *sm = s->init_data->smlists[list];
         while (sm != NULL) {
             // Make sure that the linked buffers ore on the same list
-            if (sm->type == DETECT_BYTEMATH && (sm_list == -1 || sm_list == list)) {
+            if (sm->type == DETECT_BYTEMATH && (any || sm_list == list)) {
                 const DetectByteMathData *bmd = (const DetectByteMathData *)sm->ctx;
                 if (strcmp(bmd->result, arg) == 0) {
                     SCLogDebug("Retrieved SM for \"%s\"", arg);


### PR DESCRIPTION
Continuation of #13465 

Issue: 1412

Extend the checks added for 7549 to include buffers.

Only consider sig matches with compatible ids/lists.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/1412

Describe changes:
- Extend buffer/variable checks to `buffers` init data

Updates:
- Include behavioral change note (see #13465) in upgrade notes.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2576
SU_REPO=
SU_BRANCH=
