### PR TITLE
detect/var: Restrict var usage to single buffer 

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -176,6 +176,12 @@ Major changes
   content that matched just because it fell in the inspection chunk without wholly
   belonging to any one request/response may not match any longer.
 
+- When using the `byte` keywords like ``byte_extract``, ``byte_math``, etc with
+  variables and variable usage is with a different buffer than the buffer used
+  to create the variable, a warning is printed and the rule is loaded. Use the
+  command line option ``--strict-rule-keywords`` to produce an error message and
+  to prevent the rule from loading.
+
 Removals
 ~~~~~~~~
 - The ssh keywords ``ssh.protoversion`` and ``ssh.softwareversion`` have been removed.

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -372,7 +372,7 @@ static void DetectByteExtractFree(DetectEngineCtx *de_ctx, void *ptr)
  *
  * \retval A pointer to the SigMatch if found, otherwise NULL.
  */
-SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, int sm_list, const Signature *s)
+SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, int *found_list, const Signature *s)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
         SigMatch *sm = s->init_data->buffers[x].head;
@@ -380,6 +380,7 @@ SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, int sm_list, const Sig
             if (sm->type == DETECT_BYTE_EXTRACT) {
                 const SCDetectByteExtractData *bed = (const SCDetectByteExtractData *)sm->ctx;
                 if (strcmp(bed->name, arg) == 0) {
+                    *found_list = s->init_data->buffers[x].id;
                     return sm;
                 }
             }
