### PR TITLE
app-layer: fix ippair.memcap counter

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1166,7 +1166,7 @@ void AppLayerRegisterGlobalCounters(void)
     StatsRegisterGlobalCounter("http.byterange.memuse", HTPByteRangeMemuseGlobalCounter);
     StatsRegisterGlobalCounter("http.byterange.memcap", HTPByteRangeMemcapGlobalCounter);
     StatsRegisterGlobalCounter("ippair.memuse", IPPairGetMemuse);
-    StatsRegisterGlobalCounter("ippair.memcap", IPPairGetMemuse);
+    StatsRegisterGlobalCounter("ippair.memcap", IPPairGetMemcap);
     StatsRegisterGlobalCounter("host.memuse", HostGetMemuse);
     StatsRegisterGlobalCounter("host.memcap", HostGetMemcap);
 }


### PR DESCRIPTION
Until now ippair.memcap statistic was incorrectly collected by IPPairGetMemuse function.
This resulted in ippair.memcap and ippair.memuse to be set to the same number.
Changed the counter function to IPPairGetMemcap.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7827

Changes:
- Use function IPPairGetMemcap instead of IPPairGetMemuse for collecting 'ippair.memcap' counter.

