### PR TITLE
dpdk: auto threads assign one too many threads v1

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -447,16 +447,16 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
             SCReturnInt(-ERANGE);
         }
 
-        if (remaining_auto_cpus > 0) {
-            iconf->threads++;
-            remaining_auto_cpus--;
-        } else if (remaining_auto_cpus == UINT16_MAX) {
+        if (remaining_auto_cpus == UINT16_MAX) {
             // first time auto-assignment
             remaining_auto_cpus = sched_cpus % live_dev_count;
             if (remaining_auto_cpus > 0) {
                 iconf->threads++;
                 remaining_auto_cpus--;
             }
+        } else if (remaining_auto_cpus > 0) {
+            iconf->threads++;
+            remaining_auto_cpus--;
         }
         SCLogConfig("%s: auto-assigned %u threads", iconf->iface, iconf->threads);
         SCReturnInt(0);


### PR DESCRIPTION
Configuration option `threads: auto` in DPDK's interface node overassigns available threads to the interface.
Commit 4dfd44d3 changed the signedness of the remaining threads counter, which caused surpass of the counter initialization.
The if-clause is switched to first initialize and then use the counter.

Redmine Ticket: [7798](https://redmine.openinfosecfoundation.org/issues/7798) - https://redmine.openinfosecfoundation.org/issues/7798