### PR TITLE
doc/lua: remove obsolete documentation; update docs - v1

### DIFF
--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -56,6 +56,7 @@ drop
 .. note:: the action ``pass`` is not available in firewall rules due to ambiguity around
    the existing meaning for threat detection rules.
 
+.. _rule-hooks:
 
 Explicit rule hook (states)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -52,10 +52,6 @@ Common configure options
 
     Setups Suricata for logging into /var/log/suricata/. Default ``/usr/local/var/log/suricata``
 
-.. option:: --enable-lua
-
-    Enables Lua support for detection and output.
-
 .. option:: --enable-geoip
 
     Enables GeoIP support for detection.

--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -6,22 +6,28 @@ Lua functions
 Differences between `output` and `detect`:
 ------------------------------------------
 
-Currently, the ``needs`` key initialization varies, depending on what is the goal of the script: output or detection.
-The Lua script for the ``luaxform`` transform **does not use ``needs``**.
+Currently the ``table`` returned from the ``init`` method varies,
+depending on if the script is an output script or a detection script.
 
-If the script is for detection, the ``needs`` initialization should be as seen in the example below (see :ref:`lua-detection` for a complete example of a detection script):
+Lua scripts for ``luaxform`` do not require an ``init`` method.
 
-::
+If the script is for detection, the ``init`` method should return a
+table, for example, if a packet is required:
+
+.. code-block:: lua
 
   function init (args)
-      local needs = {}
-      needs["packet"] = tostring(true)
-      return needs
+    local needs = {}
+    needs["packet"] = true
+    return needs
   end
 
-For output logs, follow the pattern below. (The complete script structure can be seen at :ref:`lua-output`:)
+See :ref:`lua-detection` for more detection script examples.
 
-::
+For output scripts, follow the pattern below. (The complete script
+structure can be seen at :ref:`lua-output`:)
+
+.. code-block:: lua
 
   function init (args)
       local needs = {}
