### PR TITLE
decode: ip-in-ip & related 70x backports - v4

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2799,6 +2799,8 @@ set the parent flow for packets, when the engine sees such IP-in-IP packets. Thi
 option can be enabled regardless of enabled the ipip tunelling.
 As this may impact signature matching and flow tracking, these are disabled by default.
 
+The stats counter `decoder.ipv4_in_ipv4` is associated with this setting.
+
 ::
 
    # IP-in-IP tunneling for ipv4 over ipv4 handling

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2788,6 +2788,27 @@ Using this default configuration, Teredo detection will run on UDP port
 3544. If the `ports` parameter is missing, or set to `any`, all ports will be
 inspected for possible presence of Teredo.
 
+IP-in-IP
+~~~~~~~~
+
+IPv4
+^^^^
+
+Enable decoding IP-in-IP tunneling for IPv4. There is also a dedicated option to
+set the parent flow for packets, when the engine sees such IP-in-IP packets. This
+option can be enabled regardless of enabled the ipip tunelling.
+As this may impact signature matching and flow tracking, these are disabled by default.
+
+::
+
+   # IP-in-IP tunneling for ipv4 over ipv4 handling
+   # disabled by default, as these will impact number of alerts seen, as well as
+   # number of flows
+   # ipv4:
+   #   ipip:
+   #     enabled: true
+   #     parent-flow: true   # disabled by default
+
 Advanced Options
 ----------------
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4222,14 +4222,24 @@
                         "ipv4": {
                             "type": "integer"
                         },
+                        "ipv4_in_ipv4": {
+                            "type": "integer",
+                            "description": "Number of IP-in-IP packets seen for ipv4-ipv4"
+                        },
                         "ipv4_in_ipv6": {
-                            "type": "integer"
+                            "type": "integer",
+                            "description": "Number of IP-in-IP packets seen for ipv4-ipv6"
                         },
                         "ipv6": {
                             "type": "integer"
                         },
+                        "ipv6_in_ipv4": {
+                            "type": "integer",
+                            "description": "Number of IP-in-IP packets seen for ipv6-ipv4"
+                        },
                         "ipv6_in_ipv6": {
-                            "type": "integer"
+                            "type": "integer",
+                            "description": "Number of IP-in-IP packets seen for ipv6-ipv6"
                         },
                         "max_mac_addrs_dst": {
                             "type": "integer"

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -618,6 +618,7 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 if (tp != NULL) {
                     PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
                     PacketEnqueueNoLock(&tv->decode_pq, tp);
+                    StatsIncr(tv, dtv->counter_ipv4inipv4);
                 }
             }
             if (g_ipv4_ipip_parent_flow_enabled) {
@@ -634,6 +635,7 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 if (tp != NULL) {
                     PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
                     PacketEnqueueNoLock(&tv->decode_pq,tp);
+                    StatsIncr(tv, dtv->counter_ipv6inipv4);
                 }
                 FlowSetupPacket(p);
                 break;

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -38,6 +38,30 @@
 #include "flow.h"
 #include "util-print.h"
 
+static bool g_ipv4_ipip_enabled = false;
+static bool g_ipv4_ipip_parent_flow_enabled = false;
+
+void DecodeIPV4IpInIpConfig(void)
+{
+    int enabled = 0;
+
+    if (ConfGetBool("decoder.ipv4.ipip.enabled", &enabled) == 1) {
+        if (enabled) {
+            g_ipv4_ipip_enabled = true;
+        } else {
+            g_ipv4_ipip_enabled = false;
+        }
+        enabled = 0;
+    }
+    if (ConfGetBool("decoder.ipv4.ipip.parent-flow", &enabled) == 1) {
+        if (enabled) {
+            g_ipv4_ipip_parent_flow_enabled = true;
+        } else {
+            g_ipv4_ipip_parent_flow_enabled = false;
+        }
+    }
+}
+
 /* Generic validation
  *
  * [--type--][--len---]
@@ -585,7 +609,22 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         case IPPROTO_ESP:
             DecodeESP(tv, dtv, p, pkt + IPV4_GET_HLEN(p), IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p));
             break;
-
+        case IPPROTO_IPIP: {
+            /* optional in Suricata 7 as it wasn't always present */
+            if (g_ipv4_ipip_enabled) {
+                /* spawn off tunnel packet */
+                Packet *tp = PacketTunnelPktSetup(tv, dtv, p, pkt + IPV4_GET_HLEN(p),
+                        IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p), DECODE_TUNNEL_IPV4);
+                if (tp != NULL) {
+                    PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
+                    PacketEnqueueNoLock(&tv->decode_pq, tp);
+                }
+            }
+            if (g_ipv4_ipip_parent_flow_enabled) {
+                FlowSetupPacket(p);
+            }
+            break;
+        }
         case IPPROTO_IPV6:
             {
                 /* spawn off tunnel packet */

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -176,6 +176,7 @@ typedef struct IPV4Vars_
     uint16_t opts_set;
 } IPV4Vars;
 
+void DecodeIPV4IpInIpConfig(void);
 
 void DecodeIPV4RegisterTests(void);
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -559,6 +559,8 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_vntag = StatsRegisterCounter("decoder.vntag", tv);
     dtv->counter_ieee8021ah = StatsRegisterCounter("decoder.ieee8021ah", tv);
     dtv->counter_teredo = StatsRegisterCounter("decoder.teredo", tv);
+    dtv->counter_ipv4inipv4 = StatsRegisterCounter("decoder.ipv4_in_ipv4", tv);
+    dtv->counter_ipv6inipv4 = StatsRegisterCounter("decoder.ipv6_in_ipv4", tv);
     dtv->counter_ipv4inipv6 = StatsRegisterCounter("decoder.ipv4_in_ipv6", tv);
     dtv->counter_ipv6inipv6 = StatsRegisterCounter("decoder.ipv6_in_ipv6", tv);
     dtv->counter_mpls = StatsRegisterCounter("decoder.mpls", tv);

--- a/src/decode.c
+++ b/src/decode.c
@@ -918,6 +918,7 @@ void CaptureStatsSetup(ThreadVars *tv)
 
 void DecodeGlobalConfig(void)
 {
+    DecodeIPV4IpInIpConfig();
     DecodeTeredoConfig();
     DecodeGeneveConfig();
     DecodeVXLANConfig();

--- a/src/decode.h
+++ b/src/decode.h
@@ -713,6 +713,8 @@ typedef struct DecodeThreadVars_
     uint16_t counter_pppoe;
     uint16_t counter_teredo;
     uint16_t counter_mpls;
+    uint16_t counter_ipv4inipv4;
+    uint16_t counter_ipv6inipv4;
     uint16_t counter_ipv4inipv6;
     uint16_t counter_ipv6inipv6;
     uint16_t counter_erspan;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1672,6 +1672,14 @@ decoder:
   # maximum number of decoder layers for a packet
   # max-layers: 16
 
+  # IP-in-IP tunneling for ipv4 over ipv4 handling
+  # disabled by default, as these will impact number of alerts seen, as well as
+  # number of flows
+  # ipv4:
+  #   ipip:
+  #     enabled: true
+  #     parent-flow: true   # disabled by default
+
 ##
 ## Performance tuning and profiling
 ##


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/13590

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7726
https://redmine.openinfosecfoundation.org/issues/7725
https://redmine.openinfosecfoundation.org/issues/7758

Describe changes:
- update doc section to have a common section for ipv4 and ipv6, since there are also optional settings for ipv6

Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2595