### PR TITLE
pcap-file: synchronize PCAP filename output v2

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -448,6 +448,7 @@ noinst_HEADERS = \
 	source-nfq.h \
 	source-pcap-file-directory-helper.h \
 	source-pcap-file-helper.h \
+	source-pcap-file-info-helper.h \
 	source-pcap-file.h \
 	source-pcap.h \
 	source-windivert-prototypes.h \
@@ -1043,6 +1044,7 @@ libsuricata_c_a_SOURCES = \
 	source-nfq.c \
 	source-pcap-file-directory-helper.c \
 	source-pcap-file-helper.c \
+	source-pcap-file-info-helper.c \
 	source-pcap-file.c \
 	source-pcap.c \
 	source-windivert.c \

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -24,6 +24,7 @@
  */
 
 #include "suricata-common.h"
+#include "source-pcap-file-info-helper.h"
 #include "threads.h"
 
 #include "flow.h"
@@ -210,6 +211,11 @@ void FlowInit(ThreadVars *tv, Flow *f, const Packet *p)
         DEBUG_VALIDATE_BUG_ON(FlowGetStorageById(f, FlowRateGetStorageID()) != NULL);
         FlowRateStore *frs = FlowRateStoreInit();
         FlowSetStorageById(f, FlowRateGetStorageID(), frs);
+    }
+
+    DEBUG_VALIDATE_BUG_ON(f->pcap_info != NULL);
+    if (p->pcap_v.info) {
+        f->pcap_info = PcapFileInfoAddReference(p->pcap_v.info);
     }
 
     SCFlowRunInitCallbacks(tv, f, p);

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -26,6 +26,7 @@
 
 #include "flow.h"
 #include "stream-tcp-private.h"
+#include "source-pcap-file-info-helper.h"
 
 #define RESET_COUNTERS(f)                                                                          \
     do {                                                                                           \
@@ -69,6 +70,7 @@
         (f)->sgh_toserver = NULL;                                                                  \
         (f)->sgh_toclient = NULL;                                                                  \
         (f)->flowvar = NULL;                                                                       \
+        (f)->pcap_info = NULL;                                                                     \
         RESET_COUNTERS((f));                                                                       \
     } while (0)
 
