### PR TITLE
exceptions: add stats counters - 70x backports - v2

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -224,19 +224,20 @@ There are stats counters for each supported exception policy scenario:
    :stub-columns: 1
 
    * - Setting
-     - Counter
+     - Counters
    * - stream.memcap
-     - tcp.ssn_memcap_exception_policy
+     - exception_policy.tcp.ssn_memcap
    * - stream.reassembly.memcap
-     - tcp.reassembly_memcap_exception_policy
+     - exception_policy.tcp.reassembly
    * - stream.midstream
-     - tcp.midstream_exception_policy
+     - exception_policy.tcp.midstream
    * - defrag.memcap
-     - defrag.memcap_exception_policy
+     - exception_policy.defrag.memcap
    * - flow.memcap
-     - flow.memcap_exception_policy
+     - exception_policy.flow.memcap
    * - app-layer.error
-     - app_layer.error.exception_policy
+     - * exception_policy.app_layer.error
+       * app_layer.error.exception_policy
 
 If a given exception policy does not apply for a setting, no related counter
 is logged.

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -7,7 +7,10 @@ Suricata has a set of configuration variables to indicate what should the engine
 do when certain exception conditions, such as hitting a memcap, are reached.
 
 They are called Exception Policies and are configurable via suricata.yaml. If
-enabled, the engine will call them when it reaches exception states.
+enabled, the engine will call them when it reaches exception states. Stats for
+any applied exception policies can be found in counters related to the specific
+configuration setting (:ref:`read more<eps_stats>`). Some configuration is
+available directly via the :ref:`stats settings<suricata_yaml_outputs>`.
 
 For developers or for researching purposes, there are also simulation options
 exposed in debug mode and passed via command-line. These exist to force or
@@ -207,6 +210,43 @@ Notes:
      of the matching packet.
 
 .. _command-line-exception-policies:
+
+.. _eps_stats:
+
+Available Stats
+---------------
+
+There are stats counters for each supported exception policy scenario:
+
+.. list-table:: **Exception Policy Stats Counters**
+   :widths: 50 50
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Setting
+     - Counter
+   * - stream.memcap
+     - tcp.ssn_memcap_exception_policy
+   * - stream.reassembly.memcap
+     - tcp.reassembly_memcap_exception_policy
+   * - stream.midstream
+     - tcp.midstream_exception_policy
+   * - defrag.memcap
+     - defrag.memcap_exception_policy
+   * - flow.memcap
+     - flow.memcap_exception_policy
+   * - app-layer.error
+     - app_layer.error.exception_policy
+
+If a given exception policy does not apply for a setting, no related counter
+is logged.
+
+Stats for application layer errors are available in summarized form or per
+application layer protocol. As the latter is extremely verbose, by default
+Suricata logs only the summary. If any further investigation is needed, it
+is recommended to enable per-app-proto exception policy error counters
+temporarily (for :ref:`stats configuration<suricata_yaml_outputs>`).
+
 
 Command-line Options for Simulating Exceptions
 ==============================================

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -60,33 +60,40 @@ Specific settings
 Exception policies are implemented for:
 
 .. list-table:: Exception Policy configuration variables
-   :widths: 20, 18, 62
+   :widths: 18, 18, 18, 44
    :header-rows: 1
 
    * - Config setting
      - Policy variable
+     - Affects
      - Expected behavior
    * - stream.memcap
      - memcap-policy
+     - Flow or packet
      - If a stream memcap limit is reached, apply the memcap policy to the packet and/or
        flow.
    * - stream.midstream
      - midstream-policy
+     - Flow
      - If a session is picked up midstream, apply the midstream policy to the flow.
    * - stream.reassembly.memcap
      - memcap-policy
+     - Flow or packet
      - If stream reassembly reaches memcap limit, apply memcap policy to the
        packet and/or flow.
    * - flow.memcap
      - memcap-policy
+     - Packet
      - Apply policy when the memcap limit for flows is reached and no flow could
        be freed up. **Policy can only be applied to the packet.**
    * - defrag.memcap
      - memcap-policy
+     - Packet
      - Apply policy when the memcap limit for defrag is reached and no tracker
        could be picked up. **Policy can only be applied to the packet.**
    * - app-layer
      - error-policy
+     - Flow or packet
      - Apply policy if a parser reaches an error state. Policy can be applied to packet and/or flow.
 
 To change any of these, go to the specific section in the suricata.yaml file

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -57,6 +57,12 @@ It is possible to disable this default, by setting the exception policies'
 **In IDS mode**, setting ``auto`` mode actually means disabling the
 ``master-switch``, or ignoring the exception policies.
 
+.. note::
+
+    If no exception policy is enabled, Suricata will not log exception policy stats.
+
+.. _eps_settings:
+
 Specific settings
 *****************
 
@@ -216,7 +222,11 @@ Notes:
 Available Stats
 ---------------
 
-There are stats counters for each supported exception policy scenario:
+There are stats counters for each supported exception policy scenario that will
+be logged when *exception policies and exception policy stats counters* are enabled.
+(By default, these stats counters are disabled, as they greatly increase the stats logs
+size):
+
 
 .. list-table:: **Exception Policy Stats Counters**
    :widths: 50 50
@@ -246,7 +256,7 @@ Stats for application layer errors are available in summarized form or per
 application layer protocol. As the latter is extremely verbose, by default
 Suricata logs only the summary. If any further investigation is needed, it
 is recommended to enable per-app-proto exception policy error counters
-temporarily (for :ref:`stats configuration<suricata_yaml_outputs>`).
+temporarily (for more, read :ref:`stats configuration<suricata_yaml_outputs>`).
 
 
 Command-line Options for Simulating Exceptions

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -346,6 +346,10 @@ Similar to the `decoder-events` option, the `stream-events` option controls
 whether the stream-events are added as counters as well. This is disabled by
 default.
 
+If any exception policy is enabled, stats counters are logged. To control
+verbosity for application layer protocol errors, leave `per-app-proto-errors`
+as false.
+
 Outputs
 ~~~~~~~
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -317,6 +317,13 @@ the global config is documented.
       #decoder-events-prefix: "decoder.event"
       # Add stream events as stats.
       #stream-events: false
+      # Exception policy stats counters options
+      # (Note: if exception policy: ignore, counters are not logged)
+      exception-policy:
+        #global-stats: true           # default: false. True will log stats for all
+                                      # valid exception policies
+        #per-app-proto-errors: false  # default: false. True will log errors for
+                                        # each app-proto. Warning: VERY verbose
 
 Statistics can be `enabled` or disabled here.
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4855,6 +4855,11 @@
                         "max_frag_hits": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "description":
+                                    "How many times defrag memcap exception policy was applied, and which one",
+                            "$ref": "#/$defs/exceptionPolicy"
+                        },
                         "ipv4": {
                             "type": "object",
                             "properties": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5297,6 +5297,11 @@
                         "midstream_pickups": {
                             "type": "integer"
                         },
+                        "midstream_exception_policy": {
+                            "description":
+                                    "How many times midstream exception policy was applied, and which one",
+                            "$ref": "#/$defs/exceptionPolicy"
+                        },
                         "no_flow": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4958,6 +4958,14 @@
                                         "How many times defrag memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             }
+                        },
+                        "flow": {
+                            "type": "object",
+                            "memcap": {
+                                "description":
+                                        "How many times flow memcap exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
+                            }
                         }
                     }
                 },
@@ -5011,11 +5019,6 @@
                         },
                         "memcap": {
                             "type": "integer"
-                        },
-                        "memcap_exception_policy": {
-                            "description":
-                                    "How many times flow memcap exception policy was applied, and which one",
-                            "$ref": "#/$defs/exceptionPolicy"
                         },
                         "memuse": {
                             "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4969,6 +4969,11 @@
                         },
                         "tcp": {
                             "type": "object",
+                            "midstream": {
+                                "description":
+                                        "How many times midstream exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
+                            },
                             "ssn_memcap": {
                                 "description":
                                         "How many times session memcap exception policy was applied, and which one",
@@ -5323,11 +5328,6 @@
                         },
                         "midstream_pickups": {
                             "type": "integer"
-                        },
-                        "midstream_exception_policy": {
-                            "description":
-                                    "How many times midstream exception policy was applied, and which one",
-                            "$ref": "#/$defs/exceptionPolicy"
                         },
                         "no_flow": {
                             "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4991,6 +4991,11 @@
                         "memcap": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "description":
+                                    "How many times flow memcap exception policy was applied, and which one",
+                            "$ref": "#/$defs/exceptionPolicy"
+                        },
                         "memuse": {
                             "type": "integer"
                         },
@@ -5655,6 +5660,35 @@
                             ]
                         }
                     ]
