### PR TITLE
feat: pcap delete only if no alerts

### DIFF
--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -85,6 +85,10 @@
    continuously feed files to a directory and have them cleaned up when done. If
    this option is not set, pcap files will not be deleted after processing.
 
+   The behavior of this option can be further controlled using the
+   ``pcap-file.delete-no-alerts-only`` configuration option in ``suricata.yaml``.
+   When set to ``true``, only pcap files that have generated no alerts will be deleted.
+
 .. _cmdline-option-pcap-file-buffer-size:
 
 .. option:: --pcap-file-buffer-size <value>

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -32,7 +32,8 @@ void AlertQueueInit(DetectEngineThreadCtx *det_ctx);
 void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
 void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
         uint8_t alert_flags);
-void PacketAlertFinalize(const DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
+void PacketAlertFinalize(const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p);
+void AlertCounter(Packet *p);
 #ifdef UNITTESTS
 int PacketAlertCheck(Packet *, uint32_t);
 #endif

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -114,6 +114,7 @@
 #include "decode-vntag.h"
 #include "decode-vxlan.h"
 #include "decode-pppoe.h"
+#include "source-pcap-file-helper.h"
 
 #include "output-json-stats.h"
 
@@ -209,6 +210,7 @@ static void RegisterUnittests(void)
     StreamingBufferRegisterTests();
     MacSetRegisterTests();
     FlowRateRegisterTests();
+    SourcePcapFileHelperRegisterTests();
 #ifdef OS_WIN32
     Win32SyscallRegisterTests();
 #endif

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -48,6 +48,10 @@ typedef struct PcapFileSharedVars_
 
     bool should_delete;
 
+    bool delete_no_alerts_only;
+
+    SC_ATOMIC_DECLARE(uint64_t, alerts_total);
+
     ThreadVars *tv;
     TmSlot *slot;
 
@@ -81,6 +85,7 @@ typedef struct PcapFileFileVars_
     const u_char *first_pkt_data;
     struct pcap_pkthdr *first_pkt_hdr;
     struct timeval first_pkt_ts;
+    uint64_t alerts_start;
 
     /** flex array member for the libc io read buffer. Size controlled by
      * PcapFileGlobalVars::read_buffer_size. */
@@ -120,5 +125,11 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv);
 TmEcode ValidateLinkType(int datalink, DecoderFunc *decoder);
 
 const char *PcapFileGetFilename(void);
+
+bool ShouldDeletePcapFile(PcapFileFileVars *pfv);
+
+#ifdef UNITTESTS
+void SourcePcapFileHelperRegisterTests(void);
+#endif
 
 #endif /* SURICATA_SOURCE_PCAP_FILE_HELPER_H */

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -267,6 +267,14 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         ptv->shared.should_delete = should_delete == 1;
     }
 
+    int delete_no_alerts_only = 0;
+    ptv->shared.delete_no_alerts_only = false;
+    if (SCConfGetBool("pcap-file.delete-no-alerts-only", &delete_no_alerts_only) == 1) {
+        ptv->shared.delete_no_alerts_only = delete_no_alerts_only == 1;
+    }
+
+    SC_ATOMIC_INIT(ptv->shared.alerts_total);
+
     DIR *directory = NULL;
     SCLogDebug("checking file or directory %s", (char*)initdata);
     if(PcapDetermineDirectoryOrFile((char *)initdata, &directory) == TM_ECODE_FAILED) {

--- a/src/source-pcap.h
+++ b/src/source-pcap.h
@@ -31,10 +31,15 @@ void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
 #define LIBPCAP_COPYWAIT    500
 #define LIBPCAP_PROMISC     1
 
+struct PcapFileSharedVars_;
+
 /* per packet Pcap vars */
 typedef struct PcapPacketVars_
 {
     uint32_t tenant_id;
+    /* Will be NULL for capture methods other
+     * than pcap-file.  */
+    struct PcapFileSharedVars_ *shared;
 } PcapPacketVars;
 
 /** needs to be able to contain Windows adapter id's, so

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -892,6 +892,7 @@ pcap-file:
 
   # tenant-id: none # applies in multi-tenant environment with "direct" selector
   # delete-when-done: false # applies to file and directory
+  # delete-no-alerts-only: false # if true, --pcap-file-delete will only remove pcaps that have generated no alerts
 
   # PCAP Directory Processing options
   # recursive: false


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
Allowing change the behaviour of --pcap-file-delete to only delete pcaps with no alerts via config.

Old PR: https://github.com/OISF/suricata/pull/13528
Changes: Make pipeline pass locally.
-
-
-

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
