### PR TITLE
detect/from_base64: Support keyword w/no opts

### DIFF
--- a/rust/src/detect/transforms/base64.rs
+++ b/rust/src/detect/transforms/base64.rs
@@ -191,7 +191,8 @@ fn parse_transform_base64(
 
 unsafe fn base64_parse(c_arg: *const c_char) -> *mut DetectTransformFromBase64Data {
     if c_arg.is_null() {
-        return std::ptr::null_mut();
+        let detect = DetectTransformFromBase64Data::default();
+        return Box::into_raw(Box::new(detect));
     }
 
     if let Ok(arg) = CStr::from_ptr(c_arg).to_str() {


### PR DESCRIPTION
Issue: 7853

Support the use of `from_base64` with no optional values. In this case, the default values for:
- mode RFC4648
- offset: 0
- bytes: buffer size will be used.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7813

Describe changes:
- Create a default set of values when a NULL is passed to setup

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2618
SU_REPO=
SU_BRANCH=
