### PR TITLE
detect/entropy: Unique flowvar names

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -538,13 +538,13 @@ In multi mode the filename takes a few special variables:
   - %n representing the thread number
   - %i representing the thread id
   - %t representing the timestamp (secs or secs.usecs based on 'ts-format')
-  
+
   Example: filename: pcap.%n.%t
 
 .. note:: It is possible to use directories but the directories are not
   created by Suricata. For example ``filename: pcaps/%n/log.%s`` will log into
   the pre-existing ``pcaps`` directory and per thread sub directories.
-  
+
 .. note:: that the limit and max-files settings are enforced per thread. So the
   size limit using 8 threads with 1000mb files and 2000 files is about 16TiB.
 
@@ -2145,8 +2145,8 @@ A logging line exists of two parts. First it displays meta information
 
   i: suricata: This is Suricata version 7.0.2 RELEASE running in USER mode
 
-(Here the part until the second `:` is the meta info, 
-"This is Suricata version 7.0.2 RELEASE running in USER mode" is the actual 
+(Here the part until the second `:` is the meta info,
+"This is Suricata version 7.0.2 RELEASE running in USER mode" is the actual
 message.)
 
 It is possible to determine which information will be displayed in
@@ -3028,6 +3028,24 @@ headers are encapsulated in the same number of headers.
 Advanced Options
 ----------------
 
+entropy
+~~~~~~~
+
+When a rule causes an entropy value to be calculated for a flow, output for the flow will include
+the calculated entropy value. The log output contains the sticky buffer name for which the
+entropy was calculated. Often, more context is needed and the configuration setting shown
+below will amend the sticky buffer name with the signature id of the rule that caused
+the entropy value calculation. The default value is ``off``. We strongly recommend
+changing this value to ``on``.
+
+::
+
+    logging:
+        # Ensure that logged entropy values have unique names by appending the signature_id
+        # of the rule where used
+        #entropy:
+            #make-unique: off
+
 stacktrace
 ~~~~~~~~~~
 Display diagnostic stacktraces when a signal unexpectedly terminates Suricata, e.g., such as
@@ -3086,7 +3104,7 @@ Suricata 7.0 default:
        #allow-rules: true
 
        # Upper bound of allocations by a Lua rule before it will fail
-       #max-bytes: 500000 
+       #max-bytes: 500000
 
        # Upper bound of lua instructions by a Lua rule before it will fail
        #max-instructions: 500000

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -749,6 +749,15 @@ the calculated entropy value with the buffer on which the value was computed::
         }
       }
 
+When ``logging.entropy.make-unique`` is enabled, the format is modified such
+that the signature id of the rule producing the entropy value is included::
+
+     "metadata": {
+        "entropy": {
+          "file_data_391933": 4.265743301617466
+        }
+      }
+
 The events where entropy is logged will depend largely on how it's used within a
 rule and the rule's protocol.
 

--- a/src/detect-entropy.c
+++ b/src/detect-entropy.c
@@ -30,6 +30,12 @@
 
 static int DetectEntropySetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
+    int unique_name;
+    SCConfGetBool("logging.entropy.make-unique", &unique_name);
+    if (unique_name) {
+        SCLogConfig("entropy values are marked with signature_id");
+    }
+
     DetectEntropyData *ded = SCDetectEntropyParse(arg);
     if (ded == NULL) {
         goto error;
@@ -41,8 +47,15 @@ static int DetectEntropySetup(DetectEngineCtx *de_ctx, Signature *s, const char 
             goto error;
 
         sm_list = s->init_data->list;
-        ded->fv_idx = VarNameStoreRegister(
-                DetectEngineBufferTypeGetNameById(de_ctx, sm_list), VAR_TYPE_FLOW_FLOAT);
+        const char *var_name_ptr = DetectEngineBufferTypeGetNameById(de_ctx, sm_list);
+        if (unique_name) {
+            /* 10 -- max sid + 1 (separator) + sticky buffer len */
+            char name_buf[10 + 1 + strlen(var_name_ptr)];
+            snprintf(name_buf, sizeof(name_buf), "%s_%d", var_name_ptr, s->id);
+            ded->fv_idx = VarNameStoreRegister(name_buf, VAR_TYPE_FLOW_FLOAT);
+        } else {
+            ded->fv_idx = VarNameStoreRegister(var_name_ptr, VAR_TYPE_FLOW_FLOAT);
+        }
     }
 
     if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_ENTROPY, (SigMatchCtx *)ded, sm_list) != NULL) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -629,6 +629,11 @@ logging:
   # message with the offending stacktrace if enabled.
   #stacktrace-on-signal: on
 
+  # Ensure that logged entropy values have unique names by appending the signature_id
+  # of the rule where used
+  #entropy:
+    #make-unique: off
+
   # Define your logging outputs.  If none are defined, or they are all
   # disabled you will get the default: console output.
   outputs:


### PR DESCRIPTION
Continuation of #13575 

Use unique variable names for each flowvar as they come from a global
namespace. The chosen name is: `<sticky_buffer>_<sid>`

Describe changes:
- Use a unique name for flowvar by appending the signature id to the name.

Updates:
- Add a config setting to control whether unique names are generated: `logging.entropy.make-unique`
- Document new configuration setting and how output is affected.

Issue: 7814

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7814

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2588
SU_REPO=
SU_BRANCH=
