### PR TITLE
7.0.x - rust: fix mismatched_lifetime_syntaxes warning

### DIFF
--- a/rust/src/ike/parser.rs
+++ b/rust/src/ike/parser.rs
@@ -275,7 +275,7 @@ pub fn parse_isakmp_header(i: &[u8]) -> IResult<&[u8], IsakmpHeader> {
     Ok((i, hdr))
 }
 
-pub fn parse_security_association(i: &[u8]) -> IResult<&[u8], SecurityAssociationPayload> {
+pub fn parse_security_association(i: &[u8]) -> IResult<&[u8], SecurityAssociationPayload<'_>> {
     let start_i = i;
     let (i, domain_of_interpretation) = be_u32(i)?;
     let (i, situation) = cond(domain_of_interpretation == 1, take(4_usize))(i)?;
@@ -292,12 +292,12 @@ pub fn parse_security_association(i: &[u8]) -> IResult<&[u8], SecurityAssociatio
     ))
 }
 
-pub fn parse_key_exchange(i: &[u8], length: u16) -> IResult<&[u8], KeyExchangePayload> {
+pub fn parse_key_exchange(i: &[u8], length: u16) -> IResult<&[u8], KeyExchangePayload<'_>> {
     let (i, key_exchange_data) = take(length as usize)(i)?;
     Ok((i, KeyExchangePayload { key_exchange_data }))
 }
 
-pub fn parse_proposal(i: &[u8]) -> IResult<&[u8], ProposalPayload> {
+pub fn parse_proposal(i: &[u8]) -> IResult<&[u8], ProposalPayload<'_>> {
     let start_i = i;
     let (i, proposal_number) = be_u8(i)?;
     let (i, proposal_type) = be_u8(i)?;
@@ -318,7 +318,7 @@ pub fn parse_proposal(i: &[u8]) -> IResult<&[u8], ProposalPayload> {
     Ok((i, payload))
 }
 
-pub fn parse_transform(i: &[u8], length: u16) -> IResult<&[u8], TransformPayload> {
+pub fn parse_transform(i: &[u8], length: u16) -> IResult<&[u8], TransformPayload<'_>> {
     let (i, transform_number) = be_u8(i)?;
     let (i, transform_type) = be_u8(i)?;
     let (i, _) = be_u16(i)?;
@@ -333,7 +333,7 @@ pub fn parse_transform(i: &[u8], length: u16) -> IResult<&[u8], TransformPayload
     ))
 }
 
-pub fn parse_vendor_id(i: &[u8], length: u16) -> IResult<&[u8], VendorPayload> {
+pub fn parse_vendor_id(i: &[u8], length: u16) -> IResult<&[u8], VendorPayload<'_>> {
     map(take(length), |v| VendorPayload { vendor_id: v })(i)
 }
 
@@ -480,12 +480,12 @@ pub fn parse_sa_attribute(i: &[u8]) -> IResult<&[u8], Vec<SaAttribute>> {
     many0(complete(parse_attribute))(i)
 }
 
-pub fn parse_nonce(i: &[u8], length: u16) -> IResult<&[u8], NoncePayload> {
+pub fn parse_nonce(i: &[u8], length: u16) -> IResult<&[u8], NoncePayload<'_>> {
     map(take(length), |v| NoncePayload { nonce_data: v })(i)
 }
 
-pub fn parse_ikev1_payload_list(i: &[u8]) -> IResult<&[u8], Vec<IsakmpPayload>> {
-    fn parse_payload(i: &[u8]) -> IResult<&[u8], IsakmpPayload> {
+pub fn parse_ikev1_payload_list(i: &[u8]) -> IResult<&[u8], Vec<IsakmpPayload<'_>>> {
+    fn parse_payload(i: &[u8]) -> IResult<&[u8], IsakmpPayload<'_>> {
         let (i, next_payload) = be_u8(i)?;
         let (i, reserved) = be_u8(i)?;
         let (i, payload_length) = be_u16(i)?;

--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -55,7 +55,7 @@ pub struct Kerberos5Ticket {
     pub sname: PrincipalName,
 }
 
-fn parse_kerberos5_request_do(blob: &[u8]) -> IResult<&[u8], ApReq, SecBlobError>
+fn parse_kerberos5_request_do(blob: &[u8]) -> IResult<&[u8], ApReq<'_>, SecBlobError>
 {
     let (_,b) = der_parser6::parse_der(blob).map_err(nom7::Err::convert)?;
     let blob = b.as_slice().or(

--- a/rust/src/mime/mod.rs
+++ b/rust/src/mime/mod.rs
@@ -55,7 +55,7 @@ pub fn mime_parse_header_token(input: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
     return Ok((input, (name, value)));
 }
 
-fn mime_parse_header_tokens(input: &[u8]) -> IResult<&[u8], MIMEHeaderTokens> {
+fn mime_parse_header_tokens(input: &[u8]) -> IResult<&[u8], MIMEHeaderTokens<'_>> {
     let (mut input, _) = take_until_and_consume(b";")(input)?;
     let mut tokens = HashMap::new();
     while !input.is_empty() {

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -28,7 +28,7 @@ pub struct Nfs2Handle<'a> {
     pub value: &'a[u8],
 }
 
-pub fn parse_nfs2_handle(i: &[u8]) -> IResult<&[u8], Nfs2Handle> {
+pub fn parse_nfs2_handle(i: &[u8]) -> IResult<&[u8], Nfs2Handle<'_>> {
     let (i, value) = take(32_usize)(i)?;
     Ok((i, Nfs2Handle { value }))
 }
@@ -39,7 +39,7 @@ pub struct Nfs2RequestLookup<'a> {
     pub name_vec: Vec<u8>,
 }
 
-pub fn parse_nfs2_request_lookup(i: &[u8]) -> IResult<&[u8], Nfs2RequestLookup> {
+pub fn parse_nfs2_request_lookup(i: &[u8]) -> IResult<&[u8], Nfs2RequestLookup<'_>> {
     let (i, handle) = parse_nfs2_handle(i)?;
     let (i, name_len) = be_u32(i)?;
     let (i, name_contents) = take(name_len as usize)(i)?;
@@ -57,7 +57,7 @@ pub struct Nfs2RequestRead<'a> {
     pub offset: u32,
 }
 
-pub fn parse_nfs2_request_read(i: &[u8]) -> IResult<&[u8], Nfs2RequestRead> {
+pub fn parse_nfs2_request_read(i: &[u8]) -> IResult<&[u8], Nfs2RequestRead<'_>> {
     let (i, handle) = parse_nfs2_handle(i)?;
     let (i, offset) = be_u32(i)?;
     let (i, _count) = be_u32(i)?;
@@ -65,7 +65,7 @@ pub fn parse_nfs2_request_read(i: &[u8]) -> IResult<&[u8], Nfs2RequestRead> {
     Ok((i, req))
 }
 
-pub fn parse_nfs2_reply_read(i: &[u8]) -> IResult<&[u8], NfsReplyRead> {
+pub fn parse_nfs2_reply_read(i: &[u8]) -> IResult<&[u8], NfsReplyRead<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, attr_blob) = take(68_usize)(i)?;
     let (i, data_len) = be_u32(i)?;

--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -31,7 +31,7 @@ pub struct Nfs3Handle<'a> {
     pub value: &'a [u8],
 }
 
-pub fn parse_nfs3_handle(i: &[u8]) -> IResult<&[u8], Nfs3Handle> {
+pub fn parse_nfs3_handle(i: &[u8]) -> IResult<&[u8], Nfs3Handle<'_>> {
     let (i, len) = be_u32(i)?;
     let (i, value) = take(len as usize)(i)?;
     let handle = Nfs3Handle { len, value };
@@ -44,7 +44,7 @@ pub struct Nfs3ReplyCreate<'a> {
     pub handle: Option<Nfs3Handle<'a>>,
 }
 
-pub fn parse_nfs3_response_create(i: &[u8]) -> IResult<&[u8], Nfs3ReplyCreate> {
+pub fn parse_nfs3_response_create(i: &[u8]) -> IResult<&[u8], Nfs3ReplyCreate<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, handle_has_value) = verify(be_u32, |&v| v <= 1)(i)?;
     let (i, handle) = cond(handle_has_value == 1, parse_nfs3_handle)(i)?;
@@ -58,7 +58,7 @@ pub struct Nfs3ReplyLookup<'a> {
     pub handle: Nfs3Handle<'a>,
 }
 
-pub fn parse_nfs3_response_lookup(i: &[u8]) -> IResult<&[u8], Nfs3ReplyLookup> {
+pub fn parse_nfs3_response_lookup(i: &[u8]) -> IResult<&[u8], Nfs3ReplyLookup<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, handle) = parse_nfs3_handle(i)?;
     let reply = Nfs3ReplyLookup { status, handle };
@@ -74,7 +74,7 @@ pub struct Nfs3RequestCreate<'a> {
     pub name_vec: Vec<u8>,
 }
 
-pub fn parse_nfs3_request_create(i: &[u8]) -> IResult<&[u8], Nfs3RequestCreate> {
+pub fn parse_nfs3_request_create(i: &[u8]) -> IResult<&[u8], Nfs3RequestCreate<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     let (i, name_len) = be_u32(i)?;
     let (i, name) = take(name_len as usize)(i)?;
@@ -98,7 +98,7 @@ pub struct Nfs3RequestRemove<'a> {
     pub name_vec: Vec<u8>,
 }
 
-pub fn parse_nfs3_request_remove(i: &[u8]) -> IResult<&[u8], Nfs3RequestRemove> {
+pub fn parse_nfs3_request_remove(i: &[u8]) -> IResult<&[u8], Nfs3RequestRemove<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     let (i, name_len) = be_u32(i)?;
     let (i, name) = take(name_len as usize)(i)?;
@@ -117,7 +117,7 @@ pub struct Nfs3RequestRmdir<'a> {
     pub name_vec: Vec<u8>,
 }
 
-pub fn parse_nfs3_request_rmdir(i: &[u8]) -> IResult<&[u8], Nfs3RequestRmdir> {
+pub fn parse_nfs3_request_rmdir(i: &[u8]) -> IResult<&[u8], Nfs3RequestRmdir<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     let (i, name_len) = be_u32(i)?;
     let (i, name) = take(name_len as usize)(i)?;
@@ -135,7 +135,7 @@ pub struct Nfs3RequestMkdir<'a> {
     pub name_vec: Vec<u8>,
 }
 
-pub fn parse_nfs3_request_mkdir(i: &[u8]) -> IResult<&[u8], Nfs3RequestMkdir> {
+pub fn parse_nfs3_request_mkdir(i: &[u8]) -> IResult<&[u8], Nfs3RequestMkdir<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     let (i, name_len) = be_u32(i)?;
     let (i, name) = take(name_len as usize)(i)?;
@@ -156,7 +156,7 @@ pub struct Nfs3RequestRename<'a> {
     pub to_name_vec: Vec<u8>,
 }
 
-pub fn parse_nfs3_request_rename(i: &[u8]) -> IResult<&[u8], Nfs3RequestRename> {
+pub fn parse_nfs3_request_rename(i: &[u8]) -> IResult<&[u8], Nfs3RequestRename<'_>> {
     let (i, from_handle) = parse_nfs3_handle(i)?;
     let (i, from_name_len) = be_u32(i)?;
     let (i, from_name) = take(from_name_len as usize)(i)?;
@@ -180,7 +180,7 @@ pub struct Nfs3RequestGetAttr<'a> {
     pub handle: Nfs3Handle<'a>,
 }
 
-pub fn parse_nfs3_request_getattr(i: &[u8]) -> IResult<&[u8], Nfs3RequestGetAttr> {
+pub fn parse_nfs3_request_getattr(i: &[u8]) -> IResult<&[u8], Nfs3RequestGetAttr<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     Ok((i, Nfs3RequestGetAttr { handle }))
 }
@@ -191,7 +191,7 @@ pub struct Nfs3RequestAccess<'a> {
     pub check_access: u32,
 }
 
-pub fn parse_nfs3_request_access(i: &[u8]) -> IResult<&[u8], Nfs3RequestAccess> {
+pub fn parse_nfs3_request_access(i: &[u8]) -> IResult<&[u8], Nfs3RequestAccess<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     let (i, check_access) = be_u32(i)?;
     let req = Nfs3RequestAccess {
@@ -206,7 +206,7 @@ pub struct Nfs3RequestCommit<'a> {
     pub handle: Nfs3Handle<'a>,
 }
 
-pub fn parse_nfs3_request_commit(i: &[u8]) -> IResult<&[u8], Nfs3RequestCommit> {
+pub fn parse_nfs3_request_commit(i: &[u8]) -> IResult<&[u8], Nfs3RequestCommit<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     let (i, _offset) = be_u64(i)?;
     let (i, _count) = be_u32(i)?;
@@ -219,7 +219,7 @@ pub struct Nfs3RequestRead<'a> {
     pub offset: u64,
 }
 
-pub fn parse_nfs3_request_read(i: &[u8]) -> IResult<&[u8], Nfs3RequestRead> {
+pub fn parse_nfs3_request_read(i: &[u8]) -> IResult<&[u8], Nfs3RequestRead<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     let (i, offset) = be_u64(i)?;
     let (i, _count) = be_u32(i)?;
@@ -232,7 +232,7 @@ pub struct Nfs3RequestLookup<'a> {
     pub name_vec: Vec<u8>,
 }
 
-pub fn parse_nfs3_request_lookup(i: &[u8]) -> IResult<&[u8], Nfs3RequestLookup> {
+pub fn parse_nfs3_request_lookup(i: &[u8]) -> IResult<&[u8], Nfs3RequestLookup<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     let (i, name_contents) = length_data(be_u32)(i)?;
     let (i, _name_padding) = rest(i)?;
@@ -251,7 +251,7 @@ pub struct Nfs3ResponseReaddirplusEntryC<'a> {
 
 pub fn parse_nfs3_response_readdirplus_entry(
     i: &[u8],
-) -> IResult<&[u8], Nfs3ResponseReaddirplusEntryC> {
+) -> IResult<&[u8], Nfs3ResponseReaddirplusEntryC<'_>> {
     let (i, _file_id) = be_u64(i)?;
     let (i, name_len) = be_u32(i)?;
     let (i, name_contents) = take(name_len as usize)(i)?;
@@ -275,7 +275,7 @@ pub struct Nfs3ResponseReaddirplusEntry<'a> {
 
 pub fn parse_nfs3_response_readdirplus_entry_cond(
     i: &[u8],
-) -> IResult<&[u8], Nfs3ResponseReaddirplusEntry> {
+) -> IResult<&[u8], Nfs3ResponseReaddirplusEntry<'_>> {
     let (i, value_follows) = verify(be_u32, |&v| v <= 1)(i)?;
     let (i, entry) = cond(value_follows == 1, parse_nfs3_response_readdirplus_entry)(i)?;
     Ok((i, Nfs3ResponseReaddirplusEntry { entry }))
@@ -287,7 +287,7 @@ pub struct Nfs3ResponseReaddirplus<'a> {
     pub data: &'a [u8],
 }
 
-pub fn parse_nfs3_response_readdirplus(i: &[u8]) -> IResult<&[u8], Nfs3ResponseReaddirplus> {
+pub fn parse_nfs3_response_readdirplus(i: &[u8]) -> IResult<&[u8], Nfs3ResponseReaddirplus<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, dir_attr_follows) = verify(be_u32, |&v| v <= 1)(i)?;
     let (i, _dir_attr) = cond(dir_attr_follows == 1, take(84_usize))(i)?;
@@ -299,7 +299,7 @@ pub fn parse_nfs3_response_readdirplus(i: &[u8]) -> IResult<&[u8], Nfs3ResponseR
 
 pub(crate) fn many0_nfs3_response_readdirplus_entries(
     input: &[u8],
-) -> IResult<&[u8], Vec<Nfs3ResponseReaddirplusEntry>> {
+) -> IResult<&[u8], Vec<Nfs3ResponseReaddirplusEntry<'_>>> {
     many0(complete(parse_nfs3_response_readdirplus_entry_cond))(input)
 }
 
@@ -313,7 +313,7 @@ pub struct Nfs3RequestReaddirplus<'a> {
     pub maxcount: u32,
 }
 
