### PR TITLE
misc: add rust analyzer and sphinx to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,8 @@ in with pkgs;
       cargo
       rustc
       rust-cbindgen
+      rust-analyzer
+      tree-sitter-grammars.tree-sitter-rust
       clang
       libclang.python
       libllvm
@@ -34,6 +36,7 @@ in with pkgs;
       pcre2
       vectorscan
       zlib
+      sphinx
     ];
 
     # the following is needed to be able to build ebpf files


### PR DESCRIPTION
This allows to have the LSP server present and permits to build the documentation.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- add sphinx for documentation build
- add rust analyzer and tree sitter rust plugin

