### PR TITLE
7.0.x - ci: use debian 12 for xdp

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1900,7 +1900,7 @@ jobs:
       - run: make check
 
   debian-12:
-    name: Debian 12
+    name: Debian 12 (xdp)
     runs-on: ubuntu-latest
     container: debian:12
     needs: [prepare-deps]
@@ -1958,7 +1958,9 @@ jobs:
               texlive-fonts-extra \
               texlive-latex-extra \
               zlib1g \
-              zlib1g-dev
+              zlib1g-dev \
+              clang \
+              libxdp-dev
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       - run: git config --global --add safe.directory /__w/suricata/suricata
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -1969,13 +1971,13 @@ jobs:
       - run: tar xf prep/suricata-update.tar.gz
       - run: tar xf prep/suricata-verify.tar.gz
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
       - run: make -j2
       - run: make check
         # -j2 caused random failures during cargo vendor
       - run: make distcheck
         env:
-          DISTCHECK_CONFIGURE_FLAGS: "--enable-unittests --enable-debug --enable-lua --enable-geoip --enable-profiling --enable-profiling-locks --enable-dpdk"
+          DISTCHECK_CONFIGURE_FLAGS: "--enable-unittests --enable-debug --enable-geoip --enable-profiling --enable-profiling-locks --enable-dpdk --enable-ebpf --enable-ebpf-build"
       - run: test -e doc/userguide/suricata.1
       - run: test -e doc/userguide/userguide.pdf
       - name: Building Rust documentation
@@ -2150,7 +2152,7 @@ jobs:
       - run: suricatasc -h
 
   debian-11:
-    name: Debian 11 (xdp)
+    name: Debian 11
     runs-on: ubuntu-latest
     container: debian:11
     needs: [prepare-deps, prepare-cbindgen]
@@ -2163,7 +2165,6 @@ jobs:
           key: cargo-registry
 
       - run: |
-          echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
           apt update
           apt -y install \
                 automake \
@@ -2196,8 +2197,7 @@ jobs:
                 zlib1g-dev \
                 clang \
                 libbpf-dev \
-                libelf-dev \
-                libxdp-dev
+                libelf-dev
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION_KNOWN -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -2211,7 +2211,7 @@ jobs:
       - run: tar xf prep/suricata-update.tar.gz
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests --enable-fuzztargets --enable-ebpf --enable-ebpf-build
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-fuzztargets
       - run: make -j2
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz


### PR DESCRIPTION
As bullseye is EOL so it is being removed from the mirrors

https://lists.debian.org/debian-backports/2024/07/msg00003.html

[Edit by JI: Add xdp to distcheck build as well.]

(cherry picked from commit 6bbba953dfe599d268c91f485a17dc9f5c88a7fd)
