### PR TITLE
util-cpu: add a mockup value for unittests v1

### DIFF
--- a/src/util-cpu.c
+++ b/src/util-cpu.c
@@ -107,6 +107,10 @@ uint16_t UtilCpuGetNumProcessorsConfigured(void)
  */
 uint16_t UtilCpuGetNumProcessorsOnline(void)
 {
+#ifdef UNITTESTS
+    return 40; // A mockup value for unittests
+#endif
+
 #ifdef SYSCONF_NPROCESSORS_ONLN_COMPAT
     long nprocs = -1;
     nprocs = sysconf(_SC_NPROCESSORS_ONLN);


### PR DESCRIPTION
Tests were previously platform-dependent, as UtilCpuGetNumProcessorsOnline retrieved the real number of CPU cores, and on systems with fewer than 4 CPU cores, some threading unit tests failed.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7831

Describe changes:
- added a mockup value of 40 cores