### PR TITLE
Fix: prevent NULL dereference in LuaHttpGetResponseLine

### DIFF
--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -26,6 +26,7 @@
 
 #include "app-layer-htp.h"
 #include "util-lua.h"
+#include "htp/htp_rs.h"
 #include "util-lua-common.h"
 #include "util-lua-http.h"
 
@@ -107,8 +108,13 @@ static int LuaHttpGetRequestLine(lua_State *luastate)
         return 1;
     }
 
-    return LuaPushStringBuffer(
-            luastate, bstr_ptr(htp_tx_request_line(tx->tx)), bstr_len(htp_tx_request_line(tx->tx)));
+    const struct bstr *line = htp_tx_request_line(tx->tx);
+    if (line == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+
+    return LuaPushStringBuffer(luastate, bstr_ptr(line), bstr_len(line));
 }
 
 static int LuaHttpGetResponseLine(lua_State *luastate)
@@ -119,8 +125,13 @@ static int LuaHttpGetResponseLine(lua_State *luastate)
         return 1;
     }
 
-    return LuaPushStringBuffer(luastate, bstr_ptr(htp_tx_response_line(tx->tx)),
-            bstr_len(htp_tx_response_line(tx->tx)));
+    const struct bstr *line = htp_tx_response_line(tx->tx);
+    if (line == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+
+    return LuaPushStringBuffer(luastate, bstr_ptr(line), bstr_len(line));
 }
 
 static int LuaHttpGetHeader(lua_State *luastate, int dir)


### PR DESCRIPTION
## Contribution style:
- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7829

Describe changes:
- This patch fixes a segmentation fault that occurs when Lua scripts call `tx:response_line()` or `tx:request_line()` on incomplete or malformed HTTP transactions.
- In both `LuaHttpGetResponseLine()` and `LuaHttpGetRequestLine()` (C code), the result of `htp_tx_*_line()` was previously passed directly into `bstr_len()` without checking for NULL.
- This led to a crash when `bstr_len(NULL)` was invoked, which can happen when no response/request line is available due to dropped packets or partially parsed streams.
- The patch adds a NULL check before calling `bstr_ptr()` or `bstr_len()`, ensuring Suricata does not crash when Lua scripts access these fields.
- No functional change for normal HTTP traffic; behavior is safer under edge cases.

### Provide values to any of the below to override the defaults.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
