### PR TITLE
github-ci: add flto build; fix lto warnings - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -789,7 +789,7 @@ jobs:
 
   # Fedora build using GCC.
   fedora-42-gcc:
-    name: Fedora 42 (gcc, debug, asan, wshadow, rust-strict)
+    name: Fedora 42 (gcc, debug, flto, asan, wshadow, rust-strict)
     runs-on: ubuntu-latest
     container: fedora:42
     needs: [prepare-deps, prepare-cbindgen]
@@ -840,6 +840,7 @@ jobs:
                 pkgconfig \
                 python3-yaml \
                 sudo \
+                vectorscan-devel \
                 which \
                 zlib-devel
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -853,7 +854,7 @@ jobs:
       - run: ./autogen.sh
       - run: ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
         env:
-          CFLAGS: "${{ env.DEFAULT_CFLAGS }} -Wshadow -fsanitize=address -fno-omit-frame-pointer"
+          CFLAGS: "${{ env.DEFAULT_CFLAGS }} -Wshadow -fsanitize=address -fno-omit-frame-pointer -flto=auto -O2"
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"
           ac_cv_func_malloc_0_nonnull: "yes"

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -186,7 +186,7 @@ static InspectionBuffer *GetDNP3Data(DetectEngineThreadCtx *det_ctx,
  */
 static int DetectDNP3FuncParseFunctionCode(const char *str, uint8_t *fc)
 {
-    if (StringParseUint8(fc, 10, (uint16_t)strlen(str), str) >= 0) {
+    if (StringParseUint8(fc, 10, (uint16_t)strlen(str), str) > 0) {
         return 1;
     }
 
@@ -335,11 +335,11 @@ static int DetectDNP3ObjParse(const char *str, uint8_t *group, uint8_t *var)
     *sep = '\0';
     varstr = sep + 1;
 
-    if (StringParseUint8(group, 0, (uint16_t)strlen(groupstr), groupstr) < 0) {
+    if (StringParseUint8(group, 0, (uint16_t)strlen(groupstr), groupstr) <= 0) {
         return 0;
     }
 
-    if (StringParseUint8(var, 0, (uint16_t)strlen(varstr), varstr) < 0) {
+    if (StringParseUint8(var, 0, (uint16_t)strlen(varstr), varstr) <= 0) {
         return 0;
     }
 

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -4339,7 +4339,7 @@ static int AddressTestCutIPv401(void)
 
 static int AddressTestCutIPv402(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0/255.255.255.0");
     b = DetectAddressParseSingle("1.2.2.0-1.2.3.4");
 
@@ -4363,7 +4363,7 @@ error:
 
 static int AddressTestCutIPv403(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0/255.255.255.0");
     b = DetectAddressParseSingle("1.2.2.0-1.2.3.4");
 
@@ -4394,7 +4394,7 @@ error:
 
 static int AddressTestCutIPv404(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.3-1.2.3.6");
     b = DetectAddressParseSingle("1.2.3.0-1.2.3.5");
 
@@ -4426,7 +4426,7 @@ error:
 
 static int AddressTestCutIPv405(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.3-1.2.3.6");
     b = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
 
@@ -4457,7 +4457,7 @@ error:
 
 static int AddressTestCutIPv406(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
     b = DetectAddressParseSingle("1.2.3.3-1.2.3.6");
 
@@ -4488,7 +4488,7 @@ error:
 
 static int AddressTestCutIPv407(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0-1.2.3.6");
     b = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
 
@@ -4517,7 +4517,7 @@ error:
 
 static int AddressTestCutIPv408(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.3-1.2.3.9");
     b = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
 
@@ -4546,7 +4546,7 @@ error:
 
 static int AddressTestCutIPv409(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
     b = DetectAddressParseSingle("1.2.3.0-1.2.3.6");
 
@@ -4575,7 +4575,7 @@ error:
 
 static int AddressTestCutIPv410(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
     b = DetectAddressParseSingle("1.2.3.3-1.2.3.9");
 

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -279,7 +279,7 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem **pdd, const char *str)
                 }
 
                 uint8_t cidr;
-                if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask, 0, 32) < 0)
+                if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask, 0, 32) <= 0)
                     goto error;
 
                 dd->netmask = cidr;

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -320,7 +320,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
         }
         uint16_t offset;
         if (StringParseUint16(&offset, 10, 0,
-                              (const char *)arg_substr) < 0) {
+                              (const char *)arg_substr) <= 0) {
             SCLogError("Invalid fast pattern offset:"
                        " \"%s\"",
                     arg_substr);
@@ -336,7 +336,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
         }
         uint16_t length;
         if (StringParseUint16(&length, 10, 0,
-                              (const char *)arg_substr) < 0) {
+                              (const char *)arg_substr) <= 0) {
             SCLogError("Invalid value for fast "
                        "pattern: \"%s\"",
                     arg_substr);

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -319,8 +319,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
             goto error;
         }
         uint16_t offset;
-        if (StringParseUint16(&offset, 10, 0,
-                              (const char *)arg_substr) <= 0) {
+        if (StringParseUint16(&offset, 10, 0, (const char *)arg_substr) <= 0) {
             SCLogError("Invalid fast pattern offset:"
                        " \"%s\"",
                     arg_substr);
@@ -335,8 +334,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
             goto error;
         }
         uint16_t length;
-        if (StringParseUint16(&length, 10, 0,
-                              (const char *)arg_substr) <= 0) {
+        if (StringParseUint16(&length, 10, 0, (const char *)arg_substr) <= 0) {
             SCLogError("Invalid value for fast "
                        "pattern: \"%s\"",
                     arg_substr);

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -211,7 +211,7 @@ static int DetectHTTP2frametypeMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectHTTP2FuncParseFrameType(const char *str, uint8_t *ft)
 {
     // first parse numeric value
-    if (ByteExtractStringUint8(ft, 10, (uint16_t)strlen(str), str) >= 0) {
+    if (ByteExtractStringUint8(ft, 10, (uint16_t)strlen(str), str) > 0) {
         return 1;
     }
 
@@ -291,7 +291,7 @@ static int DetectHTTP2errorcodeMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectHTTP2FuncParseErrorCode(const char *str, uint32_t *ec)
 {
     // first parse numeric value
-    if (ByteExtractStringUint32(ec, 10, (uint16_t)strlen(str), str) >= 0) {
+    if (ByteExtractStringUint32(ec, 10, (uint16_t)strlen(str), str) > 0) {
         return 1;
     }
 

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -156,7 +156,7 @@ static DetectIdData *DetectIdParse (const char *idstr)
     }
 
     /* ok, fill the id data */
-    if (StringParseUint16(&temp, 10, 0, (const char *)tmp_str) < 0) {
+    if (StringParseUint16(&temp, 10, 0, (const char *)tmp_str) <= 0) {
         SCLogError("invalid id option '%s'", tmp_str);
         goto error;
     }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -569,7 +569,7 @@ static uint8_t GetDnsLogVersion(SCConfNode *conf)
     }
 
     uint8_t version;
-    if (StringParseUint8(&version, 10, 0, version_string) >= 0) {
+    if (StringParseUint8(&version, 10, 0, version_string) > 0) {
         return version;
     }
     SCLogWarning("Failed to parse EVE DNS log version of \"%s\"", version_string);

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -298,10 +298,10 @@ static int SRepSplitLine(SRepCIDRTree *cidr_ctx, char *line, Address *ip, uint8_
         return 1;
 
     uint8_t c, v;
-    if (StringParseU8RangeCheck(&c, 10, 0, (const char *)ptrs[1], 0, SREP_MAX_CATS - 1) < 0)
+    if (StringParseU8RangeCheck(&c, 10, 0, (const char *)ptrs[1], 0, SREP_MAX_CATS - 1) <= 0)
         return -1;
 
-    if (StringParseU8RangeCheck(&v, 10, 0, (const char *)ptrs[2], 0, SREP_MAX_VAL) < 0)
+    if (StringParseU8RangeCheck(&v, 10, 0, (const char *)ptrs[2], 0, SREP_MAX_VAL) <= 0)
         return -1;
 
     if (strchr(ptrs[0], '/') != NULL) {

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -242,11 +242,11 @@ int BuildCpusetWithCallback(
             stop = 1;
         } else if (strchr(lnode->val, '-') != NULL) {
             char *sep = strchr(lnode->val, '-');
-            if (StringParseUint32(&a, 10, sep - lnode->val, lnode->val) < 0) {
+            if (StringParseUint32(&a, 10, sep - lnode->val, lnode->val) <= 0) {
                 SCLogError("%s: invalid cpu range (start invalid): \"%s\"", name, lnode->val);
                 return -1;
             }
-            if (StringParseUint32(&b, 10, strlen(sep) - 1, sep + 1) < 0) {
+            if (StringParseUint32(&b, 10, strlen(sep) - 1, sep + 1) <= 0) {
                 SCLogError("%s: invalid cpu range (end invalid): \"%s\"", name, lnode->val);
                 return -1;
             }
@@ -260,7 +260,7 @@ int BuildCpusetWithCallback(
                 return -1;
             }
         } else {
-            if (StringParseUint32(&a, 10, strlen(lnode->val), lnode->val) < 0) {
+            if (StringParseUint32(&a, 10, strlen(lnode->val), lnode->val) <= 0) {
                 SCLogError("%s: invalid cpu range (not an integer): \"%s\"", name, lnode->val);
                 return -1;
             }

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -140,6 +140,9 @@ int ByteExtractUint64(uint64_t *res, int e, uint16_t len, const uint8_t *bytes)
     return ret;
 }
 
+/**
+ * \retval Greater than 0 if successful, 0 or negative on failure.
+ */
 int ByteExtractUint32(uint32_t *res, int e, uint16_t len, const uint8_t *bytes)
 {
     uint64_t i64;
@@ -334,6 +337,9 @@ int StringParseUint32(uint32_t *res, int base, size_t len, const char *str)
     return ret;
 }
 
+/**
+ * \retval Greater than 0 if successful, 0 or negative on failure.
+ */
 int StringParseUint16(uint16_t *res, int base, size_t len, const char *str)
 {
     uint64_t i64;
@@ -358,6 +364,9 @@ int StringParseUint16(uint16_t *res, int base, size_t len, const char *str)
     return ret;
 }
 
+/**
+ * \retval Greater than 0 if successful, 0 or negative on failure.
+ */
 int StringParseUint8(uint8_t *res, int base, size_t len, const char *str)
 {
     uint64_t i64;
@@ -459,6 +468,9 @@ int StringParseU16RangeCheck(
     return ret;
 }
 
+/**
+ * \retval Greater than 0 if successful, 0 or negative on failure.
+ */
 int StringParseU8RangeCheck(
         uint8_t *res, int base, size_t len, const char *str, uint8_t min, uint8_t max)
 {

--- a/src/util-lua-bytevarlib.c
+++ b/src/util-lua-bytevarlib.c
@@ -56,7 +56,7 @@ static int LuaBytevarMap(lua_State *L)
 
     DetectByteIndexType idx;
     if (!DetectByteRetrieveSMVar(name, s, -1, &idx)) {
-        luaL_error(L, "unknown byte_extract or byte_math variable: %s", name);
+        return luaL_error(L, "unknown byte_extract or byte_math variable: %s", name);
     }
 
     ld->bytevar[ld->bytevars].name = SCStrdup(name);

--- a/src/util-radix4-tree.c
+++ b/src/util-radix4-tree.c
@@ -248,7 +248,7 @@ bool SCRadix4AddKeyIPV4String(
         }
 
         uint8_t cidr;
-        if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 32) < 0) {
+        if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 32) <= 0) {
             sc_errno = SC_EINVAL;
             return false;
         }

--- a/src/util-radix6-tree.c
+++ b/src/util-radix6-tree.c
@@ -281,7 +281,7 @@ bool SCRadix6AddKeyIPV6String(
         }
 
         uint8_t cidr;
-        if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 128) < 0) {
+        if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 128) <= 0) {
             sc_errno = SC_EINVAL;
             return false;
         }


### PR DESCRIPTION
# github-ci: add flto build

Ubuntu and Fedora packing system build with -flto=auto by default, so
update one test to use -flto=auto. Also build with -O2 as that
combination can cause issues such as
https://redmine.openinfosecfoundation.org/issues/7824.

Also adds vectorscan to the build.

# lua/bytevarlib: return luaL_error to suppress warning

Even though luaL_error never returns, use a return to make it
clear. Also prevents a compiler warning about idx being used
uninitialized.

# detect-engine-address: initialize pointer in unit tests

To prevent the compiler warning about "c" being used uninitialized
with LTO.

# util-byte: fix usage of util-byte integer parsers

Functions like ByteExtractStringUint8 return 0 or less on
failure. Many usages of this function treat 0 as successful as its our
common pattern.
