### PR TITLE
detect: remove unused non-pf stats counters - v3

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -179,6 +179,9 @@ Major changes
 Removals
 ~~~~~~~~
 - The ssh keywords ``ssh.protoversion`` and ``ssh.softwareversion`` have been removed.
+- The detect engine stats counters for non-mpm-prefiltered rules ``fnonmpm_list``
+  and ``nonmpm_list`` were not in use since Suricata 8.0.0 and **were thus removed
+  in 8.0.1.**
 
 Deprecations
 ~~~~~~~~~~~~

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6468,9 +6468,6 @@
                                 }
                             }
                         },
-                        "fnonmpm_list": {
-                            "type": "integer"
-                        },
                         "lua": {
                             "type": "object",
                             "additionalProperties": false,
@@ -6499,9 +6496,6 @@
                             "type": "integer"
                         },
                         "mpm_list": {
-                            "type": "integer"
-                        },
-                        "nonmpm_list": {
                             "type": "integer"
                         }
                     }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3481,10 +3481,8 @@ DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
     det_ctx->counter_alerts_overflow = StatsRegisterCounter("detect.alert_queue_overflow", tv);
     det_ctx->counter_alerts_suppressed = StatsRegisterCounter("detect.alerts_suppressed", tv);
 #ifdef PROFILING
-    uint16_t counter_mpm_list = StatsRegisterAvgCounter("detect.mpm_list", tv);
-    uint16_t counter_match_list = StatsRegisterAvgCounter("detect.match_list", tv);
-    det_ctx->counter_mpm_list = counter_mpm_list;
-    det_ctx->counter_match_list = counter_match_list;
+    det_ctx->counter_mpm_list = StatsRegisterAvgCounter("detect.mpm_list", tv);
+    det_ctx->counter_match_list = StatsRegisterAvgCounter("detect.match_list", tv);
 #endif
 
     if (mt && DetectEngineMultiTenantEnabled()) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3425,8 +3425,6 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
 
 #ifdef PROFILING
     det_ctx->counter_mpm_list = StatsRegisterAvgCounter("detect.mpm_list", tv);
-    det_ctx->counter_nonmpm_list = StatsRegisterAvgCounter("detect.nonmpm_list", tv);
-    det_ctx->counter_fnonmpm_list = StatsRegisterAvgCounter("detect.fnonmpm_list", tv);
     det_ctx->counter_match_list = StatsRegisterAvgCounter("detect.match_list", tv);
 #endif
 
@@ -3484,12 +3482,8 @@ DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
     det_ctx->counter_alerts_suppressed = StatsRegisterCounter("detect.alerts_suppressed", tv);
 #ifdef PROFILING
     uint16_t counter_mpm_list = StatsRegisterAvgCounter("detect.mpm_list", tv);
-    uint16_t counter_nonmpm_list = StatsRegisterAvgCounter("detect.nonmpm_list", tv);
-    uint16_t counter_fnonmpm_list = StatsRegisterAvgCounter("detect.fnonmpm_list", tv);
     uint16_t counter_match_list = StatsRegisterAvgCounter("detect.match_list", tv);
     det_ctx->counter_mpm_list = counter_mpm_list;
-    det_ctx->counter_nonmpm_list = counter_nonmpm_list;
-    det_ctx->counter_fnonmpm_list = counter_fnonmpm_list;
     det_ctx->counter_match_list = counter_match_list;
 #endif
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1293,8 +1293,6 @@ typedef struct DetectEngineThreadCtx_ {
     uint16_t counter_alerts_suppressed;
 #ifdef PROFILING
     uint16_t counter_mpm_list;
-    uint16_t counter_nonmpm_list;
-    uint16_t counter_fnonmpm_list;
     uint16_t counter_match_list;
 #endif
 


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/13661

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7834

Describe changes from previous PR:
- reword upgrade note to better explain when the stats counters stop being used, and when they were removed.
- minor reword in the stats counters registration commit title