@@ -391,9 +392,10 @@ SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, int sm_list, const Sig
         SigMatch *sm = s->init_data->smlists[list];
         while (sm != NULL) {
             // Make sure that the linked buffers ore on the same list
-            if (sm->type == DETECT_BYTE_EXTRACT && (sm_list == -1 || sm_list == list)) {
+            if (sm->type == DETECT_BYTE_EXTRACT) {
                 const SCDetectByteExtractData *bed = (const SCDetectByteExtractData *)sm->ctx;
                 if (strcmp(bed->name, arg) == 0) {
+                    *found_list = list;
                     return sm;
                 }
             }

--- a/src/detect-byte-extract.h
+++ b/src/detect-byte-extract.h
@@ -26,7 +26,7 @@
 
 void DetectByteExtractRegister(void);
 
-SigMatch *DetectByteExtractRetrieveSMVar(const char *, int sm_list, const Signature *);
+SigMatch *DetectByteExtractRetrieveSMVar(const char *, int *found_list, const Signature *);
 int DetectByteExtractDoMatch(DetectEngineThreadCtx *, const SigMatchData *, const Signature *,
         const uint8_t *, uint32_t, uint64_t *, uint8_t);
 

--- a/src/detect-byte.h
+++ b/src/detect-byte.h
@@ -27,6 +27,7 @@
 
 typedef uint8_t DetectByteIndexType;
 
-bool DetectByteRetrieveSMVar(const char *, const Signature *, int sm_list, DetectByteIndexType *);
+bool DetectByteRetrieveSMVar(
+        const char *, const Signature *, bool strict, int sm_list, DetectByteIndexType *);
 
 #endif /* SURICATA_DETECT_BYTE_H */

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -544,7 +544,8 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (nbytes != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(nbytes, s, sm_list, &index)) {
+        if (!DetectByteRetrieveSMVar(
+                    nbytes, s, SigMatchStrictEnabled(DETECT_BYTEJUMP), sm_list, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in byte_jump - %s",
                     nbytes);
@@ -557,7 +558,8 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (offset != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(offset, s, sm_list, &index)) {
+        if (!DetectByteRetrieveSMVar(
+                    offset, s, SigMatchStrictEnabled(DETECT_BYTEJUMP), sm_list, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in byte_jump - %s",
                     offset);

--- a/src/detect-bytemath.h
+++ b/src/detect-bytemath.h
@@ -26,7 +26,7 @@
 
 void DetectBytemathRegister(void);
 
-SigMatch *DetectByteMathRetrieveSMVar(const char *, int sm_list, const Signature *);
+SigMatch *DetectByteMathRetrieveSMVar(const char *, int *found_list, const Signature *);
 int DetectByteMathDoMatch(DetectEngineThreadCtx *, const DetectByteMathData *, const Signature *,
         const uint8_t *, const uint32_t, uint8_t, uint64_t, uint64_t *, uint8_t);
 

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -646,7 +646,8 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (value != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(value, s, sm_list, &index)) {
+        if (!DetectByteRetrieveSMVar(
+                    value, s, SigMatchStrictEnabled(DETECT_BYTETEST), sm_list, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in byte_test - %s",
                     value);
@@ -660,10 +661,11 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (offset != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(offset, s, sm_list, &index)) {
+        if (!DetectByteRetrieveSMVar(
+                    offset, s, SigMatchStrictEnabled(DETECT_BYTETEST), sm_list, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in byte_test - %s",
-                    offset);
+                    value);
             goto error;
         }
         data->offset = index;
@@ -674,7 +676,8 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     if (nbytes != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(nbytes, s, sm_list, &index)) {
+        if (!DetectByteRetrieveSMVar(
+                    nbytes, s, SigMatchStrictEnabled(DETECT_BYTETEST), sm_list, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in byte_test - %s",
                     nbytes);

--- a/src/detect-depth.c
+++ b/src/detect-depth.c
@@ -106,7 +106,7 @@ static int DetectDepthSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(str, s, -1, &index)) {
+        if (!DetectByteRetrieveSMVar(str, s, false, -1, &index)) {
             SCLogError("unknown byte_ keyword var "
                        "seen in depth - %s.",
                     str);

--- a/src/detect-distance.c
+++ b/src/detect-distance.c
@@ -108,7 +108,7 @@ static int DetectDistanceSetup (DetectEngineCtx *de_ctx, Signature *s,
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(str, s, -1, &index)) {
+        if (!DetectByteRetrieveSMVar(str, s, false, -1, &index)) {
             SCLogError("unknown byte_ keyword var "
                        "seen in distance - %s",
                     str);

--- a/src/detect-isdataat.c
+++ b/src/detect-isdataat.c
@@ -347,7 +347,7 @@ int DetectIsdataatSetup (DetectEngineCtx *de_ctx, Signature *s, const char *isda
 
     if (offset != NULL) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(offset, s, -1, &index)) {
+        if (!DetectByteRetrieveSMVar(offset, s, false, -1, &index)) {
             SCLogError("Unknown byte_extract var "
                        "seen in isdataat - %s\n",
                     offset);

--- a/src/detect-offset.c
+++ b/src/detect-offset.c
@@ -92,7 +92,7 @@ int DetectOffsetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *offset
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(str, s, -1, &index)) {
+        if (!DetectByteRetrieveSMVar(str, s, false, -1, &index)) {
             SCLogError("unknown byte_ keyword var "
                        "seen in offset - %s.",
                     str);

--- a/src/detect-within.c
+++ b/src/detect-within.c
@@ -104,7 +104,7 @@ static int DetectWithinSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
     }
     if (str[0] != '-' && isalpha((unsigned char)str[0])) {
         DetectByteIndexType index;
-        if (!DetectByteRetrieveSMVar(str, s, -1, &index)) {
+        if (!DetectByteRetrieveSMVar(str, s, false, -1, &index)) {
             SCLogError("unknown byte_ keyword var "
                        "seen in within - %s",
                     str);

--- a/src/util-lua-bytevarlib.c
+++ b/src/util-lua-bytevarlib.c
@@ -55,7 +55,7 @@ static int LuaBytevarMap(lua_State *L)
     }
 
     DetectByteIndexType idx;
-    if (!DetectByteRetrieveSMVar(name, s, -1, &idx)) {
+    if (!DetectByteRetrieveSMVar(name, s, false, -1, &idx)) {
         luaL_error(L, "unknown byte_extract or byte_math variable: %s", name);
     }
 


### PR DESCRIPTION
Continuation of #13516 

Issue: 1412

Extend the checks added for 7549 to include buffers.

Only consider sig matches with compatible ids/lists.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/1412

Describe changes:
- Extend buffer/variable checks to `buffers` init data

Updates:
- Include behavioral change note (see #13465) in upgrade notes.
- Doc format fixup (see #13509 CI failures)
- s-v rebase
- Modified behavior when mult buffers are in use: Warning if not in strict mode, else error.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2576
SU_REPO=
SU_BRANCH=
