### PR TITLE
pcap/file: add delete-non-alerts-only option to keep alerted pcaps

### DIFF
--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -85,6 +85,10 @@
    continuously feed files to a directory and have them cleaned up when done. If
    this option is not set, pcap files will not be deleted after processing.
 
+   The behavior of this option can be further controlled using the
+   ``pcap-file.delete-non-alerts-only`` configuration option in ``suricata.yaml``.
+   When set to ``true``, only pcap files that have generated no alerts will be deleted.
+
 .. _cmdline-option-pcap-file-buffer-size:
 
 .. option:: --pcap-file-buffer-size <value>

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -38,6 +38,9 @@
 
 #include "action-globals.h"
 
+#include "util-atomic.h"
+#include "source-pcap-file-helper.h"
+
 /** tag signature we use for tag alerts */
 static Signature g_tag_signature;
 /** tag packet alert structure for tag alerts */
@@ -590,6 +593,10 @@ void PacketAlertFinalize(const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *d
     if (!(p->flags & PKT_PSEUDO_STREAM_END))
         TagHandlePacket(de_ctx, det_ctx, p);
 
+    if (p->alerts.cnt > 0) {
+        (void)SC_ATOMIC_ADD(g_pcap_file_alerts, p->alerts.cnt);
+    }
+
     /* Set flag on flow to indicate that it has alerts */
     if (p->flow != NULL && p->alerts.cnt > 0) {
         if (!FlowHasAlerts(p->flow)) {
@@ -597,6 +604,8 @@ void PacketAlertFinalize(const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *d
             p->flags |= PKT_FIRST_ALERTS;
         }
     }
+
+    SCReturn;
 }
 
 #ifdef UNITTESTS

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -32,7 +32,7 @@ void AlertQueueInit(DetectEngineThreadCtx *det_ctx);
 void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
 void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
         uint8_t alert_flags);
-void PacketAlertFinalize(const DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
+void PacketAlertFinalize(const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p);
 #ifdef UNITTESTS
 int PacketAlertCheck(Packet *, uint32_t);
 #endif

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -114,6 +114,7 @@
 #include "decode-vntag.h"
 #include "decode-vxlan.h"
 #include "decode-pppoe.h"
+#include "source-pcap-file-helper.h"
 
 #include "output-json-stats.h"
 
@@ -209,6 +210,7 @@ static void RegisterUnittests(void)
     StreamingBufferRegisterTests();
     MacSetRegisterTests();
     FlowRateRegisterTests();
+    SourcePcapFileHelperRegisterTests();
 #ifdef OS_WIN32
     Win32SyscallRegisterTests();
 #endif

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -23,6 +23,7 @@
 
 #include "suricata-common.h"
 #include "tm-threads.h"
+#include "util-atomic.h"
 
 #ifndef SURICATA_SOURCE_PCAP_FILE_HELPER_H
 #define SURICATA_SOURCE_PCAP_FILE_HELPER_H
@@ -47,6 +48,8 @@ typedef struct PcapFileSharedVars_
     struct timespec last_processed;
 
     bool should_delete;
+
+    bool delete_non_alerts_only;
 
     ThreadVars *tv;
     TmSlot *slot;
@@ -120,5 +123,13 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv);
 TmEcode ValidateLinkType(int datalink, DecoderFunc *decoder);
 
 const char *PcapFileGetFilename(void);
+
+bool ShouldDeletePcapFile(PcapFileFileVars *pfv);
+
+extern SC_ATOMIC_DECLARE(uint64_t, g_pcap_file_alerts);
+
+#ifdef UNITTESTS
+void SourcePcapFileHelperRegisterTests(void);
+#endif
 
 #endif /* SURICATA_SOURCE_PCAP_FILE_HELPER_H */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -892,6 +892,7 @@ pcap-file:
 
   # tenant-id: none # applies in multi-tenant environment with "direct" selector
   # delete-when-done: false # applies to file and directory
+  # delete-non-alerts-only: false # if true, --pcap-file-delete will only remove pcaps that have generated no alerts
 
   # PCAP Directory Processing options
   # recursive: false


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket:  https://redmine.openinfosecfoundation.org/projects/suricata/issues

Describe changes:
Allowing change the behaviour of --pcap-file-delete to only delete pcaps with no alerts via config.

Previous PR: https://github.com/OISF/suricata/pull/13548
Changes:
- Simplify the alert-counting mechanism:
* Removed the pfv pointer and refcnt/alerts_total fields from PcapPacketVars and PcapFileFileVars.
* Eliminated all code that incremented/decremented those fields (packet-pool, callback, etc.).
* Added one global atomic counter g_pcap_file_alerts, reset once at the start of each new pcap file and incremented whenever alerts are generated.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=https://github.com/oferda4/suricata-verify
SV_BRANCH=feat/pcap-delete-no-alerts
SU_REPO=
SU_BRANCH=