### PR TITLE
http2: do not log empty objects for request or response

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2083,6 +2083,7 @@
                         "request": {
                             "type": "object",
                             "additionalProperties": false,
+                            "minProperties": 1,
                             "properties": {
                                 "error_code": {
                                     "type": "string"
@@ -2114,6 +2115,7 @@
                         "response": {
                             "type": "object",
                             "additionalProperties": false,
+                            "minProperties": 1,
                             "properties": {
                                 "error_code": {
                                     "type": "string"

--- a/rust/src/http2/logger.rs
+++ b/rust/src/http2/logger.rs
@@ -270,13 +270,23 @@ fn log_http2(tx: &HTTP2Transaction, js: &mut JsonBuilder) -> Result<bool, JsonEr
     js.open_object("http2")?;
 
     js.set_uint("stream_id", tx.stream_id as u64)?;
+    let mark = js.get_mark();
     js.open_object("request")?;
     let has_request = log_http2_frames(&tx.frames_ts, js)?;
-    js.close()?;
+    if has_request {
+        js.close()?;
+    } else {
+        js.restore_mark(&mark)?;
+    }
 
+    let mark = js.get_mark();
     js.open_object("response")?;
     let has_response = log_http2_frames(&tx.frames_tc, js)?;
-    js.close()?;
+    if has_response {
+        js.close()?;
+    } else {
+        js.restore_mark(&mark)?;
+    }
 
     js.close()?; // http2
     js.close()?; // http


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7741

Describe changes:
- http2: do not log empty objects for request or response

@jasonish should we enforce minProperties for every object in our json schema ?