### PR TITLE
Vxlan reserved fields 7753 v3

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -3007,6 +3007,42 @@ Using this default configuration, Teredo detection will run on UDP port
 1.    If the `ports` parameter is missing, or set to `any`, all ports will be
 inspected for possible presence of Teredo.
 
+VXLAN
+~~~~~
+
+The VXLAN decoder can be configured with different reserved bits check modes.
+It is enabled by default and uses UDP port 4789.
+
+::
+
+    decoder:
+      # VXLAN decoder is assigned to up to 4 UDP ports. By default only the
+      # IANA assigned port 4789 is enabled.
+      vxlan:
+        enabled: true
+        ports: $VXLAN_PORTS # syntax: '[8472, 4789]' or '4789'.
+        # Reserved bits check mode. Possible values are:
+        #  - strict: check all reserved bits are zero for standard VXLAN
+        #  - normal: check only the last 1-byte reserved field is zero (allows GBP extensions, default)
+        #  - permissive: do not check any reserved bits (allows private VXLAN extensions)
+        reserved-bits-check: normal
+
+Using this default configuration, VXLAN detection will run on UDP port 4789
+with normal reserved bits checking. The ``reserved-bits-check`` option controls
+how strictly the decoder validates the VXLAN header:
+
+- ``strict``: Validates all reserved bits are zero for standard VXLAN.
+  This mode will reject VXLAN extensions like GBP.
+- ``normal``: Only checks the last 1-byte reserved field (default). This mode
+  allows VXLAN extensions like GBP while still providing basic validation.
+- ``permissive``: Does not check any reserved bits. This mode accepts any
+  VXLAN-like traffic regardless of reserved bit values. This is mainly useful
+  when dealing with private VXLAN extensions that may use the last reserved byte.
+
+The ``normal`` mode is recommended as it provides a good balance between
+standard compliance and support for common VXLAN extensions used in production
+networks.
+
 Recursion Level
 ~~~~~~~~~~~~~~~
 

--- a/src/decode-udp.c
+++ b/src/decode-udp.c
@@ -103,7 +103,7 @@ int DecodeUDP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     }
 
     /* Handle VXLAN if configured */
-    if (DecodeVXLANEnabledForPort(p->sp, p->dp) &&
+    if (DecodeVXLANEnabledForPort(p->dp) &&
             unlikely(DecodeVXLAN(tv, dtv, p, p->payload, p->payload_len) == TM_ECODE_OK)) {
         /* Here we have a VXLAN packet and don't need to handle app
          * layer */

--- a/src/decode-vxlan.h
+++ b/src/decode-vxlan.h
@@ -28,6 +28,6 @@
 
 void DecodeVXLANRegisterTests(void);
 void DecodeVXLANConfig(void);
-bool DecodeVXLANEnabledForPort(const uint16_t sp, const uint16_t dp);
+bool DecodeVXLANEnabledForPort(const uint16_t dp);
 
 #endif /* !SURICATA_DECODE_VXLAN_H */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1742,6 +1742,11 @@ decoder:
   vxlan:
     enabled: true
     ports: $VXLAN_PORTS # syntax: '[8472, 4789]' or '4789'.
+    # Reserved bits check mode. Possible values are:
+    #  - strict: check all reserved bits are zero for standard VXLAN
+    #  - normal: check only the last 1-byte reserved field is zero (allows GBP extensions, default)
+    #  - permissive: do not check any reserved bits (allows private VXLAN extensions)
+    reserved-bits-check: normal
 
   # Geneve decoder is assigned to up to 4 UDP ports. By default only the
   # IANA assigned port 6081 is enabled.


### PR DESCRIPTION
Replaces: #13458

Changes since v2:
- Added configurable reserved bits validation for VXLAN.
- Fixed VXLAN port detection per RFC 7348 §5.

Changes since v1:
- Added the previously missing TCP payload in the unit test packet.

Remove strict validation of VXLAN Reserved fields per RFC 7348 §5, which requires them to be ignored on receipt.
Strict enforcement caused valid packets with non-zero Reserved bits to be dropped, especially on response paths.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7753

Describe changes:
- Remove reserved field check.
- Add unit test.

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2581
