### PR TITLE
lto backports - v5

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -681,9 +681,9 @@ jobs:
       # Check compilation against systemd
       - run: ldd src/suricata | grep libsystemd &> /dev/null
 
-  # Fedora 39 build using GCC.
-  fedora-41-gcc:
-    name: Fedora 41 (gcc, debug, asan, wshadow, rust-strict)
+  # Fedora build using GCC.
+  fedora-42-gcc:
+    name: Fedora 42 (gcc, debug, flto, asan, wshadow, rust-strict)
     runs-on: ubuntu-latest
     container: fedora:41
     needs: [prepare-deps, prepare-cbindgen]
@@ -733,6 +733,7 @@ jobs:
                 pkgconfig \
                 python3-yaml \
                 sudo \
+                vectorscan-devel \
                 which \
                 zlib-devel
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
@@ -747,7 +748,7 @@ jobs:
       - run: ./autogen.sh
       - run: ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
         env:
-          CFLAGS: "${{ env.DEFAULT_CFLAGS }} -Wshadow -fsanitize=address -fno-omit-frame-pointer"
+          CFLAGS: "${{ env.DEFAULT_CFLAGS }} -Wshadow -fsanitize=address -fno-omit-frame-pointer -flto=auto -O2"
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"
           ac_cv_func_malloc_0_nonnull: "yes"

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -7073,7 +7073,7 @@ static int HTPParserTest27(void)
     HtpTxUserData *tx_ud = SCMalloc(sizeof(HtpTxUserData));
     FAIL_IF_NULL(tx_ud);
 
