### PR TITLE
build: include first rust/gen

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2133,7 +2133,8 @@ fi
     fi
     RUST_SURICATA_LIB="${RUST_SURICATA_LIBDIR}/${RUST_SURICATA_LIBNAME}"
 
-    CFLAGS="${CFLAGS} -I\${srcdir}/../rust/gen -I\${srcdir}/../rust/dist -I../rust/gen"
+    # make sure that we use our headers for lua
+    CPPFLAGS="-I\${srcdir}/../rust/gen -I\${srcdir}/../rust/dist -I../rust/gen ${CPPFLAGS}"
     AC_SUBST(RUST_SURICATA_LIB)
     AC_SUBST(RUST_LDADD)
     if test "x$CARGO_HOME" = "x"; then


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7804

Describe changes:
- build: include first rust/gen so that we include our lua headers and not the system ones

https://github.com/OISF/suricata/pull/13635 with more CPPFLAGS thanks @jasonish 