### PR TITLE
decode/ipv6: set packet flow in ip-in-ip - 70x backports - v4

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2811,6 +2811,25 @@ The stats counter `decoder.ipv4_in_ipv4` is associated with this setting.
    #     enabled: true
    #     track-parent-flow: true   # disabled by default
 
+IPv6
+^^^^
+
+By default, for IPv4 over IPv6 tunneling, the parent flow is not set up, as this
+can lead to discrepancies in alerts and flows detected. To enable this setting,
+change::
+
+    decoder:
+      ipv6:
+        ipip-ipv4:
+          track-parent-flow: true
+
+The same is true for IPv6 over IPv6. To enable parent flow setting in this case::
+
+    decoder:
+      ipv6:
+        ipip-ipv6:
+          track-parent-flow: true
+
 Advanced Options
 ----------------
 

--- a/src/decode-ipv6.h
+++ b/src/decode-ipv6.h
@@ -240,6 +240,8 @@ typedef struct IPV6ExtHdrs_
 #define IPV6_EXTHDR_SET_RH(p)       (p)->ip6eh.rh_set = true
 #define IPV6_EXTHDR_ISSET_RH(p)     (p)->ip6eh.rh_set
 
+void DecodeIPV4InIPV6Config(void);
+void DecodeIPV6InIPV6Config(void);
 void DecodeIPV6RegisterTests(void);
 
 #endif /* __DECODE_IPV6_H__ */

--- a/src/decode.c
+++ b/src/decode.c
@@ -921,6 +921,8 @@ void CaptureStatsSetup(ThreadVars *tv)
 void DecodeGlobalConfig(void)
 {
     DecodeIPV4IpInIpConfig();
+    DecodeIPV4InIPV6Config();
+    DecodeIPV6InIPV6Config();
     DecodeTeredoConfig();
     DecodeGeneveConfig();
     DecodeVXLANConfig();

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1679,6 +1679,15 @@ decoder:
   #   ipip:
   #     enabled: true
   #     track-parent-flow: true   # disabled by default
+  # Set parent flow for packets seen in IP-in-IP tunneling for ipv4 or ipv6
+  # over ipv6.
+  # Disabled by default, as these will impact number of alerts seen, as well as
+  # number of flows.
+  # ipv6:
+  #   ipip-ipv4:
+  #     track-parent-flow: true   # disabled by default
+  #   ipip-ipv6:
+  #     track-parent-flow: true   # disabled by default
 
 ##
 ## Performance tuning and profiling


### PR DESCRIPTION
Based on cherry-picked commit, but adjusted to make changes optional.

Bug https://github.com/OISF/suricata/pull/7752

(cherry picked from commit https://github.com/OISF/suricata/commit/fdf0fa30c6479139e68d2549ece36c3f683d78e4)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7777
https://redmine.openinfosecfoundation.org/issues/7752

Previous PR: https://github.com/OISF/suricata/pull/13717

Describe changes:
- fix bug in ipv6-ipv6 setting initialization
- fix typo

Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2601