### PR TITLE
pcap-file: move packet counter to PCAP packet structure v1

### DIFF
--- a/plugins/ndpi/ndpi.c
+++ b/plugins/ndpi/ndpi.c
@@ -191,18 +191,18 @@ static int DetectnDPIProtocolPacketMatch(
     /*
     if (s->type == SIG_TYPE_PDONLY &&
             (p->flags & (PKT_PROTO_DETECT_TS_DONE | PKT_PROTO_DETECT_TC_DONE)) == 0) {
-        SCLogDebug("packet %"PRIu64": flags not set", p->pcap_cnt);
+        SCLogDebug("packet %"PRIu64": flags not set", p->pcap_v.pcap_cnt);
         SCReturnInt(0);
     }
     */
 
     if (!flowctx->detection_completed) {
-        SCLogDebug("packet %" PRIu64 ": ndpi protocol not yet detected", p->pcap_cnt);
+        SCLogDebug("packet %" PRIu64 ": ndpi protocol not yet detected", p->pcap_v.pcap_cnt);
         SCReturnInt(0);
     }
 
     if (f == NULL) {
-        SCLogDebug("packet %" PRIu64 ": no flow", p->pcap_cnt);
+        SCLogDebug("packet %" PRIu64 ": no flow", p->pcap_v.pcap_cnt);
         SCReturnInt(0);
     }
 
@@ -318,12 +318,12 @@ static int DetectnDPIRiskPacketMatch(
     SCEnter();
 
     if (!flowctx->detection_completed) {
-        SCLogDebug("packet %" PRIu64 ": ndpi risks not yet detected", p->pcap_cnt);
+        SCLogDebug("packet %" PRIu64 ": ndpi risks not yet detected", p->pcap_v.pcap_cnt);
         SCReturnInt(0);
     }
 
     if (f == NULL) {
-        SCLogDebug("packet %" PRIu64 ": no flow", p->pcap_cnt);
+        SCLogDebug("packet %" PRIu64 ": no flow", p->pcap_v.pcap_cnt);
         SCReturnInt(0);
     }
 

--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -166,8 +166,8 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
 
     MemBufferWriteString(aft->buffer, "+================\n"
                          "TIME:              %s\n", timebuf);
-    if (p->pcap_cnt > 0) {
-        MemBufferWriteString(aft->buffer, "PCAP PKT NUM:      %"PRIu64"\n", p->pcap_cnt);
+    if (p->pcap_v.pcap_cnt > 0) {
+        MemBufferWriteString(aft->buffer, "PCAP PKT NUM:      %" PRIu64 "\n", p->pcap_v.pcap_cnt);
     }
     pkt_src_str = PktSrcToString(p->pkt_src);
     MemBufferWriteString(aft->buffer, "PKT SRC:           %s\n", pkt_src_str);
@@ -326,9 +326,8 @@ static TmEcode AlertDebugLogDecoderEvent(ThreadVars *tv, const Packet *p, void *
     MemBufferWriteString(aft->buffer,
                          "+================\n"
                          "TIME:              %s\n", timebuf);
-    if (p->pcap_cnt > 0) {
-        MemBufferWriteString(aft->buffer,
-                             "PCAP PKT NUM:      %"PRIu64"\n", p->pcap_cnt);
+    if (p->pcap_v.pcap_cnt > 0) {
+        MemBufferWriteString(aft->buffer, "PCAP PKT NUM:      %" PRIu64 "\n", p->pcap_v.pcap_cnt);
     }
     pkt_src_str = PktSrcToString(p->pkt_src);
     MemBufferWriteString(aft->buffer, "PKT SRC:           %s\n", pkt_src_str);

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -179,9 +179,9 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
                             pa->s->id, pa->s->rev, pa->s->msg, pa->s->class_msg, pa->s->prio);
             PrintBufferRawLineHex(alert_buffer, &size, MAX_FASTLOG_ALERT_SIZE,
                                   GET_PKT_DATA(p), GET_PKT_LEN(p) < 32 ? GET_PKT_LEN(p) : 32);
-            if (p->pcap_cnt != 0) {
-                PrintBufferData(alert_buffer, &size, MAX_FASTLOG_ALERT_SIZE, 
-                                "] [pcap file packet: %"PRIu64"]\n", p->pcap_cnt);
+            if (p->pcap_v.pcap_cnt != 0) {
+                PrintBufferData(alert_buffer, &size, MAX_FASTLOG_ALERT_SIZE,
+                        "] [pcap file packet: %" PRIu64 "]\n", p->pcap_v.pcap_cnt);
             } else {
                 PrintBufferData(alert_buffer, &size, MAX_FASTLOG_ALERT_SIZE, "]\n");
             }

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -343,9 +343,9 @@ static TmEcode AlertSyslogDecoderEvent(ThreadVars *tv, const Packet *p, void *da
         PrintRawLineHexBuf(temp_buf_pkt, sizeof(temp_buf_pkt), GET_PKT_DATA(p), GET_PKT_LEN(p) < 32 ? GET_PKT_LEN(p) : 32);
         strlcat(alert, temp_buf_pkt, sizeof(alert));
 
-        if (p->pcap_cnt != 0) {
-            snprintf(temp_buf_tail, sizeof(temp_buf_tail), "] [pcap file packet: %"PRIu64"]",
-                    p->pcap_cnt);
+        if (p->pcap_v.pcap_cnt != 0) {
+            snprintf(temp_buf_tail, sizeof(temp_buf_tail), "] [pcap file packet: %" PRIu64 "]",
+                    p->pcap_v.pcap_cnt);
         } else {
             temp_buf_tail[0] = ']';
             temp_buf_tail[1] = '\0';

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -659,8 +659,9 @@ static int TCPProtoDetect(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                     AppLayerIncFlowCounter(tv, f);
 
                     *alproto = *alproto_otherdir;
-                    SCLogDebug("packet %"PRIu64": pd done(us %u them %u), parser called (r==%d), APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION set",
-                            p->pcap_cnt, *alproto, *alproto_otherdir, r);
+                    SCLogDebug("packet %" PRIu64 ": pd done(us %u them %u), parser called (r==%d), "
+                               "APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION set",
+                            p->pcap_v.pcap_cnt, *alproto, *alproto_otherdir, r);
                     if (r < 0) {
                         goto parser_error;
                     }

--- a/src/decode.h
+++ b/src/decode.h
@@ -622,10 +622,6 @@ typedef struct Packet_
     struct Host_ *host_src;
     struct Host_ *host_dst;
 
-    /** packet number in the pcap file, matches wireshark */
-    uint64_t pcap_cnt;
-
-
     /* engine events */
     PacketEngineEvents events;
 

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -469,8 +469,8 @@ static void DefragExceptionPolicyStatsIncr(
 static DefragTracker *DefragTrackerGetNew(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
 #ifdef DEBUG
-    if (g_eps_defrag_memcap != UINT64_MAX && g_eps_defrag_memcap == p->pcap_cnt) {
-        SCLogNotice("simulating memcap hit for packet %" PRIu64, p->pcap_cnt);
+    if (g_eps_defrag_memcap != UINT64_MAX && g_eps_defrag_memcap == p->pcap_v.pcap_cnt) {
+        SCLogNotice("simulating memcap hit for packet %" PRIu64, p->pcap_v.pcap_cnt);
         ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
         DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
         return NULL;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -584,7 +584,7 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
     uint8_t ip6_nh_set_value = 0;
 
 #ifdef DEBUG
-    uint64_t pcap_cnt = p->pcap_cnt;
+    uint64_t pcap_cnt = p->pcap_v.pcap_cnt;
 #endif
 
     if (tracker->af == AF_INET) {

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -65,13 +65,13 @@ static int DetectAppLayerProtocolPacketMatch(
     /* if the sig is PD-only we only match when PD packet flags are set */
     if (s->type == SIG_TYPE_PDONLY &&
             (p->flags & (PKT_PROTO_DETECT_TS_DONE | PKT_PROTO_DETECT_TC_DONE)) == 0) {
-        SCLogDebug("packet %"PRIu64": flags not set", p->pcap_cnt);
+        SCLogDebug("packet %" PRIu64 ": flags not set", p->pcap_v.pcap_cnt);
         SCReturnInt(0);
     }
 
     const Flow *f = p->flow;
     if (f == NULL) {
-        SCLogDebug("packet %"PRIu64": no flow", p->pcap_cnt);
+        SCLogDebug("packet %" PRIu64 ": no flow", p->pcap_v.pcap_cnt);
         SCReturnInt(0);
     }
 
@@ -289,17 +289,17 @@ PrefilterPacketAppProtoMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const vo
     const PrefilterPacketHeaderCtx *ctx = pectx;
 
     if (!PrefilterPacketHeaderExtraMatch(ctx, p)) {
-        SCLogDebug("packet %"PRIu64": extra match failed", p->pcap_cnt);
+        SCLogDebug("packet %" PRIu64 ": extra match failed", p->pcap_v.pcap_cnt);
         SCReturn;
     }
 
     if (p->flow == NULL) {
-        SCLogDebug("packet %"PRIu64": no flow, no alproto", p->pcap_cnt);
+        SCLogDebug("packet %" PRIu64 ": no flow, no alproto", p->pcap_v.pcap_cnt);
         SCReturn;
     }
 
     if ((p->flags & (PKT_PROTO_DETECT_TS_DONE|PKT_PROTO_DETECT_TC_DONE)) == 0) {
-        SCLogDebug("packet %"PRIu64": flags not set", p->pcap_cnt);
+        SCLogDebug("packet %" PRIu64 ": flags not set", p->pcap_v.pcap_cnt);
         SCReturn;
     }
 

--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -187,7 +187,7 @@ static int ConfigApply(DetectEngineThreadCtx *det_ctx,
     }
 
     if (this_packet) {
-        SCLogDebug("packet logic here: %" PRIu64, p->pcap_cnt);
+        SCLogDebug("packet logic here: %" PRIu64, p->pcap_v.pcap_cnt);
         ConfigApplyPacket(p, config);
     } else if (this_tx) {
         SCLogDebug("tx logic here: tx_id %"PRIu64, det_ctx->tx_id);

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -187,7 +187,7 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f)
  *  \param pa packet alert struct -- match, including actions after thresholding (rate_filter) */
 static void PacketApplySignatureActions(Packet *p, const Signature *s, const PacketAlert *pa)
 {
-    SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x", p->pcap_cnt, s->id,
+    SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x", p->pcap_v.pcap_cnt, s->id,
             pa->action, pa->flags);
 
     /* REJECT also sets ACTION_DROP, just make it more visible with this check */
@@ -222,11 +222,11 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const Pac
             // nothing to set in the packet
         } else if (pa->action & ACTION_ACCEPT) {
             const enum ActionScope as = pa->s->action_scope;
-            SCLogDebug("packet %" PRIu64 ": ACCEPT %u as:%u flags:%02x", p->pcap_cnt, s->id, as,
-                    pa->flags);
+            SCLogDebug("packet %" PRIu64 ": ACCEPT %u as:%u flags:%02x", p->pcap_v.pcap_cnt, s->id,
+                    as, pa->flags);
             if (as == ACTION_SCOPE_PACKET || as == ACTION_SCOPE_FLOW ||
                     (pa->flags & PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET)) {
-                SCLogDebug("packet %" PRIu64 ": sid:%u ACCEPT", p->pcap_cnt, s->id);
+                SCLogDebug("packet %" PRIu64 ": sid:%u ACCEPT", p->pcap_v.pcap_cnt, s->id);
                 p->action |= ACTION_ACCEPT;
             }
         } else if (pa->action & (ACTION_ALERT | ACTION_CONFIG)) {
@@ -449,7 +449,7 @@ static inline void FlowApplySignatureActions(
         if (pa->flags & PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW) {
             SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x (set "
                        "PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)",
-                    p->pcap_cnt, s->id, s->action, pa->flags);
+                    p->pcap_v.pcap_cnt, s->id, s->action, pa->flags);
         }
     }
 }
@@ -507,8 +507,8 @@ static inline void PacketAlertFinalizeProcessQueue(
                     }
                 }
             }
-            SCLogDebug("packet %" PRIu64 ": i:%u sid:%u skip_action_set %s", p->pcap_cnt, i, s->id,
-                    BOOL2STR(skip_action_set));
+            SCLogDebug("packet %" PRIu64 ": i:%u sid:%u skip_action_set %s", p->pcap_v.pcap_cnt, i,
+                    s->id, BOOL2STR(skip_action_set));
             if (!skip_action_set) {
                 /* set actions on the flow */
                 FlowApplySignatureActions(p, pa, s, pa->flags);

--- a/src/detect-engine-frame.c
+++ b/src/detect-engine-frame.c
@@ -73,7 +73,7 @@ static void BufferSetupUdp(DetectEngineThreadCtx *det_ctx, InspectionBuffer *buf
 void DetectRunPrefilterFrame(DetectEngineThreadCtx *det_ctx, const SigGroupHead *sgh, Packet *p,
         const Frames *frames, const Frame *frame, const AppProto alproto)
 {
-    SCLogDebug("pcap_cnt %" PRIu64, p->pcap_cnt);
+    SCLogDebug("pcap_cnt %" PRIu64, p->pcap_v.pcap_cnt);
     PrefilterEngine *engine = sgh->frame_engines;
     do {
         if ((engine->alproto == alproto || engine->alproto == ALPROTO_UNKNOWN) &&
@@ -150,7 +150,7 @@ static void PrefilterMpmFrame(DetectEngineThreadCtx *det_ctx, const void *pectx,
     const MpmCtx *mpm_ctx = ctx->mpm_ctx;
 
     SCLogDebug("packet:%" PRIu64 ", prefilter running on list %d -> frame field type %u",
-            p->pcap_cnt, ctx->list_id, frame->type);
+            p->pcap_v.pcap_cnt, ctx->list_id, frame->type);
     if (p->proto == IPPROTO_UDP) {
         // TODO can we use single here? Could it conflict with TCP?
         InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, ctx->list_id, 0);
@@ -197,7 +197,7 @@ static void PrefilterMpmFrame(DetectEngineThreadCtx *det_ctx, const void *pectx,
     }
     SCLogDebug("packet:%" PRIu64
                ", prefilter done running on list %d -> frame field type %u; have %u matches",
-            p->pcap_cnt, ctx->list_id, frame->type, det_ctx->pmq.rule_id_array_cnt);
+            p->pcap_v.pcap_cnt, ctx->list_id, frame->type, det_ctx->pmq.rule_id_array_cnt);
 }
 
 static void PrefilterMpmFrameFree(void *ptr)
@@ -272,7 +272,7 @@ static void BufferSetupUdp(DetectEngineThreadCtx *det_ctx, InspectionBuffer *buf
 
     SCLogDebug("packet %" PRIu64 " -> frame %p/%" PRIi64 "/%s offset %" PRIu64
                " type %u len %" PRIi64,
-            p->pcap_cnt, frame, frame->id,
+            p->pcap_v.pcap_cnt, frame, frame->id,
             AppLayerParserGetFrameNameById(p->flow->proto, p->flow->alproto, frame->type),
             frame->offset, frame->type, frame->len);
 
@@ -289,8 +289,8 @@ static int DetectFrameInspectUdp(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms, Packet *p, const Frames *_frames,
         const Frame *frame, const int list_id)
 {
-    SCLogDebug("packet:%" PRIu64 ", inspect: s:%p s->id:%u, transforms:%p", p->pcap_cnt, s, s->id,
-            transforms);
+    SCLogDebug("packet:%" PRIu64 ", inspect: s:%p s->id:%u, transforms:%p", p->pcap_v.pcap_cnt, s,
+            s->id, transforms);
 
     // TODO can we use single here? Could it conflict with TCP?
     InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, 0);
@@ -576,7 +576,8 @@ int DetectEngineInspectFrameBufferGeneric(DetectEngineThreadCtx *det_ctx,
 
     SCLogDebug("packet:%" PRIu64 ", frame->id:%" PRIu64
                ", list:%d, transforms:%p, s:%p, s->id:%u, engine:%p",
-            p->pcap_cnt, frame->id, engine->sm_list, engine->v1.transforms, s, s->id, engine);
+            p->pcap_v.pcap_cnt, frame->id, engine->sm_list, engine->v1.transforms, s, s->id,
+            engine);
 
     DEBUG_VALIDATE_BUG_ON(p->flow->protoctx == NULL);
     TcpSession *ssn = p->flow->protoctx;

--- a/src/detect-engine-payload.c
+++ b/src/detect-engine-payload.c
@@ -333,8 +333,8 @@ uint8_t DetectEngineInspectStream(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
             is_last = true;
     }
 
-    SCLogDebug("%s ran stream for sid %u on packet %"PRIu64" and we %s",
-            is_last? "LAST:" : "normal:", s->id, p->pcap_cnt,
+    SCLogDebug("%s ran stream for sid %u on packet %" PRIu64 " and we %s",
+            is_last ? "LAST:" : "normal:", s->id, p->pcap_v.pcap_cnt,
             match ? "matched" : "didn't match");
 
     if (match) {

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -104,7 +104,7 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
     /* reset rule store */
     det_ctx->pmq.rule_id_array_cnt = 0;
 
-    SCLogDebug("packet %" PRIu64 " tx %p progress %d tx->detect_progress %02x", p->pcap_cnt,
+    SCLogDebug("packet %" PRIu64 " tx %p progress %d tx->detect_progress %02x", p->pcap_v.pcap_cnt,
             tx->tx_ptr, tx->tx_progress, tx->detect_progress);
 
     PrefilterEngine *engine = sgh->tx_engines;

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -561,7 +561,7 @@ static void PrefilterTxFiledata(DetectEngineThreadCtx *det_ctx, const void *pect
                 local_file_id++;
                 continue;
             }
-            SCLogDebug("[%" PRIu64 "] buffer size %u", p->pcap_cnt, buffer->inspect_len);
+            SCLogDebug("[%" PRIu64 "] buffer size %u", p->pcap_v.pcap_cnt, buffer->inspect_len);
 
             if (buffer->inspect_len >= mpm_ctx->minlen) {
                 uint32_t prev_rule_id_array_cnt = det_ctx->pmq.rule_id_array_cnt;

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -971,7 +971,7 @@ static void PrefilterFlowbitFree(void *vctx)
 static void PrefilterFlowbitMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *pectx)
 {
     struct PrefilterEngineFlowbits *ctx = (struct PrefilterEngineFlowbits *)pectx;
-    SCLogDebug("%" PRIu64 ": ctx %p", p->pcap_cnt, ctx);
+    SCLogDebug("%" PRIu64 ": ctx %p", p->pcap_v.pcap_cnt, ctx);
 
     if (p->flow == NULL) {
         SCReturn;
@@ -1007,7 +1007,7 @@ static void PrefilterFlowbitPostRuleMatch(
         DetectEngineThreadCtx *det_ctx, const void *pectx, Packet *p, Flow *f)
 {
     struct PrefilterEngineFlowbits *ctx = (struct PrefilterEngineFlowbits *)pectx;
-    SCLogDebug("%" PRIu64 ": ctx %p", p->pcap_cnt, ctx);
+    SCLogDebug("%" PRIu64 ": ctx %p", p->pcap_v.pcap_cnt, ctx);
 
     if (p->flow == NULL) {
         SCReturn;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -690,7 +690,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 {
     const bool emerg = ((SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) != 0);
 #ifdef DEBUG
-    if (g_eps_flow_memcap != UINT64_MAX && g_eps_flow_memcap == p->pcap_cnt) {
+    if (g_eps_flow_memcap != UINT64_MAX && g_eps_flow_memcap == p->pcap_v.pcap_cnt) {
         NoFlowHandleIPS(tv, fls, p);
         StatsIncr(tv, fls->dtv->counter_flow_memcap);
         return NULL;

--- a/src/flow.c
+++ b/src/flow.c
@@ -401,7 +401,7 @@ static inline void FlowUpdateEthernet(
  */
 void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars *dtv)
 {
-    SCLogDebug("packet %"PRIu64" -- flow %p", p->pcap_cnt, f);
+    SCLogDebug("packet %" PRIu64 " -- flow %p", p->pcap_v.pcap_cnt, f);
 
     const int pkt_dir = FlowGetPacketDirection(f, p);
 #ifdef CAPTURE_OFFLOAD

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -168,8 +168,8 @@ static void LogTlsLogPem(LogTlsStoreLogThread *aft, const Packet *p, SSLState *s
             goto end_fwrite_fpmeta;
         if (fprintf(fpmeta, "TIME:              %s\n", timebuf) < 0)
             goto end_fwrite_fpmeta;
-        if (p->pcap_cnt > 0) {
-            if (fprintf(fpmeta, "PCAP PKT NUM:      %"PRIu64"\n", p->pcap_cnt) < 0)
+        if (p->pcap_v.pcap_cnt > 0) {
+            if (fprintf(fpmeta, "PCAP PKT NUM:      %" PRIu64 "\n", p->pcap_v.pcap_cnt) < 0)
                 goto end_fwrite_fpmeta;
         }
         if (fprintf(fpmeta, "SRC IP:            %s\n", srcip) < 0)

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -287,7 +287,7 @@ static void AlertJsonTunnel(const Packet *p, SCJsonBuilder *js)
     uint64_t pcap_cnt;
     JsonAddrInfo addr = json_addr_info_zero;
     JsonAddrInfoInit(p->root, 0, &addr);
-    pcap_cnt = p->root->pcap_cnt;
+    pcap_cnt = p->root->pcap_v.pcap_cnt;
     pkt_src = p->root->pkt_src;
 
     SCJbSetString(js, "src_ip", addr.src_ip);

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -875,8 +875,8 @@ SCJsonBuilder *CreateEveHeader(const Packet *p, enum SCOutputJsonLogDirection di
     }
 
     /* pcap_cnt */
-    if (p->pcap_cnt != 0) {
-        SCJbSetUint(js, "pcap_cnt", p->pcap_cnt);
+    if (p->pcap_v.pcap_cnt != 0) {
+        SCJbSetUint(js, "pcap_cnt", p->pcap_v.pcap_cnt);
     }
 
     if (event_type) {

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -186,7 +186,7 @@ static inline void OutputTxLogFiles(ThreadVars *tv, OutputFileLoggerThreadData *
     if (ffc || ffc_opposing)
         SCLogDebug("pcap_cnt %" PRIu64 " flow %p tx %p tx_id %" PRIu64
                    " ffc %p ffc_opposing %p tx_complete %d",
-                p->pcap_cnt, f, tx, tx_id, ffc, ffc_opposing, tx_complete);
+                p->pcap_v.pcap_cnt, f, tx, tx_id, ffc, ffc_opposing, tx_complete);
 
     if (ffc) {
         const bool file_close = ((p->flags & PKT_PSEUDO_STREAM_END)) | eof;
@@ -234,7 +234,7 @@ static inline void OutputTxLogFiles(ThreadVars *tv, OutputFileLoggerThreadData *
     } else {
         SCLogDebug("pcap_cnt %" PRIu64 " flow %p tx %p tx_id %" PRIu64
                    " NOT SETTING FILE FLAGS ffc %p ffc_opposing %p tx_complete %d",
-                p->pcap_cnt, f, tx, tx_id, ffc, ffc_opposing, tx_complete);
+                p->pcap_v.pcap_cnt, f, tx, tx_id, ffc, ffc_opposing, tx_complete);
     }
 }
 
@@ -292,8 +292,8 @@ static void OutputTxLogCallLoggers(ThreadVars *tv, OutputTxLoggerThreadData *op_
         if ((ctx->tx_logged_old & BIT_U32(logger->logger_id)) == 0) {
             SCLogDebug("alproto match %d, logging tx_id %" PRIu64, logger->alproto, tx_id);
 
-            SCLogDebug("pcap_cnt %" PRIu64 ", tx_id %" PRIu64 " logger %d. EOF %s", p->pcap_cnt,
-                    tx_id, logger->logger_id, eof ? "true" : "false");
+            SCLogDebug("pcap_cnt %" PRIu64 ", tx_id %" PRIu64 " logger %d. EOF %s",
+                    p->pcap_v.pcap_cnt, tx_id, logger->logger_id, eof ? "true" : "false");
 
             if (eof) {
                 SCLogDebug("EOF, so log now");
@@ -354,7 +354,7 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
     Flow * const f = p->flow;
     const uint8_t ipproto = f->proto;
     const AppProto alproto = f->alproto;
-    SCLogDebug("pcap_cnt %u tx logging %u/%s", (uint32_t)p->pcap_cnt, alproto,
+    SCLogDebug("pcap_cnt %u tx logging %u/%s", (uint32_t)p->pcap_v.pcap_cnt, alproto,
             AppProtoToString(alproto));
 
     const bool file_logging_active = (op_thread_data->file || op_thread_data->filedata);
@@ -378,7 +378,7 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
                 logger_expectation, LOGGER_FILE, LOGGER_FILEDATA);
         goto end;
     }
-    SCLogDebug("pcap_cnt %" PRIu64, p->pcap_cnt);
+    SCLogDebug("pcap_cnt %" PRIu64, p->pcap_v.pcap_cnt);
 
     const bool last_pseudo = (p->flowflags & FLOW_PKT_LAST_PSEUDO) != 0;
     const bool ts_eof = SCAppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF_TS) != 0;
@@ -398,8 +398,8 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
     const bool support_files = AppLayerParserSupportsFiles(ipproto, alproto);
     const uint8_t pkt_dir = STREAM_FLAGS_FOR_PACKET(p);
 
-    SCLogDebug("pcap_cnt %" PRIu64 ": tx_id %" PRIu64 " total_txs %" PRIu64, p->pcap_cnt, tx_id,
-            total_txs);
+    SCLogDebug("pcap_cnt %" PRIu64 ": tx_id %" PRIu64 " total_txs %" PRIu64, p->pcap_v.pcap_cnt,
+            tx_id, total_txs);
 
     AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(ipproto, alproto);
     AppLayerGetTxIterState state;

--- a/src/packet.c
+++ b/src/packet.c
@@ -132,7 +132,7 @@ void PacketReinit(Packet *p)
             PacketAlertRecycle(p->alerts.alerts, p->alerts.cnt);
         p->alerts.cnt = 0;
     }
-    p->pcap_cnt = 0;
+    p->pcap_v.pcap_cnt = 0;
     p->tunnel_rtv_cnt = 0;
     p->tunnel_tpr_cnt = 0;
     p->events.cnt = 0;

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -80,7 +80,7 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     p->ts = SCTIME_FROM_TIMEVAL_UNTRUSTED(&h->ts);
     SCLogDebug("p->ts.tv_sec %" PRIuMAX "", (uintmax_t)SCTIME_SECS(p->ts));
     p->datalink = ptv->datalink;
-    p->pcap_cnt = ++pcap_g.cnt;
+    p->pcap_v.pcap_cnt = ++pcap_g.cnt;
 
     p->pcap_v.tenant_id = ptv->shared->tenant_id;
     ptv->shared->pkts++;
@@ -96,8 +96,8 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     if (pcap_g.checksum_mode == CHECKSUM_VALIDATION_DISABLE) {
         p->flags |= PKT_IGNORE_CHECKSUM;
     } else if (pcap_g.checksum_mode == CHECKSUM_VALIDATION_AUTO) {
-        if (ChecksumAutoModeCheck(ptv->shared->pkts, p->pcap_cnt,
-                                  SC_ATOMIC_GET(pcap_g.invalid_checksums))) {
+        if (ChecksumAutoModeCheck(ptv->shared->pkts, p->pcap_v.pcap_cnt,
+                    SC_ATOMIC_GET(pcap_g.invalid_checksums))) {
             pcap_g.checksum_mode = CHECKSUM_VALIDATION_DISABLE;
             p->flags |= PKT_IGNORE_CHECKSUM;
         }

--- a/src/source-pcap.h
+++ b/src/source-pcap.h
@@ -32,8 +32,8 @@ void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
 #define LIBPCAP_PROMISC     1
 
 /* per packet Pcap vars */
-typedef struct PcapPacketVars_
-{
+typedef struct PcapPacketVars_ {
+    uint64_t pcap_cnt;
     uint32_t tenant_id;
 } PcapPacketVars;
 

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -272,9 +272,9 @@ enum TcpState {
         if ((p)->flags & PKT_STREAM_NO_EVENTS) {                                                   \
             SCLogDebug("not setting event %d on pkt %p (%" PRIu64 "), "                            \
                        "stream in known bad condition",                                            \
-                    (e), p, (p)->pcap_cnt);                                                        \
+                    (e), p, (p)->pcap_v.pcap_cnt);                                                 \
         } else {                                                                                   \
-            SCLogDebug("setting event %d on pkt %p (%" PRIu64 ")", (e), p, (p)->pcap_cnt);         \
+            SCLogDebug("setting event %d on pkt %p (%" PRIu64 ")", (e), p, (p)->pcap_v.pcap_cnt);  \
             ENGINE_SET_EVENT((p), (e));                                                            \
             p->l4.vars.tcp.stream_pkt_flags |= STREAM_PKT_FLAG_EVENTSET;                           \
         }                                                                                          \

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1089,9 +1089,7 @@ static void GetSessionSize(TcpSession *ssn, Packet *p)
         size = GetStreamSize(&ssn->client);
         size += GetStreamSize(&ssn->server);
 
-        //if (size > 900000)
-        //    SCLogInfo("size %"PRIu64", packet %"PRIu64, size, p->pcap_cnt);
-        SCLogDebug("size %"PRIu64", packet %"PRIu64, size, p->pcap_cnt);
+        SCLogDebug("size %" PRIu64 ", packet %" PRIu64, size, p->pcap_v.pcap_cnt);
     }
 }
 #endif
@@ -1200,7 +1198,7 @@ static inline bool CheckGap(TcpSession *ssn, TcpStream *stream, Packet *p)
             if (RB_EMPTY(&stream->sb.sbb_tree)) {
                 SCLogDebug("packet %" PRIu64 ": no GAP. "
                            "next_seq %u < last_ack %u, but no data in list",
-                        p->pcap_cnt, stream->next_seq, stream->last_ack);
+                        p->pcap_v.pcap_cnt, stream->next_seq, stream->last_ack);
                 return false;
             }
             const uint64_t next_seq_abs =
@@ -1210,7 +1208,7 @@ static inline bool CheckGap(TcpSession *ssn, TcpStream *stream, Packet *p)
                 /* ack'd data after the gap */
                 SCLogDebug("packet %" PRIu64 ": GAP. "
                            "next_seq %u < last_ack %u, but ACK'd data beyond gap.",
-                        p->pcap_cnt, stream->next_seq, stream->last_ack);
+                        p->pcap_v.pcap_cnt, stream->next_seq, stream->last_ack);
                 return true;
             }
         }
@@ -1218,12 +1216,12 @@ static inline bool CheckGap(TcpSession *ssn, TcpStream *stream, Packet *p)
         SCLogDebug("packet %" PRIu64 ": GAP! "
                    "last_ack_abs %" PRIu64 " > app_progress %" PRIu64 ", "
                    "but we have no data.",
-                p->pcap_cnt, last_ack_abs, app_progress);
+                p->pcap_v.pcap_cnt, last_ack_abs, app_progress);
         return true;
     }
-    SCLogDebug("packet %"PRIu64": no GAP. "
-            "last_ack_abs %"PRIu64" <= app_progress %"PRIu64,
-            p->pcap_cnt, last_ack_abs, app_progress);
+    SCLogDebug("packet %" PRIu64 ": no GAP. "
+               "last_ack_abs %" PRIu64 " <= app_progress %" PRIu64,
+            p->pcap_v.pcap_cnt, last_ack_abs, app_progress);
     return false;
 }
 
@@ -1337,7 +1335,7 @@ static int ReassembleUpdateAppLayer(ThreadVars *tv, TcpReassemblyThreadCtx *ra_c
 
             mydata = NULL;
             mydata_len = 0;
-            SCLogDebug("%"PRIu64" got %p/%u", p->pcap_cnt, mydata, mydata_len);
+            SCLogDebug("%" PRIu64 " got %p/%u", p->pcap_v.pcap_cnt, mydata, mydata_len);
             break;
         }
         DEBUG_VALIDATE_BUG_ON(mydata == NULL && mydata_len > 0);
@@ -1584,8 +1582,9 @@ void StreamReassembleRawUpdateProgress(TcpSession *ssn, Packet *p, const uint64_
         stream->flags &= ~STREAMTCP_STREAM_FLAG_TRIGGER_RAW;
 
     } else {
-        SCLogDebug("p->pcap_cnt %"PRIu64": progress %"PRIu64" app %"PRIu64" raw %"PRIu64" tcp win %"PRIu32,
-                p->pcap_cnt, progress, STREAM_APP_PROGRESS(stream),
+        SCLogDebug("p->pcap_v.pcap_cnt %" PRIu64 ": progress %" PRIu64 " app %" PRIu64
+                   " raw %" PRIu64 " tcp win %" PRIu32,
+                p->pcap_v.pcap_cnt, progress, STREAM_APP_PROGRESS(stream),
                 STREAM_RAW_PROGRESS(stream), stream->window);
     }
 
@@ -2029,7 +2028,7 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
         dir = UPDATE_DIR_BOTH;
     } else if ((ssn->flags & STREAMTCP_FLAG_ASYNC) != 0) {
         dir = UPDATE_DIR_PACKET;
-        SCLogDebug("%" PRIu64 ": ASYNC: UPDATE_DIR_PACKET", p->pcap_cnt);
+        SCLogDebug("%" PRIu64 ": ASYNC: UPDATE_DIR_PACKET", p->pcap_v.pcap_cnt);
     }
 
     /* handle ack received */
@@ -2074,7 +2073,7 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             SCReturnInt(-1);
         }
 
-        SCLogDebug("packet %"PRIu64" set PKT_STREAM_ADD", p->pcap_cnt);
+        SCLogDebug("packet %" PRIu64 " set PKT_STREAM_ADD", p->pcap_v.pcap_cnt);
         p->flags |= PKT_STREAM_ADD;
     } else {
         SCLogDebug("ssn %p / stream %p: not calling StreamTcpReassembleHandleSegmentHandleData:"

--- a/src/stream-tcp-sack.c
+++ b/src/stream-tcp-sack.c
@@ -277,14 +277,14 @@ int StreamTcpSackUpdatePacket(TcpStream *stream, Packet *p)
 
         /* RFC 2883 D-SACK */
         if (SEQ_LT(le, TCP_GET_RAW_ACK(tcph))) {
-            SCLogDebug("packet: %" PRIu64 ": D-SACK? %u-%u before ACK %u", p->pcap_cnt, le, re,
-                    TCP_GET_RAW_ACK(tcph));
+            SCLogDebug("packet: %" PRIu64 ": D-SACK? %u-%u before ACK %u", p->pcap_v.pcap_cnt, le,
+                    re, TCP_GET_RAW_ACK(tcph));
             STREAM_PKT_FLAG_SET(p, STREAM_PKT_FLAG_DSACK);
             goto next;
         } else if (record == 1) { // 2nd record
             if (SEQ_GEQ(first_le, le) && SEQ_LEQ(first_re, re)) {
                 SCLogDebug("packet: %" PRIu64 ": D-SACK? %u-%u inside 2nd range %u-%u ACK %u",
-                        p->pcap_cnt, first_le, first_re, le, re, TCP_GET_RAW_ACK(tcph));
+                        p->pcap_v.pcap_cnt, first_le, first_re, le, re, TCP_GET_RAW_ACK(tcph));
                 STREAM_PKT_FLAG_SET(p, STREAM_PKT_FLAG_DSACK);
             }
             goto next;

--- a/src/tests/detect-http-header.c
+++ b/src/tests/detect-http-header.c
@@ -4376,17 +4376,17 @@ static int DetectEngineHttpHeaderTest34(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    p1->pcap_cnt = 1;
+    p1->pcap_v.pcap_cnt = 1;
     p2->flow = &f;
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    p2->pcap_cnt = 2;
+    p2->pcap_v.pcap_cnt = 2;
     p3->flow = &f;
     p3->flowflags |= FLOW_PKT_TOSERVER;
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
     p3->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    p3->pcap_cnt = 3;
+    p3->pcap_v.pcap_cnt = 3;
     f.alproto = ALPROTO_HTTP1;
 
     StreamTcpInitConfig(true);
@@ -4489,17 +4489,17 @@ static int DetectEngineHttpHeaderTest35(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    p1->pcap_cnt = 1;
+    p1->pcap_v.pcap_cnt = 1;
     p2->flow = &f;
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    p2->pcap_cnt = 2;
+    p2->pcap_v.pcap_cnt = 2;
     p3->flow = &f;
     p3->flowflags |= FLOW_PKT_TOSERVER;
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
     p3->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    p3->pcap_cnt = 3;
+    p3->pcap_v.pcap_cnt = 3;
     f.alproto = ALPROTO_HTTP1;
 
     StreamTcpInitConfig(true);

--- a/src/tests/detect-tls-cert-fingerprint.c
+++ b/src/tests/detect-tls-cert-fingerprint.c
@@ -289,19 +289,19 @@ static int DetectTlsFingerprintTest02(void)
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
-    p1->pcap_cnt = 1;
+    p1->pcap_v.pcap_cnt = 1;
 
     p2->flow = &f;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
-    p2->pcap_cnt = 2;
+    p2->pcap_v.pcap_cnt = 2;
 
     p3->flow = &f;
     p3->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p3->flowflags |= FLOW_PKT_TOCLIENT;
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
-    p3->pcap_cnt = 3;
+    p3->pcap_v.pcap_cnt = 3;
 
     StreamTcpInitConfig(true);
 

--- a/src/tests/detect-tls-cert-issuer.c
+++ b/src/tests/detect-tls-cert-issuer.c
@@ -289,19 +289,19 @@ static int DetectTlsIssuerTest02(void)
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
-    p1->pcap_cnt = 1;
+    p1->pcap_v.pcap_cnt = 1;
 
     p2->flow = &f;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
-    p2->pcap_cnt = 2;
+    p2->pcap_v.pcap_cnt = 2;
 
     p3->flow = &f;
     p3->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p3->flowflags |= FLOW_PKT_TOCLIENT;
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
-    p3->pcap_cnt = 3;
+    p3->pcap_v.pcap_cnt = 3;
 
     StreamTcpInitConfig(true);
 

--- a/src/tests/detect-tls-cert-serial.c
+++ b/src/tests/detect-tls-cert-serial.c
@@ -286,19 +286,19 @@ static int DetectTlsSerialTest02(void)
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
-    p1->pcap_cnt = 1;
+    p1->pcap_v.pcap_cnt = 1;
 
     p2->flow = &f;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
-    p2->pcap_cnt = 2;
+    p2->pcap_v.pcap_cnt = 2;
 
     p3->flow = &f;
     p3->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p3->flowflags |= FLOW_PKT_TOCLIENT;
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
-    p3->pcap_cnt = 3;
+    p3->pcap_v.pcap_cnt = 3;
 
     StreamTcpInitConfig(true);
 

--- a/src/tests/detect-tls-cert-subject.c
+++ b/src/tests/detect-tls-cert-subject.c
@@ -289,19 +289,19 @@ static int DetectTlsSubjectTest02(void)
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
-    p1->pcap_cnt = 1;
+    p1->pcap_v.pcap_cnt = 1;
 
     p2->flow = &f;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
-    p2->pcap_cnt = 2;
+    p2->pcap_v.pcap_cnt = 2;
 
     p3->flow = &f;
     p3->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p3->flowflags |= FLOW_PKT_TOCLIENT;
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
-    p3->pcap_cnt = 3;
+    p3->pcap_v.pcap_cnt = 3;
 
     StreamTcpInitConfig(true);
 

--- a/src/tests/detect-tls-cert-validity.c
+++ b/src/tests/detect-tls-cert-validity.c
@@ -653,19 +653,19 @@ static int ValidityTestDetect01(void)
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
-    p1->pcap_cnt = 1;
+    p1->pcap_v.pcap_cnt = 1;
 
     p2->flow = &f;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
-    p2->pcap_cnt = 2;
+    p2->pcap_v.pcap_cnt = 2;
 
     p3->flow = &f;
     p3->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p3->flowflags |= FLOW_PKT_TOCLIENT;
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
-    p3->pcap_cnt = 3;
+    p3->pcap_v.pcap_cnt = 3;
 
     StreamTcpInitConfig(true);
 
@@ -983,19 +983,19 @@ static int ExpiredTestDetect01(void)
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
-    p1->pcap_cnt = 1;
+    p1->pcap_v.pcap_cnt = 1;
 
     p2->flow = &f;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
-    p2->pcap_cnt = 2;
+    p2->pcap_v.pcap_cnt = 2;
 
     p3->flow = &f;
     p3->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p3->flowflags |= FLOW_PKT_TOCLIENT;
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
-    p3->pcap_cnt = 3;
+    p3->pcap_v.pcap_cnt = 3;
 
     f.lastts = SCTIME_FROM_SECS(1474978656L); /* 2016-09-27 */
 
@@ -1291,19 +1291,19 @@ static int ValidTestDetect01(void)
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
-    p1->pcap_cnt = 1;
+    p1->pcap_v.pcap_cnt = 1;
 
     p2->flow = &f;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
-    p2->pcap_cnt = 2;
+    p2->pcap_v.pcap_cnt = 2;
 
     p3->flow = &f;
     p3->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p3->flowflags |= FLOW_PKT_TOCLIENT;
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
-    p3->pcap_cnt = 3;
+    p3->pcap_v.pcap_cnt = 3;
 
     f.lastts = SCTIME_FROM_SECS(1474978656L); /* 2016-09-27 */
 

--- a/src/tests/detect-tls-certs.c
+++ b/src/tests/detect-tls-certs.c
@@ -285,19 +285,19 @@ static int DetectTlsCertsTest02(void)
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
-    p1->pcap_cnt = 1;
+    p1->pcap_v.pcap_cnt = 1;
 
     p2->flow = &f;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
-    p2->pcap_cnt = 2;
+    p2->pcap_v.pcap_cnt = 2;
 
     p3->flow = &f;
     p3->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p3->flowflags |= FLOW_PKT_TOCLIENT;
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
-    p3->pcap_cnt = 3;
+    p3->pcap_v.pcap_cnt = 3;
 
     StreamTcpInitConfig(true);
 

--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -152,7 +152,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         p->ts = SCTIME_FROM_TIMEVAL(&header.ts);
         p->datalink = pkts.datalink;
         pcap_cnt++;
-        p->pcap_cnt = pcap_cnt;
+        p->pcap_v.pcap_cnt = pcap_cnt;
         p->pkt_src = PKT_SRC_WIRE;
     }
 bail:

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -196,7 +196,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         p->datalink = pcap_datalink(pkts);
         p->pkt_src = PKT_SRC_WIRE;
         pcap_cnt++;
-        p->pcap_cnt = pcap_cnt;
+        p->pcap_v.pcap_cnt = pcap_cnt;
     }
 bail:
     //close structure

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -192,7 +192,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         p->ts = SCTIME_FROM_TIMEVAL(&header.ts);
         p->datalink = pkts.datalink;
         pcap_cnt++;
-        p->pcap_cnt = pcap_cnt;
+        p->pcap_v.pcap_cnt = pcap_cnt;
     }
 bail:
     PacketFree(p);

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -135,7 +135,7 @@ enum ExceptionPolicy ExceptionPolicyTargetPolicy(uint8_t target_flag)
 
 void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason)
 {
-    SCLogDebug("start: pcap_cnt %" PRIu64 ", policy %u", p->pcap_cnt, policy);
+    SCLogDebug("start: pcap_cnt %" PRIu64 ", policy %u", p->pcap_v.pcap_cnt, policy);
     if (p->flow) {
         p->flow->applied_exception_policy |= ExceptionPolicyFlag(drop_reason);
     }

--- a/src/util-lua-packetlib.c
+++ b/src/util-lua-packetlib.c
@@ -80,7 +80,7 @@ static int LuaPacketPcapCnt(lua_State *luastate)
         LUA_ERROR("failed to get packet");
     }
 
-    lua_pushinteger(luastate, s->p->pcap_cnt);
+    lua_pushinteger(luastate, s->p->pcap_v.pcap_cnt);
     return 1;
 }
 

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -790,8 +790,7 @@ void SCProfilingPrintPacketProfile(Packet *p)
 
     /* total cost from acquisition to return to packetpool */
     uint64_t delta = p->profile->ticks_end - p->profile->ticks_start;
-    fprintf(packet_profile_csv_fp, "%"PRIu64",%"PRIu64",",
-            p->pcap_cnt, delta);
+    fprintf(packet_profile_csv_fp, "%" PRIu64 ",%" PRIu64 ",", p->pcap_v.pcap_cnt, delta);
 
     for (int i = 0; i < TMM_SIZE; i++) {
         const PktProfilingTmmData *pdt = &p->profile->tmm[i];


### PR DESCRIPTION
Code refactoring to gather all PCAP-related structure members under one structure.

This PR has no ticket, just a refactor I thought of while working on https://github.com/OISF/suricata/pull/13641

Describe changes:
- Main change - moved pcap_cnt from https://github.com/OISF/suricata/compare/master...lukashino:move-pcapcnt-v1?expand=1#diff-48e701cfe9e2223cedaa68c2dad70955a5b41c803cc1a3feba33d75a18d35533L625 to https://github.com/OISF/suricata/compare/master...lukashino:move-pcapcnt-v1?expand=1#diff-944d703ec59d9d1c4c99ead35895eb7b73c8b631cae36082ac59c13c41bc7d1fR35
- Other required code changes to make it compatible