-    tx_ud->tsflags |= HTP_STREAM_DEPTH_SET;
+    tx_ud->tsflags = HTP_STREAM_DEPTH_SET;
     tx_ud->request_body.content_len_so_far = 2500;
 
     FAIL_IF(AppLayerHtpCheckDepth(&cfg, &tx_ud->request_body, tx_ud->tsflags));

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -320,7 +320,7 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
             uint16_t multiplier;
             if (StringParseU16RangeCheck(&multiplier, 10, 0, (const char *)multiplier_str,
                         DETECT_BYTE_EXTRACT_MULTIPLIER_MIN_LIMIT,
-                        DETECT_BYTE_EXTRACT_MULTIPLIER_MAX_LIMIT) < 0) {
+                        DETECT_BYTE_EXTRACT_MULTIPLIER_MAX_LIMIT) <= 0) {
                 SCLogError("Invalid value for"
                            "multiplier: \"%s\".",
                         multiplier_str);

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -333,7 +333,7 @@ static DetectBytetestData *DetectBytetestParse(
     int res = 0;
     size_t pcre2_len;
     int i;
-    uint32_t nbytes;
+    uint32_t nbytes = 0;
     const char *str_ptr = NULL;
     pcre2_match_data *match = NULL;
 

--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -347,7 +347,7 @@ static DetectEnipCommandData *DetectEnipCommandParse(const char *rulestr)
     }
 
     uint16_t cmd;
-    if (StringParseUint16(&cmd, 10, 0, rulestr) < 0) {
+    if (StringParseUint16(&cmd, 10, 0, rulestr) <= 0) {
         SCLogError("invalid ENIP command"
                    ": \"%s\"",
                 rulestr);

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -185,7 +185,7 @@ static InspectionBuffer *GetDNP3Data(DetectEngineThreadCtx *det_ctx,
  */
 static int DetectDNP3FuncParseFunctionCode(const char *str, uint8_t *fc)
 {
-    if (StringParseUint8(fc, 10, (uint16_t)strlen(str), str) >= 0) {
+    if (StringParseUint8(fc, 10, (uint16_t)strlen(str), str) > 0) {
         return 1;
     }
 
@@ -349,11 +349,11 @@ static int DetectDNP3ObjParse(const char *str, uint8_t *group, uint8_t *var)
     *sep = '\0';
     varstr = sep + 1;
 
-    if (StringParseUint8(group, 0, (uint16_t)strlen(groupstr), groupstr) < 0) {
+    if (StringParseUint8(group, 0, (uint16_t)strlen(groupstr), groupstr) <= 0) {
         return 0;
     }
 
-    if (StringParseUint8(var, 0, (uint16_t)strlen(varstr), varstr) < 0) {
+    if (StringParseUint8(var, 0, (uint16_t)strlen(varstr), varstr) <= 0) {
         return 0;
     }
 

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -4362,7 +4362,7 @@ static int AddressTestCutIPv401(void)
 
 static int AddressTestCutIPv402(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0/255.255.255.0");
     b = DetectAddressParseSingle("1.2.2.0-1.2.3.4");
 
@@ -4386,7 +4386,7 @@ error:
 
 static int AddressTestCutIPv403(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0/255.255.255.0");
     b = DetectAddressParseSingle("1.2.2.0-1.2.3.4");
 
@@ -4417,7 +4417,7 @@ error:
 
 static int AddressTestCutIPv404(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.3-1.2.3.6");
     b = DetectAddressParseSingle("1.2.3.0-1.2.3.5");
 
@@ -4449,7 +4449,7 @@ error:
 
 static int AddressTestCutIPv405(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.3-1.2.3.6");
     b = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
 
@@ -4480,7 +4480,7 @@ error:
 
 static int AddressTestCutIPv406(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
     b = DetectAddressParseSingle("1.2.3.3-1.2.3.6");
 
@@ -4511,7 +4511,7 @@ error:
 
 static int AddressTestCutIPv407(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0-1.2.3.6");
     b = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
 
@@ -4540,7 +4540,7 @@ error:
 
 static int AddressTestCutIPv408(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.3-1.2.3.9");
     b = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
 
@@ -4569,7 +4569,7 @@ error:
 
 static int AddressTestCutIPv409(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
     b = DetectAddressParseSingle("1.2.3.0-1.2.3.6");
 
@@ -4598,7 +4598,7 @@ error:
 
 static int AddressTestCutIPv410(void)
 {
-    DetectAddress *a, *b, *c;
+    DetectAddress *a, *b, *c = NULL;
     a = DetectAddressParseSingle("1.2.3.0-1.2.3.9");
     b = DetectAddressParseSingle("1.2.3.3-1.2.3.9");
 

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -279,7 +279,7 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem **pdd, const char *str)
                 }
 
                 uint8_t cidr;
-                if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask, 0, 32) < 0)
+                if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask, 0, 32) <= 0)
                     goto error;
 
                 dd->netmask = cidr;

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -309,8 +309,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
             goto error;
         }
         uint16_t offset;
-        if (StringParseUint16(&offset, 10, 0,
-                              (const char *)arg_substr) < 0) {
+        if (StringParseUint16(&offset, 10, 0, (const char *)arg_substr) <= 0) {
             SCLogError("Invalid fast pattern offset:"
                        " \"%s\"",
                     arg_substr);
@@ -325,8 +324,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
             goto error;
         }
         uint16_t length;
-        if (StringParseUint16(&length, 10, 0,
-                              (const char *)arg_substr) < 0) {
+        if (StringParseUint16(&length, 10, 0, (const char *)arg_substr) <= 0) {
             SCLogError("Invalid value for fast "
                        "pattern: \"%s\"",
                     arg_substr);

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -222,7 +222,7 @@ static int DetectHTTP2frametypeMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectHTTP2FuncParseFrameType(const char *str, uint8_t *ft)
 {
     // first parse numeric value
-    if (ByteExtractStringUint8(ft, 10, (uint16_t)strlen(str), str) >= 0) {
+    if (ByteExtractStringUint8(ft, 10, (uint16_t)strlen(str), str) > 0) {
         return 1;
     }
 
@@ -307,7 +307,7 @@ static int DetectHTTP2errorcodeMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectHTTP2FuncParseErrorCode(const char *str, uint32_t *ec)
 {
     // first parse numeric value
-    if (ByteExtractStringUint32(ec, 10, (uint16_t)strlen(str), str) >= 0) {
+    if (ByteExtractStringUint32(ec, 10, (uint16_t)strlen(str), str) > 0) {
         return 1;
     }
 

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -154,7 +154,7 @@ static DetectIdData *DetectIdParse (const char *idstr)
     }
 
     /* ok, fill the id data */
-    if (StringParseUint16(&temp, 10, 0, (const char *)tmp_str) < 0) {
+    if (StringParseUint16(&temp, 10, 0, (const char *)tmp_str) <= 0) {
         SCLogError("invalid id option '%s'", tmp_str);
         goto error;
     }

--- a/src/detect-mqtt-qos.c
+++ b/src/detect-mqtt-qos.c
@@ -108,7 +108,7 @@ static uint8_t *DetectMQTTQosParse(const char *rawstr)
     uint8_t val;
 
     ret = StringParseU8RangeCheck(&val, 10, 0, rawstr, 0, 2);
-    if (ret < 0) {
+    if (ret <= 0) {
         SCLogError("invalid MQTT QOS level: %s", rawstr);
         return NULL;
     }

--- a/src/detect-mqtt-reason-code.c
+++ b/src/detect-mqtt-reason-code.c
@@ -126,7 +126,7 @@ static uint8_t *DetectMQTTReasonCodeParse(const char *rawstr)
     uint8_t val;
 
     ret = StringParseUint8(&val, 10, 0, rawstr);
-    if (ret < 0) {
+    if (ret <= 0) {
         SCLogError("invalid MQTT reason code: %s", rawstr);
         return NULL;
     }

--- a/src/detect-transform-compress-whitespace.c
+++ b/src/detect-transform-compress-whitespace.c
@@ -145,6 +145,7 @@ static int TransformDoubleWhitespace(InspectionBuffer *buffer)
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
     uint8_t output[input_len * 2]; // if all chars are whitespace this fits
+    memset(&output, 0, (input_len * 2));
     uint8_t *oi = output, *os = output;
 
     PrintRawDataFp(stdout, input, input_len);

--- a/src/detect-transform-strip-whitespace.c
+++ b/src/detect-transform-strip-whitespace.c
@@ -132,6 +132,7 @@ static int TransformDoubleWhitespace(InspectionBuffer *buffer)
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
     uint8_t output[input_len * 2]; // if all chars are whitespace this fits
+    memset(&output, 0, (input_len * 2));
     uint8_t *oi = output, *os = output;
 
     PrintRawDataFp(stdout, input, input_len);

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -313,10 +313,10 @@ static int SRepSplitLine(SRepCIDRTree *cidr_ctx, char *line, Address *ip, uint8_
         return 1;
 
     uint8_t c, v;
-    if (StringParseU8RangeCheck(&c, 10, 0, (const char *)ptrs[1], 0, SREP_MAX_CATS - 1) < 0)
+    if (StringParseU8RangeCheck(&c, 10, 0, (const char *)ptrs[1], 0, SREP_MAX_CATS - 1) <= 0)
         return -1;
 
-    if (StringParseU8RangeCheck(&v, 10, 0, (const char *)ptrs[2], 0, SREP_MAX_VAL) < 0)
+    if (StringParseU8RangeCheck(&v, 10, 0, (const char *)ptrs[2], 0, SREP_MAX_VAL) <= 0)
         return -1;
 
     if (strchr(ptrs[0], '/') != NULL) {

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -140,6 +140,9 @@ int ByteExtractUint64(uint64_t *res, int e, uint16_t len, const uint8_t *bytes)
     return ret;
 }
 
+/**
+ * \retval Greater than 0 if successful, 0 or negative on failure.
+ */
 int ByteExtractUint32(uint32_t *res, int e, uint16_t len, const uint8_t *bytes)
 {
     uint64_t i64;
@@ -334,6 +337,9 @@ int StringParseUint32(uint32_t *res, int base, size_t len, const char *str)
     return ret;
 }
 
+/**
+ * \retval Greater than 0 if successful, 0 or negative on failure.
+ */
 int StringParseUint16(uint16_t *res, int base, size_t len, const char *str)
 {
     uint64_t i64;
@@ -358,6 +364,9 @@ int StringParseUint16(uint16_t *res, int base, size_t len, const char *str)
     return ret;
 }
 
+/**
+ * \retval Greater than 0 if successful, 0 or negative on failure.
+ */
 int StringParseUint8(uint8_t *res, int base, size_t len, const char *str)
 {
     uint64_t i64;
@@ -459,6 +468,9 @@ int StringParseU16RangeCheck(
     return ret;
 }
 
+/**
+ * \retval Greater than 0 if successful, 0 or negative on failure.
+ */
 int StringParseU8RangeCheck(
         uint8_t *res, int base, size_t len, const char *str, uint8_t min, uint8_t max)
 {

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -1032,7 +1032,7 @@ bool SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *user)
         }
 
         /* Get binary values for cidr mask */
-        if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 32) < 0) {
+        if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 32) <= 0) {
             sc_errno = SC_EINVAL;
             return false;
         }
@@ -1096,7 +1096,6 @@ bool SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *user)
 
     /* Does it have a mask? */
     if (NULL != (mask_str = strchr(ip_str, '/'))) {
-        uint8_t cidr;
         *(mask_str++) = '\0';
 
         /* Dotted type netmask not supported (yet) */
@@ -1105,8 +1104,9 @@ bool SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *user)
             return false;
         }
 
+        uint8_t cidr;
         /* Get binary values for cidr mask */
-        if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 128) < 0) {
+        if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 128) <= 0) {
             sc_errno = SC_EINVAL;
             return false;
         }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7836
https://redmine.openinfosecfoundation.org/issues/7837 (backport ticket)

Previous PR: https://github.com/OISF/suricata/pull/13699

Describe changes:
- avoid usage of `sizeof` with variable length unknown at compile time.

Opening this to share an alternative solution.