@@ -29,9 +35,12 @@ For output logs, follow the pattern below. (The complete script structure can be
       return needs
   end
 
+Do notice that the functions and protocols available for ``log`` and
+``match`` may also vary. DNP3, for instance, is not available for
+logging.
 
-Do notice that the functions and protocols available for ``log`` and ``match`` may also vary. DNP3, for instance, is not
-available for logging.
+.. note:: By convention, many scripts use a variable name of ``needs``
+          for this table, however this is not a hard requirement.
 
 packet
 ------
@@ -71,15 +80,38 @@ For output, init with:
       return needs
   end
 
-For detection, use the specific buffer (cf :ref:`lua-detection` for a complete list), as with:
+For detection, rule hooks are used are execute the Lua script at
+specific protocol states, for example::
 
-::
+  alert http1:request_line any any -> any any (
+      msg: "Test HTTP Lua request.line";
+      lua: test-request-line.lua; sid:1;)
+
+where ``test-request-line.lua`` might look like:
+
+.. code-block:: lua
+
+  local http = require("suricata.http")
 
   function init (args)
-      local needs = {}
-      needs["http.uri"] = tostring(true)
-      return needs
+    return {}
   end
+
+  function match(args)
+    local tx, err = http.get_tx()
+    http_request_line, err = tx:request_line()
+
+    if #http_request_line > 0 then
+        --GET /base64-hello-world.txt HTTP/1.1
+        if http_request_line:find("^GET") then
+            return 1
+        end
+    end
+
+    return 0
+  end
+
+For more information on rule hooks, see :ref:`rule-hooks`.
 
 Streaming Data
 --------------

--- a/doc/userguide/output/lua-output.rst
+++ b/doc/userguide/output/lua-output.rst
@@ -29,6 +29,9 @@ Example:
 
   local config = require("suricata.config")
   local logger = require("suricata.log")
+  local http = require("suricata.http")
+  local packet = require("suricata.packet")
+  local flow = require("suricata.flow")
 
   function init (args)
       local needs = {}
@@ -44,26 +47,29 @@ Example:
   end
 
   function log(args)
-      http_uri = HttpGetRequestUriRaw()
+      local tx = http.get_tx()
+
+      http_uri = tx:request_uri_raw()
       if http_uri == nil then
           http_uri = "<unknown>"
       end
       http_uri = string.gsub(http_uri, "%c", ".")
 
-      http_host = HttpGetRequestHost()
+      http_host = tx:request_host()
       if http_host == nil then
           http_host = "<hostname unknown>"
       end
       http_host = string.gsub(http_host, "%c", ".")
 
-      http_ua = HttpGetRequestHeader("User-Agent")
+      http_ua = tx:request_header("User-Agent")
       if http_ua == nil then
           http_ua = "<useragent unknown>"
       end
       http_ua = string.gsub(http_ua, "%g", ".")
 
-      timestring = SCPacketTimeString()
-      ip_version, src_ip, dst_ip, protocol, src_port, dst_port = SCFlowTuple()
+      local p = packet.get()
+      timestring = p:timestring_legacy()
+      ip_version, src_ip, dst_ip, protocol, src_port, dst_port = p:tuple()
 
       file:write (timestring .. " " .. http_host .. " [**] " .. http_uri .. " [**] " ..
              http_ua .. " [**] " .. src_ip .. ":" .. src_port .. " -> " ..

--- a/doc/userguide/rules/lua-detection.rst
+++ b/doc/userguide/rules/lua-detection.rst
@@ -8,10 +8,6 @@ There are 2 ways that Lua can be used with detection. These are
 * ``lua`` rule keyword.
 * ``luaxform`` transform.
 
-.. note:: Lua is disabled by default for use in rules, it must be
-          enabled in the configuration file. See the ``security.lua``
-          section of ``suricata.yaml`` and enable ``allow-rules``.
-
 Lua Rule Keyword
 ----------------
 

--- a/doc/userguide/rules/lua-detection.rst
+++ b/doc/userguide/rules/lua-detection.rst
@@ -30,42 +30,37 @@ Init function
 .. code-block:: lua
 
   function init (args)
-      local needs = {}
-      needs["http.request_line"] = tostring(true)
-      return needs
+      return {}
   end
 
-The init function registers the buffer(s) that need
-inspection. Currently the following are available:
+Most Lua rule scripts can simply return an empty table in their init
+method. To hook into specific protocols states, :ref:`rule-hooks` may
+be used. However, some buffers do require explicit initialization::
 
-* packet -- entire packet, including headers
-* payload -- packet payload (not stream)
-* buffer -- the current sticky buffer
+* ja3
+* ja3s
+* packet
+* payload
 * stream
-* dnp3
-* ssh
-* smtp
-* tls
-* http.uri
-* http.uri.raw
-* http.request_line
-* http.request_headers
-* http.request_headers.raw
-* http.request_body
-* http.response_headers
-* http.response_headers.raw
-* http.response_body
 
-All the HTTP buffers have a limitation: only one can be inspected by a
-script at a time.
+To request these buffers, use an ``init`` method like:
+
+.. code-block:: lua
+
+  function init (args)
+    return {packet = true}
+  end
 
 Match function
 ^^^^^^^^^^^^^^
 
 .. code-block:: lua
 
+  local http = require("suricata.http")
+
   function match(args)
-      a = tostring(args["http.request_line"])
+      local tx = http:get_tx()
+      a = tx:request_line()
       if #a > 0 then
           if a:find("^POST%s+/.*%.php%s+HTTP/1.0$") then
               return 1
@@ -77,29 +72,6 @@ Match function
 
 The script can return 1 or 0. It should return 1 if the condition(s)
 it checks for match, 0 if not.
-
-Entire script:
-
-.. code-block:: lua
-
-  function init (args)
-      local needs = {}
-      needs["http.request_line"] = tostring(true)
-      return needs
-  end
-
-  function match(args)
-      a = tostring(args["http.request_line"])
-      if #a > 0 then
-          if a:find("^POST%s+/.*%.php%s+HTTP/1.0$") then
-              return 1
-          end
-      end
-
-      return 0
-  end
-
-  return 0
 
 Lua Transform: ``luaxform``
 ---------------------------


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/7728

Fix parts of Lua documentation that are wrong after the updates in 8.0.
