### PR TITLE
rust: fix mismatched_lifetime_syntaxes warning

### DIFF
--- a/rust/src/ldap/types.rs
+++ b/rust/src/ldap/types.rs
@@ -188,6 +188,6 @@ pub fn ldap_is_response(message: &LdapMessage) -> bool {
     return !ldap_is_request(message);
 }
 
-pub fn ldap_parse_msg(input: &[u8]) -> ParseResult<LdapMessage, LdapError> {
+pub fn ldap_parse_msg(input: &[u8]) -> ParseResult<'_, LdapMessage<'_>, LdapError> {
     LdapMessage::from_ber(input)
 }


### PR DESCRIPTION
Fix new warning present in Rust 1.89.

warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/ldap/types.rs:191:30
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
