### PR TITLE
doc: add some missing url and desc

### DIFF
--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -74,6 +74,8 @@ void DetectBytemathRegister(void)
     sigmatch_table[DETECT_BYTEMATH].Match = NULL;
     sigmatch_table[DETECT_BYTEMATH].Setup = DetectByteMathSetup;
     sigmatch_table[DETECT_BYTEMATH].Free = DetectByteMathFree;
+    sigmatch_table[DETECT_BYTEMATH].desc = "used to perform mathematical operations on byte values";
+    sigmatch_table[DETECT_BYTEMATH].url = "/rules/payload-keywords.html#byte-math";
 #ifdef UNITTESTS
     sigmatch_table[DETECT_BYTEMATH].RegisterTests = DetectByteMathRegisterTests;
 #endif

--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -77,6 +77,9 @@ void DetectConfigRegister(void)
     sigmatch_table[DETECT_CONFIG].Match = DetectConfigPostMatch;
     sigmatch_table[DETECT_CONFIG].Setup = DetectConfigSetup;
     sigmatch_table[DETECT_CONFIG].Free  = DetectConfigFree;
+    sigmatch_table[DETECT_CONFIG].desc =
+            "apply different configuration settings to a flow, packet or other unit";
+    sigmatch_table[DETECT_CONFIG].url = "/rules/config.html";
 #ifdef UNITTESTS
     sigmatch_table[DETECT_CONFIG].RegisterTests = DetectConfigRegisterTests;
 #endif

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -142,6 +142,7 @@ void DetectCsumRegister (void)
     sigmatch_table[DETECT_IPV4_CSUM].Match = DetectIPV4CsumMatch;
     sigmatch_table[DETECT_IPV4_CSUM].Setup = DetectIPV4CsumSetup;
     sigmatch_table[DETECT_IPV4_CSUM].Free  = DetectIPV4CsumFree;
+    sigmatch_table[DETECT_IPV4_CSUM].desc = "match on IPv4 checksum";
 #ifdef UNITTESTS
     sigmatch_table[DETECT_IPV4_CSUM].RegisterTests = DetectCsumRegisterTests;
 #endif
@@ -150,31 +151,37 @@ void DetectCsumRegister (void)
     sigmatch_table[DETECT_TCPV4_CSUM].Match = DetectTCPV4CsumMatch;
     sigmatch_table[DETECT_TCPV4_CSUM].Setup = DetectTCPV4CsumSetup;
     sigmatch_table[DETECT_TCPV4_CSUM].Free  = DetectTCPV4CsumFree;
+    sigmatch_table[DETECT_TCPV4_CSUM].desc = "match on IPv4/TCP checksum";
 
     sigmatch_table[DETECT_TCPV6_CSUM].name = "tcpv6-csum";
     sigmatch_table[DETECT_TCPV6_CSUM].Match = DetectTCPV6CsumMatch;
     sigmatch_table[DETECT_TCPV6_CSUM].Setup = DetectTCPV6CsumSetup;
     sigmatch_table[DETECT_TCPV6_CSUM].Free  = DetectTCPV6CsumFree;
+    sigmatch_table[DETECT_TCPV6_CSUM].desc = "match on IPv6/TCP checksum";
 
     sigmatch_table[DETECT_UDPV4_CSUM].name = "udpv4-csum";
     sigmatch_table[DETECT_UDPV4_CSUM].Match = DetectUDPV4CsumMatch;
     sigmatch_table[DETECT_UDPV4_CSUM].Setup = DetectUDPV4CsumSetup;
     sigmatch_table[DETECT_UDPV4_CSUM].Free  = DetectUDPV4CsumFree;
+    sigmatch_table[DETECT_UDPV4_CSUM].desc = "match on IPv4/UDP checksum";
 
     sigmatch_table[DETECT_UDPV6_CSUM].name = "udpv6-csum";
     sigmatch_table[DETECT_UDPV6_CSUM].Match = DetectUDPV6CsumMatch;
     sigmatch_table[DETECT_UDPV6_CSUM].Setup = DetectUDPV6CsumSetup;
     sigmatch_table[DETECT_UDPV6_CSUM].Free  = DetectUDPV6CsumFree;