-pub fn parse_nfs3_request_readdirplus(i: &[u8]) -> IResult<&[u8], Nfs3RequestReaddirplus> {
+pub fn parse_nfs3_request_readdirplus(i: &[u8]) -> IResult<&[u8], Nfs3RequestReaddirplus<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     let (i, cookie) = be_u64(i)?;
     let (i, verifier) = take(8_usize)(i)?;
@@ -358,7 +358,7 @@ fn parse_nfs3_data_partial(i: &[u8], file_len: usize, fill_bytes: usize) -> IRes
 /// 1. we have the complete RPC data
 /// 2. we have incomplete data but enough for all file data (partial fill bytes)
 /// 3. we have incomplete file data
-pub fn parse_nfs3_request_write(i: &[u8], complete: bool) -> IResult<&[u8], Nfs3RequestWrite> {
+pub fn parse_nfs3_request_write(i: &[u8], complete: bool) -> IResult<&[u8], Nfs3RequestWrite<'_>> {
     let (i, handle) = parse_nfs3_handle(i)?;
     let (i, offset) = be_u64(i)?;
     let (i, count) = be_u32(i)?;
@@ -384,7 +384,7 @@ pub fn parse_nfs3_request_write(i: &[u8], complete: bool) -> IResult<&[u8], Nfs3
     Ok((i, req))
 }
 
-pub fn parse_nfs3_reply_read(i: &[u8], complete: bool) -> IResult<&[u8], NfsReplyRead> {
+pub fn parse_nfs3_reply_read(i: &[u8], complete: bool) -> IResult<&[u8], NfsReplyRead<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, attr_follows) = verify(be_u32, |&v| v <= 1)(i)?;
     let (i, attr_blob) = take(84_usize)(i)?; // fixed size?

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -112,7 +112,7 @@ pub struct Nfs4StateId<'a> {
     pub data: &'a[u8],
 }
 
-fn nfs4_parse_stateid(i: &[u8]) -> IResult<&[u8], Nfs4StateId> {
+fn nfs4_parse_stateid(i: &[u8]) -> IResult<&[u8], Nfs4StateId<'_>> {
     let (i, seqid) = be_u32(i)?;
     let (i, data) = take(12_usize)(i)?;
     let state = Nfs4StateId { seqid, data };
@@ -125,7 +125,7 @@ pub struct Nfs4Handle<'a> {
     pub value: &'a[u8],
 }
 
-fn nfs4_parse_handle(i: &[u8]) -> IResult<&[u8], Nfs4Handle> {
+fn nfs4_parse_handle(i: &[u8]) -> IResult<&[u8], Nfs4Handle<'_>> {
     let (i, len) = be_u32(i)?;
     let (i, value) = take(len as usize)(i)?;
     let handle = Nfs4Handle { len, value };
@@ -148,7 +148,7 @@ pub struct Nfs4RequestLayoutReturn<'a> {
     pub lrf_data: &'a[u8],
 }
 
-fn nfs4_req_layoutreturn(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_layoutreturn(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, _reclaim) = verify(be_u32, |&v| v <= 1)(i)?;
     let (i, layout_type) = be_u32(i)?;
     let (i, _iq_mode) = be_u32(i)?;
@@ -175,7 +175,7 @@ pub struct Nfs4RequestGetDevInfo<'a> {
     pub notify_mask: u32,
 }
 
-fn nfs4_req_getdevinfo(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_getdevinfo(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, device_id) = take(16_usize)(i)?;
     let (i, layout_type) = be_u32(i)?;
     let (i, maxcount) = be_u32(i)?;
@@ -197,7 +197,7 @@ pub struct Nfs4RequestCreateSession<'a> {
     pub machine_name: &'a[u8],
 }
 
