### PR TITLE
pcap: refactor delete-when-done to support non-alerts

### DIFF
--- a/doc/userguide/capture-hardware/pcap-file.rst
+++ b/doc/userguide/capture-hardware/pcap-file.rst
@@ -15,7 +15,7 @@ Configuration
     checksum-checks: auto
     # buffer-size: 128 KiB
     # tenant-id: none
-    # delete-when-done: false
+    # delete-when-done: false   # Options: false (default), true, "non-alerts"
     # recursive: false
     # continuous: false
     # delay: 30
@@ -85,9 +85,22 @@ Other options
 
 **delete-when-done**
 
-- If ``true``, Suricata deletes the PCAP file after processing.
-- The command-line option is
-  :ref:`--pcap-file-delete <cmdline-option-pcap-file-delete>`
+Controls when PCAP files are deleted after processing. Three values are supported:
+
+- ``false`` (default): Files are never deleted
+- ``true``: Files are always deleted after processing
+- ``"non-alerts"``: Files are deleted only if they generated no alerts
+
+.. note::
+
+   The command-line option :ref:`--pcap-file-delete <cmdline-option-pcap-file-delete>`
+   overrides this configuration and forces "always delete" mode (``true``).
+
+.. warning::
+
+   When using ``"non-alerts"`` mode, file deletion is deferred until thread 
+   cleanup to ensure alert counts are finalized. This may delay deletion 
+   compared to other modes.
 
 **BPF filter**
 

--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -80,10 +80,23 @@
 
 .. option:: --pcap-file-delete
 
-   Used with the -r option to indicate that the mode should delete pcap files
-   after they have been processed. This is useful with pcap-file-continuous to
-   continuously feed files to a directory and have them cleaned up when done. If
-   this option is not set, pcap files will not be deleted after processing.
+   Used with the -r option to force deletion of pcap files after they have been 
+   processed. This is useful with pcap-file-continuous to continuously feed files 
+   to a directory and have them cleaned up when done.
+
+   **Command Line vs Configuration**: This command line option overrides the 
+   ``pcap-file.delete-when-done`` configuration option in ``suricata.yaml`` and 
+   forces "always delete" mode (equivalent to ``delete-when-done: true``).
+
+   **For more control**, use the ``pcap-file.delete-when-done`` configuration 
+   option instead, which supports three values:
+   
+   - ``false`` (default): No files are deleted
+   - ``true``: All files are deleted after processing  
+   - ``"non-alerts"``: Only files that generated no alerts are deleted
+
+   If neither ``--pcap-file-delete`` nor ``delete-when-done`` is configured, 
+   pcap files will not be deleted after processing.
 
 .. _cmdline-option-pcap-file-buffer-size:
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -37,6 +37,7 @@
 #include "util-validate.h"
 
 #include "action-globals.h"
+#include "source-pcap-file-helper.h"
 
 /** tag signature we use for tag alerts */
 static Signature g_tag_signature;
@@ -597,6 +598,13 @@ void PacketAlertFinalize(const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *d
             p->flags |= PKT_FIRST_ALERTS;
         }
     }
+
+    /* Count alerts for pcap file deletion logic */
+    if (p->alerts.cnt > 0 && p->pcap_v.pfv != NULL) {
+        PcapFileAddAlerts(p->pcap_v.pfv, p->alerts.cnt);
+    }
+
+    SCReturn;
 }
 
 #ifdef UNITTESTS

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -32,7 +32,7 @@ void AlertQueueInit(DetectEngineThreadCtx *det_ctx);
 void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
 void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
         uint8_t alert_flags);
