### PR TITLE
hyperscan: prevent LTO to opmitize out hash calculation v2

### DIFF
--- a/src/util-mpm-hs-cache.c
+++ b/src/util-mpm-hs-cache.c
@@ -222,14 +222,12 @@ cleanup:
 
 uint64_t HSHashDb(const PatternDatabase *pd)
 {
-    uint64_t cached_hash = 0;
-    uint32_t *hash = (uint32_t *)(&cached_hash);
+    uint32_t hash[2] = { 0 };
     hashword2(&pd->pattern_cnt, 1, &hash[0], &hash[1]);
     for (uint32_t i = 0; i < pd->pattern_cnt; i++) {
         SCHSCachePatternHash(pd->parray[i], &hash[0], &hash[1]);
     }
-
-    return cached_hash;
+    return ((uint64_t)hash[0] << 32) | hash[1];
 }
 
 void HSSaveCacheIterator(void *data, void *aux)


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7824

Describe changes:
- replaced uin64_t hash calculation referenced 2x 32bit numbers to directly working with the 32bit numbers