### PR TITLE
lib: opt-in signal handlers - v1

### DIFF
--- a/examples/lib/custom/main.c
+++ b/examples/lib/custom/main.c
@@ -202,6 +202,12 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    /* Enable default signal handlers including SIGHUP for log file rotation,
+     * and SIGUSR2 for reloading rules. This should be done with care by a
+     * library user as the application may already have signal handlers
+     * loaded. */
+    SCEnableDefaultSignalHandlers();
+
     /* Set "offline" runmode to replay a pcap in library mode. */
     if (!SCConfSetFromString("runmode=offline", 1)) {
         exit(EXIT_FAILURE);

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -47,6 +47,9 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    /* Enable default signal handlers just like Suricata. */
+    SCEnableDefaultSignalHandlers();
+
     SuricataInit();
     SuricataPostInit();
 

--- a/src/main.c
+++ b/src/main.c
@@ -49,6 +49,9 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    /* Enable default signal handlers */
+    SCEnableDefaultSignalHandlers();
+
     /* Initialization tasks: apply configuration, drop privileges,
      * etc. */
     SuricataInit();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -286,6 +286,11 @@ void SCRunmodeSet(SCRunMode run_mode)
     suricata.run_mode = run_mode;
 }
 
+void SCEnableDefaultSignalHandlers(void)
+{
+    suricata.install_signal_handlers = true;
+}
+
 /** signal handlers
  *
  *  WARNING: don't use the SCLog* API in the handlers. The API is complex
@@ -2870,8 +2875,10 @@ int PostConfLoadedSetup(SCInstance *suri)
     if (MayDaemonize(suri) != TM_ECODE_OK)
         SCReturnInt(TM_ECODE_FAILED);
 
-    if (InitSignalHandler(suri) != TM_ECODE_OK)
-        SCReturnInt(TM_ECODE_FAILED);
+    if (suri->install_signal_handlers) {
+        if (InitSignalHandler(suri) != TM_ECODE_OK)
+            SCReturnInt(TM_ECODE_FAILED);
+    }
 
     /* Check for the existence of the default logging directory which we pick
      * from suricata.yaml.  If not found, shut the engine down */

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -160,6 +160,8 @@ typedef struct SCInstance_ {
     bool set_datadir;
     bool unix_socket_enabled;
 
+    bool install_signal_handlers; /**< Install default signal handlers */
+
     int delayed_detect;
     int disabled_detect;
     int daemon;
@@ -213,6 +215,11 @@ SCRunMode SCRunmodeGet(void);
  * Mainly exposed outside of suricata.c as a unit-test helper.
  */
 void SCRunmodeSet(SCRunMode run_mode);
+
+/**
+ * \brief Enable default signal handlers.
+ */
+void SCEnableDefaultSignalHandlers(void);
 
 int SuriHasSigFile(void);
 


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/6814

Instead of enabling signal handlers by default, require the user of
the library to opt-in. This is done with the call to
SCEnableDefaultSignalHandlers, which sets a flag to add the default
signal handlers.

This seems like the least invasive way to do this at this time, but it
will require some re-thinking for 9.0, especially if migrate globals
to engine instances, signal handling will need to be re-thought.
