### PR TITLE
Bugon 1484 v4

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -982,7 +982,7 @@ static void DNP3HandleUserDataResponse(
         tx->iin = *iin;
     }
 
-    BUG_ON(tx->is_request);
+    DEBUG_VALIDATE_BUG_ON(tx->is_request);
 
     if (!DNP3ReassembleApplicationLayer(input + sizeof(DNP3LinkHeader),
                 input_len - sizeof(DNP3LinkHeader), &tx->buffer, &tx->buffer_len)) {

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1090,7 +1090,7 @@ static AppLayerResult FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
         }
     }
 
-    BUG_ON((direction & ftpdata_state->direction) == 0); // should be unreachable
+    DEBUG_VALIDATE_BUG_ON((direction & ftpdata_state->direction) == 0); // should be unreachable
     if (eof) {
         ret = FileCloseFile(ftpdata_state->files, &sbcfg, NULL, 0, flags);
         ftpdata_state->state = FTPDATA_STATE_FINISHED;

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -607,7 +607,7 @@ static void HttpRangeBlockDerefContainer(HttpRangeContainerBlock *b)
 void HttpRangeFreeBlock(HttpRangeContainerBlock *b)
 {
     if (b) {
-        BUG_ON(b->container == NULL && b->files != NULL);
+        DEBUG_VALIDATE_BUG_ON(b->container == NULL && b->files != NULL);
         const StreamingBufferConfig *sbcfg = b->container ? b->container->sbcfg : NULL;
 
         HttpRangeBlockDerefContainer(b);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -340,7 +340,7 @@ static void HTPParserRegisterTests(void);
 static inline uint64_t HtpGetActiveRequestTxID(HtpState *s)
 {
     uint64_t id = HTPStateGetTxCnt(s);
-    BUG_ON(id == 0);
+    DEBUG_VALIDATE_BUG_ON(id == 0);
     return id - 1;
 }
 
@@ -1404,7 +1404,7 @@ static int HTPCallbackRequestBodyData(const htp_connp_t *connp, htp_tx_data_t *d
         uint32_t len = AppLayerHtpComputeChunkLength(tx_ud->request_body.content_len_so_far,
                 hstate->cfg->request.body_limit, stream_depth, tx_ud->tsflags,
                 (uint32_t)htp_tx_data_len(d));
-        BUG_ON(len > (uint32_t)htp_tx_data_len(d));
+        DEBUG_VALIDATE_BUG_ON(len > (uint32_t)htp_tx_data_len(d));
 
         HtpBodyAppendChunk(&tx_ud->request_body, htp_tx_data_data(d), len);
 
@@ -1525,7 +1525,7 @@ static int HTPCallbackResponseBodyData(const htp_connp_t *connp, htp_tx_data_t *
         uint32_t len = AppLayerHtpComputeChunkLength(tx_ud->response_body.content_len_so_far,
                 hstate->cfg->response.body_limit, stream_depth, tx_ud->tcflags,
                 (uint32_t)htp_tx_data_len(d));
-        BUG_ON(len > (uint32_t)htp_tx_data_len(d));
+        DEBUG_VALIDATE_BUG_ON(len > (uint32_t)htp_tx_data_len(d));
 
         HtpBodyAppendChunk(&tx_ud->response_body, htp_tx_data_data(d), len);
 

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -50,7 +50,7 @@ const char *AppProtoToString(AppProto alproto)
             break;
         default:
             if (alproto < g_alproto_max) {
-                BUG_ON(g_alproto_strings[alproto].alproto != alproto);
+                DEBUG_VALIDATE_BUG_ON(g_alproto_strings[alproto].alproto != alproto);
                 proto_name = g_alproto_strings[alproto].str;
             }
     }

--- a/src/counters.c
+++ b/src/counters.c
@@ -696,7 +696,7 @@ static int StatsOutput(ThreadVars *tv)
     sts = stats_ctx->sts;
     SCLogDebug("sts %p", sts);
     while (sts != NULL) {
-        BUG_ON(thread < 0);
+        DEBUG_VALIDATE_BUG_ON(thread < 0);
 
         SCLogDebug("Thread %d %s ctx %p", thread, sts->name, sts->ctx);
 
@@ -1104,10 +1104,14 @@ static int StatsThreadRegister(const char *thread_name, StatsPublicThreadContext
         id = HashTableLookup(stats_ctx->counters_id_hash, &t, sizeof(t));
         if (id == NULL) {
             id = SCCalloc(1, sizeof(*id));
-            BUG_ON(id == NULL);
+            DEBUG_VALIDATE_BUG_ON(id == NULL);
             id->id = counters_global_id++;
             id->string = pc->name;
-            BUG_ON(HashTableAdd(stats_ctx->counters_id_hash, id, sizeof(*id)) < 0);
+#ifdef DEBUG_VALIDATION
+            DEBUG_VALIDATE_BUG_ON(HashTableAdd(stats_ctx->counters_id_hash, id, sizeof(*id)) < 0);
+#else
+            HashTableAdd(stats_ctx->counters_id_hash, id, sizeof(*id));
+#endif
         }
         pc->gid = id->id;
         pc = pc->next;

--- a/src/decode.c
+++ b/src/decode.c
@@ -140,7 +140,7 @@ ExceptionPolicyStatsSetts flow_memcap_eps_stats = {
 PacketAlert *PacketAlertCreate(void)
 {
     PacketAlert *pa_array = SCCalloc(packet_alert_max, sizeof(PacketAlert));
-    BUG_ON(pa_array == NULL);
+    DEBUG_VALIDATE_BUG_ON(pa_array == NULL);
 
     return pa_array;
 }

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -156,7 +156,7 @@ int DetectByteMathDoMatch(DetectEngineThreadCtx *det_ctx, const DetectByteMathDa
         }
     }
 
-    BUG_ON(extbytes > len);
+    DEBUG_VALIDATE_BUG_ON(extbytes > len);
 
     ptr += extbytes;
 

--- a/src/detect-engine-frame.c
+++ b/src/detect-engine-frame.c
@@ -173,7 +173,7 @@ static void PrefilterMpmFrame(DetectEngineThreadCtx *det_ctx, const void *pectx,
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, data_len);
         }
     } else if (p->proto == IPPROTO_TCP) {
-        BUG_ON(p->flow->protoctx == NULL);
+        DEBUG_VALIDATE_BUG_ON(p->flow->protoctx == NULL);
         TcpSession *ssn = p->flow->protoctx;
         TcpStream *stream;
         if (PKT_IS_TOSERVER(p)) {
@@ -228,7 +228,7 @@ int PrefilterGenericMpmFrameRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
 bool DetectRunFrameInspectRule(ThreadVars *tv, DetectEngineThreadCtx *det_ctx, const Signature *s,
         Flow *f, Packet *p, const Frames *frames, const Frame *frame)
 {
-    BUG_ON(s->frame_inspect == NULL);
+    DEBUG_VALIDATE_BUG_ON(s->frame_inspect == NULL);
 
     SCLogDebug("inspecting rule %u against frame %p/%" PRIi64 "/%s", s->id, frame, frame->id,
             AppLayerParserGetFrameNameById(f->proto, f->alproto, frame->type));
@@ -367,7 +367,7 @@ static bool BufferSetup(struct FrameStreamData *fsd, InspectionBuffer *buffer, c
             }
 
             /* in: relative to start of input data */
-            BUG_ON(so_inspect_offset < input_offset);
+            DEBUG_VALIDATE_BUG_ON(so_inspect_offset < input_offset);
             DEBUG_VALIDATE_BUG_ON(so_inspect_offset - input_offset > UINT32_MAX);
             const uint32_t in_data_offset = (uint32_t)(so_inspect_offset - input_offset);
             data += in_data_offset;
@@ -382,7 +382,7 @@ static bool BufferSetup(struct FrameStreamData *fsd, InspectionBuffer *buffer, c
             data_len = input_len - in_data_offset - in_data_excess;
         } else {
             /* in: relative to start of input data */
-            BUG_ON(so_inspect_offset < input_offset);
+            DEBUG_VALIDATE_BUG_ON(so_inspect_offset < input_offset);
             DEBUG_VALIDATE_BUG_ON(so_inspect_offset - input_offset > UINT32_MAX);
             const uint32_t in_data_offset = (uint32_t)(so_inspect_offset - input_offset);
             data += in_data_offset;
@@ -475,7 +475,7 @@ static int FrameStreamDataInspectFunc(
     // PrintRawDataFp(stdout, data, data_len);
     // PrintRawDataFp(stdout, data, MIN(64, data_len));
 #endif
-    BUG_ON(fsd->frame->len > 0 && (int64_t)data_len > fsd->frame->len);
+    DEBUG_VALIDATE_BUG_ON(fsd->frame->len > 0 && (int64_t)data_len > fsd->frame->len);
 
     const bool match = DetectEngineContentInspection(det_ctx->de_ctx, det_ctx, s, engine->smd, p,
             p->flow, data, data_len, data_offset, buffer->flags,
@@ -578,7 +578,7 @@ int DetectEngineInspectFrameBufferGeneric(DetectEngineThreadCtx *det_ctx,
                ", list:%d, transforms:%p, s:%p, s->id:%u, engine:%p",
             p->pcap_cnt, frame->id, engine->sm_list, engine->v1.transforms, s, s->id, engine);
 
-    BUG_ON(p->flow->protoctx == NULL);
+    DEBUG_VALIDATE_BUG_ON(p->flow->protoctx == NULL);
     TcpSession *ssn = p->flow->protoctx;
     TcpStream *stream;
     if (PKT_IS_TOSERVER(p)) {

--- a/src/detect-engine-inspect-buffer.c
+++ b/src/detect-engine-inspect-buffer.c
@@ -118,7 +118,7 @@ static inline void InspectionBufferApplyTransformsInternal(DetectEngineThreadCtx
             const int id = transforms->transforms[i].transform;
             if (id == 0)
                 break;
-            BUG_ON(sigmatch_table[id].Transform == NULL);
+            DEBUG_VALIDATE_BUG_ON(sigmatch_table[id].Transform == NULL);
             sigmatch_table[id].Transform(det_ctx, buffer, transforms->transforms[i].options);
             SCLogDebug("applied transform %s", sigmatch_table[id].name);
         }

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -96,10 +96,8 @@ static void RegisterInternal(const char *name, int direction, int priority,
 
     BUG_ON(tx_min_progress >= 48);
 
-    if (PrefilterRegister == PrefilterGenericMpmRegister && GetData == NULL) {
-        // must register GetData with PrefilterGenericMpmRegister
-        abort();
-    }
+    // must register GetData with PrefilterGenericMpmRegister
+    BUG_ON(PrefilterRegister == PrefilterGenericMpmRegister && GetData == NULL);
 
     DetectBufferTypeSupportsMpm(name);
     DetectBufferTypeSupportsTransformations(name);
@@ -557,10 +555,8 @@ void DetectPktMpmRegister(const char *name, int priority,
     SCLogDebug("registering %s/%d/%p/%p", name, priority,
             PrefilterRegister, GetData);
 
-    if (PrefilterRegister == PrefilterGenericMpmPktRegister && GetData == NULL) {
-        // must register GetData with PrefilterGenericMpmRegister
-        abort();
-    }
+    // must register GetData with PrefilterGenericMpmRegister
+    BUG_ON(PrefilterRegister == PrefilterGenericMpmPktRegister && GetData == NULL);
 
     DetectBufferTypeSupportsMpm(name);
     DetectBufferTypeSupportsTransformations(name);
@@ -2156,8 +2152,7 @@ static void PrepareMpms(DetectEngineCtx *de_ctx, SigGroupHead *sh)
                 break;
             }
             default:
-                abort();
-                break;
+                BUG_ON(1);
         }
     }
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -865,11 +865,9 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
      */
     if (s->init_data->buffer_index == 0 && s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {
         uint8_t dir = 0;
-        if ((s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)) ==
-                (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT))
-            abort();
-        if ((s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)) == 0)
-            abort();
+        BUG_ON((s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)) ==
+                (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT));
+        BUG_ON((s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)) == 0);
         if (s->flags & SIG_FLAG_TOSERVER)
             dir = 0;
         else if (s->flags & SIG_FLAG_TOCLIENT)

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -4630,7 +4630,7 @@ DetectEngineCtx *DetectEngineGetByTenantId(uint32_t tenant_id)
 
 void DetectEngineDeReference(DetectEngineCtx **de_ctx)
 {
-    BUG_ON((*de_ctx)->ref_cnt == 0);
+    DEBUG_VALIDATE_BUG_ON((*de_ctx)->ref_cnt == 0);
     (*de_ctx)->ref_cnt--;
     *de_ctx = NULL;
 }

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -387,7 +387,7 @@ static InspectionBuffer *FiledataGetDataCallback(DetectEngineThreadCtx *det_ctx,
             }
         } else {
             uint64_t new_data = file_size - cur_file->content_inspected;
-            BUG_ON(new_data == 0);
+            DEBUG_VALIDATE_BUG_ON(new_data == 0);
             if (new_data < cur_file->inspect_window) {
                 uint64_t inspect_short = cur_file->inspect_window - new_data;
                 if (cur_file->content_inspected < inspect_short) {

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -218,7 +218,7 @@ static int DetectXbitTxMatch(DetectEngineThreadCtx *det_ctx, Flow *f, uint8_t fl
         void *txv, const Signature *s, const SigMatchCtx *ctx)
 {
     const DetectXbitsData *xd = (const DetectXbitsData *)ctx;
-    BUG_ON(xd == NULL);
+    DEBUG_VALIDATE_BUG_ON(xd == NULL);
 
     AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, txv);
 

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -114,7 +114,7 @@ static void CloseFile(const Packet *p, Flow *f, File *file, void *txv)
     DEBUG_VALIDATE_BUG_ON((file->flags & FILE_STORED) != 0);
 
     AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, txv);
-    BUG_ON(f->alproto == ALPROTO_SMB && txd->files_logged != 0);
+    DEBUG_VALIDATE_BUG_ON(f->alproto == ALPROTO_SMB && txd->files_logged != 0);
     txd->files_stored++;
     file->flags |= FILE_STORED;
 }

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -233,7 +233,7 @@ static int JsonFileLogger(ThreadVars *tv, void *thread_data, const Packet *p, co
     SCEnter();
     JsonFileLogThread *aft = (JsonFileLogThread *)thread_data;
 
-    BUG_ON(ff->flags & FILE_LOGGED);
+    DEBUG_VALIDATE_BUG_ON(ff->flags & FILE_LOGGED);
 
     SCLogDebug("ff %p", ff);
 

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -326,7 +326,7 @@ static int FrameJson(ThreadVars *tv, JsonFrameLogThread *aft, const Packet *p)
 {
     FrameJsonOutputCtx *json_output_ctx = aft->json_output_ctx;
 
-    BUG_ON(p->flow == NULL);
+    DEBUG_VALIDATE_BUG_ON(p->flow == NULL);
 
     FramesContainer *frames_container = AppLayerFramesGetContainer(p->flow);
     if (frames_container == NULL)
@@ -336,8 +336,8 @@ static int FrameJson(ThreadVars *tv, JsonFrameLogThread *aft, const Packet *p)
         return FrameJsonUdp(tv, aft, p, p->flow, frames_container);
     }
 
-    BUG_ON(p->proto != IPPROTO_TCP);
-    BUG_ON(p->flow->protoctx == NULL);
+    DEBUG_VALIDATE_BUG_ON(p->proto != IPPROTO_TCP);
+    DEBUG_VALIDATE_BUG_ON(p->flow->protoctx == NULL);
 
     /* TODO can we set these EOF flags once per packet? We have them in detect, tx, file, filedata,
      * etc */

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -292,7 +292,7 @@ static int LuaFileLogger(ThreadVars *tv, void *thread_data, const Packet *p, con
     if ((!(PacketIsIPv4(p))) && (!(PacketIsIPv6(p))))
         return 0;
 
-    BUG_ON(ff->flags & FILE_LOGGED);
+    DEBUG_VALIDATE_BUG_ON(ff->flags & FILE_LOGGED);
 
     SCLogDebug("ff %p", ff);
 

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -158,7 +158,7 @@ static inline void OutputTxLogFiles(ThreadVars *tv, OutputFileLoggerThreadData *
         packet_dir_ready = eof | tc_ready | tc_eof;
         opposing_tx_ready = ts_ready;
     } else {
-        abort();
+        DEBUG_VALIDATE_BUG_ON(1);
     }
 
     SCLogDebug("eof %d ts_ready %d ts_eof %d", eof, ts_ready, ts_eof);

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -159,6 +159,7 @@ static inline void OutputTxLogFiles(ThreadVars *tv, OutputFileLoggerThreadData *
         opposing_tx_ready = ts_ready;
     } else {
         DEBUG_VALIDATE_BUG_ON(1);
+        return;
     }
 
     SCLogDebug("eof %d ts_ready %d ts_eof %d", eof, ts_ready, ts_eof);

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -432,7 +432,7 @@ static TmEcode DecodePcapFile(ThreadVars *tv, Packet *p, void *data)
     SCEnter();
     DecodeThreadVars *dtv = (DecodeThreadVars *)data;
 
-    BUG_ON(PKT_IS_PSEUDOPKT(p));
+    DEBUG_VALIDATE_BUG_ON(PKT_IS_PSEUDOPKT(p));
 
     /* update counters */
     DecodeUpdatePacketCounters(tv, dtv, p);

--- a/src/stream-tcp-inline.c
+++ b/src/stream-tcp-inline.c
@@ -98,7 +98,7 @@ int StreamTcpInlineSegmentCompare(const TcpStream *stream,
 
         uint32_t range = end - seq;
         SCLogDebug("range %u", range);
-        BUG_ON(range > 65536);
+        DEBUG_VALIDATE_BUG_ON(range > 65536);
 
         if (range) {
             int r = SCMemcmp(p->payload + pkt_off, seg_data + seg_off, range);
@@ -154,7 +154,7 @@ void StreamTcpInlineSegmentReplacePacket(const TcpStream *stream,
 
     uint32_t range = end - seq;
     SCLogDebug("range %u", range);
-    BUG_ON(range > 65536);
+    DEBUG_VALIDATE_BUG_ON(range > 65536);
 
     if (range) {
         /* update the packets payload. As payload is a ptr to either

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1147,7 +1147,7 @@ static bool GetAppBuffer(const TcpStream *stream, const uint8_t **data, uint32_t
             SCLogDebug("blk at offset");
 
             StreamingBufferSBBGetData(&stream->sb, blk, data, data_len);
-            BUG_ON(blk->len != *data_len);
+            DEBUG_VALIDATE_BUG_ON(blk->len != *data_len);
 
             gap_ahead = check_for_gap && GapAhead(stream, blk);
 
@@ -1247,9 +1247,8 @@ static inline uint32_t AdjustToAcked(const Packet *p,
 
             /* see if the buffer contains unack'd data as well */
             if (app_progress <= last_ack_abs && app_progress + data_len > last_ack_abs) {
-                uint32_t check = data_len;
                 adjusted = (uint32_t)(last_ack_abs - app_progress);
-                BUG_ON(adjusted > check);
+                DEBUG_VALIDATE_BUG_ON(adjusted > data_len);
                 SCLogDebug("data len adjusted to %u to make sure only ACK'd "
                         "data is considered", adjusted);
             }
@@ -1750,7 +1749,7 @@ static int StreamReassembleRawInline(TcpSession *ssn, const Packet *p,
 
     /* run the callback */
     r = Callback(cb_data, mydata, mydata_len, mydata_offset);
-    BUG_ON(r < 0);
+    DEBUG_VALIDATE_BUG_ON(r < 0);
 
     if (return_progress) {
         *progress_out = (mydata_offset + mydata_len);
@@ -1847,9 +1846,11 @@ static int StreamReassembleRawDo(const TcpSession *ssn, const TcpStream *stream,
 
             /* see if the buffer contains unack'd data as well */
             if (progress + mydata_len > re) {
+#ifdef DEBUG_VALIDATION
                 uint32_t check = mydata_len;
+#endif
                 mydata_len = (uint32_t)(re - progress);
-                BUG_ON(check < mydata_len);
+                DEBUG_VALIDATE_BUG_ON(check < mydata_len);
                 SCLogDebug("data len adjusted to %u to make sure only ACK'd "
                         "data is considered", mydata_len);
             }
@@ -1861,7 +1862,7 @@ static int StreamReassembleRawDo(const TcpSession *ssn, const TcpStream *stream,
 
         /* we have data. */
         r = Callback(cb_data, mydata, mydata_len, mydata_offset);
-        BUG_ON(r < 0);
+        DEBUG_VALIDATE_BUG_ON(r < 0);
 
         if (mydata_offset == progress) {
             SCLogDebug("progress %"PRIu64" increasing with data len %u to %"PRIu64,

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1800,7 +1800,7 @@ static inline bool StateSynSentValidateTimestamp(TcpSession *ssn, Packet *p)
 
 static void TcpStateQueueInitFromSsnSyn(const TcpSession *ssn, TcpStateQueue *q)
 {
-    BUG_ON(ssn->state != TCP_SYN_SENT); // TODO
+    DEBUG_VALIDATE_BUG_ON(ssn->state != TCP_SYN_SENT); // TODO
     memset(q, 0, sizeof(*q));
 
     /* SYN won't use wscale yet. So window should be limited to 16 bits. */

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1501,7 +1501,7 @@ static void TmThreadDebugValidateNoMorePackets(void)
         if (ThreadStillHasPackets(tv)) {
             SCMutexUnlock(&tv_root_lock);
             TmThreadDumpThreads();
-            abort();
+            DEBUG_VALIDATE_BUG_ON(1);
         }
     }
     SCMutexUnlock(&tv_root_lock);

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -2360,7 +2360,7 @@ void TmThreadsInitThreadsTimestamp(const SCTime_t ts)
 
 SCTime_t TmThreadsGetThreadTime(const int idx)
 {
-    BUG_ON(idx == 0);
+    DEBUG_VALIDATE_BUG_ON(idx == 0);
     const int i = idx - 1;
     Thread *t = &thread_store.threads[i];
     return SC_ATOMIC_GET(t->pktts);

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -368,7 +368,7 @@ static SCError SCLogMessageGetBuffer(SCTime_t tval, bool color, SCLogOPType type
     /* no of characters_written(cw) by snprintf */
     int cw = 0;
 
-    BUG_ON(sc_log_module_initialized != 1);
+    DEBUG_VALIDATE_BUG_ON(sc_log_module_initialized != 1);
 
     /* make a copy of the format string as it will be modified below */
     const int add_M = strstr(log_format, "%M") == NULL;

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -214,7 +214,7 @@ static int SCLogFileWriteNoLock(const char *buffer, int buffer_len, LogFileCtx *
 {
     int ret = 0;
 
-    BUG_ON(log_ctx->is_sock);
+    DEBUG_VALIDATE_BUG_ON(log_ctx->is_sock);
 
     /* Check for rotation. */
     if (log_ctx->rotation_flag) {

--- a/src/util-lua-sandbox.c
+++ b/src/util-lua-sandbox.c
@@ -58,7 +58,7 @@ static void *LuaAlloc(void *ud, void *ptr, size_t osize, size_t nsize)
             /* This happens, ignore. */
             return NULL;
         }
-        BUG_ON(osize > ctx->alloc_bytes);
+        DEBUG_VALIDATE_BUG_ON(osize > ctx->alloc_bytes);
         SCFree(ptr);
         ctx->alloc_bytes -= osize;
         return NULL;
@@ -82,8 +82,8 @@ static void *LuaAlloc(void *ud, void *ptr, size_t osize, size_t nsize)
 
         void *nptr = SCRealloc(ptr, nsize);
         if (nptr != NULL) {
-            BUG_ON((ssize_t)ctx->alloc_bytes + diff < 0);
-            BUG_ON(osize > ctx->alloc_bytes);
+            DEBUG_VALIDATE_BUG_ON((ssize_t)ctx->alloc_bytes + diff < 0);
+            DEBUG_VALIDATE_BUG_ON(osize > ctx->alloc_bytes);
             ctx->alloc_bytes += diff;
         }
         return nptr;

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -1049,8 +1049,8 @@ uint32_t SCHSSearch(const MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
 
     /* scratch should have been cloned from g_scratch_proto at thread init. */
     hs_scratch_t *scratch = hs_thread_ctx->scratch;
-    BUG_ON(pd->hs_db == NULL);
-    BUG_ON(scratch == NULL);
+    DEBUG_VALIDATE_BUG_ON(pd->hs_db == NULL);
+    DEBUG_VALIDATE_BUG_ON(scratch == NULL);
 
     hs_error_t err = hs_scan(pd->hs_db, (const char *)buf, buflen, 0, scratch,
                              SCHSMatchEvent, &cctx);

--- a/src/util-pool-thread.c
+++ b/src/util-pool-thread.c
@@ -34,6 +34,7 @@
 #include "util-pool-thread.h"
 #include "util-unittest.h"
 #include "util-debug.h"
+#include "util-validate.h"
 
 /**
  *  \brief per thread Pool, initialization function
@@ -206,21 +207,21 @@ void PoolThreadReturn(PoolThread *pt, void *data)
 
 void PoolThreadLock(PoolThread *pt, PoolThreadId id)
 {
-    BUG_ON(pt == NULL || id >= pt->size);
+    DEBUG_VALIDATE_BUG_ON(pt == NULL || id >= pt->size);
     PoolThreadElement *e = &pt->array[id];
     SCMutexLock(&e->lock);
 }
 
 void PoolThreadReturnRaw(PoolThread *pt, PoolThreadId id, void *data)
 {
-    BUG_ON(pt == NULL || id >= pt->size);
+    DEBUG_VALIDATE_BUG_ON(pt == NULL || id >= pt->size);
     PoolThreadElement *e = &pt->array[id];
     PoolReturn(e->pool, data);
 }
 
 void PoolThreadUnlock(PoolThread *pt, PoolThreadId id)
 {
-    BUG_ON(pt == NULL || id >= pt->size);
+    DEBUG_VALIDATE_BUG_ON(pt == NULL || id >= pt->size);
     PoolThreadElement *e = &pt->array[id];
     SCMutexUnlock(&e->lock);
 }

--- a/src/util-radix-tree-common.h
+++ b/src/util-radix-tree-common.h
@@ -215,7 +215,7 @@ static int NetmaskCount(RADIX_NODE_TYPE *node)
 static int ContainNetmaskAndSetUserData(
         RADIX_NODE_TYPE *node, uint8_t netmask, bool exact_match, void **user_data_result)
 {
-    BUG_ON(!node);
+    DEBUG_VALIDATE_BUG_ON(!node);
 
     RadixUserData *user_data = node->user_data;
     /* Check if we have a match for an exact ip.  An exact ip as in not a proper

--- a/src/util-radix6-tree.c
+++ b/src/util-radix6-tree.c
@@ -240,7 +240,7 @@ static void SCRadix6ValidateIPv6Key(uint8_t *key, const uint8_t netmask)
         PrintInet(AF_INET6, (void *)&address, ostr, sizeof(ostr));
         PrintInet(AF_INET6, (void *)&masked, nstr, sizeof(nstr));
         SCLogNotice("input %s/%u != expected %s/%u", ostr, netmask, nstr, netmask);
-        abort();
+        DEBUG_VALIDATE_BUG_ON(1);
     }
 }
 #endif

--- a/src/util-spm-hs.c
+++ b/src/util-spm-hs.c
@@ -28,6 +28,7 @@
 #include "util-spm.h"
 #include "util-spm-hs.h"
 #include "util-debug.h"
+#include "util-validate.h"
 
 #ifdef BUILD_HYPERSCAN
 
@@ -41,7 +42,7 @@ static int MatchEvent(unsigned int id, unsigned long long from,
                       unsigned long long to, unsigned int flags, void *context)
 {
     uint64_t *match_offset = context;
-    BUG_ON(*match_offset != UINT64_MAX);
+    DEBUG_VALIDATE_BUG_ON(*match_offset != UINT64_MAX);
     *match_offset = to;
     return 1; /* Terminate matching. */
 }
@@ -158,7 +159,7 @@ static uint8_t *HSScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
         return NULL;
     }
 
-    BUG_ON(match_offset < sctx->needle_len);
+    DEBUG_VALIDATE_BUG_ON(match_offset < sctx->needle_len);
 
     /* Note: existing API returns non-const ptr */
     return (uint8_t *)haystack + (match_offset - sctx->needle_len);

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -600,7 +600,11 @@ static THashData *THashDataGetNew(THashTableContext *ctx, void *data)
     }
 
     // setup the data
-    BUG_ON(ctx->config.DataSet(h->data, data) != 0);
+#ifdef DEBUG_VALIDATION
+    DEBUG_VALIDATE_BUG_ON(ctx->config.DataSet(h->data, data) != 0);
+#else
+    ctx->config.DataSet(h->data, data);
+#endif
     (void) SC_ATOMIC_ADD(ctx->counter, 1);
     SCMutexLock(&h->m);
     return h;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/1484

Describe changes:
- remove BUG_ON in packet path
- remove direct `abort` in favor of macros

Methodology : run SV with modified suricata with commit https://github.com/catenacyber/suricata/commit/a8b56a20eae90837c3836f5799294dda99044a66

gather all BUG_ON files and lines with `grep -r "lol BUG" tests/ | cut -d: -f2- | sort | uniq`

Then run some
```python
f = open("lol2.txt")
for l in f.readlines():
    # sed -i -e '343s/BUG_ON/DEBUG_VALIDATE_BUG_ON/' src/app-layer-htp.c
    print("sed -i -e '%ss/BUG_ON/DEBUG_VALIDATE_BUG_ON/' src/%s" % (l.split()[1], l.split()[0]))
```

#13537 with clean history