### PR TITLE
detect-file-hash: drop redundant rule_file NULL check

### DIFF
--- a/src/detect-file-hash-common.c
+++ b/src/detect-file-hash-common.c
@@ -230,6 +230,8 @@ static DetectFileHashData *DetectFileHashParse (const DetectEngineCtx *de_ctx,
         goto error;
     }
 
+    /* de_ctx->rule_file is already set by the rule loader before this
+     * function is called, so it is guaranteed to be non-NULL here. */
     rule_filename = SCStrdup(de_ctx->rule_file);
     if (rule_filename == NULL) {
         goto error;
@@ -239,16 +241,14 @@ static DetectFileHashData *DetectFileHashParse (const DetectEngineCtx *de_ctx,
     fp = fopen(filename, "r");
     if (fp == NULL) {
 #ifdef HAVE_LIBGEN_H
-        if (de_ctx->rule_file != NULL) {
-            char *dir = dirname(rule_filename);
-            if (dir != NULL) {
-                char path[PATH_MAX];
-                snprintf(path, sizeof(path), "%s/%s", dir, str);
-                fp = fopen(path, "r");
-                if (fp == NULL) {
-                    SCLogError("opening hash file %s: %s", path, strerror(errno));
-                    goto error;
-                }
+        char *dir = dirname(rule_filename);
+        if (dir != NULL) {
+            char path[PATH_MAX];
+            snprintf(path, sizeof(path), "%s/%s", dir, str);
+            fp = fopen(path, "r");
+            if (fp == NULL) {
+                SCLogError("opening hash file %s: %s", path, strerror(errno));
+                goto error;
             }
         }
         if (fp == NULL) {


### PR DESCRIPTION
de_ctx->rule_file is never NULL inside DetectFileHashParse(); add a comment stating this fact and remove the superfluous NULL guard.

No functional change – the patch only clarifies the code and trims a few lines of dead code.

Bug 7769

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7769
