### PR TITLE
pcap: refactor delete-when-done to support non-alerts

### DIFF
--- a/doc/userguide/capture-hardware/pcap-file.rst
+++ b/doc/userguide/capture-hardware/pcap-file.rst
@@ -15,6 +15,8 @@ Configuration
     checksum-checks: auto
     # buffer-size: 128 KiB
     # tenant-id: none
+    # Applies to file and directory. Options: false (no deletion), true (always delete), 
+    #   "non-alerts" (delete only files with no alerts)
     # delete-when-done: false
     # recursive: false
     # continuous: false
@@ -85,9 +87,22 @@ Other options
 
 **delete-when-done**
 
-- If ``true``, Suricata deletes the PCAP file after processing.
-- The command-line option is
-  :ref:`--pcap-file-delete <cmdline-option-pcap-file-delete>`
+Controls when PCAP files are deleted after processing. Three values are supported:
+
+- ``false`` (default): Files are never deleted
+- ``true``: Files are always deleted after processing
+- ``"non-alerts"``: Files are deleted only if they generated no alerts
+
+.. note::
+
+   The command-line option :ref:`--pcap-file-delete <cmdline-option-pcap-file-delete>`
+   overrides this configuration and forces "always delete" mode (``true``).
+
+.. warning::
+
+   When using ``"non-alerts"`` mode, file deletion is deferred until thread 
+   cleanup to ensure alert counts are finalized. This may delay deletion 
+   compared to other modes.
 
 **BPF filter**
 

--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -80,10 +80,23 @@
 
 .. option:: --pcap-file-delete
 
-   Used with the -r option to indicate that the mode should delete pcap files
-   after they have been processed. This is useful with pcap-file-continuous to
-   continuously feed files to a directory and have them cleaned up when done. If
-   this option is not set, pcap files will not be deleted after processing.
+   Used with the -r option to force deletion of pcap files after they have been 
+   processed. This is useful with pcap-file-continuous to continuously feed files 
+   to a directory and have them cleaned up when done.
+
+   **Command Line vs Configuration**: This command line option overrides the 
+   ``pcap-file.delete-when-done`` configuration option in ``suricata.yaml`` and 
+   forces "always delete" mode (equivalent to ``delete-when-done: true``).
+
+   **For more control**, use the ``pcap-file.delete-when-done`` configuration 
+   option instead, which supports three values:
+   
+   - ``false`` (default): No files are deleted
+   - ``true``: All files are deleted after processing  
+   - ``"non-alerts"``: Only files that generated no alerts are deleted
+
+   If neither ``--pcap-file-delete`` nor ``delete-when-done`` is configured, 
+   pcap files will not be deleted after processing.
 
 .. _cmdline-option-pcap-file-buffer-size:
 

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -114,6 +114,7 @@
 #include "decode-vntag.h"
 #include "decode-vxlan.h"
 #include "decode-pppoe.h"
+#include "source-pcap-file-helper.h"
 
 #include "output-json-stats.h"
 
@@ -209,6 +210,7 @@ static void RegisterUnittests(void)
     StreamingBufferRegisterTests();
     MacSetRegisterTests();
     FlowRateRegisterTests();
+    SourcePcapFileHelperRegisterTests();
 #ifdef OS_WIN32
     Win32SyscallRegisterTests();
 #endif

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -30,11 +30,22 @@
 #include "util-profiling.h"
 #include "source-pcap-file.h"
 #include "util-exception-policy.h"
+#include "conf-yaml-loader.h"
 
 extern uint32_t max_pending_packets;
 extern PcapFileGlobalVars pcap_g;
 
 static void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt);
