### PR TITLE
ci: use debian 12 for xdp

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2645,10 +2645,10 @@ jobs:
       - run: suricata-update -V
       - run: suricatasc -h
 
-  debian-11:
-    name: Debian 11 (xdp)
+  debian-12-xdp:
+    name: Debian 12 (xdp)
     runs-on: ubuntu-latest
-    container: debian:11
+    container: debian:12
     needs: [prepare-deps, prepare-cbindgen]
     steps:
       # Cache Rust stuff.


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
No ticket, just keeping CI green

Describe changes:
- ci: use debian 12 for xdp

As bullseye is EOL so it is being removed from the mirrors, so there is no longer the libxdp-dev package available

https://lists.debian.org/debian-backports/2024/07/msg00003.html