@@ -80,6 +82,7 @@
 #define FLOW_RECYCLE(f)                                                                            \
     do {                                                                                           \
         FlowCleanupAppLayer((f));                                                                  \
+        PcapFileInfoDeref(&((f)->pcap_info));                                                      \
         (f)->sp = 0;                                                                               \
         (f)->dp = 0;                                                                               \
         (f)->proto = 0;                                                                            \
@@ -119,6 +122,7 @@
 #define FLOW_DESTROY(f)                                                                            \
     do {                                                                                           \
         FlowCleanupAppLayer((f));                                                                  \
+        PcapFileInfoDeref(&((f)->pcap_info));                                                      \
                                                                                                    \
         FLOWLOCK_DESTROY((f));                                                                     \
         GenericVarFree((f)->flowvar);                                                              \

--- a/src/flow.h
+++ b/src/flow.h
@@ -27,6 +27,7 @@
 /* forward declaration for macset include */
 typedef struct FlowStorageId FlowStorageId;
 
+#include "source-pcap-file-info-helper.h"
 #include "decode.h"
 #include "util-time.h"
 #include "util-exception-policy.h"
@@ -496,6 +497,8 @@ typedef struct Flow_
     uint32_t tosrcpktcnt;
     uint64_t todstbytecnt;
     uint64_t tosrcbytecnt;
+
+    PcapFileInfo *pcap_info;
 
     Storage storage[];
 } Flow;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1022,7 +1022,16 @@ void OutputJsonBuilderBuffer(
     }
 
     if (file_ctx->is_pcap_offline) {
-        SCJbSetString(js, "pcap_filename", PcapFileGetFilename());
+        if (f && f->pcap_info && f->pcap_info->filename) {
+            // intended for e.g. Flow managers (flow events)
+            SCJbSetString(js, "pcap_filename", f->pcap_info->filename);
+        } else if (p && p->pcap_v.info && p->pcap_v.info->filename) {
+            // intended for e.g. Workers (alert events)
+            SCJbSetString(js, "pcap_filename", p->pcap_v.info->filename);
+        } else {
+            // intended for e.g. (stats events)
+            SCJbSetString(js, "pcap_filename", PcapFileGetFilename());
+        }
     }
 
     SCEveRunCallbacks(tv, p, f, js);

--- a/src/packet.c
+++ b/src/packet.c
@@ -15,6 +15,7 @@
  * 02110-1301, USA.
  */
 
+#include "source-pcap-file-info-helper.h"
 #include "packet.h"
 #include "pkt-var.h"
 #include "flow.h"
@@ -65,10 +66,12 @@ void PacketInit(Packet *p)
     SCSpinInit(&p->persistent.tunnel_lock, 0);
     p->alerts.alerts = PacketAlertCreate();
     p->livedev = NULL;
+    p->pcap_v.info = NULL;
 }
 
 void PacketReleaseRefs(Packet *p)
 {
+    PcapFileInfoDeref(&(p->pcap_v.info));
     FlowDeReference(&p->flow);
     HostDeReference(&p->host_src);
     HostDeReference(&p->host_dst);

--- a/src/source-pcap-file-directory-helper.c
+++ b/src/source-pcap-file-directory-helper.c
@@ -423,9 +423,8 @@ TmEcode PcapDirectoryDispatchForTimeRange(PcapFileDirectoryVars *pv,
                     SCReturnInt(TM_ECODE_FAILED);
                 }
 
-                pftv->filename = SCStrdup(current_file->filename);
-                if (unlikely(pftv->filename == NULL)) {
-                    SCLogError("Failed to allocate filename");
+                pftv->info = PcapFileInfoInit(current_file->filename);
+                if (unlikely(pftv->info == NULL)) {
                     CleanupPcapFileFileVars(pftv);
                     SCReturnInt(TM_ECODE_FAILED);
                 }

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -43,15 +43,16 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv)
             pcap_close(pfv->pcap_handle);
             pfv->pcap_handle = NULL;
         }
