### PR TITLE
output: fix NULL deref if no app-layer is logged

### DIFF
--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -627,6 +627,12 @@ static TmEcode OutputTxLogThreadDeinit(ThreadVars *tv, void *thread_data)
 
 static uint32_t OutputTxLoggerGetActiveCount(void)
 {
+    if (list == NULL) {
+        // This may happen in socket mode playing pcaps
+        // when suricata.yaml logs only alerts (and no app-layer events)
+        return 0;
+    }
+
     uint32_t cnt = 0;
     for (AppProto alproto = 0; alproto < g_alproto_max; alproto++) {
         for (OutputTxLogger *p = list[alproto]; p != NULL; p = p->next) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7815

Describe changes:
- output: fix NULL deref if no app-layer is logged

I wonder
- if there is another way to trigger the bug besides unix-socket mode
- how to have CI run the good test for this ? (using minimal suricata.yaml + list of sockets commands)