### PR TITLE
detect/mt: Prevent deadlock when adding tenants

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -274,7 +274,7 @@ void DetectAppLayerInspectEngineRegister(const char *name, AppProto alproto, uin
         int progress, InspectEngineFuncPtr Callback, InspectionBufferGetDataPtr GetData)
 {
     /* before adding, check that we don't add a duplicate entry, which will
-     * propegate all the way into the packet runtime if allowed. */
+     * propagate all the way into the packet runtime if allowed. */
     DetectEngineAppInspectionEngine *t = g_app_inspect_engines;
     while (t != NULL) {
         const uint32_t t_direction = t->dir == 0 ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;
@@ -296,7 +296,7 @@ void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alprot
         int progress, InspectEngineFuncPtr Callback, InspectionSingleBufferGetDataPtr GetData)
 {
     /* before adding, check that we don't add a duplicate entry, which will
-     * propegate all the way into the packet runtime if allowed. */
+     * propagate all the way into the packet runtime if allowed. */
     DetectEngineAppInspectionEngine *t = g_app_inspect_engines;
     while (t != NULL) {
         const uint32_t t_direction = t->dir == 0 ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -106,6 +106,7 @@ static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet
 static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromPcap(const void *ctx, const Packet *p);
 
+static bool DetectEngineMultiTenantEnabledWithLock(void);
 static DetectEngineAppInspectionEngine *g_app_inspect_engines = NULL;
 static DetectEnginePktInspectionEngine *g_pkt_inspect_engines = NULL;
 static DetectEngineFrameInspectionEngine *g_frame_inspect_engines = NULL;
@@ -3153,7 +3154,6 @@ static void DetectEngineThreadCtxDeinitKeywords(DetectEngineCtx *de_ctx, DetectE
 static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThreadCtx *det_ctx)
 {
     DetectEngineMasterCtx *master = &g_master_de_ctx;
-    SCMutexLock(&master->lock);
 
     DetectEngineTenantMapping *map_array = NULL;
     uint32_t map_array_size = 0;
@@ -3164,7 +3164,6 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
     if (master->tenant_selector == TENANT_SELECTOR_UNKNOWN) {
         SCLogError("no tenant selector set: "
                    "set using multi-detect.selector");
-        SCMutexUnlock(&master->lock);
         return TM_ECODE_FAILED;
     }
 
@@ -3258,7 +3257,6 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
             break;
     }
 
-    SCMutexUnlock(&master->lock);
     return TM_ECODE_OK;
 error:
     if (map_array != NULL)
@@ -3266,7 +3264,6 @@ error:
     if (mt_det_ctxs_hash != NULL)
         HashTableFree(mt_det_ctxs_hash);
 
-    SCMutexUnlock(&master->lock);
     return TM_ECODE_FAILED;
 }
 
@@ -3431,10 +3428,14 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
 #endif
 
     if (DetectEngineMultiTenantEnabled()) {
+        DetectEngineMasterCtx *master = &g_master_de_ctx;
+        SCMutexLock(&master->lock);
         if (DetectEngineThreadCtxInitForMT(tv, det_ctx) != TM_ECODE_OK) {
             DetectEngineThreadCtxDeinit(tv, det_ctx);
+            SCMutexUnlock(&master->lock);
             return TM_ECODE_FAILED;
         }
+        SCMutexUnlock(&master->lock);
     }
 
     /* pass thread data back to caller */
@@ -3493,7 +3494,7 @@ DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
     det_ctx->counter_match_list = counter_match_list;
 #endif
 
-    if (mt && DetectEngineMultiTenantEnabled()) {
+    if (mt && DetectEngineMultiTenantEnabledWithLock()) {
         if (DetectEngineThreadCtxInitForMT(tv, det_ctx) != TM_ECODE_OK) {
             DetectEngineDeReference(&det_ctx->de_ctx);
             SCFree(det_ctx);
@@ -3872,12 +3873,17 @@ DetectEngineCtx *DetectEngineReference(DetectEngineCtx *de_ctx)
     de_ctx->ref_cnt++;
     return de_ctx;
 }
+static bool DetectEngineMultiTenantEnabledWithLock(void)
+{
+    DetectEngineMasterCtx *master = &g_master_de_ctx;
+    return master->multi_tenant_enabled;
+}
 
 bool DetectEngineMultiTenantEnabled(void)
 {
     DetectEngineMasterCtx *master = &g_master_de_ctx;
     SCMutexLock(&master->lock);
-    bool enabled = master->multi_tenant_enabled;
+    bool enabled = DetectEngineMultiTenantEnabledWithLock();
     SCMutexUnlock(&master->lock);
     return enabled;
 }


### PR DESCRIPTION
Continuation of #13673 

This commit modifies the call path for registering MT tenants to avoid deadlocks on the master->lock

Issue: 7819

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7819

Describe changes:
- Recognize when master lock is held for MT case to avoid deadlock

Updates:
- Address review comments (see #13673 )

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