-        if (pfv->filename != NULL) {
+        if (pfv->info != NULL && pfv->info->filename != NULL) {
             if (pfv->shared != NULL && pfv->shared->should_delete) {
-                SCLogDebug("Deleting pcap file %s", pfv->filename);
-                if (unlink(pfv->filename) != 0) {
-                    SCLogWarning("Failed to delete %s: %s", pfv->filename, strerror(errno));
+                SCLogDebug("Deleting pcap file %s", pfv->info->filename);
+                if (unlink(pfv->info->filename) != 0) {
+                    SCLogWarning("Failed to delete %s: %s", pfv->info->filename, strerror(errno));
                 }
             }
-            SCFree(pfv->filename);
-            pfv->filename = NULL;
+        }
+        if (pfv->info != NULL) {
+            PcapFileInfoDeref(&(pfv->info));
         }
         pfv->shared = NULL;
         SCFree(pfv);
@@ -83,6 +84,8 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     p->pcap_cnt = ++pcap_g.cnt;
 
     p->pcap_v.tenant_id = ptv->shared->tenant_id;
+    DEBUG_VALIDATE_BUG_ON(p->pcap_v.info != NULL);
+    p->pcap_v.info = PcapFileInfoAddReference(ptv->info);
     ptv->shared->pkts++;
     ptv->shared->bytes += h->caplen;
 
@@ -138,7 +141,7 @@ TmEcode PcapFileDispatch(PcapFileFileVars *ptv)
 
     int packet_q_len = 64;
     TmEcode loop_result = TM_ECODE_OK;
-    strlcpy(pcap_filename, ptv->filename, sizeof(pcap_filename));
+    strlcpy(pcap_filename, ptv->info->filename, sizeof(pcap_filename));
 
     while (loop_result == TM_ECODE_OK) {
         if (suricata_ctl_flags & SURICATA_STOP) {
@@ -154,18 +157,18 @@ TmEcode PcapFileDispatch(PcapFileFileVars *ptv)
                           (pcap_handler)PcapFileCallbackLoop, (u_char *)ptv);
         if (unlikely(r == -1)) {
             SCLogError("error code %" PRId32 " %s for %s", r, pcap_geterr(ptv->pcap_handle),
-                    ptv->filename);
+                    ptv->info->filename);
             if (ptv->shared->cb_result == TM_ECODE_FAILED) {
                 SCReturnInt(TM_ECODE_FAILED);
             }
             loop_result = TM_ECODE_DONE;
         } else if (unlikely(r == 0)) {
             SCLogInfo("pcap file %s end of file reached (pcap err code %" PRId32 ")",
-                      ptv->filename, r);
+                    ptv->info->filename, r);
             ptv->shared->files++;
             loop_result = TM_ECODE_DONE;
         } else if (ptv->shared->cb_result == TM_ECODE_FAILED) {
-            SCLogError("Pcap callback PcapFileCallbackLoop failed for %s", ptv->filename);
+            SCLogError("Pcap callback PcapFileCallbackLoop failed for %s", ptv->info->filename);
             loop_result = TM_ECODE_FAILED;
         }
         StatsSyncCountersIfSignalled(ptv->shared->tv);
@@ -197,12 +200,12 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
 {
     char errbuf[PCAP_ERRBUF_SIZE] = "";
 
-    if(unlikely(pfv->filename == NULL)) {
+    if (unlikely(pfv->info->filename == NULL)) {
         SCLogError("Filename was null");
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    pfv->pcap_handle = pcap_open_offline(pfv->filename, errbuf);
+    pfv->pcap_handle = pcap_open_offline(pfv->info->filename, errbuf);
     if (pfv->pcap_handle == NULL) {
         SCLogError("%s", errbuf);
         SCReturnInt(TM_ECODE_FAILED);
@@ -223,13 +226,13 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
 
         if (pcap_compile(pfv->pcap_handle, &pfv->filter, pfv->shared->bpf_string, 1, 0) < 0) {
             SCLogError("bpf compilation error %s for %s", pcap_geterr(pfv->pcap_handle),
-                    pfv->filename);
+                    pfv->info->filename);
             SCReturnInt(TM_ECODE_FAILED);
         }
 
         if (pcap_setfilter(pfv->pcap_handle, &pfv->filter) < 0) {
             SCLogError("could not set bpf filter %s for %s", pcap_geterr(pfv->pcap_handle),
-                    pfv->filename);
+                    pfv->info->filename);
             pcap_freecode(&pfv->filter);
             SCReturnInt(TM_ECODE_FAILED);
         }

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -22,6 +22,7 @@
  */
 
 #include "suricata-common.h"
+#include "source-pcap-file-info-helper.h"
 #include "tm-threads.h"
 
 #ifndef SURICATA_SOURCE_PCAP_FILE_HELPER_H
@@ -68,7 +69,7 @@ typedef struct PcapFileSharedVars_
  */
 typedef struct PcapFileFileVars_
 {
-    char *filename;
+    PcapFileInfo *info;
     pcap_t *pcap_handle;
 
     int datalink;

--- a/src/source-pcap-file-info-helper.h
+++ b/src/source-pcap-file-info-helper.h
@@ -34,6 +34,6 @@ typedef struct PcapFileInfo_ {
 
 PcapFileInfo *PcapFileInfoAddReference(PcapFileInfo *pfi);
 PcapFileInfo *PcapFileInfoInit(const char *filename);
-void PcapFileInfoDeref(PcapFileInfo *pfi);
+void PcapFileInfoDeref(PcapFileInfo **pfi);
 
 #endif /* SURICATA_SOURCE_PCAP_FILE_INFO_HELPER_H */

--- a/src/source-pcap-file-info-helper.h
+++ b/src/source-pcap-file-info-helper.h
@@ -1,0 +1,39 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Lukas Sismis <lsismis@oisf.net>
+ */
+
+#include "suricata-common.h"
+
+#ifndef SURICATA_SOURCE_PCAP_FILE_INFO_HELPER_H
+#define SURICATA_SOURCE_PCAP_FILE_INFO_HELPER_H
+
+// Initialized once by RX thread, used by all threads, read only
+typedef struct PcapFileInfo_ {
+    char *filename;
+    SC_ATOMIC_DECLARE(uint32_t, ref);
+} PcapFileInfo;
+
+PcapFileInfo *PcapFileInfoAddReference(PcapFileInfo *pfi);
+PcapFileInfo *PcapFileInfoInit(const char *filename);
+void PcapFileInfoDeref(PcapFileInfo *pfi);
+
+#endif /* SURICATA_SOURCE_PCAP_FILE_INFO_HELPER_H */

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -24,6 +24,7 @@
  */
 
 #include "suricata-common.h"
+#include "source-pcap-file-info-helper.h"
 #include "source-pcap-file.h"
 #include "source-pcap-file-helper.h"
 #include "source-pcap-file-directory-helper.h"
@@ -203,7 +204,7 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
     TmThreadsSetFlag(tv, THV_RUNNING);
 
     if(ptv->is_directory == 0) {
-        SCLogInfo("Starting file run for %s", ptv->behavior.file->filename);
+        SCLogInfo("Starting file run for %s", ptv->behavior.file->info->filename);
         status = PcapFileDispatch(ptv->behavior.file);
         CleanupPcapFileFromThreadVars(ptv, ptv->behavior.file);
     } else {
@@ -284,9 +285,9 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             SCReturnInt(TM_ECODE_OK);
         }
 
-        pv->filename = SCStrdup((char *)initdata);
-        if (unlikely(pv->filename == NULL)) {
-            SCLogError("Failed to allocate filename");
+        pv->info = PcapFileInfoInit((char *)initdata);
+        if (unlikely(pv->info == NULL)) {
+            SCLogError("Failed to allocate PcapFileInfo");
             CleanupPcapFileFileVars(pv);
             CleanupPcapFileThreadVars(ptv);
             SCReturnInt(TM_ECODE_OK);
@@ -298,7 +299,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             ptv->is_directory = 0;
             ptv->behavior.file = pv;
         } else {
-            SCLogWarning("Failed to init pcap file %s, skipping", pv->filename);
+            SCLogWarning("Failed to init pcap file %s, skipping", pv->info->filename);
             CleanupPcapFileFileVars(pv);
             CleanupPcapFileThreadVars(ptv);
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-pcap.h
+++ b/src/source-pcap.h
@@ -24,6 +24,8 @@
 #ifndef SURICATA_SOURCE_PCAP_H
 #define SURICATA_SOURCE_PCAP_H
 
+#include "source-pcap-file-info-helper.h"
+
 void TmModuleReceivePcapRegister (void);
 void TmModuleDecodePcapRegister (void);
 void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
@@ -35,6 +37,7 @@ void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
 typedef struct PcapPacketVars_
 {
     uint32_t tenant_id;
+    PcapFileInfo *info;
 } PcapPacketVars;
 
 /** needs to be able to contain Windows adapter id's, so


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/5255

Describe changes:
v2:
- Add runmode guard to PCAP file-related functions to fix running in other capture modes since pcap_v is in union with other capture modes.

v1: 
- added file structure tracked by packets/flows to report true filename

When RX thread was reading packets from multiple PCAPs, it held
internally pcap_filename variable of the currently processed PCAP.
This variable, accessed through PcapFileGetFilename(), was used to add
pcap_filename property to all eve.json events by all threads.

However, as RX thread is connected to Worker/Detect threads with queues,
packets of previous PCAPs were still in queues, while RX thread was
reading different PCAPs. This is a synchronizaiton issue.

PcapFileInfo structure is used to reference the PCAP file name. RX
thread associates the structure with all packets, Workers in turn
associate the flow with the filename. PcapFileGetFilename() is still
used when reporting stats events.