### PR TITLE
feat: pcap delete only if no alerts

### DIFF
--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -85,6 +85,10 @@
    continuously feed files to a directory and have them cleaned up when done. If
    this option is not set, pcap files will not be deleted after processing.
 
+   The behavior of this option can be further controlled using the
+   ``pcap-file.delete-no-alerts-only`` configuration option in ``suricata.yaml``.
+   When set to ``true``, only pcap files that have generated no alerts will be deleted.
+
 .. _cmdline-option-pcap-file-buffer-size:
 
 .. option:: --pcap-file-buffer-size <value>

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -32,7 +32,8 @@ void AlertQueueInit(DetectEngineThreadCtx *det_ctx);
 void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
 void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
         uint8_t alert_flags);
-void PacketAlertFinalize(const DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
+void PacketAlertFinalize(const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p);
+void AlertCounter(Packet *p);
 #ifdef UNITTESTS
 int PacketAlertCheck(Packet *, uint32_t);
 #endif

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -114,6 +114,7 @@
 #include "decode-vntag.h"
 #include "decode-vxlan.h"
 #include "decode-pppoe.h"
+#include "source-pcap-file-helper.h"
 
 #include "output-json-stats.h"
 
@@ -209,6 +210,7 @@ static void RegisterUnittests(void)
     StreamingBufferRegisterTests();
     MacSetRegisterTests();
     FlowRateRegisterTests();
+    SourcePcapFileHelperRegisterTests();
 #ifdef OS_WIN32
     Win32SyscallRegisterTests();
 #endif

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -30,6 +30,10 @@
 #include "util-profiling.h"
 #include "source-pcap-file.h"
 #include "util-exception-policy.h"
+#include <unistd.h>
+#include "detect-engine-alert.h" /* For AlertCounter */
+#include "conf-yaml-loader.h"    /* For SCConfYamlLoadString */
+#include "util-unittest.h"
 
 extern uint32_t max_pending_packets;
 extern PcapFileGlobalVars pcap_g;
@@ -44,7 +48,7 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv)
             pfv->pcap_handle = NULL;
         }
         if (pfv->filename != NULL) {
-            if (pfv->shared != NULL && pfv->shared->should_delete) {
+            if (ShouldDeletePcapFile(pfv)) {
                 SCLogDebug("Deleting pcap file %s", pfv->filename);
                 if (unlink(pfv->filename) != 0) {
                     SCLogWarning("Failed to delete %s: %s", pfv->filename, strerror(errno));
@@ -83,6 +87,7 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     p->pcap_cnt = ++pcap_g.cnt;
 
     p->pcap_v.tenant_id = ptv->shared->tenant_id;
+    p->pcap_v.shared = ptv->shared;
     ptv->shared->pkts++;
     ptv->shared->bytes += h->caplen;
 
@@ -236,6 +241,10 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
         pcap_freecode(&pfv->filter);
     }
 
+    if (pfv->shared != NULL) {
+        pfv->alerts_start = SC_ATOMIC_GET(pfv->shared->alerts_total);
+    }
+
     pfv->datalink = pcap_datalink(pfv->pcap_handle);
     SCLogDebug("datalink %" PRId32 "", pfv->datalink);
     DatalinkSetGlobalType(pfv->datalink);
@@ -285,3 +294,182 @@ TmEcode ValidateLinkType(int datalink, DecoderFunc *DecoderFn)
 
     SCReturnInt(TM_ECODE_OK);
 }
+
+bool ShouldDeletePcapFile(PcapFileFileVars *pfv)
+{
+    if (pfv == NULL || pfv->shared == NULL)
+        return false;
+
+    if (!pfv->shared->should_delete) {
+        return false;
+    }
+
+    uint64_t alerts_before = pfv->alerts_start;
+    uint64_t alerts_now = SC_ATOMIC_GET(pfv->shared->alerts_total);
+    uint64_t file_alerts = alerts_now - alerts_before;
+
+    if (!pfv->shared->delete_no_alerts_only) {
+        return true;
+    }
+
+    if (file_alerts != 0) {
+        SCLogInfo("Skipping deletion of %s due to %" PRIu64 " alert(s) generated.", pfv->filename,
+                file_alerts);
+        return false;
+    }
+
+    return true;
+}
+
+#ifdef UNITTESTS
+/**
+ * \test Tests that the ShouldDeletePcapFile function correctly applies the
+ * delete-no-alerts-only configuration.
+ */
+static int SourcePcapFileHelperTest01(void)
+{
+    PcapFileSharedVars shared;
+    memset(&shared, 0, sizeof(shared));
+    shared.should_delete = true;
+    shared.delete_no_alerts_only = false;
+    SC_ATOMIC_INIT(shared.alerts_total);
+    SC_ATOMIC_SET(shared.alerts_total, 0);
+
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    pfv.shared = &shared;
+    pfv.filename = SCStrdup("test.pcap");
+    pfv.alerts_start = 0;
+
+    /* Test case 1: Basic delete with no alerts filter disabled */
+    int result1 = ShouldDeletePcapFile(&pfv);
+    FAIL_IF(result1 != true);
+
+    /* Test case 2: With delete_no_alerts_only=true, but no alerts */
+    shared.delete_no_alerts_only = true;
+    int result2 = ShouldDeletePcapFile(&pfv);
+    FAIL_IF(result2 != true);
+
+    /* Test case 3: With delete_no_alerts_only=true, and alerts */
+    SC_ATOMIC_ADD(shared.alerts_total, 1);
+    int result3 = ShouldDeletePcapFile(&pfv);
+    FAIL_IF(result3 != false);
+
+    /* Test case 4: With delete_no_alerts_only=false and alerts */
+    shared.delete_no_alerts_only = false;
+    int result4 = ShouldDeletePcapFile(&pfv);
+    FAIL_IF(result4 != true);
+
+    /* Test case 5: With should_delete=false */
+    shared.should_delete = false;
+    int result5 = ShouldDeletePcapFile(&pfv);
+    FAIL_IF(result5 != false);
+
+    SCFree(pfv.filename);
+
+    PASS;
+}
+
+/**
+ * \test Test that alert counters are properly incremented
+ */
+static int SourcePcapFileHelperTest02(void)
+{
+    PcapFileSharedVars shared;
+    memset(&shared, 0, sizeof(shared));
+    SC_ATOMIC_INIT(shared.alerts_total);
+    SC_ATOMIC_SET(shared.alerts_total, 0);
+
+    Packet p;
+    memset(&p, 0, sizeof(p));
+    p.pcap_v.shared = &shared;
+
+    /* Create alert structure */
+    p.alerts.cnt = 2;
+
+    /* Call function in detect-engine-alert.c */
+    AlertCounter(&p);
+
+    /* Check if the counter was incremented correctly */
+    uint64_t alerts_count = SC_ATOMIC_GET(shared.alerts_total);
+    FAIL_IF(alerts_count != 2);
+
+    /* Add another alert */
+    p.alerts.cnt = 3;
+    AlertCounter(&p);
+
+    /* Check if the counter was incremented correctly */
+    alerts_count = SC_ATOMIC_GET(shared.alerts_total);
+    FAIL_IF(alerts_count != 5);
+
+    PASS;
+}
+
+/* Mock for configuration testing */
+static int SetupYamlConf(const char *conf_string)
+{
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    return SCConfYamlLoadString(conf_string, strlen(conf_string));
+}
+
+static void CleanupYamlConf(void)
+{
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+}
+
+/**
+ * \test Test that configuration is properly parsed
+ */
+static int SourcePcapFileHelperTest03(void)
+{
+    int result = 0;
+    PcapFileSharedVars shared;
+    memset(&shared, 0, sizeof(shared));
+    int delete_no_alerts_only = 0;
+
+    const char *conf_string = "%YAML 1.1\n"
+                              "---\n"
+                              "pcap-file:\n"
+                              "  delete-no-alerts-only: true\n";
+
+    /* Initialize configuration */
+    SetupYamlConf(conf_string);
+
+    /* Test the SCConfGetBool function directly */
+    result = SCConfGetBool("pcap-file.delete-no-alerts-only", &delete_no_alerts_only);
+    FAIL_IF(result != 1);
+    FAIL_IF(delete_no_alerts_only != 1);
+
+    /* Check with false value */
+    CleanupYamlConf();
+
+    const char *conf_string2 = "%YAML 1.1\n"
+                               "---\n"
+                               "pcap-file:\n"
+                               "  delete-no-alerts-only: false\n";
+
+    SetupYamlConf(conf_string2);
+
+    result = SCConfGetBool("pcap-file.delete-no-alerts-only", &delete_no_alerts_only);
+    FAIL_IF(result != 1);
+    FAIL_IF(delete_no_alerts_only != 0);
+
+    /* Clean up */
+    CleanupYamlConf();
+
+    PASS;
+}
+
+/**
+ * \brief Register unit tests for pcap file helper
+ */
+void SourcePcapFileHelperRegisterTests(void)
+{
+    UtRegisterTest("SourcePcapFileHelperTest01", SourcePcapFileHelperTest01);
+    UtRegisterTest("SourcePcapFileHelperTest02", SourcePcapFileHelperTest02);
+    UtRegisterTest("SourcePcapFileHelperTest03", SourcePcapFileHelperTest03);
+}
+#endif /* UNITTESTS */

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -48,6 +48,10 @@ typedef struct PcapFileSharedVars_
 
     bool should_delete;
 
+    bool delete_no_alerts_only;
+
+    SC_ATOMIC_DECLARE(uint64_t, alerts_total);
+
     ThreadVars *tv;
     TmSlot *slot;
 
@@ -81,6 +85,7 @@ typedef struct PcapFileFileVars_
     const u_char *first_pkt_data;
     struct pcap_pkthdr *first_pkt_hdr;
     struct timeval first_pkt_ts;
+    uint64_t alerts_start;
 
     /** flex array member for the libc io read buffer. Size controlled by
      * PcapFileGlobalVars::read_buffer_size. */
@@ -120,5 +125,11 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv);
 TmEcode ValidateLinkType(int datalink, DecoderFunc *decoder);
 
 const char *PcapFileGetFilename(void);
+
+bool ShouldDeletePcapFile(PcapFileFileVars *pfv);
+
+#ifdef UNITTESTS
+void SourcePcapFileHelperRegisterTests(void);
+#endif
 
 #endif /* SURICATA_SOURCE_PCAP_FILE_HELPER_H */

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -267,6 +267,14 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         ptv->shared.should_delete = should_delete == 1;
     }
 
