### PR TITLE
detect/entropy: Unique flowvar names

### DIFF
--- a/src/detect-entropy.c
+++ b/src/detect-entropy.c
@@ -41,8 +41,10 @@ static int DetectEntropySetup(DetectEngineCtx *de_ctx, Signature *s, const char 
             goto error;
 
         sm_list = s->init_data->list;
-        ded->fv_idx = VarNameStoreRegister(
-                DetectEngineBufferTypeGetNameById(de_ctx, sm_list), VAR_TYPE_FLOW_FLOAT);
+        char name_buf[30];
+        snprintf(name_buf, sizeof(name_buf), "%s_%d",
+                DetectEngineBufferTypeGetNameById(de_ctx, sm_list), s->id);
+        ded->fv_idx = VarNameStoreRegister(name_buf, VAR_TYPE_FLOW_FLOAT);
     }
 
     if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_ENTROPY, (SigMatchCtx *)ded, sm_list) != NULL) {


### PR DESCRIPTION
Use unique variable names for each flowvar as they come from a global
namespace. The chosen name is: <sticky_buffer>_<sid>

Describe changes:
- Use a unique name for flowvar by appending the signature id to the name.


### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2588
SU_REPO=
SU_BRANCH=
