### PR TITLE
dpdk: add initial unittests for DPDK codebase v8.4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -714,6 +714,7 @@ jobs:
                 ccache \
                 clang \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -739,6 +740,7 @@ jobs:
                 lz4-devel \
                 make \
                 parallel \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python \
@@ -758,7 +760,7 @@ jobs:
       - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow" ./configure --disable-shared
       - run: make check
       - run: make distclean
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         env:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"
@@ -814,6 +816,7 @@ jobs:
                 cbindgen \
                 ccache \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -836,6 +839,7 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -851,7 +855,7 @@ jobs:
           path: prep
       - run: tar xf prep/suricata-update.tar.gz
       - run: ./autogen.sh
-      - run: ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         env:
           CFLAGS: "${{ env.DEFAULT_CFLAGS }} -Wshadow -fsanitize=address -fno-omit-frame-pointer"
           LDFLAGS: "-fsanitize=address"
@@ -903,6 +907,7 @@ jobs:
                 ccache \
                 clang \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -925,6 +930,7 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -951,7 +957,7 @@ jobs:
       - run: >-
           sudo -u suricata -s env PATH="/home/suricata/.cargo/bin:$PATH" ./configure --enable-warnings
           --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis
-          --enable-nfqueue --disable-ja3 --disable-ja4
+          --enable-nfqueue --enable-dpdk --disable-ja3 --disable-ja4
         working-directory: /home/suricata/suricata
         env:
           ac_cv_func_realloc_0_nonnull: "yes"
@@ -1196,6 +1202,7 @@ jobs:
                 automake \
                 clang-19 \
                 curl \
+                dpdk-dev \
                 git \
                 hwloc \
                 libhwloc-dev \
@@ -1240,7 +1247,7 @@ jobs:
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.85.1 -y
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
-      - run: ./configure --enable-warnings --disable-shared --enable-unittests
+      - run: ./configure --enable-warnings --disable-shared --enable-unittests --enable-dpdk
         env:
           CC: "clang-19"
           CXX: "clang++-19"
@@ -2669,6 +2676,7 @@ jobs:
                 autoconf \
                 build-essential \
                 ccache \
+                dpdk-dev \
                 curl \
                 git \
                 hwloc \
@@ -2682,6 +2690,7 @@ jobs:
                 libcap-ng-dev \
                 libcap-ng0 \
                 libmagic-dev \
+                libnuma-dev \
                 libjansson-dev \
                 libgeoip-dev \
                 libhiredis-dev \
@@ -2710,7 +2719,7 @@ jobs:
       - run: tar xf prep/suricata-update.tar.gz
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-fuzztargets --enable-ebpf --enable-ebpf-build
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-fuzztargets --enable-ebpf --enable-ebpf-build --enable-dpdk
       - run: make -j ${{ env.CPUS }}
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2298,7 +2298,7 @@ jobs:
     needs: [ prepare-deps, prepare-cbindgen ]
     strategy:
       matrix:
-        dpdk_version: [ 22.11.4, 21.11.6, 20.11.10, 19.11.14 ]
+        dpdk_version: [ 22.11.8, 21.11.9, 20.11.10, 19.11.14 ]
     steps:
 
       # Cache Rust stuff.

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2298,7 +2298,7 @@ jobs:
     needs: [ prepare-deps, prepare-cbindgen ]
     strategy:
       matrix:
-        dpdk_version: [ 22.11.8, 21.11.9, 20.11.10, 19.11.14 ]
+        dpdk_version: [ 24.11.2, 23.11.4, 22.11.8, 21.11.9, 20.11.10, 19.11.14 ]
     steps:
 
       # Cache Rust stuff.

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -469,7 +469,7 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
         SCReturnInt(-EINVAL);
     }
 
