### PR TITLE
detect-bytetest: remove meaningless NULL check on data_offset

### DIFF
--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -468,12 +468,6 @@ static DetectBytetestData *DetectBytetestParse(
         memmove(data_offset, str_ptr, end_ptr - str_ptr);
         data_offset[end_ptr-str_ptr] = '\0';
         if (data_offset[0] != '-' && isalpha((unsigned char)data_offset[0])) {
-            if (data_offset == NULL) {
-                SCLogError("byte_test supplied with "
-                           "var name for offset.  \"offset\" argument supplied to "
-                           "this function has to be non-NULL");
-                goto error;
-            }
             *offset = SCStrdup(data_offset);
             if (*offset == NULL)
                 goto error;


### PR DESCRIPTION
The condition data_offset == NULL can never be true: data_offset has already been validated as non-NULL a few lines earlier. The guard seems to have been intended for the offset argument, yet throughout the codebase offset is never passed as NULL. (In the unit tests, offset is NULL, but those tests pass the value parameter as NULL, which causes the function to return before offset is dereferenced.)

Remove the pointless check to simplify control flow and silence static-analysis warnings.

No functional change.

Bug 7767

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7767