-void PacketAlertFinalize(const DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
+void PacketAlertFinalize(const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p);
 #ifdef UNITTESTS
 int PacketAlertCheck(Packet *, uint32_t);
 #endif

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -114,6 +114,7 @@
 #include "decode-vntag.h"
 #include "decode-vxlan.h"
 #include "decode-pppoe.h"
+#include "source-pcap-file-helper.h"
 
 #include "output-json-stats.h"
 
@@ -209,6 +210,7 @@ static void RegisterUnittests(void)
     StreamingBufferRegisterTests();
     MacSetRegisterTests();
     FlowRateRegisterTests();
+    SourcePcapFileHelperRegisterTests();
 #ifdef OS_WIN32
     Win32SyscallRegisterTests();
 #endif

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -23,9 +23,16 @@
 
 #include "suricata-common.h"
 #include "tm-threads.h"
+#include "util-atomic.h"
 
 #ifndef SURICATA_SOURCE_PCAP_FILE_HELPER_H
 #define SURICATA_SOURCE_PCAP_FILE_HELPER_H
+
+typedef enum {
+    PCAP_FILE_DELETE_NONE = 0,
+    PCAP_FILE_DELETE_ALWAYS,
+    PCAP_FILE_DELETE_NON_ALERTS
+} PcapFileDeleteMode;
 
 typedef struct PcapFileGlobalVars_ {
     uint64_t cnt; /** packet counter */
@@ -46,7 +53,7 @@ typedef struct PcapFileSharedVars_
 
     struct timespec last_processed;
 
-    bool should_delete;
+    PcapFileDeleteMode delete_mode;
 
     ThreadVars *tv;
     TmSlot *slot;
@@ -75,6 +82,8 @@ typedef struct PcapFileFileVars_
     struct bpf_program filter;
 
     PcapFileSharedVars *shared;
+
+    SC_ATOMIC_DECLARE(uint64_t, alerts_count);
 
     /* fields used to get the first packet's timestamp early,
      * so it can be used to setup the time subsys. */
@@ -120,5 +129,15 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv);
 TmEcode ValidateLinkType(int datalink, DecoderFunc *decoder);
 
 const char *PcapFileGetFilename(void);
+
+bool ShouldDeletePcapFile(PcapFileFileVars *pfv);
+
+void PcapFileAddAlerts(PcapFileFileVars *pfv, uint16_t alert_count);
+
+PcapFileDeleteMode PcapFileParseDeleteMode(void);
+
+#ifdef UNITTESTS
+void SourcePcapFileHelperRegisterTests(void);
+#endif
 
 #endif /* SURICATA_SOURCE_PCAP_FILE_HELPER_H */

--- a/src/source-pcap.h
+++ b/src/source-pcap.h
@@ -24,6 +24,8 @@
 #ifndef SURICATA_SOURCE_PCAP_H
 #define SURICATA_SOURCE_PCAP_H
 
+typedef struct PcapFileFileVars_ PcapFileFileVars;
+
 void TmModuleReceivePcapRegister (void);
 void TmModuleDecodePcapRegister (void);
 void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
@@ -35,6 +37,7 @@ void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
 typedef struct PcapPacketVars_
 {
     uint32_t tenant_id;
+    PcapFileFileVars *pfv;
 } PcapPacketVars;
 
 /** needs to be able to contain Windows adapter id's, so

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -892,6 +892,7 @@ pcap-file:
 
   # tenant-id: none # applies in multi-tenant environment with "direct" selector
   # delete-when-done: false # applies to file and directory
+  #   Options: false (no deletion), true (always delete), "non-alerts" (delete only files with no alerts)
 
   # PCAP Directory Processing options
   # recursive: false


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket:  https://redmine.openinfosecfoundation.org/projects/suricata/issues

Describe changes:
Allowing change the behaviour of --pcap-file-delete to only delete pcaps with no alerts via config.

Previous PR: https://github.com/OISF/suricata/pull/13551
Changes:
- Use existing `pcap-file.delete-when-done` option and make it's options an enum.
- Avoid using globals.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_PR=https://github.com/OISF/suricata-verify/pull/2587
SV_REPO=https://github.com/oferda4/suricata-verify
SV_BRANCH=feat/pcap-delete-no-alerts
SU_REPO=
SU_BRANCH=