-    if (iconf->threads <= 0) {
+    if (iconf->threads == 0) {
         SCLogError("%s: positive number of threads required", iconf->iface);
         SCReturnInt(-ERANGE);
     }

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -35,6 +35,7 @@
 #include "runmode-dpdk.h"
 #include "decode.h"
 #include "source-dpdk.h"
+#include "util-affinity.h"
 #include "util-runmodes.h"
 #include "util-byte.h"
 #include "util-cpu.h"

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -46,4 +46,6 @@ int RunModeIdsDpdkWorkers(void);
 void RunModeDpdkRegister(void);
 const char *RunModeDpdkGetDefaultMode(void);
 
+void DPDKRunmodeRegisterTests(void);
+
 #endif /* SURICATA_RUNMODE_DPDK_H */

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -126,6 +126,8 @@
 #include "source-windivert.h"
 #endif
 
+#include "runmode-dpdk.h"
+
 #endif /* UNITTESTS */
 
 void TmqhSetup (void);
@@ -220,6 +222,9 @@ static void RegisterUnittests(void)
     UtilCIDRTests();
     OutputJsonStatsRegisterTests();
     CoredumpConfigRegisterTests();
+#ifdef HAVE_DPDK
+    DPDKRunmodeRegisterTests();
+#endif
 }
 #endif
 

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -1106,7 +1106,7 @@ void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *
  * \brief Helper function to reset affinity state for unit tests
  * This properly clears CPU sets without destroying initialized mutexes
  */
-static void ResetAffinityForTest(void)
+void ResetAffinityForTest(void)
 {
     thread_affinity_init_done = 0;
     for (int i = 0; i < MAX_CPU_SET; i++) {

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -1088,12 +1088,15 @@ uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType 
  */
 void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf)
 {
-    cpu_set_t tmpset;
     SCMutexLock(&mod_taf->taf_mutex);
     SCMutexLock(&static_taf->taf_mutex);
-    CPU_XOR(&tmpset, &mod_taf->cpu_set, &static_taf->cpu_set);
+    int max_cpus = UtilCpuGetNumProcessorsOnline();
+    for (int cpu = 0; cpu < max_cpus; cpu++) {
+        if (CPU_ISSET(cpu, &mod_taf->cpu_set) && CPU_ISSET(cpu, &static_taf->cpu_set)) {
+            CPU_CLR(cpu, &mod_taf->cpu_set);
+        }
+    }
     SCMutexUnlock(&static_taf->taf_mutex);
-    mod_taf->cpu_set = tmpset;
     SCMutexUnlock(&mod_taf->taf_mutex);
 }
 #endif /* HAVE_DPDK */

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -111,6 +111,7 @@ uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf);
 uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2);
 void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf);
 #endif /* HAVE_DPDK */
+void ResetAffinityForTest(void);
 
 int BuildCpusetWithCallback(
         const char *name, SCConfNode *node, void (*Callback)(int i, void *data), void *data);

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -360,6 +360,8 @@ int LiveDeviceListClean(void)
         SCFree(pd);
     }
 
+    // set the list to NULL
+    TAILQ_INIT(&live_devices);
     SCReturnInt(TM_ECODE_OK);
 }
 
@@ -471,6 +473,9 @@ void LiveDeviceFinalize(void)
         }
         SCFree(ld);
     }
+
+    // set the list to NULL
+    TAILQ_INIT(&pre_live_devices);
 }
 
 static void LiveDevExtensionFree(void *x)

