### PR TITLE
lua: fix null dereference in  tx HTTP accessor functions

### DIFF
--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -23,7 +23,7 @@
  */
 
 #include "suricata-common.h"
-
+#include "htp/htp_rs.h"
 #include "app-layer-htp.h"
 #include "util-lua.h"
 #include "util-lua-common.h"
@@ -65,9 +65,13 @@ static int LuaHttpGetRequestHost(lua_State *luastate)
         lua_pushnil(luastate);
         return 1;
     }
+    const struct bstr *host = htp_tx_request_hostname(tx->tx);
+    if (host == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
 
-    return LuaPushStringBuffer(luastate, bstr_ptr(htp_tx_request_hostname(tx->tx)),
-            bstr_len(htp_tx_request_hostname(tx->tx)));
+    return LuaPushStringBuffer(luastate, bstr_ptr(host), bstr_len(host));
 }
 
 static int LuaHttpGetRequestUriRaw(lua_State *luastate)
@@ -77,9 +81,13 @@ static int LuaHttpGetRequestUriRaw(lua_State *luastate)
         lua_pushnil(luastate);
         return 1;
     }
+    const struct bstr *uri = htp_tx_request_uri(tx->tx);
+    if (uri == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
 
-    return LuaPushStringBuffer(
-            luastate, bstr_ptr(htp_tx_request_uri(tx->tx)), bstr_len(htp_tx_request_uri(tx->tx)));
+    return LuaPushStringBuffer(luastate, bstr_ptr(uri), bstr_len(uri));
 }
 
 static int LuaHttpGetRequestUriNormalized(lua_State *luastate)
@@ -107,8 +115,13 @@ static int LuaHttpGetRequestLine(lua_State *luastate)
         return 1;
     }
 
-    return LuaPushStringBuffer(
-            luastate, bstr_ptr(htp_tx_request_line(tx->tx)), bstr_len(htp_tx_request_line(tx->tx)));
+    const struct bstr *line = htp_tx_request_line(tx->tx);
+    if (line == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+
+    return LuaPushStringBuffer(luastate, bstr_ptr(line), bstr_len(line));
 }
 
 static int LuaHttpGetResponseLine(lua_State *luastate)
@@ -119,8 +132,13 @@ static int LuaHttpGetResponseLine(lua_State *luastate)
         return 1;
     }
 
-    return LuaPushStringBuffer(luastate, bstr_ptr(htp_tx_response_line(tx->tx)),
-            bstr_len(htp_tx_response_line(tx->tx)));
+    const struct bstr *line = htp_tx_response_line(tx->tx);
+    if (line == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+
+    return LuaPushStringBuffer(luastate, bstr_ptr(line), bstr_len(line));
 }
 
 static int LuaHttpGetHeader(lua_State *luastate, int dir)


### PR DESCRIPTION
Fix crashes in Lua when calling tx:response_line(), tx:request_line(), tx:request_uri_raw(), or tx:request_host() on incomplete or malformed HTTP transactions.

These functions return bstr pointers which may be NULL. Add NULL checks before calling bstr_ptr() and bstr_len() to avoid segfaults.

Ticket: #7829

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7829

Describe changes:
-This patch fixes segmentation faults that occur when Lua scripts call
tx:response_line(), tx:request_line(), tx:request_uri_raw(), or
tx:request_host() on incomplete or malformed HTTP transactions.

Previously, the result of htp_tx_*() functions was passed directly to
bstr_len() or bstr_ptr() without checking for NULL. In edge cases
such as dropped packets, truncated streams, or partial parsing, these
accessor functions may return NULL, resulting in a crash due to
bstr_len(NULL) or bstr_ptr(NULL).

This patch adds NULL checks in the following C binding functions:
LuaHttpGetResponseLine
LuaHttpGetRequestLine
LuaHttpGetRequestUriRaw
LuaHttpGetRequestHost
By validating the return pointer before accessing the bstr, the patch
ensures Suricata does not crash when Lua scripts access unavailable HTTP fields.

There is no functional change for fully parsed HTTP transactions.
This change improves robustness in edge cases and defensive behavior under
network loss or malformed sessions.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