-fn nfs4_req_create_session(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_create_session(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, client_id) = take(8_usize)(i)?;
     let (i, seqid) = be_u32(i)?;
     let (i, _flags) = be_u32(i)?;
@@ -218,7 +218,7 @@ fn nfs4_req_create_session(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
     Ok((i, req))
 }
 
-fn nfs4_req_putfh(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_putfh(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     map(nfs4_parse_handle, Nfs4RequestContent::PutFH)(i)
 }
 
@@ -229,7 +229,7 @@ pub struct Nfs4RequestSetClientId<'a> {
     pub r_addr: &'a[u8],
 }
 
-fn nfs4_req_setclientid(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_setclientid(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, _client_verifier) = take(8_usize)(i)?;
     let (i, client_id) = nfs4_parse_nfsstring(i)?;
     let (i, _cb_program) = be_u32(i)?;
@@ -244,7 +244,7 @@ fn nfs4_req_setclientid(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
     Ok((i, req))
 }
 
-fn nfs4_req_setclientid_confirm(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_setclientid_confirm(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, _client_id) = take(8_usize)(i)?;
     let (i, _verifier) = take(8_usize)(i)?;
     Ok((i, Nfs4RequestContent::SetClientIdConfirm))
@@ -257,7 +257,7 @@ pub struct Nfs4RequestCreate<'a> {
     pub link_content: &'a[u8],
 }
 
-fn nfs4_req_create(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_create(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, ftype4) = be_u32(i)?;
     let (i, link_content) = cond(ftype4 == 5, nfs4_parse_nfsstring)(i)?;
     let (i, filename) = nfs4_parse_nfsstring(i)?;
@@ -277,19 +277,19 @@ pub enum Nfs4OpenRequestContent<'a> {
     Guarded4(Nfs4Attr),
 }
 
-fn nfs4_req_open_unchecked4(i: &[u8]) -> IResult<&[u8], Nfs4OpenRequestContent> {
+fn nfs4_req_open_unchecked4(i: &[u8]) -> IResult<&[u8], Nfs4OpenRequestContent<'_>> {
     map(nfs4_parse_attrs, Nfs4OpenRequestContent::Unchecked4)(i)
 }
 
-fn nfs4_req_open_guarded4(i: &[u8]) -> IResult<&[u8], Nfs4OpenRequestContent> {
+fn nfs4_req_open_guarded4(i: &[u8]) -> IResult<&[u8], Nfs4OpenRequestContent<'_>> {
     map(nfs4_parse_attrs, Nfs4OpenRequestContent::Guarded4)(i)
 }
 
-fn nfs4_req_open_exclusive4(i: &[u8]) -> IResult<&[u8], Nfs4OpenRequestContent> {
+fn nfs4_req_open_exclusive4(i: &[u8]) -> IResult<&[u8], Nfs4OpenRequestContent<'_>> {
     map(take(8_usize), Nfs4OpenRequestContent::Exclusive4)(i)
 }
 
-fn nfs4_req_open_type(i: &[u8]) -> IResult<&[u8], Nfs4OpenRequestContent> {
+fn nfs4_req_open_type(i: &[u8]) -> IResult<&[u8], Nfs4OpenRequestContent<'_>> {
     let (i, mode) = be_u32(i)?;
     let (i, data) = match mode {
         0 => nfs4_req_open_unchecked4(i)?,
@@ -307,7 +307,7 @@ pub struct Nfs4RequestOpen<'a> {
     pub open_data: Option<Nfs4OpenRequestContent<'a>>,
 }
 
-fn nfs4_req_open(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_open(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, _seq_id) = be_u32(i)?;
     let (i, _share_access) = be_u32(i)?;
     let (i, _share_deny) = be_u32(i)?;
@@ -326,7 +326,7 @@ fn nfs4_req_open(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
     Ok((i, req))
 }
 
-fn nfs4_req_readdir(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_readdir(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, _cookie) = be_u64(i)?;
     let (i, _cookie_verf) = be_u64(i)?;
     let (i, _dir_cnt) = be_u32(i)?;
@@ -341,7 +341,7 @@ pub struct Nfs4RequestRename<'a> {
     pub newname: &'a[u8],
 }
 
-fn nfs4_req_rename(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_rename(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, oldname) = nfs4_parse_nfsstring(i)?;
     let (i, newname) = nfs4_parse_nfsstring(i)?;
     let req = Nfs4RequestContent::Rename(Nfs4RequestRename {
@@ -356,22 +356,22 @@ pub struct Nfs4RequestLookup<'a> {
     pub filename: &'a[u8],
 }
 
-fn nfs4_req_destroy_session(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_destroy_session(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, ssn_id) = take(16_usize)(i)?;
     Ok((i, Nfs4RequestContent::DestroySession(ssn_id)))
 }
 
-fn nfs4_req_lookup(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_lookup(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     map(nfs4_parse_nfsstring, |filename| {
         Nfs4RequestContent::Lookup(Nfs4RequestLookup { filename })
     })(i)
 }
 
-fn nfs4_req_remove(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_remove(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     map(nfs4_parse_nfsstring, Nfs4RequestContent::Remove)(i)
 }
 
-fn nfs4_req_secinfo_no_name(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_secinfo_no_name(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     map(be_u32, Nfs4RequestContent::SecInfoNoName) (i)
 }
 
@@ -380,14 +380,14 @@ pub struct Nfs4RequestSetAttr<'a> {
     pub stateid: Nfs4StateId<'a>,
 }
 
-fn nfs4_req_setattr(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_setattr(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, stateid) = nfs4_parse_stateid(i)?;
     let (i, _attrs) = nfs4_parse_attrs(i)?;
     let req = Nfs4RequestContent::SetAttr(Nfs4RequestSetAttr { stateid });
     Ok((i, req))
 }
 
-fn nfs4_req_getattr(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_getattr(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     map(nfs4_parse_attrbits, Nfs4RequestContent::GetAttr)(i)
 }
 
@@ -400,7 +400,7 @@ pub struct Nfs4RequestWrite<'a> {
     pub data: &'a[u8],
 }
 
-fn nfs4_req_write(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_write(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, stateid) = nfs4_parse_stateid(i)?;
     let (i, offset) = be_u64(i)?;
     let (i, stable) = be_u32(i)?;
@@ -424,7 +424,7 @@ pub struct Nfs4RequestRead<'a> {
     pub count: u32,
 }
 
-fn nfs4_req_read(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_read(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, stateid) = nfs4_parse_stateid(i)?;
     let (i, offset) = be_u64(i)?;
     let (i, count) = be_u32(i)?;
@@ -436,7 +436,7 @@ fn nfs4_req_read(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
     Ok((i, req))
 }
 
-fn nfs4_req_close(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_close(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, _seq_id) = be_u32(i)?;
     let (i, stateid) = nfs4_parse_stateid(i)?;
     Ok((i, Nfs4RequestContent::Close(stateid)))
@@ -447,7 +447,7 @@ pub struct Nfs4RequestOpenConfirm<'a> {
     pub stateid: Nfs4StateId<'a>,
 }
 
-fn nfs4_req_open_confirm(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_open_confirm(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, _seq_id) = be_u32(i)?;
     let (i, stateid) = nfs4_parse_stateid(i)?;
     let req = Nfs4RequestContent::OpenConfirm(Nfs4RequestOpenConfirm {
@@ -456,41 +456,41 @@ fn nfs4_req_open_confirm(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
     Ok((i, req))
 }
 
-fn nfs4_req_delegreturn(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_delegreturn(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     map(nfs4_parse_stateid, Nfs4RequestContent::DelegReturn)(i)
 }
 
-fn nfs4_req_renew(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_renew(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     map(be_u64, Nfs4RequestContent::Renew)(i)
 }
 
-fn nfs4_req_getfh(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_getfh(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     Ok((i, Nfs4RequestContent::GetFH))
 }
 
-fn nfs4_req_savefh(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_savefh(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     Ok((i, Nfs4RequestContent::SaveFH))
 }
 
-fn nfs4_req_putrootfh(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_putrootfh(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     Ok((i, Nfs4RequestContent::PutRootFH))
 }
 
-fn nfs4_req_access(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_access(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     map(be_u32, Nfs4RequestContent::Access)(i)
 }
 
-fn nfs4_req_commit(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_commit(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, _offset) = be_u64(i)?;
     let (i, _count) = be_u32(i)?;
     Ok((i, Nfs4RequestContent::Commit))
 }
 
-fn nfs4_req_reclaim_complete(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_reclaim_complete(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     map(verify(be_u32, |&v| v <= 1), Nfs4RequestContent::ReclaimComplete) (i)
 }
 
-fn nfs4_req_destroy_clientid(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_destroy_clientid(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, client_id) = take(8_usize)(i)?;
     Ok((i, Nfs4RequestContent::DestroyClientID(client_id)))
 }
@@ -503,7 +503,7 @@ pub struct Nfs4RequestLayoutGet<'a> {
     pub stateid: Nfs4StateId<'a>,
 }
 
-fn nfs4_req_layoutget(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_layoutget(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, _layout_available) = verify(be_u32, |&v| v <= 1)(i)?;
     let (i, layout_type) = be_u32(i)?;
     let (i, _iq_mode) = be_u32(i)?;
@@ -528,7 +528,7 @@ pub struct Nfs4RequestExchangeId<'a> {
     pub nii_name: &'a[u8],
 }
 
-fn nfs4_req_exchangeid(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_exchangeid(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, _verifier) = take(8_usize)(i)?;
     let (i, eia_clientstring) = nfs4_parse_nfsstring(i)?;
     let (i, _eia_clientflags) = be_u32(i)?;
@@ -551,7 +551,7 @@ pub struct Nfs4RequestSequence<'a> {
     pub ssn_id: &'a[u8],
 }
 
-fn nfs4_req_sequence(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn nfs4_req_sequence(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, ssn_id) = take(16_usize)(i)?;
     let (i, _seq_id) = be_u32(i)?;
     let (i, _slot_id) = be_u32(i)?;
@@ -563,7 +563,7 @@ fn nfs4_req_sequence(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
     Ok((i, req))
 }
 
-fn parse_request_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent> {
+fn parse_request_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4RequestContent<'_>> {
     let (i, cmd) = be_u32(i)?;
     let (i, cmd_data) = match cmd {
         NFSPROC4_PUTFH => nfs4_req_putfh(i)?,
@@ -608,7 +608,7 @@ pub struct Nfs4RequestCompoundRecord<'a> {
     pub commands: Vec<Nfs4RequestContent<'a>>,
 }
 
-pub fn parse_nfs4_request_compound(i: &[u8]) -> IResult<&[u8], Nfs4RequestCompoundRecord> {
+pub fn parse_nfs4_request_compound(i: &[u8]) -> IResult<&[u8], Nfs4RequestCompoundRecord<'_>> {
     let (i, tag_len) = be_u32(i)?;
     let (i, _tag) = cond(tag_len > 0, take(tag_len as usize))(i)?;
     let (i, _min_ver) = be_u32(i)?;
@@ -657,7 +657,7 @@ pub enum Nfs4ResponseContent<'a> {
 }
 
 // might need improvement with a stateid_present = yes case
-fn nfs4_res_layoutreturn(i:&[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_layoutreturn(i:&[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, _stateid_present) = verify(be_u32, |&v| v <= 1)(i)?;
     Ok((i, Nfs4ResponseContent::LayoutReturn(status)))
@@ -669,7 +669,7 @@ pub struct Nfs4ResponseCreateSession<'a> {
     pub seq_id: u32,
 }
 
-fn nfs4_parse_res_create_session(i: &[u8]) -> IResult<&[u8], Nfs4ResponseCreateSession> {
+fn nfs4_parse_res_create_session(i: &[u8]) -> IResult<&[u8], Nfs4ResponseCreateSession<'_>> {
     let (i, ssn_id) = take(16_usize)(i)?;
     let (i, seq_id) = be_u32(i)?;
     let (i, _flags) = be_u32(i)?;
@@ -681,7 +681,7 @@ fn nfs4_parse_res_create_session(i: &[u8]) -> IResult<&[u8], Nfs4ResponseCreateS
     }))
 }
 
-fn nfs4_res_create_session(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_create_session(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, create_ssn_data) = cond(status == 0, nfs4_parse_res_create_session)(i)?;
     Ok((i, Nfs4ResponseContent::CreateSession( status, create_ssn_data )))
@@ -696,7 +696,7 @@ pub struct Nfs4ResponseExchangeId<'a> {
     pub nii_name: &'a[u8],
 }
 
-fn nfs4_parse_res_exchangeid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseExchangeId> {
+fn nfs4_parse_res_exchangeid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseExchangeId<'_>> {
     let (i, client_id) = take(8_usize)(i)?;
     let (i, _seqid) = be_u32(i)?;
     let (i, _flags) = be_u32(i)?;
@@ -718,11 +718,11 @@ fn nfs4_parse_res_exchangeid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseExchangeId>
     }))
 }
 
-fn nfs4_res_reclaim_complete(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_reclaim_complete(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::ReclaimComplete) (i)
 }
 
-fn nfs4_res_exchangeid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_exchangeid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, xchngid_data) = cond(status == 0, nfs4_parse_res_exchangeid)(i)?;
     Ok((i, Nfs4ResponseContent::ExchangeId( status, xchngid_data)))
@@ -741,7 +741,7 @@ fn nfs4_res_write_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseWrite> {
     Ok((i, Nfs4ResponseWrite { count, committed }))
 }
 
-fn nfs4_res_write(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_write(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, wd) = cond(status == 0, nfs4_res_write_ok)(i)?;
     Ok((i, Nfs4ResponseContent::Write(status, wd)))
@@ -754,7 +754,7 @@ pub struct Nfs4ResponseRead<'a> {
     pub data: &'a[u8],
 }
 
-fn nfs4_res_read_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseRead> {
+fn nfs4_res_read_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseRead<'_>> {
     let (i, eof) = verify(be_u32, |&v| v <= 1)(i)?;
     let (i, read_len) = be_u32(i)?;
     let (i, read_data) = take(read_len as usize)(i)?;
@@ -766,7 +766,7 @@ fn nfs4_res_read_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseRead> {
     Ok((i, resp))
 }
 
-fn nfs4_res_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, rd) = cond(status == 0, nfs4_res_read_ok)(i)?;
     Ok((i, Nfs4ResponseContent::Read(status, rd)))
@@ -792,7 +792,7 @@ pub struct Nfs4ResponseOpenDelegateWrite<'a> {
     pub who: &'a[u8],
 }
 
-fn nfs4_res_open_ok_delegate_write(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation> {
+fn nfs4_res_open_ok_delegate_write(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation<'_>> {
     let (i, stateid) = nfs4_parse_stateid(i)?;
     let (i, _recall) = be_u32(i)?;
     let (i, _space_limit) = be_u32(i)?;
@@ -812,7 +812,7 @@ pub struct Nfs4ResponseOpenDelegateRead<'a> {
     pub stateid: Nfs4StateId<'a>,
 }
 
-fn nfs4_res_open_ok_delegate_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation> {
+fn nfs4_res_open_ok_delegate_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation<'_>> {
     let (i, stateid) = nfs4_parse_stateid(i)?;
     let (i, _recall) = be_u32(i)?;
     let (i, _ace_type) = be_u32(i)?;
@@ -825,7 +825,7 @@ fn nfs4_res_open_ok_delegate_read(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDe
     })))
 }
 
-fn nfs4_parse_file_delegation(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation> {
+fn nfs4_parse_file_delegation(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelegation<'_>> {
     let (i, delegation_type) = be_u32(i)?;
     let (i, file_delegation) = match delegation_type {
         OPEN_DELEGATE_READ => nfs4_res_open_ok_delegate_read(i)?,
@@ -836,7 +836,7 @@ fn nfs4_parse_file_delegation(i: &[u8]) -> IResult<&[u8], Nfs4ResponseFileDelega
     Ok((i, file_delegation))
 }
 
-fn nfs4_res_open_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpen> {
+fn nfs4_res_open_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpen<'_>> {
     let (i, stateid) = nfs4_parse_stateid(i)?;
     let (i, _change_info) = take(20_usize)(i)?;
     let (i, result_flags) = be_u32(i)?;
@@ -850,7 +850,7 @@ fn nfs4_res_open_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseOpen> {
     Ok((i, resp))
 }
 
-fn nfs4_res_open(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_open(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, open_data) = cond(status == 0, nfs4_res_open_ok)(i)?;
     Ok((i, Nfs4ResponseContent::Open(status, open_data)))
@@ -864,7 +864,7 @@ pub struct Nfs4ResponseGetDevInfo<'a> {
     pub notify_mask: u32,
 }
 
-fn nfs4_parse_res_getdevinfo(i: &[u8]) -> IResult<&[u8], Nfs4ResponseGetDevInfo> {
+fn nfs4_parse_res_getdevinfo(i: &[u8]) -> IResult<&[u8], Nfs4ResponseGetDevInfo<'_>> {
     let (i, layout_type) = be_u32(i)?;
     let (i, _) = be_u64(i)?;
     let (i, _device_index) = be_u32(i)?;
@@ -880,7 +880,7 @@ fn nfs4_parse_res_getdevinfo(i: &[u8]) -> IResult<&[u8], Nfs4ResponseGetDevInfo>
     }))
 }
 
-fn nfs4_res_getdevinfo(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_getdevinfo(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, getdevinfo) = cond(status == 0, nfs4_parse_res_getdevinfo)(i)?;
     Ok((i, Nfs4ResponseContent::GetDevInfo( status, getdevinfo )))
@@ -897,7 +897,7 @@ pub struct Nfs4ResponseLayoutGet<'a> {
     pub file_handles: Vec<Nfs4Handle<'a>>,
 }
 
-fn nfs4_parse_res_layoutget(i: &[u8]) -> IResult<&[u8], Nfs4ResponseLayoutGet> {
+fn nfs4_parse_res_layoutget(i: &[u8]) -> IResult<&[u8], Nfs4ResponseLayoutGet<'_>> {
     let (i, _return_on_close) =  verify(be_u32, |&v| v <= 1)(i)?;
     let (i, stateid) = nfs4_parse_stateid(i)?;
     let (i, _layout_seg) = be_u32(i)?;
@@ -926,7 +926,7 @@ fn nfs4_parse_res_layoutget(i: &[u8]) -> IResult<&[u8], Nfs4ResponseLayoutGet> {
     }))
 }
 
-fn nfs4_res_layoutget(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_layoutget(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, lyg_data) = cond(status == 0, nfs4_parse_res_layoutget)(i)?;
     Ok((i, Nfs4ResponseContent::LayoutGet( status, lyg_data )))
@@ -952,7 +952,7 @@ fn nfs4_parse_flavors(i: &[u8]) -> IResult<&[u8], u32> {
     Ok((i, flavor_type))
 }
 
-fn nfs4_res_secinfo_no_name(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_secinfo_no_name(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, flavors_cnt) = be_u32(i)?;
     // do not use nom's count as it allocates a Vector first
@@ -976,20 +976,20 @@ pub struct Nfs4ResponseReaddir<'a> {
     pub listing: Vec<Option<Nfs4ResponseReaddirEntry<'a>>>,
 }
 
-fn nfs4_res_readdir_entry_do(i: &[u8]) -> IResult<&[u8], Nfs4ResponseReaddirEntry> {
+fn nfs4_res_readdir_entry_do(i: &[u8]) -> IResult<&[u8], Nfs4ResponseReaddirEntry<'_>> {
     let (i, _cookie) = be_u64(i)?;
     let (i, name) = nfs4_parse_nfsstring(i)?;
     let (i, _attrs) = nfs4_parse_attrs(i)?;
     Ok((i, Nfs4ResponseReaddirEntry { name }))
 }
 
-fn nfs4_res_readdir_entry(i: &[u8]) -> IResult<&[u8], Option<Nfs4ResponseReaddirEntry>> {
+fn nfs4_res_readdir_entry(i: &[u8]) -> IResult<&[u8], Option<Nfs4ResponseReaddirEntry<'_>>> {
     let (i, value_follows) = verify(be_u32, |&v| v <= 1)(i)?;
     let (i, entry) = cond(value_follows == 1, nfs4_res_readdir_entry_do)(i)?;
     Ok((i, entry))
 }
 
-fn nfs4_res_readdir_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseReaddir> {
+fn nfs4_res_readdir_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseReaddir<'_>> {
     let (i, _verifier) = be_u64(i)?;
     // run parser until we find a 'value follows == 0'
     let (i, listing) = many_till(
@@ -1008,7 +1008,7 @@ fn nfs4_res_readdir_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseReaddir> {
     ))
 }
 
-fn nfs4_res_readdir(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_readdir(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, rd) = cond(status == 0, nfs4_res_readdir_ok)(i)?;
     Ok((i, Nfs4ResponseContent::ReadDir(status, rd)))
@@ -1019,7 +1019,7 @@ fn nfs4_res_create_ok(i: &[u8]) -> IResult<&[u8], Nfs4Attr> {
     nfs4_parse_attrbits(i)
 }
 
-fn nfs4_res_create(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_create(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, _attrs) = cond(status == 0, nfs4_res_create_ok)(i)?;
     Ok((i, Nfs4ResponseContent::Create(status)))
@@ -1029,7 +1029,7 @@ fn nfs4_res_setattr_ok(i: &[u8]) -> IResult<&[u8], Nfs4Attr> {
     nfs4_parse_attrbits(i)
 }
 
-fn nfs4_res_setattr(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_setattr(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, _attrs) = cond(status == 0, nfs4_res_setattr_ok)(i)?;
     Ok((i, Nfs4ResponseContent::SetAttr(status)))
@@ -1039,76 +1039,76 @@ fn nfs4_res_getattr_ok(i: &[u8]) -> IResult<&[u8], Nfs4Attr> {
     nfs4_parse_attrs(i)
 }
 
-fn nfs4_res_getattr(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_getattr(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, attrs) = cond(status == 0, nfs4_res_getattr_ok)(i)?;
     Ok((i, Nfs4ResponseContent::GetAttr(status, attrs)))
 }
 
-fn nfs4_res_openconfirm(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_openconfirm(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, stateid) = cond(status == 0, nfs4_parse_stateid)(i)?;
     Ok((i, Nfs4ResponseContent::OpenConfirm(status, stateid)))
 }
 
-fn nfs4_res_close(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_close(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, stateid) = cond(status == 0, nfs4_parse_stateid)(i)?;
     Ok((i, Nfs4ResponseContent::Close(status, stateid)))
 }
 
-fn nfs4_res_remove(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_remove(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, _) = cond(status == 0, take(20_usize))(i)?;
     Ok((i, Nfs4ResponseContent::Remove(status)))
 }
 
-fn nfs4_res_rename(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_rename(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::Rename)(i)
 }
 
-fn nfs4_res_savefh(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_savefh(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::SaveFH)(i)
 }
 
-fn nfs4_res_lookup(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_lookup(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::Lookup)(i)
 }
 
-fn nfs4_res_renew(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_renew(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::Renew)(i)
 }
 
-fn nfs4_res_getfh(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_getfh(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, fh) = cond(status == 0, nfs4_parse_handle)(i)?;
     Ok((i, Nfs4ResponseContent::GetFH(status, fh)))
 }
 
-fn nfs4_res_putfh(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_putfh(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::PutFH)(i)
 }
 
-fn nfs4_res_putrootfh(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_putrootfh(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::PutRootFH)(i)
 }
 
-fn nfs4_res_delegreturn(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_delegreturn(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::DelegReturn)(i)
 }
 
-fn nfs4_res_setclientid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_setclientid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, _client_id) = be_u64(i)?;
     let (i, _verifier) = be_u32(i)?;
     Ok((i, Nfs4ResponseContent::SetClientId(status)))
 }
 
-fn nfs4_res_setclientid_confirm(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_setclientid_confirm(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::SetClientIdConfirm)(i)
 }
 
-fn nfs4_res_commit(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_commit(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, _verifier) = cond(status == 0, take(8_usize))(i)?;
     Ok((i, Nfs4ResponseContent::Commit(status)))
@@ -1130,7 +1130,7 @@ fn nfs4_res_access_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseAccess> {
     Ok((i, resp))
 }
 
-fn nfs4_res_access(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_access(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, ad) = cond(status == 0, nfs4_res_access_ok)(i)?;
     Ok((i, Nfs4ResponseContent::Access(status, ad)))
@@ -1141,7 +1141,7 @@ pub struct Nfs4ResponseSequence<'a> {
     pub ssn_id: &'a[u8],
 }
 
-fn nfs4_res_sequence_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseSequence> {
+fn nfs4_res_sequence_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseSequence<'_>> {
     let (i, ssn_id) = take(16_usize)(i)?;
     let (i, _seqid) = be_u32(i)?;
     let (i, _slots) = take(12_usize)(i)?;
@@ -1149,21 +1149,21 @@ fn nfs4_res_sequence_ok(i: &[u8]) -> IResult<&[u8], Nfs4ResponseSequence> {
     Ok((i, Nfs4ResponseSequence { ssn_id }))
 }
 
-fn nfs4_res_sequence(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_sequence(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, seq) = cond(status == 0, nfs4_res_sequence_ok)(i)?;
     Ok((i, Nfs4ResponseContent::Sequence(status, seq)))
 }
 
-fn nfs4_res_destroy_session(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_destroy_session(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::DestroySession) (i)
 }
 
-fn nfs4_res_destroy_clientid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_destroy_clientid(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     map(be_u32, Nfs4ResponseContent::DestroyClientID) (i)
 }
 
-fn nfs4_res_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent> {
+fn nfs4_res_compound_command(i: &[u8]) -> IResult<&[u8], Nfs4ResponseContent<'_>> {
     let (i, cmd) = be_u32(i)?;
     let (i, cmd_data) = match cmd {
         NFSPROC4_READ => nfs4_res_read(i)?,
@@ -1209,7 +1209,7 @@ pub struct Nfs4ResponseCompoundRecord<'a> {
     pub commands: Vec<Nfs4ResponseContent<'a>>,
 }
 
-pub fn parse_nfs4_response_compound(i: &[u8]) -> IResult<&[u8], Nfs4ResponseCompoundRecord> {
+pub fn parse_nfs4_response_compound(i: &[u8]) -> IResult<&[u8], Nfs4ResponseCompoundRecord<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, tag_len) = be_u32(i)?;
     let (i, _tag) = cond(tag_len > 0, take(tag_len as usize))(i)?;

--- a/rust/src/nfs/rpc_records.rs
+++ b/rust/src/nfs/rpc_records.rs
@@ -53,7 +53,7 @@ pub struct RpcRequestCredsUnix<'a> {
 //    many0!(be_u32)
 //);
 
-fn parse_rpc_request_creds_unix(i: &[u8]) -> IResult<&[u8], RpcRequestCreds> {
+fn parse_rpc_request_creds_unix(i: &[u8]) -> IResult<&[u8], RpcRequestCreds<'_>> {
     let (i, stamp) = be_u32(i)?;
     let (i, machine_name_len) = verify(be_u32, |&size| size < RPC_MAX_MACHINE_SIZE)(i)?;
     let (i, machine_name_buf) = take(machine_name_len as usize)(i)?;
@@ -81,7 +81,7 @@ pub struct RpcRequestCredsGssApi<'a> {
     pub ctx: &'a [u8],
 }
 
-fn parse_rpc_request_creds_gssapi(i: &[u8]) -> IResult<&[u8], RpcRequestCreds> {
+fn parse_rpc_request_creds_gssapi(i: &[u8]) -> IResult<&[u8], RpcRequestCreds<'_>> {
     let (i, version) = be_u32(i)?;
     let (i, procedure) = be_u32(i)?;
     let (i, seq_num) = be_u32(i)?;
@@ -97,7 +97,7 @@ fn parse_rpc_request_creds_gssapi(i: &[u8]) -> IResult<&[u8], RpcRequestCreds> {
     Ok((i, creds))
 }
 
-fn parse_rpc_request_creds_unknown(i: &[u8]) -> IResult<&[u8], RpcRequestCreds> {
+fn parse_rpc_request_creds_unknown(i: &[u8]) -> IResult<&[u8], RpcRequestCreds<'_>> {
     Ok((&[], RpcRequestCreds::Unknown(i)))
 }
 
@@ -109,7 +109,7 @@ pub struct RpcGssApiIntegrity<'a> {
 
 // Parse the GSSAPI Integrity envelope to get to the
 // data we care about.
-pub fn parse_rpc_gssapi_integrity(i: &[u8]) -> IResult<&[u8], RpcGssApiIntegrity> {
+pub fn parse_rpc_gssapi_integrity(i: &[u8]) -> IResult<&[u8], RpcGssApiIntegrity<'_>> {
     let (i, len) = verify(be_u32, |&size| size < RPC_MAX_CREDS_SIZE)(i)?;
     let (i, seq_num) = be_u32(i)?;
     let (i, data) = take(len as usize)(i)?;
@@ -217,7 +217,7 @@ pub struct RpcPacket<'a> {
 /// Arguments:
 /// * `complete`: do full parsing, including of `prog_data`
 ///
-pub fn parse_rpc(start_i: &[u8], complete: bool) -> IResult<&[u8], RpcPacket> {
+pub fn parse_rpc(start_i: &[u8], complete: bool) -> IResult<&[u8], RpcPacket<'_>> {
     let (i, hdr) = parse_rpc_packet_header(start_i)?;
     let rec_size = hdr.frag_len as usize + 4;
 
@@ -282,7 +282,7 @@ pub fn parse_rpc(start_i: &[u8], complete: bool) -> IResult<&[u8], RpcPacket> {
 /// Arguments:
 /// * `complete`: do full parsing, including of `prog_data`
 ///
-pub fn parse_rpc_reply(start_i: &[u8], complete: bool) -> IResult<&[u8], RpcReplyPacket> {
+pub fn parse_rpc_reply(start_i: &[u8], complete: bool) -> IResult<&[u8], RpcReplyPacket<'_>> {
     let (i, hdr) = parse_rpc_packet_header(start_i)?;
     let rec_size = hdr.frag_len + 4;
 
@@ -334,7 +334,7 @@ pub fn parse_rpc_udp_packet_header(i: &[u8]) -> IResult<&[u8], RpcPacketHeader> 
     Ok((i, hdr))
 }
 
-pub fn parse_rpc_udp_request(i: &[u8]) -> IResult<&[u8], RpcPacket> {
+pub fn parse_rpc_udp_request(i: &[u8]) -> IResult<&[u8], RpcPacket<'_>> {
     let (i, hdr) = parse_rpc_udp_packet_header(i)?;
 
     let (i, rpcver) = be_u32(i)?;
@@ -379,7 +379,7 @@ pub fn parse_rpc_udp_request(i: &[u8]) -> IResult<&[u8], RpcPacket> {
     Ok((i, packet))
 }
 
-pub fn parse_rpc_udp_reply(i: &[u8]) -> IResult<&[u8], RpcReplyPacket> {
+pub fn parse_rpc_udp_reply(i: &[u8]) -> IResult<&[u8], RpcReplyPacket<'_>> {
     let (i, hdr) = parse_rpc_udp_packet_header(i)?;
 
     let (i, verifier_flavor) = be_u32(i)?;

--- a/rust/src/smb/dcerpc_records.rs
+++ b/rust/src/smb/dcerpc_records.rs
@@ -34,7 +34,7 @@ pub struct DceRpcResponseRecord<'a> {
 /// parse a packet type 'response' DCERPC record. Implemented
 /// as function to be able to pass the fraglen in.
 pub fn parse_dcerpc_response_record(i:&[u8], frag_len: u16 )
-    -> IResult<&[u8], DceRpcResponseRecord, SmbError>
+    -> IResult<&[u8], DceRpcResponseRecord<'_>, SmbError>
 {
     if frag_len < 24 {
         return Err(Err::Error(SmbError::RecordTooSmall));
@@ -55,7 +55,7 @@ pub struct DceRpcRequestRecord<'a> {
 /// parse a packet type 'request' DCERPC record. Implemented
 /// as function to be able to pass the fraglen in.
 pub fn parse_dcerpc_request_record(i:&[u8], frag_len: u16, little: bool)
-    -> IResult<&[u8], DceRpcRequestRecord, SmbError>
+    -> IResult<&[u8], DceRpcRequestRecord<'_>, SmbError>
 {
     if frag_len < 24 {
         return Err(Err::Error(SmbError::RecordTooSmall));
@@ -76,7 +76,7 @@ pub struct DceRpcBindIface<'a> {
     pub ver_min: u16,
 }
 
-pub fn parse_dcerpc_bind_iface(i: &[u8]) -> IResult<&[u8], DceRpcBindIface> {
+pub fn parse_dcerpc_bind_iface(i: &[u8]) -> IResult<&[u8], DceRpcBindIface<'_>> {
     let (i, _ctx_id) = le_u16(i)?;
     let (i, _num_trans_items) = le_u8(i)?;
     let (i, _) = take(1_usize)(i)?; // reserved
@@ -92,7 +92,7 @@ pub fn parse_dcerpc_bind_iface(i: &[u8]) -> IResult<&[u8], DceRpcBindIface> {
     Ok((i, res))
 }
 
-pub fn parse_dcerpc_bind_iface_big(i: &[u8]) -> IResult<&[u8], DceRpcBindIface> {
+pub fn parse_dcerpc_bind_iface_big(i: &[u8]) -> IResult<&[u8], DceRpcBindIface<'_>> {
     let (i, _ctx_id) = le_u16(i)?;
     let (i, _num_trans_items) = le_u8(i)?;
     let (i, _) = take(1_usize)(i)?; // reserved
@@ -114,7 +114,7 @@ pub struct DceRpcBindRecord<'a> {
     pub ifaces: Vec<DceRpcBindIface<'a>>,
 }
 
-pub fn parse_dcerpc_bind_record(i: &[u8]) -> IResult<&[u8], DceRpcBindRecord> {
+pub fn parse_dcerpc_bind_record(i: &[u8]) -> IResult<&[u8], DceRpcBindRecord<'_>> {
     let (i, _max_xmit_frag) = le_u16(i)?;
     let (i, _max_recv_frag) = le_u16(i)?;
     let (i, _assoc_group) = take(4_usize)(i)?;
@@ -128,7 +128,7 @@ pub fn parse_dcerpc_bind_record(i: &[u8]) -> IResult<&[u8], DceRpcBindRecord> {
     Ok((i, record))
 }
 
-pub fn parse_dcerpc_bind_record_big(i: &[u8]) -> IResult<&[u8], DceRpcBindRecord> {
+pub fn parse_dcerpc_bind_record_big(i: &[u8]) -> IResult<&[u8], DceRpcBindRecord<'_>> {
     let (i, _max_xmit_frag) = be_u16(i)?;
     let (i, _max_recv_frag) = be_u16(i)?;
     let (i, _assoc_group) = take(4_usize)(i)?;
@@ -150,7 +150,7 @@ pub struct DceRpcBindAckResult<'a> {
     pub syntax_version: u32,
 }
 
-pub fn parse_dcerpc_bindack_result(i: &[u8]) -> IResult<&[u8], DceRpcBindAckResult> {
+pub fn parse_dcerpc_bindack_result(i: &[u8]) -> IResult<&[u8], DceRpcBindAckResult<'_>> {
     let (i, ack_result) = le_u16(i)?;
     let (i, ack_reason) = le_u16(i)?;
     let (i, transfer_syntax) = take(16_usize)(i)?;
@@ -170,7 +170,7 @@ pub struct DceRpcBindAckRecord<'a> {
     pub results: Vec<DceRpcBindAckResult<'a>>,
 }
 
-pub fn parse_dcerpc_bindack_record(i: &[u8]) -> IResult<&[u8], DceRpcBindAckRecord> {
+pub fn parse_dcerpc_bindack_record(i: &[u8]) -> IResult<&[u8], DceRpcBindAckRecord<'_>> {
     let (i, _max_xmit_frag) = le_u16(i)?;
     let (i, _max_recv_frag) = le_u16(i)?;
     let (i, _assoc_group) = take(4_usize)(i)?;
@@ -222,7 +222,7 @@ fn parse_dcerpc_flags2(i:&[u8]) -> IResult<&[u8],(u32,u32,u32)> {
     )))(i)
 }
 
-pub fn parse_dcerpc_record(i: &[u8]) -> IResult<&[u8], DceRpcRecord> {
+pub fn parse_dcerpc_record(i: &[u8]) -> IResult<&[u8], DceRpcRecord<'_>> {
     let (i, version_major) = le_u8(i)?;
     let (i, version_minor) = le_u8(i)?;
     let (i, packet_type) = le_u8(i)?;

--- a/rust/src/smb/nbss_records.rs
+++ b/rust/src/smb/nbss_records.rs
@@ -59,7 +59,7 @@ impl NbssRecord<'_> {
     }
 }
 
-pub fn parse_nbss_record(i: &[u8]) -> IResult<&[u8], NbssRecord> {
+pub fn parse_nbss_record(i: &[u8]) -> IResult<&[u8], NbssRecord<'_>> {
     let (i, buf) = be_u32(i)?;
     let message_type = (buf >> 24) as u8;
     let length = buf & 0xff_ffff;
@@ -72,7 +72,7 @@ pub fn parse_nbss_record(i: &[u8]) -> IResult<&[u8], NbssRecord> {
     Ok((i, record))
 }
 
-pub fn parse_nbss_record_partial(i: &[u8]) -> IResult<&[u8], NbssRecord> {
+pub fn parse_nbss_record_partial(i: &[u8]) -> IResult<&[u8], NbssRecord<'_>> {
     let (i, buf) = be_u32(i)?;
     let message_type = (buf >> 24) as u8;
     let length = buf & 0xff_ffff;

--- a/rust/src/smb/ntlmssp_records.rs
+++ b/rust/src/smb/ntlmssp_records.rs
@@ -96,7 +96,7 @@ fn extract_ntlm_substring(i: &[u8], offset: u32, length: u16) -> IResult<&[u8], 
     return Ok((i, &i[start..end]));
 }
 
-pub fn parse_ntlm_auth_record(i: &[u8]) -> IResult<&[u8], NTLMSSPAuthRecord> {
+pub fn parse_ntlm_auth_record(i: &[u8]) -> IResult<&[u8], NTLMSSPAuthRecord<'_>> {
     let orig_i = i;
     let record_len = i.len() + NTLMSSP_IDTYPE_LEN; // identifier (8) and type (4) are cut before we are called
 
@@ -169,7 +169,7 @@ pub struct NTLMSSPRecord<'a> {
     pub data: &'a [u8],
 }
 
-pub fn parse_ntlmssp(i: &[u8]) -> IResult<&[u8], NTLMSSPRecord> {
+pub fn parse_ntlmssp(i: &[u8]) -> IResult<&[u8], NTLMSSPRecord<'_>> {
     let (i, _) = take_until_and_consume(b"NTLMSSP\x00")(i)?;
     let (i, msg_type) = le_u32(i)?;
     let (i, data) = rest(i)?;

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -76,7 +76,7 @@ pub struct Smb1WriteRequestRecord<'a> {
     pub data: &'a[u8],
 }
 
-pub fn parse_smb1_write_request_record(i: &[u8]) -> IResult<&[u8], Smb1WriteRequestRecord> {
+pub fn parse_smb1_write_request_record(i: &[u8]) -> IResult<&[u8], Smb1WriteRequestRecord<'_>> {
     let (i, _wct) = le_u8(i)?;
     let (i, fid) = take(2_usize)(i)?;
     let (i, _count) = le_u16(i)?;
@@ -95,7 +95,7 @@ pub fn parse_smb1_write_request_record(i: &[u8]) -> IResult<&[u8], Smb1WriteRequ
     Ok((i, record))
 }
 
-pub fn parse_smb1_write_andx_request_record(i : &[u8], andx_offset: usize) -> IResult<&[u8], Smb1WriteRequestRecord> {
+pub fn parse_smb1_write_andx_request_record(i : &[u8], andx_offset: usize) -> IResult<&[u8], Smb1WriteRequestRecord<'_>> {
     let origin_i = i;
     let ax = andx_offset as u16;
     let (i, wct) = le_u8(i)?;
@@ -128,7 +128,7 @@ pub fn parse_smb1_write_andx_request_record(i : &[u8], andx_offset: usize) -> IR
     Ok((i, record))
 }
 
-pub fn parse_smb1_write_and_close_request_record(i: &[u8]) -> IResult<&[u8], Smb1WriteRequestRecord> {
+pub fn parse_smb1_write_and_close_request_record(i: &[u8]) -> IResult<&[u8], Smb1WriteRequestRecord<'_>> {
     let (i, _wct) = le_u8(i)?;
     let (i, fid) = take(2_usize)(i)?;
     let (i, count) = le_u16(i)?;
@@ -153,7 +153,7 @@ pub struct Smb1NegotiateProtocolResponseRecord<'a> {
 }
 
 pub fn parse_smb1_negotiate_protocol_response_record_error(i: &[u8])
-    -> IResult<&[u8], Smb1NegotiateProtocolResponseRecord> {
+    -> IResult<&[u8], Smb1NegotiateProtocolResponseRecord<'_>> {
      let (i, _wct) = le_u8(i)?;
      let (i, _bcc) = le_u16(i)?;
      let record = Smb1NegotiateProtocolResponseRecord {
@@ -164,7 +164,7 @@ pub fn parse_smb1_negotiate_protocol_response_record_error(i: &[u8])
 }
 
 pub fn parse_smb1_negotiate_protocol_response_record_ok(i: &[u8])
-    -> IResult<&[u8], Smb1NegotiateProtocolResponseRecord> {
+    -> IResult<&[u8], Smb1NegotiateProtocolResponseRecord<'_>> {
     let (i, _wct) = le_u8(i)?;
     let (i, dialect_idx) = le_u16(i)?;
     let (i, _sec_mode) = le_u8(i)?;
@@ -183,7 +183,7 @@ pub fn parse_smb1_negotiate_protocol_response_record_ok(i: &[u8])
 }
 
 pub fn parse_smb1_negotiate_protocol_response_record(i: &[u8])
-    -> IResult<&[u8], Smb1NegotiateProtocolResponseRecord> {
+    -> IResult<&[u8], Smb1NegotiateProtocolResponseRecord<'_>> {
     let (i, wct) = peek(le_u8)(i)?;
     match wct {
         0 => parse_smb1_negotiate_protocol_response_record_error(i),
@@ -197,7 +197,7 @@ pub struct Smb1NegotiateProtocolRecord<'a> {
 }
 
 pub fn parse_smb1_negotiate_protocol_record(i: &[u8])
-    -> IResult<&[u8], Smb1NegotiateProtocolRecord> {
+    -> IResult<&[u8], Smb1NegotiateProtocolRecord<'_>> {
     let (i, _wtc) = le_u8(i)?;
     let (i, _bcc) = le_u16(i)?;
     // dialects is a list of [1 byte buffer format][string][0 terminator]
@@ -214,7 +214,7 @@ pub struct Smb1ResponseRecordTreeConnectAndX<'a> {
 }
 
 pub fn parse_smb_connect_tree_andx_response_record(i: &[u8])
-    -> IResult<&[u8], Smb1ResponseRecordTreeConnectAndX> {
+    -> IResult<&[u8], Smb1ResponseRecordTreeConnectAndX<'_>> {
     let (i, wct) = le_u8(i)?;
     let (i, _andx_command) = le_u8(i)?;
     let (i, _) = take(1_usize)(i)?; // reserved
@@ -267,7 +267,7 @@ pub struct SmbPipeProtocolRecord<'a> {
 }
 
 pub fn parse_smb_trans_request_record_pipe(i: &[u8])
-    -> IResult<&[u8], SmbPipeProtocolRecord, SmbError> {
+    -> IResult<&[u8], SmbPipeProtocolRecord<'_>, SmbError> {
     let (i, fun) = le_u16(i)?;
     let (i, fid) = take(2_usize)(i)?;
     let record = SmbPipeProtocolRecord {
@@ -289,7 +289,7 @@ pub struct SmbRecordTransRequestParams<> {
 }
 
 pub fn parse_smb_trans_request_record_params(i: &[u8])
-    -> IResult<&[u8], (SmbRecordTransRequestParams, Option<SmbPipeProtocolRecord>), SmbError>
+    -> IResult<&[u8], (SmbRecordTransRequestParams, Option<SmbPipeProtocolRecord<'_>>), SmbError>
 {
    let (i, wct) = le_u8(i)?;
    let (i, _total_param_cnt) = le_u16(i)?;
@@ -327,7 +327,7 @@ pub struct SmbRecordTransRequestData<'a> {
 
 pub fn parse_smb_trans_request_record_data(i: &[u8],
         pad1: usize, param_cnt: u16, pad2: usize, data_len: u16)
-    -> IResult<&[u8], SmbRecordTransRequestData, SmbError>
+    -> IResult<&[u8], SmbRecordTransRequestData<'_>, SmbError>
 {
     let (i, _) = take(pad1)(i)?;
     let (i, _) = take(param_cnt)(i)?;
@@ -395,7 +395,7 @@ pub struct SmbRecordTransResponse<'a> {
     pub data: &'a[u8],
 }
 
-pub fn parse_smb_trans_response_error_record(i: &[u8]) -> IResult<&[u8], SmbRecordTransResponse> {
+pub fn parse_smb_trans_response_error_record(i: &[u8]) -> IResult<&[u8], SmbRecordTransResponse<'_>> {
    let (i, _wct) = le_u8(i)?;
    let (i, bcc) = le_u16(i)?;
    let resp = SmbRecordTransResponse {
@@ -406,7 +406,7 @@ pub fn parse_smb_trans_response_error_record(i: &[u8]) -> IResult<&[u8], SmbReco
    Ok((i, resp))
 }
 
-pub fn parse_smb_trans_response_regular_record(i: &[u8]) -> IResult<&[u8], SmbRecordTransResponse> {
+pub fn parse_smb_trans_response_regular_record(i: &[u8]) -> IResult<&[u8], SmbRecordTransResponse<'_>> {
    let (i, wct) = le_u8(i)?;
    let (i, _total_param_cnt) = le_u16(i)?;
    let (i, _total_data_count) = le_u16(i)?;
@@ -434,7 +434,7 @@ pub fn parse_smb_trans_response_regular_record(i: &[u8]) -> IResult<&[u8], SmbRe
    Ok((i, resp))
 }
 
-pub fn parse_smb_trans_response_record(i: &[u8]) -> IResult<&[u8], SmbRecordTransResponse> {
+pub fn parse_smb_trans_response_record(i: &[u8]) -> IResult<&[u8], SmbRecordTransResponse<'_>> {
     let (i, wct) = peek(le_u8)(i)?;
     match wct {
         0 => parse_smb_trans_response_error_record(i),
@@ -447,7 +447,7 @@ pub struct SmbRecordSetupAndX<'a> {
     pub sec_blob: &'a[u8],
 }
 
-pub fn parse_smb_setup_andx_record(i: &[u8]) -> IResult<&[u8], SmbRecordSetupAndX> {
+pub fn parse_smb_setup_andx_record(i: &[u8]) -> IResult<&[u8], SmbRecordSetupAndX<'_>> {
     let (i, _skip1) = take(15_usize)(i)?;
     let (i, sec_blob_len) = le_u16(i)?;
     let (i, _skip2) = take(8_usize)(i)?;
@@ -462,7 +462,7 @@ pub struct SmbResponseRecordSetupAndX<'a> {
     pub sec_blob: &'a[u8],
 }
 
-fn response_setup_andx_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecordSetupAndX> {
+fn response_setup_andx_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecordSetupAndX<'_>> {
    let (i, _skip1) = take(7_usize)(i)?;
    let (i, sec_blob_len) = le_u16(i)?;
    let (i, _bcc) = le_u16(i)?;
@@ -471,7 +471,7 @@ fn response_setup_andx_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecordSetup
    Ok((i, record))
 }
 
-fn response_setup_andx_wct3_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecordSetupAndX> {
+fn response_setup_andx_wct3_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecordSetupAndX<'_>> {
    let (i, _skip1) = take(7_usize)(i)?;
    let (i, _bcc) = le_u16(i)?;
    let record = SmbResponseRecordSetupAndX {
@@ -480,7 +480,7 @@ fn response_setup_andx_wct3_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecord
    Ok((i, record))
 }
 
-fn response_setup_andx_error_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecordSetupAndX> {
+fn response_setup_andx_error_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecordSetupAndX<'_>> {
    let (i, _wct) = le_u8(i)?;
    let (i, _bcc) = le_u16(i)?;
    let record = SmbResponseRecordSetupAndX {
@@ -489,7 +489,7 @@ fn response_setup_andx_error_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecor
    Ok((i, record))
 }
 
-pub fn parse_smb_response_setup_andx_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecordSetupAndX> {
+pub fn parse_smb_response_setup_andx_record(i: &[u8]) -> IResult<&[u8], SmbResponseRecordSetupAndX<'_>> {
     let (i, wct) = peek(le_u8)(i)?;
     match wct {
         0 => response_setup_andx_error_record(i),
@@ -505,7 +505,7 @@ pub struct SmbRequestReadAndXRecord<'a> {
     pub offset: u64,
 }
 
-pub fn parse_smb_read_andx_request_record(i: &[u8]) -> IResult<&[u8], SmbRequestReadAndXRecord> {
+pub fn parse_smb_read_andx_request_record(i: &[u8]) -> IResult<&[u8], SmbRequestReadAndXRecord<'_>> {
     let (i, wct) = le_u8(i)?;
     let (i, _andx_command) = le_u8(i)?;
     let (i, _) = take(1_usize)(i)?; // reserved
@@ -531,7 +531,7 @@ pub struct SmbResponseReadAndXRecord<'a> {
     pub data: &'a[u8],
 }
 
-pub fn parse_smb_read_andx_response_record(i: &[u8]) -> IResult<&[u8], SmbResponseReadAndXRecord> {
+pub fn parse_smb_read_andx_response_record(i: &[u8]) -> IResult<&[u8], SmbResponseReadAndXRecord<'_>> {
     let (i, wct) = le_u8(i)?;
     let (i, _andx_command) = le_u8(i)?;
     let (i, _) = take(1_usize)(i)?; // reserved
@@ -630,7 +630,7 @@ pub struct Trans2RecordParamSetFileInfo<'a> {
     pub loi: u16,
 }
 
-pub fn parse_trans2_request_params_set_file_info(i: &[u8]) -> IResult<&[u8], Trans2RecordParamSetFileInfo> {
+pub fn parse_trans2_request_params_set_file_info(i: &[u8]) -> IResult<&[u8], Trans2RecordParamSetFileInfo<'_>> {
     let (i, fid) = take(2_usize)(i)?;
     let (i, loi) = le_u16(i)?;
     let record = Trans2RecordParamSetFileInfo { fid, loi };
@@ -643,7 +643,7 @@ pub struct Trans2RecordParamSetFileInfoRename<'a> {
     pub newname: &'a[u8],
 }
 
-pub fn parse_trans2_request_data_set_file_info_rename(i: &[u8]) -> IResult<&[u8], Trans2RecordParamSetFileInfoRename> {
+pub fn parse_trans2_request_data_set_file_info_rename(i: &[u8]) -> IResult<&[u8], Trans2RecordParamSetFileInfoRename<'_>> {
     let (i, replace) = le_u8(i)?;
     let (i, _reserved) = take(3_usize)(i)?;
     let (i, _root_dir) = take(4_usize)(i)?;
@@ -676,7 +676,7 @@ pub struct Trans2RecordParamSetPathInfoRename<'a> {
     pub newname: &'a[u8],
 }
 
-pub fn parse_trans2_request_data_set_path_info_rename(i: &[u8]) -> IResult<&[u8], Trans2RecordParamSetPathInfoRename> {
+pub fn parse_trans2_request_data_set_path_info_rename(i: &[u8]) -> IResult<&[u8], Trans2RecordParamSetPathInfoRename<'_>> {
     let (i, replace) = le_u8(i)?;
     let (i, _reserved) = take(3_usize)(i)?;
     let (i, _root_dir) = take(4_usize)(i)?;
@@ -696,7 +696,7 @@ pub struct SmbRequestTrans2Record<'a> {
     pub data_blob: &'a[u8],
 }
 
-pub fn parse_smb_trans2_request_record(i: &[u8]) -> IResult<&[u8], SmbRequestTrans2Record> {
+pub fn parse_smb_trans2_request_record(i: &[u8]) -> IResult<&[u8], SmbRequestTrans2Record<'_>> {
     let (i, _wct) = le_u8(i)?;
     let (i, _total_param_cnt) = le_u16(i)?;
     let (i, _total_data_cnt) = le_u16(i)?;
@@ -742,7 +742,7 @@ pub struct SmbResponseCreateAndXRecord<'a> {
     pub file_size: u64,
 }
 
-pub fn parse_smb_create_andx_response_record(i: &[u8]) -> IResult<&[u8], SmbResponseCreateAndXRecord> {
+pub fn parse_smb_create_andx_response_record(i: &[u8]) -> IResult<&[u8], SmbResponseCreateAndXRecord<'_>> {
     let (i, wct) = le_u8(i)?;
     let (i, _andx_command) = le_u8(i)?;
     let (i, _) = take(1_usize)(i)?; // reserved
@@ -778,7 +778,7 @@ pub struct SmbRequestCloseRecord<'a> {
     pub fid: &'a[u8],
 }
 
-pub fn parse_smb1_close_request_record(i: &[u8]) -> IResult<&[u8], SmbRequestCloseRecord> {
+pub fn parse_smb1_close_request_record(i: &[u8]) -> IResult<&[u8], SmbRequestCloseRecord<'_>> {
     let (i, _) = take(1_usize)(i)?;
     let (i, fid) = take(2_usize)(i)?;
     let record = SmbRequestCloseRecord {
@@ -833,7 +833,7 @@ impl SmbRecord<'_> {
     }
 }
 
-pub fn parse_smb_record(i: &[u8]) -> IResult<&[u8], SmbRecord> {
+pub fn parse_smb_record(i: &[u8]) -> IResult<&[u8], SmbRecord<'_>> {
     let (i, _) = tag(b"\xffSMB")(i)?;
     let (i, command) = le_u8(i)?;
     let (i, nt_status) = le_u32(i)?;

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -32,7 +32,7 @@ pub struct Smb2SecBlobRecord<'a> {
     pub data: &'a [u8],
 }
 
-pub fn parse_smb2_sec_blob(i: &[u8]) -> IResult<&[u8], Smb2SecBlobRecord> {
+pub fn parse_smb2_sec_blob(i: &[u8]) -> IResult<&[u8], Smb2SecBlobRecord<'_>> {
     let (i, data) = rest(i)?;
     Ok((i, Smb2SecBlobRecord { data }))
 }
@@ -94,7 +94,7 @@ fn parse_smb2_flags(i: &[u8]) -> IResult<&[u8], SmbFlags> {
     ))
 }
 
-pub fn parse_smb2_request_record(i: &[u8]) -> IResult<&[u8], Smb2Record> {
+pub fn parse_smb2_request_record(i: &[u8]) -> IResult<&[u8], Smb2Record<'_>> {
     let (i, _server_component) = tag(b"\xfeSMB")(i)?;
     let (i, hlen) = le_u16(i)?;
     let (i, _credit_charge) = le_u16(i)?;
@@ -136,7 +136,7 @@ pub struct Smb2NegotiateProtocolRequestRecord<'a> {
 
 pub fn parse_smb2_request_negotiate_protocol(
     i: &[u8],
-) -> IResult<&[u8], Smb2NegotiateProtocolRequestRecord> {
+) -> IResult<&[u8], Smb2NegotiateProtocolRequestRecord<'_>> {
     let (i, _struct_size) = take(2_usize)(i)?;
     let (i, dialects_count) = le_u16(i)?;
     let (i, _sec_mode) = le_u16(i)?;
@@ -165,7 +165,7 @@ pub struct Smb2NegotiateProtocolResponseRecord<'a> {
 
 pub fn parse_smb2_response_negotiate_protocol(
     i: &[u8],
-) -> IResult<&[u8], Smb2NegotiateProtocolResponseRecord> {
+) -> IResult<&[u8], Smb2NegotiateProtocolResponseRecord<'_>> {
     let (i, _struct_size) = take(2_usize)(i)?;
     let (i, _skip1) = take(2_usize)(i)?;
     let (i, dialect) = le_u16(i)?;
@@ -187,7 +187,7 @@ pub fn parse_smb2_response_negotiate_protocol(
 
 pub fn parse_smb2_response_negotiate_protocol_error(
     i: &[u8],
-) -> IResult<&[u8], Smb2NegotiateProtocolResponseRecord> {
+) -> IResult<&[u8], Smb2NegotiateProtocolResponseRecord<'_>> {
     let (i, _struct_size) = take(2_usize)(i)?;
     let (i, _skip1) = take(2_usize)(i)?;
     let record = Smb2NegotiateProtocolResponseRecord {
@@ -205,7 +205,7 @@ pub struct Smb2SessionSetupRequestRecord<'a> {
     pub data: &'a [u8],
 }
 
-pub fn parse_smb2_request_session_setup(i: &[u8]) -> IResult<&[u8], Smb2SessionSetupRequestRecord> {
+pub fn parse_smb2_request_session_setup(i: &[u8]) -> IResult<&[u8], Smb2SessionSetupRequestRecord<'_>> {
     let (i, _struct_size) = take(2_usize)(i)?;
     let (i, _flags) = le_u8(i)?;
     let (i, _security_mode) = le_u8(i)?;
@@ -224,7 +224,7 @@ pub struct Smb2TreeConnectRequestRecord<'a> {
     pub share_name: &'a [u8],
 }
 
-pub fn parse_smb2_request_tree_connect(i: &[u8]) -> IResult<&[u8], Smb2TreeConnectRequestRecord> {
+pub fn parse_smb2_request_tree_connect(i: &[u8]) -> IResult<&[u8], Smb2TreeConnectRequestRecord<'_>> {
     let (i, _struct_size) = take(2_usize)(i)?;
     let (i, _offset_length) = take(4_usize)(i)?;
     let (i, data) = rest(i)?;
@@ -254,7 +254,7 @@ pub struct Smb2CreateRequestRecord<'a> {
     pub data: &'a [u8],
 }
 
-pub fn parse_smb2_request_create(i: &[u8]) -> IResult<&[u8], Smb2CreateRequestRecord> {
+pub fn parse_smb2_request_create(i: &[u8]) -> IResult<&[u8], Smb2CreateRequestRecord<'_>> {
     let (i, _skip1) = take(36_usize)(i)?;
     let (i, disposition) = le_u32(i)?;
     let (i, create_options) = le_u32(i)?;
@@ -279,7 +279,7 @@ pub struct Smb2IOCtlRequestRecord<'a> {
     pub data: &'a [u8],
 }
 
-pub fn parse_smb2_request_ioctl(i: &[u8]) -> IResult<&[u8], Smb2IOCtlRequestRecord> {
+pub fn parse_smb2_request_ioctl(i: &[u8]) -> IResult<&[u8], Smb2IOCtlRequestRecord<'_>> {
     let (i, _skip) = take(2_usize)(i)?; // structure size
     let (i, _) = take(2_usize)(i)?; // reserved
     let (i, func) = le_u32(i)?;
@@ -311,7 +311,7 @@ pub struct Smb2IOCtlResponseRecord<'a> {
     pub outdata_offset: u32,
 }
 
-pub fn parse_smb2_response_ioctl(i: &[u8]) -> IResult<&[u8], Smb2IOCtlResponseRecord> {
+pub fn parse_smb2_response_ioctl(i: &[u8]) -> IResult<&[u8], Smb2IOCtlResponseRecord<'_>> {
     let (i, _skip) = take(2_usize)(i)?; // structure size
     let (i, _) = take(2_usize)(i)?; // reserved
     let (i, func) = le_u32(i)?;
@@ -340,7 +340,7 @@ pub struct Smb2CloseRequestRecord<'a> {
     pub guid: &'a [u8],
 }
 
-pub fn parse_smb2_request_close(i: &[u8]) -> IResult<&[u8], Smb2CloseRequestRecord> {
+pub fn parse_smb2_request_close(i: &[u8]) -> IResult<&[u8], Smb2CloseRequestRecord<'_>> {
     let (i, _skip) = take(8_usize)(i)?;
     let (i, guid) = take(16_usize)(i)?;
     let record = Smb2CloseRequestRecord { guid };
@@ -352,7 +352,7 @@ pub struct Smb2SetInfoRequestRenameRecord<'a> {
     pub name: &'a [u8],
 }
 
-pub fn parse_smb2_request_setinfo_rename(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestData> {
+pub fn parse_smb2_request_setinfo_rename(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestData<'_>> {
     let (i, _replace) = le_u8(i)?;
     let (i, _reserved) = take(7_usize)(i)?;
     let (i, _root_handle) = take(8_usize)(i)?;
@@ -367,7 +367,7 @@ pub struct Smb2SetInfoRequestDispoRecord {
     pub delete: bool,
 }
 
-pub fn parse_smb2_request_setinfo_disposition(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestData> {
+pub fn parse_smb2_request_setinfo_disposition(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestData<'_>> {
     let (i, info) = le_u8(i)?;
     let record = Smb2SetInfoRequestData::DISPOSITION(Smb2SetInfoRequestDispoRecord {
         delete: info & 1 != 0,
@@ -392,7 +392,7 @@ pub struct Smb2SetInfoRequestRecord<'a> {
 
 fn parse_smb2_request_setinfo_data(
     i: &[u8], class: u8, infolvl: u8,
-) -> IResult<&[u8], Smb2SetInfoRequestData> {
+) -> IResult<&[u8], Smb2SetInfoRequestData<'_>> {
     if class == 1 {
         // constants from [MS-FSCC] section 2.4
         match infolvl {
@@ -408,7 +408,7 @@ fn parse_smb2_request_setinfo_data(
     return Ok((i, Smb2SetInfoRequestData::UNHANDLED));
 }
 
-pub fn parse_smb2_request_setinfo(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestRecord> {
+pub fn parse_smb2_request_setinfo(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestRecord<'_>> {
     let (i, _struct_size) = le_u16(i)?;
     let (i, class) = le_u8(i)?;
     let (i, infolvl) = le_u8(i)?;
@@ -438,7 +438,7 @@ pub struct Smb2WriteRequestRecord<'a> {
 }
 
 // can be called on incomplete records
-pub fn parse_smb2_request_write(i: &[u8]) -> IResult<&[u8], Smb2WriteRequestRecord> {
+pub fn parse_smb2_request_write(i: &[u8]) -> IResult<&[u8], Smb2WriteRequestRecord<'_>> {
     let (i, _skip1) = take(4_usize)(i)?;
     let (i, wr_len) = le_u32(i)?;
     let (i, wr_offset) = le_u64(i)?;
@@ -464,7 +464,7 @@ pub struct Smb2ReadRequestRecord<'a> {
     pub guid: &'a [u8],
 }
 
-pub fn parse_smb2_request_read(i: &[u8]) -> IResult<&[u8], Smb2ReadRequestRecord> {
+pub fn parse_smb2_request_read(i: &[u8]) -> IResult<&[u8], Smb2ReadRequestRecord<'_>> {
     let (i, _skip1) = take(4_usize)(i)?;
     let (i, rd_len) = le_u32(i)?;
     let (i, rd_offset) = le_u64(i)?;
@@ -499,7 +499,7 @@ fn parse_smb2_data(i: &[u8], len: u32) -> IResult<&[u8], &[u8]> {
 }
 
 // can be called on incomplete records
-pub fn parse_smb2_response_read(i: &[u8]) -> IResult<&[u8], Smb2ReadResponseRecord> {
+pub fn parse_smb2_response_read(i: &[u8]) -> IResult<&[u8], Smb2ReadResponseRecord<'_>> {
     let (i, _struct_size) = le_u16(i)?;
     let (i, _data_offset) = le_u16(i)?;
     let (i, rd_len) = le_u32(i)?;
@@ -520,7 +520,7 @@ pub struct Smb2CreateResponseRecord<'a> {
     pub size: u64,
 }
 
-pub fn parse_smb2_response_create(i: &[u8]) -> IResult<&[u8], Smb2CreateResponseRecord> {
+pub fn parse_smb2_response_create(i: &[u8]) -> IResult<&[u8], Smb2CreateResponseRecord<'_>> {
     let (i, _ssize) = le_u16(i)?;
     let (i, _oplock) = le_u8(i)?;
     let (i, _resp_flags) = le_u8(i)?;
@@ -559,7 +559,7 @@ pub fn parse_smb2_response_write(i: &[u8]) -> IResult<&[u8], Smb2WriteResponseRe
     Ok((i, record))
 }
 
-pub fn parse_smb2_response_record(i: &[u8]) -> IResult<&[u8], Smb2Record> {
+pub fn parse_smb2_response_record(i: &[u8]) -> IResult<&[u8], Smb2Record<'_>> {
     let (i, _) = tag(b"\xfeSMB")(i)?;
     let (i, hlen) = le_u16(i)?;
     let (i, _credit_charge) = le_u16(i)?;

--- a/rust/src/smb/smb3.rs
+++ b/rust/src/smb/smb3.rs
@@ -26,7 +26,7 @@ pub struct Smb3TransformRecord<'a> {
     pub enc_data: &'a[u8],
 }
 
-pub fn parse_smb3_transform_record(i: &[u8]) -> IResult<&[u8], Smb3TransformRecord> {
+pub fn parse_smb3_transform_record(i: &[u8]) -> IResult<&[u8], Smb3TransformRecord<'_>> {
     let (i, _) = tag(b"\xfdSMB")(i)?;
     let (i, _signature) = take(16_usize)(i)?;
     let (i, _nonce) = take(16_usize)(i)?;

--- a/rust/src/snmp/log.rs
+++ b/rust/src/snmp/log.rs
@@ -22,7 +22,7 @@ use crate::snmp::snmp::SNMPTransaction;
 use crate::snmp::snmp_parser::{NetworkAddress,PduType};
 use std::borrow::Cow;
 
-fn str_of_pdu_type(t:&PduType) -> Cow<str> {
+fn str_of_pdu_type(t:&PduType) -> Cow<'_, str> {
     match t {
         &PduType::GetRequest => Cow::Borrowed("get_request"),
         &PduType::GetNextRequest => Cow::Borrowed("get_next_request"),

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -209,7 +209,7 @@ impl<'a> SNMPState<'a> {
         SNMPTransaction::new(direction, self.version, self.tx_id)
     }
 
-    fn get_tx_by_id(&mut self, tx_id: u64) -> Option<&SNMPTransaction> {
+    fn get_tx_by_id(&mut self, tx_id: u64) -> Option<&SNMPTransaction<'_>> {
         self.transactions.iter().rev().find(|&tx| tx.id == tx_id + 1)
     }
 

--- a/rust/src/ssh/parser.rs
+++ b/rust/src/ssh/parser.rs
@@ -92,7 +92,7 @@ pub struct SshBanner<'a> {
 
 // Could be simplified adding dummy \n at the end
 // or use nom5 nom::bytes::complete::is_not
-pub fn ssh_parse_banner(i: &[u8]) -> IResult<&[u8], SshBanner> {
+pub fn ssh_parse_banner(i: &[u8]) -> IResult<&[u8], SshBanner<'_>> {
     let (i, _) = tag("SSH-")(i)?;
     let (i, protover) = is_not("-")(i)?;
     let (i, _) = char('-')(i)?;
@@ -207,7 +207,7 @@ fn parse_string(i: &[u8]) -> IResult<&[u8], &[u8]> {
     length_data(be_u32)(i)
 }
 
-pub fn ssh_parse_key_exchange(i: &[u8]) -> IResult<&[u8], SshPacketKeyExchange> {
+pub fn ssh_parse_key_exchange(i: &[u8]) -> IResult<&[u8], SshPacketKeyExchange<'_>> {
     let (i, cookie) = take(16_usize)(i)?;
     let (i, kex_algs) = parse_string(i)?;
     let (i, server_host_key_algs) = parse_string(i)?;

--- a/rust/src/telnet/parser.rs
+++ b/rust/src/telnet/parser.rs
@@ -53,7 +53,7 @@ pub fn parse_ctl_message(oi: &[u8]) -> IResult<&[u8], &[u8]> {
     Ok((i, d))
 }
 
-pub fn parse_message(i: &[u8]) -> IResult<&[u8], TelnetMessageType> {
+pub fn parse_message(i: &[u8]) -> IResult<&[u8], TelnetMessageType<'_>> {
     let (i, v) = peek(le_u8)(i)?;
     if v == b'\xff' {
         let (i, c) = parse_ctl_message(i)?;
@@ -65,7 +65,7 @@ pub fn parse_message(i: &[u8]) -> IResult<&[u8], TelnetMessageType> {
 }
 
 // 'login: ', 'Password: ', possibly with leading ctls
-pub fn parse_welcome_message(i: &[u8]) -> IResult<&[u8], TelnetMessageType> {
+pub fn parse_welcome_message(i: &[u8]) -> IResult<&[u8], TelnetMessageType<'_>> {
     let (i, v) = peek(le_u8)(i)?;
     if v == b'\xff' {
         let (i, c) = parse_ctl_message(i)?;


### PR DESCRIPTION
Fix new warning present in Rust 1.89, for example:

warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/ike/parser.rs:295:30
295 | pub fn parse_key_exchange(i: &[u8], length: u16) -> IResult<&[u8], KeyExchangePayload> {
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