+                }
+            }
+        },
+        "exceptionPolicy": {
+            "type": "object",
+            "properties": {
+                "drop_flow": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "drop_packet": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "pass_flow": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "pass_packet": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "bypass": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "reject": {
+                    "type": "integer",
+                    "minimum": 0
                 }
             }
         }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3764,11 +3764,6 @@
                         "error": {
                             "type": "object",
                             "properties": {
-                                "exception_policy": {
-                                    "description":
-                                            "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
-                                    "$ref": "#/$defs/exceptionPolicy"
-                                },
                                 "bittorrent-dht": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
@@ -4949,6 +4944,19 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "exception_policy": {
+                    "type": "object",
+                    "properties": {
+                        "app_layer": {
+                            "type": "object",
+                            "error": {
+                                "description":
+                                    "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
+                            }
+                        }
+                    }
                 },
                 "file_store": {
                     "type": "object",

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3764,6 +3764,11 @@
                         "error": {
                             "type": "object",
                             "properties": {
+                                "exception_policy": {
+                                    "description":
+                                            "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
+                                },
                                 "bittorrent-dht": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
@@ -5625,6 +5630,11 @@
                 },
                 "internal": {
                     "type": "integer"
+                },
+                "exception_policy": {
+                    "description":
+                            "How many times app-layer error exception policy was applied, and which one",
+                    "$ref": "#/$defs/exceptionPolicy"
                 }
             },
             "additionalProperties": false

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4973,6 +4973,11 @@
                                 "description":
                                         "How many times session memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
+                            },
+                            "reassembly": {
+                                "description":
+                                        "How many times reassembly memcap exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
                             }
                         }
                     }
@@ -5341,11 +5346,6 @@
                         },
                         "pseudo_failed": {
                             "type": "integer"
-                        },
-                        "reassembly_exception_policy": {
-                            "description":
-                                    "How many times reassembly memcap exception policy was applied, and which one",
-                            "$ref": "#/$defs/exceptionPolicy"
                         },
                         "reassembly_gap": {
                             "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4855,11 +4855,6 @@
                         "max_frag_hits": {
                             "type": "integer"
                         },
-                        "memcap_exception_policy": {
-                            "description":
-                                    "How many times defrag memcap exception policy was applied, and which one",
-                            "$ref": "#/$defs/exceptionPolicy"
-                        },
                         "ipv4": {
                             "type": "object",
                             "properties": {
@@ -4953,6 +4948,14 @@
                             "error": {
                                 "description":
                                     "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
+                            }
+                        },
+                        "defrag": {
+                            "type": "object",
+                            "memcap": {
+                                "description":
+                                        "How many times defrag memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             }
                         }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5345,6 +5345,11 @@
                         "ssn_memcap_drop": {
                             "type": "integer"
                         },
+                        "ssn_memcap_exception_policy": {
+                            "description":
+                                    "How many times session memcap exception policy was applied, and which one",
+                            "$ref": "#/$defs/exceptionPolicy"
+                        },
                         "stream_depth_reached": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5315,6 +5315,11 @@
                         "pseudo_failed": {
                             "type": "integer"
                         },
+                        "reassembly_exception_policy": {
+                            "description":
+                                    "How many times reassembly memcap exception policy was applied, and which one",
+                            "$ref": "#/$defs/exceptionPolicy"
+                        },
                         "reassembly_gap": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4966,6 +4966,14 @@
                                         "How many times flow memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             }
+                        },
+                        "tcp": {
+                            "type": "object",
+                            "ssn_memcap": {
+                                "description":
+                                        "How many times session memcap exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
+                            }
                         }
                     }
                 },
@@ -5368,11 +5376,6 @@
                         },
                         "ssn_memcap_drop": {
                             "type": "integer"
-                        },
-                        "ssn_memcap_exception_policy": {
-                            "description":
-                                    "How many times session memcap exception policy was applied, and which one",
-                            "$ref": "#/$defs/exceptionPolicy"
                         },
                         "stream_depth_reached": {
                             "type": "integer"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -542,6 +542,7 @@ noinst_HEADERS = \
 	util-enum.h \
 	util-error.h \
 	util-exception-policy.h \
+	util-exception-policy-types.h \
 	util-file-decompression.h \
 	util-file.h \
 	util-file-swf-decompression.h \

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -49,6 +49,8 @@
 #include "app-layer-htp-mem.h"
 #include "util-exception-policy.h"
 
+extern bool g_eps_stats_counters;
+extern bool g_stats_eps_per_app_proto_errors;
 /**
  * \brief This is for the app layer in general and it contains per thread
  *        context relevant to both the alpd and alp.
@@ -80,6 +82,7 @@ typedef struct AppLayerCounterNames_ {
     char parser_error[MAX_COUNTER_SIZE];
     char internal_error[MAX_COUNTER_SIZE];
     char alloc_error[MAX_COUNTER_SIZE];
+    char eps_name[EXCEPTION_POLICY_MAX][MAX_COUNTER_SIZE];
 } AppLayerCounterNames;
 
 typedef struct AppLayerCounters_ {
@@ -89,12 +92,41 @@ typedef struct AppLayerCounters_ {
     uint16_t parser_error_id;
     uint16_t internal_error_id;
     uint16_t alloc_error_id;
+    ExceptionPolicyCounters eps_error;
 } AppLayerCounters;
 
 /* counter names. Only used at init. */
 AppLayerCounterNames applayer_counter_names[FLOW_PROTO_APPLAYER_MAX][ALPROTO_MAX];
 /* counter id's. Used that runtime. */
 AppLayerCounters applayer_counters[FLOW_PROTO_APPLAYER_MAX][ALPROTO_MAX];
+/* Exception policy global counters ids */
+ExceptionPolicyCounters eps_error_summary;
+
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts app_layer_error_eps_stats = {
+    .valid_settings_ids = {
+       /* EXCEPTION_POLICY_NOT_SET */      false,
+       /* EXCEPTION_POLICY_AUTO */         false,
+       /* EXCEPTION_POLICY_PASS_PACKET */  true,
+       /* EXCEPTION_POLICY_PASS_FLOW */    true,
+       /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+       /* EXCEPTION_POLICY_DROP_PACKET */  false,
+       /* EXCEPTION_POLICY_DROP_FLOW */    false,
+       /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    .valid_settings_ips = {
+       /* EXCEPTION_POLICY_NOT_SET */      false,
+       /* EXCEPTION_POLICY_AUTO */         false,
+       /* EXCEPTION_POLICY_PASS_PACKET */  true,
+       /* EXCEPTION_POLICY_PASS_FLOW */    true,
+       /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+       /* EXCEPTION_POLICY_DROP_PACKET */  true,
+       /* EXCEPTION_POLICY_DROP_FLOW */    true,
+       /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
 
 void AppLayerSetupCounters(void);
 void AppLayerDeSetupCounters(void);
@@ -156,6 +188,25 @@ void AppLayerIncInternalErrorCounter(ThreadVars *tv, Flow *f)
     const uint16_t id = applayer_counters[f->protomap][f->alproto].internal_error_id;
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
+    }
+}
+
+static void AppLayerIncrErrorExcPolicyCounter(ThreadVars *tv, Flow *f, enum ExceptionPolicy policy)
+{
+#ifdef UNITTESTS
+    if (tv == NULL) {
+        return;
+    }
+#endif
+    uint16_t id = applayer_counters[f->protomap][f->alproto].eps_error.eps_id[policy];
+    /* for the summary values */
+    uint16_t g_id = eps_error_summary.eps_id[policy];
+
+    if (likely(id > 0)) {
+        StatsIncr(tv, id);
+    }
+    if (likely(g_id > 0)) {
+        StatsIncr(tv, g_id);
     }
 }
 
@@ -642,6 +693,7 @@ static int TCPProtoDetect(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
     SCReturnInt(0);
 parser_error:
     ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+    AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
     SCReturnInt(-1);
 detect_error:
     DisableAppLayer(tv, f, p);
@@ -710,6 +762,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, Packet
         StreamTcpUpdateAppLayerProgress(ssn, direction, data_len);
         if (r < 0) {
             ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+            AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
             SCReturnInt(-1);
         }
         goto end;
@@ -796,6 +849,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, Packet
                 if (r < 0) {
                     ExceptionPolicyApply(
                             p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+                    AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
                     SCReturnInt(-1);
                 }
             }
@@ -936,6 +990,7 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
     }
     if (r < 0) {
         ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+        AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
         SCReturnInt(-1);
     }
 
@@ -1066,6 +1121,30 @@ void AppLayerRegisterGlobalCounters(void)
     StatsRegisterGlobalCounter("app_layer.expectations", ExpectationGetCounter);
 }
 
+static bool IsAppLayerErrorExceptionPolicyStatsValid(enum ExceptionPolicy policy)
+{
+    if (EngineModeIsIPS()) {
+        return app_layer_error_eps_stats.valid_settings_ips[policy];
+    }
+    return app_layer_error_eps_stats.valid_settings_ids[policy];
+}
+
+static void AppLayerSetupExceptionPolicyPerProtoCounters(
+        uint8_t ipproto_map, AppProto alproto, const char *alproto_str, const char *ipproto_suffix)
+{
+    if (g_stats_eps_per_app_proto_errors &&
+            g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
+        for (enum ExceptionPolicy i = EXCEPTION_POLICY_NOT_SET + 1; i < EXCEPTION_POLICY_MAX; i++) {
+            if (IsAppLayerErrorExceptionPolicyStatsValid(i)) {
+                snprintf(applayer_counter_names[ipproto_map][alproto].eps_name[i],
+                        sizeof(applayer_counter_names[ipproto_map][alproto].eps_name[i]),
+                        "app_layer.error.%s%s.exception_policy.%s", alproto_str, ipproto_suffix,
+                        ExceptionPolicyEnumToString(i, true));
+            }
+        }
+    }
+}
+
 #define IPPROTOS_MAX 2
 void AppLayerSetupCounters(void)
 {
@@ -1073,6 +1152,19 @@ void AppLayerSetupCounters(void)
     AppProto alprotos[ALPROTO_MAX];
     const char *str = "app_layer.flow.";
     const char *estr = "app_layer.error.";
+
+    /* We don't log stats counters if exception policy is `ignore`/`not set` */
+    if (g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET && g_eps_stats_counters) {
+        /* Register global counters for app layer error exception policy summary */
+        const char *eps_default_str = "app_layer.error.exception_policy.";
+        for (enum ExceptionPolicy i = EXCEPTION_POLICY_NOT_SET + 1; i < EXCEPTION_POLICY_MAX; i++) {
+            if (IsAppLayerErrorExceptionPolicyStatsValid(i)) {
+                snprintf(app_layer_error_eps_stats.eps_name[i],
+                        sizeof(app_layer_error_eps_stats.eps_name[i]), "%s%s", eps_default_str,
+                        ExceptionPolicyEnumToString(i, true));
+            }
+        }
+    }
 
     AppLayerProtoDetectSupportedAppProtocols(alprotos);
 
@@ -1110,6 +1202,9 @@ void AppLayerSetupCounters(void)
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
                             "%s%s%s.internal", estr, alproto_str, ipproto_suffix);
+
+                    AppLayerSetupExceptionPolicyPerProtoCounters(
+                            ipproto_map, alproto, alproto_str, ipproto_suffix);
                 } else {
                     snprintf(applayer_counter_names[ipproto_map][alproto].name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].name),
