### PR TITLE
decode: ip-in-ip & related 70x backports - v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4222,10 +4222,16 @@
                         "ipv4": {
                             "type": "integer"
                         },
+                        "ipv4_in_ipv4": {
+                            "type": "integer"
+                        },
                         "ipv4_in_ipv6": {
                             "type": "integer"
                         },
                         "ipv6": {
+                            "type": "integer"
+                        },
+                        "ipv6_in_ipv4": {
                             "type": "integer"
                         },
                         "ipv6_in_ipv6": {

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -609,6 +609,7 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 if (tp != NULL) {
                     PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
                     PacketEnqueueNoLock(&tv->decode_pq, tp);
+                    StatsIncr(tv, dtv->counter_ipv4inipv4);
                 }
             }
             FlowSetupPacket(p);
@@ -623,6 +624,7 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 if (tp != NULL) {
                     PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
                     PacketEnqueueNoLock(&tv->decode_pq,tp);
+                    StatsIncr(tv, dtv->counter_ipv6inipv4);
                 }
                 FlowSetupPacket(p);
                 break;

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -38,6 +38,21 @@
 #include "flow.h"
 #include "util-print.h"
 
+static bool g_ipv4_ipinip_enabled = false;
+
+void DecodeIPV4IpInIpConfig(void)
+{
+    int enabled = 0;
+
+    if (ConfGetBool("decoder.ipv4.enabled", &enabled) == 1) {
+        if (enabled) {
+            g_ipv4_ipinip_enabled = true;
+        } else {
+            g_ipv4_ipinip_enabled = false;
+        }
+    }
+}
+
 /* Generic validation
  *
  * [--type--][--len---]
@@ -585,7 +600,20 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         case IPPROTO_ESP:
             DecodeESP(tv, dtv, p, pkt + IPV4_GET_HLEN(p), IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p));
             break;
-
+        case IPPROTO_IPIP: {
+            /* optional in Suricata 7 as it wasn't always present */
+            if (g_ipv4_ipinip_enabled) {
+                /* spawn off tunnel packet */
+                Packet *tp = PacketTunnelPktSetup(tv, dtv, p, pkt + IPV4_GET_HLEN(p),
+                        IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p), DECODE_TUNNEL_IPV4);
+                if (tp != NULL) {
+                    PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
+                    PacketEnqueueNoLock(&tv->decode_pq, tp);
+                }
+            }
+            FlowSetupPacket(p);
+            break;
+        }
         case IPPROTO_IPV6:
             {
                 /* spawn off tunnel packet */

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -176,6 +176,7 @@ typedef struct IPV4Vars_
     uint16_t opts_set;
 } IPV4Vars;
 
+void DecodeIPV4IpInIpConfig(void);
 
 void DecodeIPV4RegisterTests(void);
 

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -34,6 +34,7 @@
 #include "decode-ipv6.h"
 #include "decode.h"
 #include "defrag.h"
+#include "flow-hash.h"
 #include "util-print.h"
 #include "util-validate.h"
 
@@ -54,8 +55,8 @@ static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, c
             PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV6);
             PacketEnqueueNoLock(&tv->decode_pq,tp);
             StatsIncr(tv, dtv->counter_ipv4inipv6);
-            return;
         }
+        FlowSetupPacket(p);
     } else {
         ENGINE_SET_EVENT(p, IPV4_IN_IPV6_WRONG_IP_VER);
     }
@@ -81,6 +82,7 @@ static int DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             PacketEnqueueNoLock(&tv->decode_pq,tp);
             StatsIncr(tv, dtv->counter_ipv6inipv6);
         }
+        FlowSetupPacket(p);
     } else {
         ENGINE_SET_EVENT(p, IPV6_IN_IPV6_WRONG_IP_VER);
     }

--- a/src/decode.c
+++ b/src/decode.c
@@ -559,6 +559,8 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_vntag = StatsRegisterCounter("decoder.vntag", tv);
     dtv->counter_ieee8021ah = StatsRegisterCounter("decoder.ieee8021ah", tv);
     dtv->counter_teredo = StatsRegisterCounter("decoder.teredo", tv);
+    dtv->counter_ipv4inipv4 = StatsRegisterCounter("decoder.ipv4_in_ipv4", tv);
+    dtv->counter_ipv6inipv4 = StatsRegisterCounter("decoder.ipv6_in_ipv4", tv);
     dtv->counter_ipv4inipv6 = StatsRegisterCounter("decoder.ipv4_in_ipv6", tv);
     dtv->counter_ipv6inipv6 = StatsRegisterCounter("decoder.ipv6_in_ipv6", tv);
     dtv->counter_mpls = StatsRegisterCounter("decoder.mpls", tv);

--- a/src/decode.c
+++ b/src/decode.c
@@ -918,6 +918,7 @@ void CaptureStatsSetup(ThreadVars *tv)
 
 void DecodeGlobalConfig(void)
 {
+    DecodeIPV4IpInIpConfig();
     DecodeTeredoConfig();
     DecodeGeneveConfig();
     DecodeVXLANConfig();

--- a/src/decode.h
+++ b/src/decode.h
@@ -713,6 +713,8 @@ typedef struct DecodeThreadVars_
     uint16_t counter_pppoe;
     uint16_t counter_teredo;
     uint16_t counter_mpls;
+    uint16_t counter_ipv4inipv4;
+    uint16_t counter_ipv6inipv4;
     uint16_t counter_ipv4inipv6;
     uint16_t counter_ipv6inipv6;
     uint16_t counter_erspan;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1672,6 +1672,11 @@ decoder:
   # maximum number of decoder layers for a packet
   # max-layers: 16
 
+  # IP-in-IP tunneling for ipv4 over ipv4 handling
+  # disabled by default
+  # ipv4:
+  #   enabled: true
+
 ##
 ## Performance tuning and profiling
 ##


### PR DESCRIPTION
Previous PR: #13441

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7726
https://redmine.openinfosecfoundation.org/issues/7725
https://redmine.openinfosecfoundation.org/issues/7752
https://redmine.openinfosecfoundation.org/issues/7758

Describe changes:
- also bring backports from https://github.com/OISF/suricata/pull/13471 (one of the changes couldn't be a clean cherry-pick, so the commit message is different)
- made the ip-in-ip for ipv4 optional -- not sure if the chosen approach is good

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2571