--- a/src/util-dpdk-bonding.c
+++ b/src/util-dpdk-bonding.c
@@ -52,7 +52,18 @@ uint16_t BondingMemberDevicesGet(
 {
 #ifdef HAVE_DPDK_BOND
 #if RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0)
+
+#if RTE_VERSION < RTE_VERSION_NUM(24, 11, 0, 0) // DPDK 23.11 - 24.07
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif /* RTE_VERSION < RTE_VERSION_NUM(24, 11, 0, 0) */
+
     int32_t len = rte_eth_bond_members_get(bond_pid, bonded_devs, bonded_devs_length);
+
+#if RTE_VERSION < RTE_VERSION_NUM(24, 11, 0, 0)
+#pragma GCC diagnostic pop
+#endif /* RTE_VERSION < RTE_VERSION_NUM(24, 11, 0, 0) */
+
 #else
     int32_t len = rte_eth_bond_slaves_get(bond_pid, bonded_devs, bonded_devs_length);
 #endif /* RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0) */

--- a/src/util-unittest.c
+++ b/src/util-unittest.c
@@ -188,7 +188,7 @@ void UtListTests(const char *regex_arg)
 uint32_t UtRunTests(const char *regex_arg)
 {
     UtTest *ut;
-    uint32_t good = 0, bad = 0, matchcnt = 0;
+    uint32_t good = 0, skip = 0, bad = 0, matchcnt = 0;
     int ret = 0, rcomp = 0;
 
     StreamTcpInitMemuse();
@@ -225,22 +225,28 @@ uint32_t UtRunTests(const char *regex_arg)
                     ret = 0;
                 }
 
-                printf("%s\n", ret ? "pass" : "FAILED");
-
                 if (!ret) {
                     if (unittests_fatal == 1) {
                         fprintf(stderr, "ERROR: unittest failed.\n");
                         exit(EXIT_FAILURE);
                     }
                     bad++;
+                    printf("FAILED\n");
+                } else if (ret == 2) {
+                    skip++;
+                    printf("skip\n");
                 } else {
                     good++;
+                    printf("pass\n");
                 }
             }
         }
         if(matchcnt > 0){
             printf("==== TEST RESULTS ====\n");
             printf("PASSED: %" PRIu32 "\n", good);
+            if (skip > 0) {
+                printf("SKIPPED: %" PRIu32 "\n", skip);
+            }
             printf("FAILED: %" PRIu32 "\n", bad);
             printf("======================\n");
         } else {

--- a/src/util-unittest.h
+++ b/src/util-unittest.h
@@ -106,6 +106,18 @@ extern int unittests_fatal;
         return 1; \
     } while (0)
 
+/**
+ * \brief Skip the test.
+ *
+ * Used to skip the tests that cannot be run in the current environment.
+ * The aim is to keep this at 0.
+ */
+#define SKIP(reason)                                                                               \
+    do {                                                                                           \
+        SCLogInfo("Test skipped: %s", reason);                                                     \
+        return 2;                                                                                  \
+    } while (0)
+
 #endif
 
 #endif /* SURICATA_UTIL_UNITTEST_H */


### PR DESCRIPTION
Follow-up of: #13506 

Redmine tickets:
- https://redmine.openinfosecfoundation.org/issues/6382
- https://redmine.openinfosecfoundation.org/issues/6927
- https://redmine.openinfosecfoundation.org/issues/7009

The PR is adding unit tests tailored to verify CPU threading logic and the automatic calculation of mempool cache of the interface.

Describe changes:
v8.4:
- rebased

v8.3:
- rebased
- Fedora build fixes

v8.2:
- rebased
- bumped up DPDK versions in GH CI
- changed AutoRemainingThreadsInit(bool force_reinit) to AutoRemainingThreadsInit(void) to avoid mysterious bool param

v7:
- moved UnitTestsUtilAffinityVerifyCPURequirement to runmode-dpdk next to unit tests
- commit split as per https://github.com/OISF/suricata/pull/12083#discussion_r1827614240
- added git references to commit
- rebased

v6:
- github ci runs reverted to suppressing the "deprecated" error
- expanded the explanation in the commit now

v5:
- fixed the includes
- github ci runs with experimental DPDK features in the build test for DPDK v23.11.*
- no more GCC deprecation warning pushes

v4
- fixed live device cleaning function
- silenced 23.11 DPDK bond warning about "deprecated" (experimental) function on Fedora 40 builds
- rebased

v3
- comments from Philippe
- I left TAILQ_INIT in the finalize/cleanup functions - all elements of the arrays are cleaned but not the base pointer of the array itself. TAILQ_* functions don't offer reset function but TAILQ_INIT provides the desired outcome
- moved guards around - per Philippe's suggestions

v2
- added a FatalError check on the number of LiveDevices
- changed #if HAVE_DPDK to #if defined(HAVE_DPDK) && defined(UNITTESTS)
- enabled unit tests in the Github workflow runs on Ubuntu and Fedora tasks

v1
- function-guarded variable
- fix the CPU exclude logic
- add DPDK unit tests