@@ -1132,6 +1227,8 @@ void AppLayerSetupCounters(void)
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
                             "%s%s.internal", estr, alproto_str);
+                    AppLayerSetupExceptionPolicyPerProtoCounters(
+                            ipproto_map, alproto, alproto_str, "");
                 }
             } else if (alproto == ALPROTO_FAILED) {
                 snprintf(applayer_counter_names[ipproto_map][alproto].name,
@@ -1152,6 +1249,17 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
     const uint8_t ipprotos[] = { IPPROTO_TCP, IPPROTO_UDP };
     AppProto alprotos[ALPROTO_MAX];
     AppLayerProtoDetectSupportedAppProtocols(alprotos);
+
+    /* We don't log stats counters if exception policy is `ignore`/`not set` */
+    if (g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET && g_eps_stats_counters) {
+        /* Register global counters for app layer error exception policy summary */
+        for (enum ExceptionPolicy i = EXCEPTION_POLICY_NOT_SET + 1; i < EXCEPTION_POLICY_MAX; i++) {
+            if (IsAppLayerErrorExceptionPolicyStatsValid(i)) {
+                eps_error_summary.eps_id[i] =
+                        StatsRegisterCounter(app_layer_error_eps_stats.eps_name[i], tv);
+            }
+        }
+    }
 
     for (uint8_t p = 0; p < IPPROTOS_MAX; p++) {
         const uint8_t ipproto = ipprotos[p];
@@ -1175,6 +1283,18 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
                         applayer_counter_names[ipproto_map][alproto].parser_error, tv);
                 applayer_counters[ipproto_map][alproto].internal_error_id = StatsRegisterCounter(
                         applayer_counter_names[ipproto_map][alproto].internal_error, tv);
+                /* We don't log stats counters if exception policy is `ignore`/`not set` */
+                if (g_stats_eps_per_app_proto_errors &&
+                        g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
+                    for (enum ExceptionPolicy i = EXCEPTION_POLICY_NOT_SET + 1;
+                            i < EXCEPTION_POLICY_MAX; i++) {
+                        if (IsAppLayerErrorExceptionPolicyStatsValid(i)) {
+                            applayer_counters[ipproto_map][alproto]
+                                    .eps_error.eps_id[i] = StatsRegisterCounter(
+                                    applayer_counter_names[ipproto_map][alproto].eps_name[i], tv);
+                        }
+                    }
+                }
             } else if (alproto == ALPROTO_FAILED) {
                 applayer_counters[ipproto_map][alproto].counter_id =
                     StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].name, tv);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1156,7 +1156,7 @@ void AppLayerSetupCounters(void)
     /* We don't log stats counters if exception policy is `ignore`/`not set` */
     if (g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET && g_eps_stats_counters) {
         /* Register global counters for app layer error exception policy summary */
-        const char *eps_default_str = "app_layer.error.exception_policy.";
+        const char *eps_default_str = "exception_policy.app_layer.error.";
         for (enum ExceptionPolicy i = EXCEPTION_POLICY_NOT_SET + 1; i < EXCEPTION_POLICY_MAX; i++) {
             if (IsAppLayerErrorExceptionPolicyStatsValid(i)) {
                 snprintf(app_layer_error_eps_stats.eps_name[i],

--- a/src/counters.c
+++ b/src/counters.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode.c
+++ b/src/decode.c
@@ -76,6 +76,32 @@ extern bool stats_stream_events;
 uint8_t decoder_max_layers = PKT_DEFAULT_MAX_DECODED_LAYERS;
 uint16_t packet_alert_max = PACKET_ALERT_MAX;
 
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts flow_memcap_eps_stats = {
+    .valid_settings_ids = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    false,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    .valid_settings_ips = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    false,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  true,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
+
 /**
  * \brief Initialize PacketAlerts with dynamic alerts array size
  *
@@ -521,6 +547,14 @@ void DecodeUnregisterCounters(void)
     SCMutexUnlock(&g_counter_table_mutex);
 }
 
+static bool IsFlowMemcapExceptionPolicyStatsValid(enum ExceptionPolicy policy)
+{
+    if (EngineModeIsIPS()) {
+        return flow_memcap_eps_stats.valid_settings_ips[policy];
+    }
+    return flow_memcap_eps_stats.valid_settings_ids[policy];
+}
+
 void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
 {
     /* register counters */
@@ -571,6 +605,9 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_erspan = StatsRegisterMaxCounter("decoder.erspan", tv);
     dtv->counter_nsh = StatsRegisterMaxCounter("decoder.nsh", tv);
     dtv->counter_flow_memcap = StatsRegisterCounter("flow.memcap", tv);
+    ExceptionPolicySetStatsCounters(tv, &dtv->counter_flow_memcap_eps, &flow_memcap_eps_stats,
+            FlowGetMemcapExceptionPolicy(), "flow.memcap_exception_policy.",
+            IsFlowMemcapExceptionPolicyStatsValid);
 
     dtv->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", tv);
     dtv->counter_flow_total = StatsRegisterCounter("flow.total", tv);

--- a/src/decode.c
+++ b/src/decode.c
@@ -644,7 +644,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_nsh = StatsRegisterMaxCounter("decoder.nsh", tv);
     dtv->counter_flow_memcap = StatsRegisterCounter("flow.memcap", tv);
     ExceptionPolicySetStatsCounters(tv, &dtv->counter_flow_memcap_eps, &flow_memcap_eps_stats,
-            FlowGetMemcapExceptionPolicy(), "flow.memcap_exception_policy.",
+            FlowGetMemcapExceptionPolicy(), "exception_policy.flow.memcap.",
             IsFlowMemcapExceptionPolicyStatsValid);
 
     dtv->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", tv);

--- a/src/decode.c
+++ b/src/decode.c
@@ -676,7 +676,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
         StatsRegisterCounter("defrag.max_frag_hits", tv);
 
     ExceptionPolicySetStatsCounters(tv, &dtv->counter_defrag_memcap_eps, &defrag_memcap_eps_stats,
-            DefragGetMemcapExceptionPolicy(), "defrag.memcap_exception_policy.",
+            DefragGetMemcapExceptionPolicy(), "exception_policy.defrag.memcap.",
             IsDefragMemcapExceptionPolicyStatsValid);
 
     for (int i = 0; i < DECODE_EVENT_MAX; i++) {

--- a/src/decode.c
+++ b/src/decode.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -62,11 +62,15 @@
 #include "decode-erspan.h"
 #include "decode-teredo.h"
 
+#include "defrag-hash.h"
+
 #include "util-hash.h"
 #include "util-hash-string.h"
 #include "util-print.h"
 #include "util-profiling.h"
 #include "util-validate.h"
+#include "util-debug.h"
+#include "util-exception-policy.h"
 #include "action-globals.h"
 
 uint32_t default_packet_size = 0;
@@ -75,6 +79,32 @@ extern const char *stats_decoder_events_prefix;
 extern bool stats_stream_events;
 uint8_t decoder_max_layers = PKT_DEFAULT_MAX_DECODED_LAYERS;
 uint16_t packet_alert_max = PACKET_ALERT_MAX;
+
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts defrag_memcap_eps_stats = {
+    .valid_settings_ids = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    false,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    .valid_settings_ips = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    false,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  true,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
 
 /* Settings order as in the enum */
 // clang-format off
@@ -547,6 +577,14 @@ void DecodeUnregisterCounters(void)
     SCMutexUnlock(&g_counter_table_mutex);
 }
 
+static bool IsDefragMemcapExceptionPolicyStatsValid(enum ExceptionPolicy policy)
+{
+    if (EngineModeIsIPS()) {
+        return defrag_memcap_eps_stats.valid_settings_ips[policy];
+    }
+    return defrag_memcap_eps_stats.valid_settings_ids[policy];
+}
+
 static bool IsFlowMemcapExceptionPolicyStatsValid(enum ExceptionPolicy policy)
 {
     if (EngineModeIsIPS()) {
@@ -636,6 +674,10 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_defrag_ipv6_reassembled = StatsRegisterCounter("defrag.ipv6.reassembled", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
+
+    ExceptionPolicySetStatsCounters(tv, &dtv->counter_defrag_memcap_eps, &defrag_memcap_eps_stats,
+            DefragGetMemcapExceptionPolicy(), "defrag.memcap_exception_policy.",
+            IsDefragMemcapExceptionPolicyStatsValid);
 
     for (int i = 0; i < DECODE_EVENT_MAX; i++) {
         BUG_ON(i != (int)DEvents[i].code);

--- a/src/decode.h
+++ b/src/decode.h
@@ -32,6 +32,7 @@
 #include "threadvars.h"
 #include "util-debug.h"
 #include "decode-events.h"
+#include "util-exception-policy-types.h"
 #ifdef PROFILING
 #include "flow-worker.h"
 #include "app-layer-protos.h"
@@ -728,6 +729,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_max_hit;
 
     uint16_t counter_flow_memcap;
+    ExceptionPolicyCounters counter_flow_memcap_eps;
 
     uint16_t counter_tcp_active_sessions;
     uint16_t counter_flow_total;

--- a/src/decode.h
+++ b/src/decode.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -727,6 +727,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
     uint16_t counter_defrag_max_hit;
+    ExceptionPolicyCounters counter_defrag_memcap_eps;
 
     uint16_t counter_flow_memcap;
     ExceptionPolicyCounters counter_flow_memcap_eps;

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -27,6 +27,7 @@
 #include "decode.h"
 #include "defrag.h"
 #include "util-exception-policy.h"
+#include "util-exception-policy-types.h"
 
 /** Spinlocks or Mutex for the flow buckets. */
 //#define DRLOCK_SPIN
@@ -92,7 +93,7 @@ void DefragInitConfig(bool quiet);
 void DefragHashShutdown(void);
 
 DefragTracker *DefragLookupTrackerFromHash (Packet *);
-DefragTracker *DefragGetTrackerFromHash (Packet *);
+DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *);
 void DefragTrackerRelease(DefragTracker *);
 void DefragTrackerClearMemory(DefragTracker *);
 void DefragTrackerMoveToSpare(DefragTracker *);
@@ -101,6 +102,7 @@ uint32_t DefragTrackerSpareQueueGetSize(void);
 int DefragTrackerSetMemcap(uint64_t);
 uint64_t DefragTrackerGetMemcap(void);
 uint64_t DefragTrackerGetMemuse(void);
+enum ExceptionPolicy DefragGetMemcapExceptionPolicy(void);
 
 #endif /* __DEFRAG_HASH_H__ */
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1038,7 +1038,7 @@ DefragGetOsPolicy(Packet *p)
 static DefragTracker *
 DefragGetTracker(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
-    return DefragGetTrackerFromHash(p);
+    return DefragGetTrackerFromHash(tv, dtv, p);
 }
 
 /**

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -641,9 +641,24 @@ static inline Flow *FlowSpareSync(ThreadVars *tv, FlowLookupStruct *fls,
     return f;
 }
 
-static inline void NoFlowHandleIPS(Packet *p)
+static void FlowExceptionPolicyStatsIncr(
+        ThreadVars *tv, FlowLookupStruct *fls, enum ExceptionPolicy policy)
+{
+#ifdef UNITTESTS
+    if (tv == NULL) {
+        return;
+    }
+#endif
+    uint16_t id = fls->dtv->counter_flow_memcap_eps.eps_id[policy];
+    if (likely(id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
+static inline void NoFlowHandleIPS(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 {
     ExceptionPolicyApply(p, flow_config.memcap_policy, PKT_DROP_REASON_FLOW_MEMCAP);
+    FlowExceptionPolicyStatsIncr(tv, fls, flow_config.memcap_policy);
 }
 
 /**
@@ -663,7 +678,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
     const bool emerg = ((SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) != 0);
 #ifdef DEBUG
     if (g_eps_flow_memcap != UINT64_MAX && g_eps_flow_memcap == p->pcap_cnt) {
-        NoFlowHandleIPS(p);
+        NoFlowHandleIPS(tv, fls, p);
         StatsIncr(tv, fls->dtv->counter_flow_memcap);
         return NULL;
     }
@@ -689,7 +704,14 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 
             f = FlowGetUsedFlow(tv, fls->dtv, p->ts);
             if (f == NULL) {
-                NoFlowHandleIPS(p);
+                NoFlowHandleIPS(tv, fls, p);
+#ifdef UNITTESTS
+                if (tv != NULL && fls->dtv != NULL) {
+#endif
+                    StatsIncr(tv, fls->dtv->counter_flow_memcap);
+#ifdef UNITTESTS
+                }
+#endif
                 return NULL;
             }
 #ifdef UNITTESTS
@@ -714,7 +736,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 #ifdef UNITTESTS
             }
 #endif
-            NoFlowHandleIPS(p);
+            NoFlowHandleIPS(tv, fls, p);
             return NULL;
         }
 

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -645,7 +645,7 @@ static void FlowExceptionPolicyStatsIncr(
         ThreadVars *tv, FlowLookupStruct *fls, enum ExceptionPolicy policy)
 {
 #ifdef UNITTESTS
-    if (tv == NULL) {
+    if (tv == NULL || fls->dtv == NULL) {
         return;
     }
 #endif

--- a/src/flow.c
+++ b/src/flow.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -141,6 +141,11 @@ uint64_t FlowGetMemuse(void)
 {
     uint64_t memusecopy = SC_ATOMIC_GET(flow_memuse);
     return memusecopy;
+}
+
+enum ExceptionPolicy FlowGetMemcapExceptionPolicy(void)
+{
+    return flow_config.memcap_policy;
 }
 
 void FlowCleanupAppLayer(Flow *f)

--- a/src/flow.h
+++ b/src/flow.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -30,6 +30,7 @@ typedef struct FlowStorageId FlowStorageId;
 #include "decode.h"
 #include "util-time.h"
 #include "util-exception-policy.h"
+#include "util-exception-policy-types.h"
 #include "util-var.h"
 #include "util-optimize.h"
 #include "app-layer-protos.h"
@@ -572,6 +573,7 @@ void FlowUpdateState(Flow *f, enum FlowState s);
 int FlowSetMemcap(uint64_t size);
 uint64_t FlowGetMemcap(void);
 uint64_t FlowGetMemuse(void);
+enum ExceptionPolicy FlowGetMemcapExceptionPolicy(void);
 
 FlowStorageId GetFlowBypassInfoID(void);
 void RegisterFlowBypassInfo(void);

--- a/src/log-stats.c
+++ b/src/log-stats.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -89,17 +89,16 @@ static int LogStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *s
     int days = in_hours / 24;
 
     MemBufferWriteString(aft->buffer, "----------------------------------------------"
-            "--------------------------------------\n");
+                                      "-----------------------------------------------------\n");
     MemBufferWriteString(aft->buffer, "Date: %" PRId32 "/%" PRId32 "/%04d -- "
             "%02d:%02d:%02d (uptime: %"PRId32"d, %02dh %02dm %02ds)\n",
             tms->tm_mon + 1, tms->tm_mday, tms->tm_year + 1900, tms->tm_hour,
             tms->tm_min, tms->tm_sec, days, hours, min, sec);
     MemBufferWriteString(aft->buffer, "----------------------------------------------"
-            "--------------------------------------\n");
-    MemBufferWriteString(aft->buffer, "%-45s | %-25s | %-s\n", "Counter", "TM Name",
-            "Value");
+                                      "-----------------------------------------------------\n");
+    MemBufferWriteString(aft->buffer, "%-60s | %-25s | %-s\n", "Counter", "TM Name", "Value");
     MemBufferWriteString(aft->buffer, "----------------------------------------------"
-            "--------------------------------------\n");
+                                      "-----------------------------------------------------\n");
 
     /* global stats */
     uint32_t u = 0;
@@ -112,7 +111,7 @@ static int LogStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *s
                 continue;
 
             char line[256];
-            size_t len = snprintf(line, sizeof(line), "%-45s | %-25s | %-" PRIu64 "\n",
+            size_t len = snprintf(line, sizeof(line), "%-60s | %-25s | %-" PRIu64 "\n",
                     st->stats[u].name, st->stats[u].tm_name, st->stats[u].value);
 
             /* since we can have many threads, the buffer might not be big enough.
@@ -207,7 +206,7 @@ TmEcode LogStatsLogThreadDeinit(ThreadVars *t, void *data)
 
 /** \brief Create a new http log LogFileCtx.
  *  \param conf Pointer to ConfNode containing this loggers configuration.
- *  \return NULL if failure, LogFileCtx* to the file_ctx if succesful
+ *  \return NULL if failure, LogFileCtx* to the file_ctx if successful
  * */
 static OutputInitResult LogStatsLogInitCtx(ConfNode *conf)
 {

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014-2020 Open Information Security Foundation
+/* Copyright (C) 2014-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1993,6 +1993,15 @@ static int StreamTcpReassembleHandleSegmentUpdateACK (ThreadVars *tv,
     SCReturnInt(0);
 }
 
+static void StreamTcpReassembleExceptionPolicyStatsIncr(
+        ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, enum ExceptionPolicy policy)
+{
+    uint16_t id = ra_ctx->counter_tcp_reas_eps.eps_id[policy];
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
 int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         TcpSession *ssn, TcpStream *stream, Packet *p)
 {
@@ -2059,6 +2068,8 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             /* failure can only be because of memcap hit, so see if this should lead to a drop */
             ExceptionPolicyApply(
                     p, stream_config.reassembly_memcap_policy, PKT_DROP_REASON_STREAM_REASSEMBLY);
+            StreamTcpReassembleExceptionPolicyStatsIncr(
+                    tv, ra_ctx, stream_config.reassembly_memcap_policy);
             SCReturnInt(-1);
         }
 

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -28,6 +28,7 @@
 #include "suricata.h"
 #include "flow.h"
 #include "stream-tcp-private.h"
+#include "util-exception-policy.h"
 
 /** Supported OS list and default OS policy is BSD */
 enum
@@ -64,6 +65,8 @@ typedef struct TcpReassemblyThreadCtx_ {
 
     /** TCP segments which are not being reassembled due to memcap was reached */
     uint16_t counter_tcp_segment_memcap;
+    /** times exception policy for stream reassembly memcap was applied **/
+    ExceptionPolicyCounters counter_tcp_reas_eps;
 
     uint16_t counter_tcp_segment_from_cache;
     uint16_t counter_tcp_segment_from_pool;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -90,6 +90,32 @@
 #define STREAMTCP_DEFAULT_MAX_SYN_QUEUED        10
 #define STREAMTCP_DEFAULT_MAX_SYNACK_QUEUED     5
 
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts stream_memcap_eps_stats = {
+    .valid_settings_ids = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    .valid_settings_ips = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  true,
+    /* EXCEPTION_POLICY_DROP_FLOW */    true,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
+
 static int StreamTcpHandleFin(ThreadVars *tv, StreamTcpThread *, TcpSession *, Packet *);
 void StreamTcpReturnStreamSegments (TcpStream *);
 void StreamTcpInitConfig(bool);
@@ -771,6 +797,23 @@ void StreamTcpFreeConfig(bool quiet)
     SCLogDebug("ssn_pool_cnt %"PRIu64"", ssn_pool_cnt);
 }
 
+static bool IsStreamTcpSessionMemcapExceptionPolicyStatsValid(enum ExceptionPolicy policy)
+{
+    if (EngineModeIsIPS()) {
+        return stream_memcap_eps_stats.valid_settings_ips[policy];
+    }
+    return stream_memcap_eps_stats.valid_settings_ids[policy];
+}
+
+static void StreamTcpSsnMemcapExceptionPolicyStatsIncr(
+        ThreadVars *tv, StreamTcpThread *stt, enum ExceptionPolicy policy)
+{
+    const uint16_t id = stt->counter_tcp_ssn_memcap_eps.eps_id[policy];
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
 /** \internal
  *  \brief The function is used to fetch a TCP session from the
  *         ssn_pool, when a TCP SYN is received.
@@ -810,6 +853,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
                       g_eps_stream_ssn_memcap == t_pcapcnt))) {
             SCLogNotice("simulating memcap reached condition for packet %" PRIu64, t_pcapcnt);
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpSsnMemcapExceptionPolicyStatsIncr(tv, stt, stream_config.ssn_memcap_policy);
             return NULL;
         }
 #endif
@@ -817,6 +861,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
         if (ssn == NULL) {
             SCLogDebug("ssn_pool is empty");
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpSsnMemcapExceptionPolicyStatsIncr(tv, stt, stream_config.ssn_memcap_policy);
             return NULL;
         }
 
@@ -5808,6 +5853,10 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_ssn_memcap = StatsRegisterCounter("tcp.ssn_memcap_drop", tv);
     stt->counter_tcp_ssn_from_cache = StatsRegisterCounter("tcp.ssn_from_cache", tv);
     stt->counter_tcp_ssn_from_pool = StatsRegisterCounter("tcp.ssn_from_pool", tv);
+    ExceptionPolicySetStatsCounters(tv, &stt->counter_tcp_ssn_memcap_eps, &stream_memcap_eps_stats,
+            stream_config.ssn_memcap_policy, "tcp.ssn_memcap_exception_policy.",
+            IsStreamTcpSessionMemcapExceptionPolicyStatsValid);
+
     stt->counter_tcp_pseudo = StatsRegisterCounter("tcp.pseudo", tv);
     stt->counter_tcp_pseudo_failed = StatsRegisterCounter("tcp.pseudo_failed", tv);
     stt->counter_tcp_invalid_checksum = StatsRegisterCounter("tcp.invalid_checksum", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -142,6 +142,58 @@ ExceptionPolicyStatsSetts stream_reassembly_memcap_eps_stats = {
 };
 // clang-format on
 
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts stream_midstream_enabled_eps_stats = {
+    .valid_settings_ids = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  false,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  false,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       false,
+    },
+    .valid_settings_ips = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  false,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  false,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       false,
+    },
+};
+// clang-format on
+
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts stream_midstream_disabled_eps_stats = {
+    .valid_settings_ids = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  false,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    .valid_settings_ips = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  false,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    true,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
+
 static int StreamTcpHandleFin(ThreadVars *tv, StreamTcpThread *, TcpSession *, Packet *);
 void StreamTcpReturnStreamSegments (TcpStream *);
 void StreamTcpInitConfig(bool);
@@ -1051,6 +1103,29 @@ static inline void StreamTcpCloseSsnWithReset(Packet *p, TcpSession *ssn)
             "TCP_CLOSED", ssn, StreamTcpStateAsString(ssn->state));
 }
 
+static bool IsMidstreamExceptionPolicyStatsValid(enum ExceptionPolicy policy)
+{
+    if (EngineModeIsIPS()) {
+        if (stream_config.midstream) {
+            return stream_midstream_enabled_eps_stats.valid_settings_ips[policy];
+        }
+        return stream_midstream_disabled_eps_stats.valid_settings_ips[policy];
+    }
+    if (stream_config.midstream) {
+        return stream_midstream_enabled_eps_stats.valid_settings_ids[policy];
+    }
+    return stream_midstream_disabled_eps_stats.valid_settings_ids[policy];
+}
+
+static void StreamTcpMidstreamExceptionPolicyStatsIncr(
+        ThreadVars *tv, StreamTcpThread *stt, enum ExceptionPolicy policy)
+{
+    const uint16_t id = stt->counter_tcp_midstream_eps.eps_id[policy];
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
 static int StreamTcpPacketIsRetransmission(TcpStream *stream, Packet *p)
 {
     if (p->payload_len == 0)
@@ -1104,6 +1179,7 @@ static int StreamTcpPacketStateNone(
     } else if (p->tcph->th_flags & TH_FIN) {
         /* Drop reason will only be used if midstream policy is set to fail closed */
         ExceptionPolicyApply(p, stream_config.midstream_policy, PKT_DROP_REASON_STREAM_MIDSTREAM);
+        StreamTcpMidstreamExceptionPolicyStatsIncr(tv, stt, stream_config.midstream_policy);
 
         if (!stream_config.midstream || p->payload_len == 0) {
             StreamTcpSetEvent(p, STREAM_FIN_BUT_NO_SESSION);
@@ -1200,6 +1276,7 @@ static int StreamTcpPacketStateNone(
     } else if ((p->tcph->th_flags & (TH_SYN | TH_ACK)) == (TH_SYN | TH_ACK)) {
         /* Drop reason will only be used if midstream policy is set to fail closed */
         ExceptionPolicyApply(p, stream_config.midstream_policy, PKT_DROP_REASON_STREAM_MIDSTREAM);
+        StreamTcpMidstreamExceptionPolicyStatsIncr(tv, stt, stream_config.midstream_policy);
 
         if (!stream_config.midstream && !stream_config.async_oneside) {
             SCLogDebug("Midstream not enabled, so won't pick up a session");
@@ -1372,6 +1449,7 @@ static int StreamTcpPacketStateNone(
     } else if (p->tcph->th_flags & TH_ACK) {
         /* Drop reason will only be used if midstream policy is set to fail closed */
         ExceptionPolicyApply(p, stream_config.midstream_policy, PKT_DROP_REASON_STREAM_MIDSTREAM);
+        StreamTcpMidstreamExceptionPolicyStatsIncr(tv, stt, stream_config.midstream_policy);
 
         if (!stream_config.midstream) {
             SCLogDebug("Midstream not enabled, so won't pick up a session");
@@ -5895,6 +5973,16 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_pseudo_failed = StatsRegisterCounter("tcp.pseudo_failed", tv);
     stt->counter_tcp_invalid_checksum = StatsRegisterCounter("tcp.invalid_checksum", tv);
     stt->counter_tcp_midstream_pickups = StatsRegisterCounter("tcp.midstream_pickups", tv);
+    if (stream_config.midstream) {
+        ExceptionPolicySetStatsCounters(tv, &stt->counter_tcp_midstream_eps,
+                &stream_midstream_enabled_eps_stats, stream_config.midstream_policy,
+                "tcp.midstream_exception_policy.", IsMidstreamExceptionPolicyStatsValid);
+    } else {
+        ExceptionPolicySetStatsCounters(tv, &stt->counter_tcp_midstream_eps,
+                &stream_midstream_disabled_eps_stats, stream_config.midstream_policy,
+                "tcp.midstream_exception_policy.", IsMidstreamExceptionPolicyStatsValid);
+    }
+
     stt->counter_tcp_wrong_thread = StatsRegisterCounter("tcp.pkt_on_wrong_thread", tv);
     stt->counter_tcp_ack_unseen_data = StatsRegisterCounter("tcp.ack_unseen_data", tv);
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5995,7 +5995,7 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     ExceptionPolicySetStatsCounters(tv, &stt->ra_ctx->counter_tcp_reas_eps,
             &stream_reassembly_memcap_eps_stats, stream_config.reassembly_memcap_policy,
-            "tcp.reassembly_exception_policy.", IsReassemblyMemcapExceptionPolicyStatsValid);
+            "exception_policy.tcp.reassembly.", IsReassemblyMemcapExceptionPolicyStatsValid);
 
     stt->ra_ctx->counter_tcp_segment_from_cache =
             StatsRegisterCounter("tcp.segment_from_cache", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5966,7 +5966,7 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_ssn_from_cache = StatsRegisterCounter("tcp.ssn_from_cache", tv);
     stt->counter_tcp_ssn_from_pool = StatsRegisterCounter("tcp.ssn_from_pool", tv);
     ExceptionPolicySetStatsCounters(tv, &stt->counter_tcp_ssn_memcap_eps, &stream_memcap_eps_stats,
-            stream_config.ssn_memcap_policy, "tcp.ssn_memcap_exception_policy.",
+            stream_config.ssn_memcap_policy, "exception_policy.tcp.ssn_memcap.",
             IsStreamTcpSessionMemcapExceptionPolicyStatsValid);
 
     stt->counter_tcp_pseudo = StatsRegisterCounter("tcp.pseudo", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5976,11 +5976,11 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     if (stream_config.midstream) {
         ExceptionPolicySetStatsCounters(tv, &stt->counter_tcp_midstream_eps,
                 &stream_midstream_enabled_eps_stats, stream_config.midstream_policy,
-                "tcp.midstream_exception_policy.", IsMidstreamExceptionPolicyStatsValid);
+                "exception_policy.tcp.midstream.", IsMidstreamExceptionPolicyStatsValid);
     } else {
         ExceptionPolicySetStatsCounters(tv, &stt->counter_tcp_midstream_eps,
                 &stream_midstream_disabled_eps_stats, stream_config.midstream_policy,
-                "tcp.midstream_exception_policy.", IsMidstreamExceptionPolicyStatsValid);
+                "exception_policy.tcp.midstream.", IsMidstreamExceptionPolicyStatsValid);
     }
 
     stt->counter_tcp_wrong_thread = StatsRegisterCounter("tcp.pkt_on_wrong_thread", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -93,6 +93,32 @@
 /* Settings order as in the enum */
 // clang-format off
 ExceptionPolicyStatsSetts stream_memcap_eps_stats = {
+    .valid_settings_ids = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    .valid_settings_ips = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  true,
+    /* EXCEPTION_POLICY_DROP_FLOW */    true,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
+
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts stream_reassembly_memcap_eps_stats = {
     .valid_settings_ids = {
     /* EXCEPTION_POLICY_NOT_SET */      false,
     /* EXCEPTION_POLICY_AUTO */         false,
@@ -795,6 +821,14 @@ void StreamTcpFreeConfig(bool quiet)
     SCMutexDestroy(&ssn_pool_mutex);
 
     SCLogDebug("ssn_pool_cnt %"PRIu64"", ssn_pool_cnt);
+}
+
+static bool IsReassemblyMemcapExceptionPolicyStatsValid(enum ExceptionPolicy exception_policy)
+{
+    if (EngineModeIsIPS()) {
+        return stream_reassembly_memcap_eps_stats.valid_settings_ips[exception_policy];
+    }
+    return stream_reassembly_memcap_eps_stats.valid_settings_ids[exception_policy];
 }
 
 static bool IsStreamTcpSessionMemcapExceptionPolicyStatsValid(enum ExceptionPolicy policy)
@@ -5870,6 +5904,11 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
 
     stt->ra_ctx->counter_tcp_segment_memcap = StatsRegisterCounter("tcp.segment_memcap_drop", tv);
+
+    ExceptionPolicySetStatsCounters(tv, &stt->ra_ctx->counter_tcp_reas_eps,
+            &stream_reassembly_memcap_eps_stats, stream_config.reassembly_memcap_policy,
+            "tcp.reassembly_exception_policy.", IsReassemblyMemcapExceptionPolicyStatsValid);
+
     stt->ra_ctx->counter_tcp_segment_from_cache =
             StatsRegisterCounter("tcp.segment_from_cache", tv);
     stt->ra_ctx->counter_tcp_segment_from_pool = StatsRegisterCounter("tcp.segment_from_pool", tv);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -108,6 +108,8 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_invalid_checksum;
     /** midstream pickups */
     uint16_t counter_tcp_midstream_pickups;
+    /** exception policy stats */
+    ExceptionPolicyCounters counter_tcp_midstream_eps;
     /** wrong thread */
     uint16_t counter_tcp_wrong_thread;
     /** ack for unseen data */

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -30,6 +30,7 @@
 #include "stream.h"
 #include "stream-tcp-reassemble.h"
 #include "suricata.h"
+#include "util-exception-policy-types.h"
 
 #define STREAM_VERBOSE false
 /* Flag to indicate that the checksum validation for the stream engine
@@ -97,6 +98,8 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_ssn_memcap;
     uint16_t counter_tcp_ssn_from_cache;
     uint16_t counter_tcp_ssn_from_pool;
+    /** exception policy */
+    ExceptionPolicyCounters counter_tcp_ssn_memcap_eps;
     /** pseudo packets processed */
     uint16_t counter_tcp_pseudo;
     /** pseudo packets failed to setup */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -213,6 +213,10 @@ uint16_t g_livedev_mask = 0xffff;
  * support */
 bool g_disable_hashing = false;
 
+/** add per-proto app-layer error counters for exception policies stats? disabled by default */
+bool g_stats_eps_per_app_proto_errors = false;
+bool g_eps_stats_counters = false;
+
 /** Suricata instance */
 SCInstance suricata;
 
@@ -2711,6 +2715,16 @@ int PostConfLoadedSetup(SCInstance *suri)
     /* Must occur prior to output mod registration
        and app layer setup. */
     FeatureTrackingRegister();
+
+    ConfNode *eps = ConfGetNode("stats.exception-policy");
+    if (eps != NULL) {
+        if (ConfNodeChildValueIsTrue(eps, "per-app-proto-errors")) {
+            g_stats_eps_per_app_proto_errors = true;
+        }
+        if (ConfNodeChildValueIsTrue(eps, "global-stats")) {
+            g_eps_stats_counters = true;
+        }
+    }
 
     AppLayerSetup();
 

--- a/src/util-exception-policy-types.h
+++ b/src/util-exception-policy-types.h
@@ -1,0 +1,54 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ */
+
+#ifndef UTIL_EXCEPTION_POLICY_TYPES_H
+#define UTIL_EXCEPTION_POLICY_TYPES_H
+
+enum ExceptionPolicy {
+    EXCEPTION_POLICY_NOT_SET = 0,
+    EXCEPTION_POLICY_AUTO,
+    EXCEPTION_POLICY_PASS_PACKET,
+    EXCEPTION_POLICY_PASS_FLOW,
+    EXCEPTION_POLICY_BYPASS_FLOW,
+    EXCEPTION_POLICY_DROP_PACKET,
+    EXCEPTION_POLICY_DROP_FLOW,
+    EXCEPTION_POLICY_REJECT,
+};
+
+#define EXCEPTION_POLICY_MAX EXCEPTION_POLICY_REJECT + 1
+
+/* Max length = possible exception policy scenarios + counter names
+ * + exception policy type. E.g.:
+ * "tcp.reassembly_exception_policy.drop_packet" + 1 */
+#define EXCEPTION_POLICY_COUNTER_MAX_LEN 44
+
+typedef struct ExceptionPolicyCounters_ {
+    /* Follows enum order */
+    uint16_t eps_id[EXCEPTION_POLICY_MAX];
+} ExceptionPolicyCounters;
+
+typedef struct ExceptionPolicyStatsSetts_ {
+    char eps_name[EXCEPTION_POLICY_MAX][EXCEPTION_POLICY_COUNTER_MAX_LEN];
+    bool valid_settings_ids[EXCEPTION_POLICY_MAX];
+    bool valid_settings_ips[EXCEPTION_POLICY_MAX];
+} ExceptionPolicyStatsSetts;
+
+#endif

--- a/src/util-exception-policy-types.h
+++ b/src/util-exception-policy-types.h
@@ -38,7 +38,7 @@ enum ExceptionPolicy {
 /* Max length = possible exception policy scenarios + counter names
  * + exception policy type. E.g.:
  * "tcp.reassembly_exception_policy.drop_packet" + 1 */
-#define EXCEPTION_POLICY_COUNTER_MAX_LEN 44
+#define EXCEPTION_POLICY_COUNTER_MAX_LEN 45
 
 typedef struct ExceptionPolicyCounters_ {
     /* Follows enum order */

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022-2023 Open Information Security Foundation
+/* Copyright (C) 2022-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -31,7 +31,7 @@ enum ExceptionPolicy g_eps_master_switch = EXCEPTION_POLICY_NOT_SET;
 /** true if exception policy was defined in config */
 static bool g_eps_have_exception_policy = false;
 
-static const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy)
+const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy, bool is_json)
 {
     switch (policy) {
         case EXCEPTION_POLICY_NOT_SET:
@@ -43,13 +43,13 @@ static const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy)
         case EXCEPTION_POLICY_BYPASS_FLOW:
             return "bypass";
         case EXCEPTION_POLICY_DROP_FLOW:
-            return "drop-flow";
+            return is_json ? "drop_flow" : "drop-flow";
         case EXCEPTION_POLICY_DROP_PACKET:
-            return "drop-packet";
+            return is_json ? "drop_packet" : "drop-packet";
         case EXCEPTION_POLICY_PASS_PACKET:
-            return "pass-packet";
+            return is_json ? "pass_packet" : "pass-packet";
         case EXCEPTION_POLICY_PASS_FLOW:
-            return "pass-flow";
+            return is_json ? "pass_flow" : "pass-flow";
     }
     // TODO we shouldn't reach this, but if we do, better not to leave this as simply null...
     return "not set";
@@ -197,7 +197,7 @@ static enum ExceptionPolicy ExceptionPolicyMasterParse(const char *value)
     }
     g_eps_have_exception_policy = true;
 
-    SCLogInfo("master exception-policy set to: %s", ExceptionPolicyEnumToString(policy));
+    SCLogInfo("master exception-policy set to: %s", ExceptionPolicyEnumToString(policy, false));
 
     return policy;
 }
@@ -217,13 +217,13 @@ static enum ExceptionPolicy ExceptionPolicyGetDefault(
             p = PickPacketAction(option, p);
         }
         SCLogConfig("%s: %s (defined via 'exception-policy' master switch)", option,
-                ExceptionPolicyEnumToString(p));
+                ExceptionPolicyEnumToString(p, false));
         return p;
     } else if (EngineModeIsIPS() && !midstream) {
         p = EXCEPTION_POLICY_DROP_FLOW;
     }
     SCLogConfig("%s: %s (defined via 'built-in default' for %s-mode)", option,
-            ExceptionPolicyEnumToString(p), EngineModeIsIPS() ? "IPS" : "IDS");
+            ExceptionPolicyEnumToString(p, false), EngineModeIsIPS() ? "IPS" : "IDS");
 
     return p;
 }
@@ -244,7 +244,7 @@ enum ExceptionPolicy ExceptionPolicyParse(const char *option, bool support_flow)
             if (!support_flow) {
                 policy = PickPacketAction(option, policy);
             }
-            SCLogConfig("%s: %s", option, ExceptionPolicyEnumToString(policy));
+            SCLogConfig("%s: %s", option, ExceptionPolicyEnumToString(policy, false));
         }
     } else {
         policy = ExceptionPolicyGetDefault(option, support_flow, false);

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022-2023 Open Information Security Foundation
+/* Copyright (C) 2022-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -23,18 +23,9 @@
 #define __UTIL_EXCEPTION_POLICY_H__
 
 #include "decode.h"
+#include "util-exception-policy-types.h"
 
-enum ExceptionPolicy {
-    EXCEPTION_POLICY_NOT_SET = 0,
-    EXCEPTION_POLICY_AUTO,
-    EXCEPTION_POLICY_PASS_PACKET,
-    EXCEPTION_POLICY_PASS_FLOW,
-    EXCEPTION_POLICY_BYPASS_FLOW,
-    EXCEPTION_POLICY_DROP_PACKET,
-    EXCEPTION_POLICY_DROP_FLOW,
-    EXCEPTION_POLICY_REJECT,
-};
-
+const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy, bool is_json);
 void SetMasterExceptionPolicy(void);
 void ExceptionPolicyApply(
         Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason);

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -31,6 +31,9 @@ void ExceptionPolicyApply(
         Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason);
 enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support_flow);
 enum ExceptionPolicy ExceptionPolicyMidstreamParse(bool midstream_enabled);
+void ExceptionPolicySetStatsCounters(ThreadVars *tv, ExceptionPolicyCounters *counter,
+        ExceptionPolicyStatsSetts *setting, enum ExceptionPolicy conf_policy,
+        const char *default_str, bool (*isExceptionPolicyValid)(enum ExceptionPolicy));
 
 extern enum ExceptionPolicy g_eps_master_switch;
 #ifdef DEBUG

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -73,6 +73,11 @@ stats:
   #decoder-events-prefix: "decoder.event"
   # Add stream events as stats.
   #stream-events: false
+  exception-policy:
+    #global-stats: true           # default: false. True will log stats counters
+                                  # for each exception policy.
+    #per-app-proto-errors: false  # default: false. True will log errors for
+                                  # each app-proto. Warning: VERY verbose
 
 # Plugins -- Experimental -- specify the filename for each plugin shared object
 plugins:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -879,9 +879,9 @@ pcap-file:
 
 # Configure the app-layer parsers.
 #
-# The error-policy setting applies to all app-layer parsers. Values can be
-# "drop-flow", "pass-flow", "bypass", "drop-packet", "pass-packet", "reject" or
-# "ignore" (the default).
+# The exception policy error-policy setting applies to all app-layer parsers.
+#  Values can be "drop-flow", "pass-flow", "bypass", "drop-packet", "pass-packet",
+#  "reject" or "ignore" (the default).
 #
 # The protocol's section details each protocol.
 #
@@ -1417,8 +1417,8 @@ host-os-policy:
 
 # Defrag settings:
 
-# The memcap-policy value can be "drop-packet", "pass-packet", "reject" or
-# "ignore" (which is the default).
+# The exception policy memcap-policy value can be "drop-packet", "pass-packet",
+#  "reject" or "ignore" (which is the default).
 defrag:
   memcap: 32mb
   # memcap-policy: ignore
@@ -1461,8 +1461,8 @@ defrag:
 # last time seen flows.
 # The memcap can be specified in kb, mb, gb.  Just a number indicates it's
 # in bytes.
-# The memcap-policy can be "drop-packet", "pass-packet", "reject" or "ignore"
-# (which is the default).
+# The exception policy memcap-policy can be "drop-packet", "pass-packet",
+#  "reject" or "ignore" (which is the default).
 
 flow:
   memcap: 128mb
@@ -1545,9 +1545,9 @@ flow-timeouts:
 # stream:
 #   memcap: 64mb                # Can be specified in kb, mb, gb.  Just a
 #                               # number indicates it's in bytes.
-#   memcap-policy: ignore       # Can be "drop-flow", "pass-flow", "bypass",
-#                               # "drop-packet", "pass-packet", "reject" or
-#                               # "ignore" default is "ignore"
+#   memcap-policy: ignore       # The exception policy value can be "drop-flow",
+#                               # "pass-flow", "bypass", "drop-packet",
+#                               # "pass-packet", "reject" or "ignore" default is "ignore"
 #   checksum-validation: yes    # To validate the checksum of received
 #                               # packet. If csum validation is specified as
 #                               # "yes", then packets with invalid csum values will not
@@ -1559,9 +1559,9 @@ flow-timeouts:
 #                               # option
 #   prealloc-sessions: 2048     # 2k sessions prealloc'd per stream thread
 #   midstream: false            # don't allow midstream session pickups
-#   midstream-policy: ignore    # Can be "drop-flow", "pass-flow", "bypass",
-#                               # "drop-packet", "pass-packet", "reject" or
-#                               # "ignore" default is "ignore"
+#   midstream-policy: ignore    # The exception policy value can be "drop-flow",
+#                               # "pass-flow", "bypass", "drop-packet",
+#                               # "pass-packet", "reject" or "ignore" default is "ignore"
 #   async-oneside: false        # don't enable async stream handling
 #   inline: no                  # stream inline mode
 #   drop-invalid: yes           # in inline mode, drop packets that are invalid with regards to streaming engine
@@ -1576,9 +1576,9 @@ flow-timeouts:
 #   reassembly:
 #     memcap: 256mb             # Can be specified in kb, mb, gb.  Just a number
 #                               # indicates it's in bytes.
-#     memcap-policy: ignore     # Can be "drop-flow", "pass-flow", "bypass",
-#                               # "drop-packet", "pass-packet", "reject" or
-#                               # "ignore" default is "ignore"
+#     memcap-policy: ignore     # The exception policy value can be "drop-flow",
+#                               # "pass-flow", "bypass", "drop-packet", "pass-packet",
+#                               # "reject" or "ignore" default is "ignore"
 #     depth: 1mb                # Can be specified in kb, mb, gb.  Just a number
 #                               # indicates it's in bytes.
 #     toserver-chunk-size: 2560 # inspect raw stream in chunks of at least


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6509

We've agreed in a dev meeting that the backports should be ok, but since they can potentially make the stats logs much bigger, this should be optional, in suricata 7.

Describe changes:
- mostly clean cherry-picks of work related to original exception stats counters changes and the follow-up commits to update the JSON object structure and names

Previous PR: https://github.com/OISF/suricata/pull/13530

Updates from Previous PR:
- make exception policy stats counters optional for suri 7 by adding a configuration option `stats.exception-policy.global-stats` that will enable logging of exception policy stats for valid exception policies.
- fix exception policy stats counter for tcp.stream-reassembly memcap in the docs
- cherry-pick of ee59d9a894ba6d to avoid unittests failures

If global exception policy counters are disabled but `per-app-proto` ones are enabled, those will be logged.

Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2608