+    sigmatch_table[DETECT_UDPV6_CSUM].desc = "match on IPv6/UDP checksum";
 
     sigmatch_table[DETECT_ICMPV4_CSUM].name = "icmpv4-csum";
     sigmatch_table[DETECT_ICMPV4_CSUM].Match = DetectICMPV4CsumMatch;
     sigmatch_table[DETECT_ICMPV4_CSUM].Setup = DetectICMPV4CsumSetup;
     sigmatch_table[DETECT_ICMPV4_CSUM].Free  = DetectICMPV4CsumFree;
+    sigmatch_table[DETECT_ICMPV4_CSUM].desc = "match on IPv4/ICMP checksum";
 
     sigmatch_table[DETECT_ICMPV6_CSUM].name = "icmpv6-csum";
     sigmatch_table[DETECT_ICMPV6_CSUM].Match = DetectICMPV6CsumMatch;
     sigmatch_table[DETECT_ICMPV6_CSUM].Setup = DetectICMPV6CsumSetup;
     sigmatch_table[DETECT_ICMPV6_CSUM].Free  = DetectICMPV6CsumFree;
+    sigmatch_table[DETECT_ICMPV6_CSUM].desc = "match on IPv6/ICMPv6 checksum";
 }
 
 /**

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -70,6 +70,9 @@ void DetectDceIfaceRegister(void)
     sigmatch_table[DETECT_DCE_IFACE].AppLayerTxMatch = DetectDceIfaceMatchRust;
     sigmatch_table[DETECT_DCE_IFACE].Setup = DetectDceIfaceSetup;
     sigmatch_table[DETECT_DCE_IFACE].Free = DetectDceIfaceFree;
+    sigmatch_table[DETECT_DCE_IFACE].desc =
+            "match on the value of the interface UUID in a DCERPC header";
+    sigmatch_table[DETECT_DCE_IFACE].url = "/rules/dcerpc-keywords.html#dcerpc-iface";
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 
     g_dce_generic_list_id = DetectBufferTypeRegister("dce_generic");

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -74,6 +74,9 @@ void DetectDceOpnumRegister(void)
     sigmatch_table[DETECT_DCE_OPNUM].AppLayerTxMatch = DetectDceOpnumMatchRust;
     sigmatch_table[DETECT_DCE_OPNUM].Setup = DetectDceOpnumSetup;
     sigmatch_table[DETECT_DCE_OPNUM].Free  = DetectDceOpnumFree;
+    sigmatch_table[DETECT_DCE_OPNUM].desc =
+            "match on one or many operation numbers within the interface in a DCERPC header";
+    sigmatch_table[DETECT_DCE_OPNUM].url = "/rules/dcerpc-keywords.html#dcerpc-opnum";
 #ifdef UNITTESTS
     sigmatch_table[DETECT_DCE_OPNUM].RegisterTests = DetectDceOpnumRegisterTests;
 #endif

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -120,6 +120,8 @@ void DetectDceStubDataRegister(void)
     sigmatch_table[DETECT_DCE_STUB_DATA].name = "dcerpc.stub_data";
     sigmatch_table[DETECT_DCE_STUB_DATA].alias = "dce_stub_data";
     sigmatch_table[DETECT_DCE_STUB_DATA].Setup = DetectDceStubDataSetup;
+    sigmatch_table[DETECT_DCE_STUB_DATA].desc = "match on the stub data in a DCERPC packet";
+    sigmatch_table[DETECT_DCE_STUB_DATA].url = "/rules/dcerpc-keywords.html#dcerpc-stub-data";
 #ifdef UNITTESTS
     sigmatch_table[DETECT_DCE_STUB_DATA].RegisterTests = DetectDceStubDataRegisterTests;
 #endif

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -138,6 +138,9 @@ void DetectEngineEventRegister (void)
     sigmatch_table[DETECT_DECODE_EVENT].Match = DetectEngineEventMatch;
     sigmatch_table[DETECT_DECODE_EVENT].Setup = DetectDecodeEventSetup;
     sigmatch_table[DETECT_DECODE_EVENT].Free  = DetectEngineEventFree;
+    sigmatch_table[DETECT_DECODE_EVENT].desc =
+            "match on events triggered by structural or invalid values during packet decoding";
+    sigmatch_table[DETECT_DECODE_EVENT].url = "/rules/decode-layer.html#decode-event";
     sigmatch_table[DETECT_DECODE_EVENT].flags |= SIGMATCH_DEONLY_COMPAT;
     sigmatch_table[DETECT_DECODE_EVENT].SupportsPrefilter = PrefilterDecodeEventIsPrefilterable;
     sigmatch_table[DETECT_DECODE_EVENT].SetupPrefilter = PrefilterSetupDecodeEvent;
@@ -146,6 +149,8 @@ void DetectEngineEventRegister (void)
     sigmatch_table[DETECT_STREAM_EVENT].Match = DetectEngineEventMatch;
     sigmatch_table[DETECT_STREAM_EVENT].Setup = DetectStreamEventSetup;
     sigmatch_table[DETECT_STREAM_EVENT].Free  = DetectEngineEventFree;
+    sigmatch_table[DETECT_STREAM_EVENT].desc =
+            "match on events triggered by anomalies during TCP streaming";
     sigmatch_table[DETECT_STREAM_EVENT].SupportsPrefilter = PrefilterStreamEventIsPrefilterable;
     sigmatch_table[DETECT_STREAM_EVENT].SetupPrefilter = PrefilterSetupStreamEvent;
 

--- a/src/detect-smb-ntlmssp.c
+++ b/src/detect-smb-ntlmssp.c
@@ -80,6 +80,7 @@ void DetectSmbNtlmsspUserRegister(void)
     sigmatch_table[KEYWORD_ID].Setup = DetectSmbNtlmsspUserSetup;
     sigmatch_table[KEYWORD_ID].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     sigmatch_table[KEYWORD_ID].desc = "sticky buffer to match on SMB ntlmssp user in session setup";
+    sigmatch_table[KEYWORD_ID].url = "/rules/smb-keywords.html#smb-ntlmssp-user";
 
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetNtlmsspUserData, ALPROTO_SMB, 1);
@@ -137,6 +138,7 @@ void DetectSmbNtlmsspDomainRegister(void)
     sigmatch_table[KEYWORD_ID].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     sigmatch_table[KEYWORD_ID].desc =
             "sticky buffer to match on SMB ntlmssp domain in session setup";
+    sigmatch_table[KEYWORD_ID].url = "/rules/smb-keywords.html#smb-ntlmssp-domain";
 
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetNtlmsspDomainData, ALPROTO_SMB, 1);

--- a/src/detect-smb-share.c
+++ b/src/detect-smb-share.c
@@ -82,6 +82,7 @@ void DetectSmbNamedPipeRegister(void)
     sigmatch_table[KEYWORD_ID].Setup = DetectSmbNamedPipeSetup;
     sigmatch_table[KEYWORD_ID].flags |= SIGMATCH_NOOPT|SIGMATCH_INFO_STICKY_BUFFER;
     sigmatch_table[KEYWORD_ID].desc = "sticky buffer to match on SMB named pipe in tree connect";
+    sigmatch_table[KEYWORD_ID].url = "/rules/smb-keywords.html#smb-named-pipe";
 
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetNamedPipeData, ALPROTO_SMB, 1);
@@ -142,6 +143,7 @@ void DetectSmbShareRegister(void)
     sigmatch_table[KEYWORD_ID].Setup = DetectSmbShareSetup;
     sigmatch_table[KEYWORD_ID].flags |= SIGMATCH_NOOPT|SIGMATCH_INFO_STICKY_BUFFER;
     sigmatch_table[KEYWORD_ID].desc = "sticky buffer to match on SMB share name in tree connect";
+    sigmatch_table[KEYWORD_ID].url = "/rules/smb-keywords.html#smb-share";
 
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetShareData, ALPROTO_SMB, 1);

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -72,6 +72,8 @@ void DetectTagRegister(void)
     sigmatch_table[DETECT_TAG].Match = DetectTagMatch;
     sigmatch_table[DETECT_TAG].Setup = DetectTagSetup;
     sigmatch_table[DETECT_TAG].Free  = DetectTagDataFree;
+    sigmatch_table[DETECT_TAG].desc = "tag of current and future packets for a flow or host";
+    sigmatch_table[DETECT_TAG].url = "/rules/tag.html#tag";
 #ifdef UNITTESTS
     sigmatch_table[DETECT_TAG].RegisterTests = DetectTagRegisterTests;
 #endif


### PR DESCRIPTION
Keywords registration should provide a desc and a link to the documentation. This patch adds desc and/or url for on most keywords missing that.

This allows better output for list-keywords command line which is then use in Suricata Language Server.

Issue https://redmine.openinfosecfoundation.org/issues/7806 describes the status once this PR is in.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7806

Describe changes:
- add desc and/or url to keywords where it was missing