+
+static void PcapFileReleasePacket(Packet *p)
+{
+    PcapFileFileVars *pfv = p->pcap_v.pfv;
+    if (pfv != NULL) {
+        PcapFileAddAlerts(pfv, p->alerts.cnt);
+    }
+
+    PacketFreeOrRelease(p);
+}
 
 void CleanupPcapFileFileVars(PcapFileFileVars *pfv)
 {
@@ -44,7 +55,7 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv)
             pfv->pcap_handle = NULL;
         }
         if (pfv->filename != NULL) {
-            if (pfv->shared != NULL && pfv->shared->should_delete) {
+            if (PcapFileShouldDeletePcapFile(pfv)) {
                 SCLogDebug("Deleting pcap file %s", pfv->filename);
                 if (unlink(pfv->filename) != 0) {
                     SCLogWarning("Failed to delete %s: %s", pfv->filename, strerror(errno));
@@ -83,8 +94,11 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     p->pcap_cnt = ++pcap_g.cnt;
 
     p->pcap_v.tenant_id = ptv->shared->tenant_id;
+    p->pcap_v.pfv = ptv;
     ptv->shared->pkts++;
     ptv->shared->bytes += h->caplen;
+
+    p->ReleasePacket = PcapFileReleasePacket;
 
     if (unlikely(PacketCopyData(p, pkt, h->caplen))) {
         TmqhOutputPacketpool(ptv->shared->tv, p);
@@ -236,6 +250,9 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
         pcap_freecode(&pfv->filter);
     }
 
+    SC_ATOMIC_INIT(pfv->alerts_count);
+    SC_ATOMIC_SET(pfv->alerts_count, 0);
+
     pfv->datalink = pcap_datalink(pfv->pcap_handle);
     SCLogDebug("datalink %" PRId32 "", pfv->datalink);
     DatalinkSetGlobalType(pfv->datalink);
@@ -285,3 +302,325 @@ TmEcode ValidateLinkType(int datalink, DecoderFunc *DecoderFn)
 
     SCReturnInt(TM_ECODE_OK);
 }
+
+bool PcapFileShouldDeletePcapFile(PcapFileFileVars *pfv)
+{
+    if (pfv == NULL || pfv->shared == NULL) {
+        return false;
+    }
+
+    if (pfv->shared->delete_mode == PCAP_FILE_DELETE_NONE) {
+        return false;
+    }
+
+    if (pfv->shared->delete_mode == PCAP_FILE_DELETE_ALWAYS) {
+        return true;
+    }
+
+    /* PCAP_FILE_DELETE_NON_ALERTS mode */
+    uint64_t file_alerts = SC_ATOMIC_GET(pfv->alerts_count);
+
+    if (file_alerts != 0) {
+        SCLogDebug("Skipping deletion of %s due to %" PRIu64 " alert(s) generated.", pfv->filename,
+                file_alerts);
+        return false;
+    }
+
+    return true;
+}
+
+void PcapFileAddAlerts(PcapFileFileVars *pfv, uint16_t alert_count)
+{
+    if (pfv != NULL && alert_count > 0) {
+        SC_ATOMIC_ADD(pfv->alerts_count, alert_count);
+    }
+}
+
+PcapFileDeleteMode PcapFileParseDeleteMode(void)
+{
+    PcapFileDeleteMode delete_mode = PCAP_FILE_DELETE_NONE;
+    const char *delete_when_done_str = NULL;
+
+    if (SCConfGet("pcap-file.delete-when-done", &delete_when_done_str) == 1) {
+        if (strcmp(delete_when_done_str, "non-alerts") == 0) {
+            delete_mode = PCAP_FILE_DELETE_NON_ALERTS;
+        } else {
+            int delete_always = 0;
+            if (SCConfGetBool("pcap-file.delete-when-done", &delete_always) == 1) {
+                if (delete_always == 1) {
+                    delete_mode = PCAP_FILE_DELETE_ALWAYS;
+                }
+            }
+        }
+    }
+
+    return delete_mode;
+}
+
+#ifdef UNITTESTS
+/**
+ * \test Tests that the PcapFileShouldDeletePcapFile function correctly applies the
+ * delete mode configuration.
+ */
+static int SourcePcapFileHelperTest01(void)
+{
+    PcapFileSharedVars shared;
+    memset(&shared, 0, sizeof(shared));
+    shared.delete_mode = PCAP_FILE_DELETE_ALWAYS;
+
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    pfv.shared = &shared;
+    pfv.filename = SCStrdup("test.pcap");
+    SC_ATOMIC_INIT(pfv.alerts_count);
+    SC_ATOMIC_SET(pfv.alerts_count, 0);
+
+    /* Test case 1: Always delete mode */
+    int result1 = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(result1 != true);
+
+    /* Test case 2: Non-alerts mode with no alerts */
+    shared.delete_mode = PCAP_FILE_DELETE_NON_ALERTS;
+    int result2 = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(result2 != true);
+
+    /* Test case 3: Non-alerts mode with alerts */
+    SC_ATOMIC_ADD(pfv.alerts_count, 1);
+    int result3 = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(result3 != false);
+
+    /* Test case 4: Always delete mode with alerts */
+    shared.delete_mode = PCAP_FILE_DELETE_ALWAYS;
+    int result4 = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(result4 != true);
+
+    /* Test case 5: No delete mode */
+    shared.delete_mode = PCAP_FILE_DELETE_NONE;
+    int result5 = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(result5 != false);
+
+    SCFree(pfv.filename);
+
+    PASS;
+}
+
+/**
+ * \test Test that alert counters are properly incremented
+ */
+static int SourcePcapFileHelperTest02(void)
+{
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    SC_ATOMIC_INIT(pfv.alerts_count);
+    SC_ATOMIC_SET(pfv.alerts_count, 0);
+
+    Packet p;
+    memset(&p, 0, sizeof(p));
+
+    /* first batch */
+    p.alerts.cnt = 2;
+    SC_ATOMIC_ADD(pfv.alerts_count, p.alerts.cnt);
+    uint64_t alerts_count = SC_ATOMIC_GET(pfv.alerts_count);
+    FAIL_IF(alerts_count != 2);
+
+    /* second batch */
+    p.alerts.cnt = 3;
+    SC_ATOMIC_ADD(pfv.alerts_count, p.alerts.cnt);
+    alerts_count = SC_ATOMIC_GET(pfv.alerts_count);
+    FAIL_IF(alerts_count != 5);
+
+    PASS;
+}
+
+/* Mock for configuration testing */
+static int SetupYamlConf(const char *conf_string)
+{
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    return SCConfYamlLoadString(conf_string, strlen(conf_string));
+}
+
+static void CleanupYamlConf(void)
+{
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+}
+
+/**
+ * \test Test that configuration is properly parsed
+ */
+static int SourcePcapFileHelperTest03(void)
+{
+    const char *delete_when_done_str = NULL;
+
+    const char *conf_string = "%YAML 1.1\n"
+                              "---\n"
+                              "pcap-file:\n"
+                              "  delete-when-done: non-alerts\n";
+
+    SetupYamlConf(conf_string);
+
+    int result = SCConfGet("pcap-file.delete-when-done", &delete_when_done_str);
+    FAIL_IF(result != 1);
+    FAIL_IF(strcmp(delete_when_done_str, "non-alerts") != 0);
+
+    CleanupYamlConf();
+
+    const char *conf_string2 = "%YAML 1.1\n"
+                               "---\n"
+                               "pcap-file:\n"
+                               "  delete-when-done: true\n";
+
+    SetupYamlConf(conf_string2);
+
+    int delete_always = 0;
+    result = SCConfGetBool("pcap-file.delete-when-done", &delete_always);
+    FAIL_IF(result != 1);
+    FAIL_IF(delete_always != 1);
+
+    CleanupYamlConf();
+
+    PASS;
+}
+
+/**
+ * \test pfv is NULL.
+ */
+static int SourcePcapFileHelperTest04(void)
+{
+    int rc = PcapFileShouldDeletePcapFile(NULL);
+    FAIL_IF(rc != false);
+    PASS;
+}
+
+/**
+ * \test pfv->shared is NULL.
+ */
+static int SourcePcapFileHelperTest05(void)
+{
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+
+    int rc = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(rc != false);
+    PASS;
+}
+
+static int SourcePcapFileHelperTest06(void)
+{
+    PcapFileSharedVars shared;
+    memset(&shared, 0, sizeof(shared));
+    shared.delete_mode = PCAP_FILE_DELETE_NONE;
+
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    pfv.shared = &shared;
+    SC_ATOMIC_INIT(pfv.alerts_count);
+    SC_ATOMIC_SET(pfv.alerts_count, 0);
+
+    int rc = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(rc != false);
+    PASS;
+}
+
+/**
+ * \test Test PcapFileAddAlerts function directly
+ */
+static int SourcePcapFileHelperTest07(void)
+{
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    SC_ATOMIC_INIT(pfv.alerts_count);
+    SC_ATOMIC_SET(pfv.alerts_count, 0);
+
+    /* Test adding alerts */
+    PcapFileAddAlerts(&pfv, 5);
+    uint64_t count = SC_ATOMIC_GET(pfv.alerts_count);
+    FAIL_IF(count != 5);
+
+    /* Test adding more alerts */
+    PcapFileAddAlerts(&pfv, 3);
+    count = SC_ATOMIC_GET(pfv.alerts_count);
+    FAIL_IF(count != 8);
+
+    /* Test with zero alerts (should not increment) */
+    PcapFileAddAlerts(&pfv, 0);
+    count = SC_ATOMIC_GET(pfv.alerts_count);
+    FAIL_IF(count != 8);
+
+    /* Test with NULL pfv (should not crash) */
+    PcapFileAddAlerts(NULL, 10);
+
+    PASS;
+}
+
+/**
+ * \test Test command line --pcap-file-delete override behavior
+ */
+static int SourcePcapFileHelperTest08(void)
+{
+    /* Test 1: Command line overrides YAML "false" */
+    const char *conf_false = "%YAML 1.1\n"
+                             "---\n"
+                             "pcap-file:\n"
+                             "  delete-when-done: false\n";
+
+    SetupYamlConf(conf_false);
+
+    /* Simulate --pcap-file-delete command line option */
+    int set_result = SCConfSetFinal("pcap-file.delete-when-done", "true");
+    FAIL_IF(set_result != 1);
+
+    PcapFileDeleteMode result = PcapFileParseDeleteMode();
+    FAIL_IF(result != PCAP_FILE_DELETE_ALWAYS); /* Should override YAML false */
+    CleanupYamlConf();
+
+    /* Test 2: Command line overrides YAML "non-alerts" */
+    const char *conf_non_alerts = "%YAML 1.1\n"
+                                  "---\n"
+                                  "pcap-file:\n"
+                                  "  delete-when-done: \"non-alerts\"\n";
+
+    SetupYamlConf(conf_non_alerts);
+
+    /* Simulate --pcap-file-delete command line option */
+    set_result = SCConfSetFinal("pcap-file.delete-when-done", "true");
+    FAIL_IF(set_result != 1);
+
+    result = PcapFileParseDeleteMode();
+    FAIL_IF(result != PCAP_FILE_DELETE_ALWAYS); /* Should override YAML "non-alerts" */
+    CleanupYamlConf();
+
+    /* Test 3: Command line overrides no YAML config */
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    /* Simulate --pcap-file-delete command line option with no YAML config */
+    set_result = SCConfSetFinal("pcap-file.delete-when-done", "true");
+    FAIL_IF(set_result != 1);
+
+    result = PcapFileParseDeleteMode();
+    FAIL_IF(result != PCAP_FILE_DELETE_ALWAYS); /* Should set to always delete */
+
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+
+    PASS;
+}
+
+/**
+ * \brief Register unit tests for pcap file helper
+ */
+void SourcePcapFileHelperRegisterTests(void)
+{
+    UtRegisterTest("SourcePcapFileHelperTest01", SourcePcapFileHelperTest01);
+    UtRegisterTest("SourcePcapFileHelperTest02", SourcePcapFileHelperTest02);
+    UtRegisterTest("SourcePcapFileHelperTest03", SourcePcapFileHelperTest03);
+    UtRegisterTest("SourcePcapFileHelperTest04", SourcePcapFileHelperTest04);
+    UtRegisterTest("SourcePcapFileHelperTest05", SourcePcapFileHelperTest05);
+    UtRegisterTest("SourcePcapFileHelperTest06", SourcePcapFileHelperTest06);
+    UtRegisterTest("SourcePcapFileHelperTest07", SourcePcapFileHelperTest07);
+    UtRegisterTest("SourcePcapFileHelperTest08", SourcePcapFileHelperTest08);
+}
+#endif /* UNITTESTS */

--- a/src/source-pcap.h
+++ b/src/source-pcap.h
@@ -24,6 +24,8 @@
 #ifndef SURICATA_SOURCE_PCAP_H
 #define SURICATA_SOURCE_PCAP_H
 
+typedef struct PcapFileFileVars_ PcapFileFileVars;
+
 void TmModuleReceivePcapRegister (void);
 void TmModuleDecodePcapRegister (void);
 void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
@@ -35,6 +37,7 @@ void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
 typedef struct PcapPacketVars_
 {
     uint32_t tenant_id;
+    PcapFileFileVars *pfv;
 } PcapPacketVars;
 
 /** needs to be able to contain Windows adapter id's, so

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -891,7 +891,9 @@ pcap-file:
   # buffer-size: 128 KiB
 
   # tenant-id: none # applies in multi-tenant environment with "direct" selector
-  # delete-when-done: false # applies to file and directory
+  # Applies to file and directory. Options: false (no deletion), true (always delete), 
+  #   "non-alerts" (delete only files with no alerts)
+  # delete-when-done: false
 
   # PCAP Directory Processing options
   # recursive: false


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/issues/7786?next_issue_id=7785

Describe changes:
Allowing change the behaviour of --pcap-file-delete to only delete pcaps with no alerts via config.

Previous PR: https://github.com/OISF/suricata/pull/13592
Changes:
- Function naming conventions.
- Removed unrelated changes.
- Put explanations for option above the option.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2596