+    int delete_no_alerts_only = 0;
+    ptv->shared.delete_no_alerts_only = false;
+    if (SCConfGetBool("pcap-file.delete-no-alerts-only", &delete_no_alerts_only) == 1) {
+        ptv->shared.delete_no_alerts_only = delete_no_alerts_only == 1;
+    }
+
+    SC_ATOMIC_INIT(ptv->shared.alerts_total);
+
     DIR *directory = NULL;
     SCLogDebug("checking file or directory %s", (char*)initdata);
     if(PcapDetermineDirectoryOrFile((char *)initdata, &directory) == TM_ECODE_FAILED) {

--- a/src/source-pcap.h
+++ b/src/source-pcap.h
@@ -31,10 +31,15 @@ void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
 #define LIBPCAP_COPYWAIT    500
 #define LIBPCAP_PROMISC     1
 
+struct PcapFileSharedVars_;
+
 /* per packet Pcap vars */
 typedef struct PcapPacketVars_
 {
     uint32_t tenant_id;
+    /* Will be NULL for capture methods other
+     * than pcap-file.  */
+    struct PcapFileSharedVars_ *shared;
 } PcapPacketVars;
 
 /** needs to be able to contain Windows adapter id's, so

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -892,6 +892,7 @@ pcap-file:
 
   # tenant-id: none # applies in multi-tenant environment with "direct" selector
   # delete-when-done: false # applies to file and directory
+  # delete-no-alerts-only: false # if true, --pcap-file-delete will only remove pcaps that have generated no alerts
 
   # PCAP Directory Processing options
   # recursive: false


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7786

Describe changes:
Allowing change the behaviour of --pcap-file-delete to only delete pcaps with no alerts via config.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
