### PR TITLE
decode/ipv6: set packet flow in ip-in-ip - 70x backports - v2

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2788,6 +2788,28 @@ Using this default configuration, Teredo detection will run on UDP port
 3544. If the `ports` parameter is missing, or set to `any`, all ports will be
 inspected for possible presence of Teredo.
 
+IP-in-IP
+~~~~~~~~
+
+IPv6
+^^^^
+
+By default, for IPv4 over IPv6 tunneling, the parent flow is not set up, as this
+can lead to discrepancies in alerts and flows detected. This enable this setting,
+change::
+
+    decoder:
+      ipv6:
+        ipip-ipv4:
+          track-parent-flow: true
+
+The same is true for IPv6 over IPv6. To enable parent flow setting in this case::
+
+    decoder:
+      ipv6:
+        ipip-ipv6:
+          track-parent-flow: true
+
 Advanced Options
 ----------------
 

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -34,8 +34,38 @@
 #include "decode-ipv6.h"
 #include "decode.h"
 #include "defrag.h"
+#include "flow-hash.h"
 #include "util-print.h"
 #include "util-validate.h"
+
+static bool g_ipv4_in_ipv6_parent_flow_enabled = false;
+static bool g_ipv6_in_ipv6_parent_flow_enabled = false;
+
+void DecodeIPV4InIPV6Config(void)
+{
+    int enabled = 0;
+
+    if (ConfGetBool("decoder.ipv6.ipip-ipv4.track-parent-flow", &enabled) == 1) {
+        if (enabled) {
+            g_ipv4_in_ipv6_parent_flow_enabled = true;
+        } else {
+            g_ipv4_in_ipv6_parent_flow_enabled = false;
+        }
+    }
+}
+
+void DecodeIPV6InIPV6Config(void)
+{
+    int enabled = 0;
+
+    if (ConfGetBool("decoder.ipv6.ipip-ipv6.track-parent-flow", &enabled) == 1) {
+        if (enabled) {
+            g_ipv6_in_ipv6_parent_flow_enabled = true;
+        } else {
+            g_ipv6_in_ipv6_parent_flow_enabled = true;
+        }
+    }
+}
 
 /**
  * \brief Function to decode IPv4 in IPv6 packets
@@ -54,7 +84,9 @@ static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, c
             PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV6);
             PacketEnqueueNoLock(&tv->decode_pq,tp);
             StatsIncr(tv, dtv->counter_ipv4inipv6);
-            return;
+        }
+        if (g_ipv4_in_ipv6_parent_flow_enabled) {
+            FlowSetupPacket(p);
         }
     } else {
         ENGINE_SET_EVENT(p, IPV4_IN_IPV6_WRONG_IP_VER);
@@ -80,6 +112,9 @@ static int DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV6);
             PacketEnqueueNoLock(&tv->decode_pq,tp);
             StatsIncr(tv, dtv->counter_ipv6inipv6);
+        }
+        if (g_ipv6_in_ipv6_parent_flow_enabled) {
+            FlowSetupPacket(p);
         }
     } else {
         ENGINE_SET_EVENT(p, IPV6_IN_IPV6_WRONG_IP_VER);

--- a/src/decode-ipv6.h
+++ b/src/decode-ipv6.h
@@ -240,6 +240,8 @@ typedef struct IPV6ExtHdrs_
 #define IPV6_EXTHDR_SET_RH(p)       (p)->ip6eh.rh_set = true
 #define IPV6_EXTHDR_ISSET_RH(p)     (p)->ip6eh.rh_set
 
+void DecodeIPV4InIPV6Config(void);
+void DecodeIPV6InIPV6Config(void);
 void DecodeIPV6RegisterTests(void);
 
 #endif /* __DECODE_IPV6_H__ */

--- a/src/decode.c
+++ b/src/decode.c
@@ -918,6 +918,8 @@ void CaptureStatsSetup(ThreadVars *tv)
 
 void DecodeGlobalConfig(void)
 {
+    DecodeIPV4InIPV6Config();
+    DecodeIPV6InIPV6Config();
     DecodeTeredoConfig();
     DecodeGeneveConfig();
     DecodeVXLANConfig();

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1672,6 +1672,16 @@ decoder:
   # maximum number of decoder layers for a packet
   # max-layers: 16
 
+  # Set parent flow for packets seen in IP-in-IP tunneling for ipv4 or ipv6
+  # over ipv6.
+  # Disabled by default, as these will impact number of alerts seen, as well as
+  # number of flows.
+  # ipv6:
+  #   ipip-ipv4:
+  #     track-parent-flow: true   # disabled by default
+  #   ipip-ipv6:
+  #     track-parent-flow: true   # disabled by default
+
 ##
 ## Performance tuning and profiling
 ##


### PR DESCRIPTION
Based on cherry-picked commit, but adjusted to make changes optional.

Bug #7752

(cherry picked from commit fdf0fa30c6479139e68d2549ece36c3f683d78e4)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7777
https://redmine.openinfosecfoundation.org/issues/7752

Previous PR: #13604 

Describe changes:
- adapt suricata.yaml variable settings to follow suggestion for #13609 

Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2601