### PR TITLE
detect/mt: Prevent deadlock when adding tenants 

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -274,7 +274,7 @@ void DetectAppLayerInspectEngineRegister(const char *name, AppProto alproto, uin
         int progress, InspectEngineFuncPtr Callback, InspectionBufferGetDataPtr GetData)
 {
     /* before adding, check that we don't add a duplicate entry, which will
-     * propegate all the way into the packet runtime if allowed. */
+     * propagate all the way into the packet runtime if allowed. */
     DetectEngineAppInspectionEngine *t = g_app_inspect_engines;
     while (t != NULL) {
         const uint32_t t_direction = t->dir == 0 ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;
@@ -296,7 +296,7 @@ void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alprot
         int progress, InspectEngineFuncPtr Callback, InspectionSingleBufferGetDataPtr GetData)
 {
     /* before adding, check that we don't add a duplicate entry, which will
-     * propegate all the way into the packet runtime if allowed. */
+     * propagate all the way into the packet runtime if allowed. */
     DetectEngineAppInspectionEngine *t = g_app_inspect_engines;
     while (t != NULL) {
         const uint32_t t_direction = t->dir == 0 ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;


### PR DESCRIPTION
Continuation of #13719 

This commit modifies the call path for registering MT tenants to avoid deadlocks on the `master->lock`

When performing tenant operations, e.g., using `suricatasc` to send a `register-tenant` command, a deadlock occurs when
- `DetectEngineMTApply`: acquires `master->lock`
- Calls `DetectEngineReloadThreads`
- Within `DetectEngineReloadThreads`, calls `DetectEngineMultiTenantEnabled`
- Which first acquires `master->lock`

Commit 2bea5af2c8d introduced changes to the `master->lock` usage leading to the deadlock situation.

Issue: 7819

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7819

Describe changes:
- Move lock acquisition so master->lock is held when calling DetectEngineThreadCtxInitForMT

Updates:
- Address review comments (see #13680 )
- Include a brief description of how deadlock occurs
- Update commit message with additional context and hash where behavior changed.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
