### PR TITLE
doc/reload: Expand rule-reload discussion

### DIFF
--- a/doc/userguide/rule-management/rule-reload.rst
+++ b/doc/userguide/rule-management/rule-reload.rst
@@ -1,32 +1,83 @@
 Rule Reloads
 ============
 
-Suricata can reload the rules without restarting. This way, there
-is minimal service disruption.
+Suricata was designed to reload rules while it is actively processing
+network traffic to minimize service disruption.
 
-This works by sending Suricata a signal or by using the unix socket. When Suricata is told to reload the rules these are the basic steps it takes:
+Suricata must be administratively directed to reload rules while it is running; there
+are two ways to cause this:
 
-* Load new config to update rule variables and values.
-* Load new rules
-* Construct new detection engine
-* Swap old and new detection engines
-* Make sure all threads are updated
-* Free old detection engine
+* Via a UNIX domain socket with the command ``reload-rules`` or ``ruleset-reload-nonblocking``
+* Upon receipt of the ``USR2`` signal
 
-Suricata will continue to process packets normally during this process. Keep in mind though, that the system should have enough memory for both detection engines.
-
-Signal::
+Reload Triggers
+~~~~~~~~~~~~~~~
+There are multiple ways to trigger a rule reload. Note that the steps using ``suricatasc``
+can be done using the suricata`
+Via process signal
+^^^^^^^^^^^^^^^^^^
 
   kill -USR2 $(pidof suricata)
 
-There are two methods available when using the Unix socket.
+Via the UNIX domain socket.
 
-Blocking reload ::
+Blocking reload
+^^^^^^^^^^^^^^^
 
   suricatasc -c reload-rules
 
-Non blocking reload ::
+Non-blocking reload
+^^^^^^^^^^^^^^^^^^^
 
   suricatasc -c ruleset-reload-nonblocking
 
-It is also possible to get information about the last reload via dedicated commands. See :ref:`standard-unix-socket-commands` for more information.
+It is also possible to get information about the last reload via dedicated commands.
+See :ref:`standard-unix-socket-commands` for more information.
+
+Resources Reloaded
+~~~~~~~~~~~~~~~~~~
+
+There are two types of resources that are reloaded during a rule reload.
+
+* Rule-related configuration:
+
+  * Suricata's configuration file(s): ``suricata.yaml`` and any specified with the command-line
+    options ``--include <config-file.yaml>``. Only rule-related information is reloaded.
+
+    * Rule variables: items in the ``vars`` section.
+    * Rule files from the ``rule-files`` section (if the ``-S`` command line option was not used)
+
+  * Ancillary rule-related configuration files: ``classification.config``, ``reference.config``
+    and ``threshold.config``
+
+When to reload rules
+~~~~~~~~~~~~~~~~~~~~
+
+Rule reloads are used in situations when:
+
+* Rules have been changed since the last reload. Vendors often add rules frequently and
+  sometimes update existing rules. Rules should be reloaded according to a security policy
+  that includes Suricata rule and configuration settings.
+* Rule variables have been changed. Rule reloads will use rule variables from the Suricata
+  configuration file.  When updating these, reload the rules in order to the updated rule
+  variables take effect.
+* Ancillary rule-related configuration files are updated.
+
+Advanced: Rule Reload Steps
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When reloading rules, Suricata executes the following steps to ensure a safe
+and consistent update:
+
+* The main Suricata configuration is reloaded to update rule variables and values,
+  including the rule related files ``classification.config``, ``reference.config`` and
+  ``theshold.config``.
+* All rule files are reloaded with new rule variables applied.
+* A new detection engine is created for the updated rules.
+* The previous and newly created detection engines are swapped.
+* Ensure all threads are updated.
+* Free old detection engine and associated resources.
+
+Suricata will continue to process packets during the update process. Note that additional system
+memory is used during the reload process as a new detection engine and the reloaded rules are
+associated with it.


### PR DESCRIPTION
Continuation of #13522 

Clarify the resources involved in a rule reload.

Issue: 5078

Link to ticket: https://redmine.openinfosecfoundation.org/issues/5078

Describe changes:
- Expand the discussion with more context and identify resources.

Updates:
- Address review feedback from #13522 

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
