### PR TITLE
rust/htp: follow suricata versioning - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2537,6 +2537,7 @@ AC_CONFIG_FILES(Makefile src/Makefile rust/Makefile rust/Cargo.lock rust/Cargo.t
 AC_CONFIG_FILES(rust/sys/Makefile rust/sys/Cargo.toml)
 AC_CONFIG_FILES(rust/suricatactl/Makefile rust/suricatactl/Cargo.toml)
 AC_CONFIG_FILES(rust/suricatasc/Makefile rust/suricatasc/Cargo.toml)
+AC_CONFIG_FILES(rust/htp/Makefile rust/htp/Cargo.toml)
 AC_CONFIG_FILES(qa/Makefile qa/coccinelle/Makefile)
 AC_CONFIG_FILES(rules/Makefile doc/Makefile doc/userguide/Makefile)
 AC_CONFIG_FILES(suricata.yaml etc/Makefile etc/suricata.logrotate etc/suricata.service)

--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "suricata-htp"
-version = "2.0.0"
+version = "8.0.0-dev"
 dependencies = [
  "base64",
  "brotli",

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -87,7 +87,7 @@ suricata-sys = { path = "./sys", version = "@PACKAGE_VERSION@" }
 
 suricata-lua-sys = { version = "5.4.8002" }
 
-htp = { package = "suricata-htp", path = "./htp", version = "2.0.0" }
+htp = { package = "suricata-htp", path = "./htp", version = "@PACKAGE_VERSION@" }
 
 [dev-dependencies]
 test-case = "~3.3.1"

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,4 +1,5 @@
-SUBDIRS =	sys \
+SUBDIRS =	htp \
+		sys \
 		suricatasc \
 		suricatactl
 
@@ -13,8 +14,7 @@ EXTRA_DIST =	src derive htp \
 		sys \
 		sys/Cargo.toml \
 		suricatasc \
-		suricatactl \
-		htp/Cargo.toml
+		suricatactl
 
 if !DEBUG
 RELEASE = --release

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -3,18 +3,21 @@ SUBDIRS =	htp \
 		suricatasc \
 		suricatactl
 
-EXTRA_DIST =	src derive htp \
-		.cargo/config.toml.in \
+EXTRA_DIST =	.cargo/config.toml.in \
+		Cargo.lock \
+		Cargo.toml \
 		cbindgen.toml \
-		dist/rust-bindings.h \
-		dist/htp/htp_rs.h \
-		vendor \
-		Cargo.toml Cargo.lock \
+		derive \
 		derive/Cargo.toml \
+		dist/htp/htp_rs.h \
+		dist/rust-bindings.h \
+		htp \
+		src \
+		suricatactl \
+		suricatasc \
 		sys \
 		sys/Cargo.toml \
-		suricatasc \
-		suricatactl
+		vendor
 
 if !DEBUG
 RELEASE = --release

--- a/rust/htp/.gitignore
+++ b/rust/htp/.gitignore
@@ -1,1 +1,0 @@
-!Cargo.toml

--- a/rust/htp/Cargo.toml.in
+++ b/rust/htp/Cargo.toml.in
@@ -1,6 +1,6 @@
 [package]
 name = "suricata-htp"
-version = "2.0.0"
+version = "@PACKAGE_VERSION@"
 edition = "2021"
 autobins = false
 license-file = "LICENSE"

--- a/rust/htp/Makefile.am
+++ b/rust/htp/Makefile.am
@@ -1,0 +1,3 @@
+EXTRA_DIST =	Cargo.toml
+
+all-local: Cargo.toml


### PR DESCRIPTION
Have htp follow Suricata versioning so we don't have to worry about
version updates as it changes.

For example, between 8.0.0-beta1 and 8.0.0-rc1 there were changes to
the htp, however the version stayed at 2.0.0 making it impossible to
publish these changes to crates.io.
