### PR TITLE
counters: hard fail on allocation failure during init

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -1104,7 +1104,7 @@ static int StatsThreadRegister(const char *thread_name, StatsPublicThreadContext
         id = HashTableLookup(stats_ctx->counters_id_hash, &t, sizeof(t));
         if (id == NULL) {
             id = SCCalloc(1, sizeof(*id));
-            DEBUG_VALIDATE_BUG_ON(id == NULL);
+            BUG_ON(id == NULL);
             id->id = counters_global_id++;
             id->string = pc->name;
 #ifdef DEBUG_VALIDATION


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7813

Describe changes:
- counters: hard fail on allocation failure during init

I wonder if qa/coccinelle/malloc-error-check.cocci could be improved to distinguish BUG_ON and DEBUG_VALIDATE_BUG_ON