### PR TITLE
ci: use debian 12 for xdp

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2447,6 +2447,7 @@ jobs:
               texlive-latex-extra \
               zlib1g \
               zlib1g-dev \
+              clang \
               libxdp-dev
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: git config --global --add safe.directory /__w/suricata/suricata
@@ -2663,7 +2664,6 @@ jobs:
         run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
       - run: |
-          echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
           apt update
           apt -y install \
                 automake \

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2387,8 +2387,8 @@ jobs:
       - run: |
           ./.github/workflows/live/dpdk.sh ".github/workflows/dpdk/suricata-null-ips.yaml"
 
-  debian-12:
-    name: Debian 12
+  debian-12-xdp:
+    name: Debian 12 (xdp)
     runs-on: ubuntu-latest
     container: debian:12
     needs: [prepare-deps]
@@ -2446,7 +2446,8 @@ jobs:
               texlive-fonts-extra \
               texlive-latex-extra \
               zlib1g \
-              zlib1g-dev
+              zlib1g-dev \
+              libxdp-dev
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: git config --global --add safe.directory /__w/suricata/suricata
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -2460,7 +2461,7 @@ jobs:
       - run: tar xf prep/suricata-update.tar.gz
       - run: tar xf prep/suricata-verify.tar.gz
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
       - run: make -j ${{ env.CPUS }}
       - run: make check
         # -j2 caused random failures during cargo vendor
@@ -2646,7 +2647,7 @@ jobs:
       - run: suricatasc -h
 
   debian-11:
-    name: Debian 11 (xdp)
+    name: Debian 11
     runs-on: ubuntu-latest
     container: debian:11
     needs: [prepare-deps, prepare-cbindgen]
@@ -2696,8 +2697,7 @@ jobs:
                 zlib1g-dev \
                 clang \
                 libbpf-dev \
-                libelf-dev \
-                libxdp-dev
+                libelf-dev
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION_KNOWN -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -2710,7 +2710,7 @@ jobs:
       - run: tar xf prep/suricata-update.tar.gz
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-fuzztargets --enable-ebpf --enable-ebpf-build
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-fuzztargets
       - run: make -j ${{ env.CPUS }}
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
No ticket, just keeping CI green

Describe changes:
- ci: use debian 12 for xdp

As bullseye is EOL so it is being removed from the mirrors, so there is no longer the libxdp-dev package available

https://lists.debian.org/debian-backports/2024/07/msg00003.html

https://github.com/OISF/suricata/pull/13630 with keeping build for debian 11