### PR TITLE
doc: fix flow timestamps() return value order in documentation

### DIFF
--- a/doc/userguide/lua/libs/flowlib.rst
+++ b/doc/userguide/lua/libs/flowlib.rst
@@ -29,7 +29,7 @@ Get timestamps of the first and the last packets from the flow, as seconds and
 microseconds since `1970-01-01 00:00:00` UTC, returning 4 numbers::
 
     f = flow.get()
-    local start_sec, start_usec, last_sec, last_usec = f:timestamps()
+    local start_sec, last_sec, start_usec, last_usec = f:timestamps()
 
 ``timestring_legacy``
 ^^^^^^^^^^^^^^^^^^^^^

--- a/doc/userguide/lua/libs/flowlib.rst
+++ b/doc/userguide/lua/libs/flowlib.rst
@@ -58,7 +58,7 @@ Ports and Addresses
 ~~~~~~~~~~~~~~~~~~~
 
 ``tuple``
-~~~~~~~~~
+^^^^^^^^^
 
 Using the `tuple` method, the IP version (4 or 6), src IP and dest IP (as
 string), IP protocol (int), and ports (ints) are retrieved.


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7854

Describe changes:
- Fixed incorrect return value order in flow timestamps documentation
  - According to `LuaFlowTimestamps()` in <a href='https://github.com/OISF/suricata/blob/master/src/util-lua-flowlib.c#L149'>src/util-lua-flowlib.c</a>, the function returns values in this order:
    1. start_sec (SCTIME_SECS(f->startts))
    2. last_sec (SCTIME_SECS(f->lastts))
    3. start_usec (SCTIME_USECS(f->startts))
    4. last_usec (SCTIME_USECS(f->lastts))
  - Updated documentation in <a href='https://github.com/OISF/suricata/blob/b93a27722c29e10f69ff32eadbd2964aa254000e/doc/userguide/lua/libs/flowlib.rst?plain=1#L32'>doc/userguide/lua/libs/flowlib.rst</a> to reflect the correct order: `start_sec, last_sec, start_usec,
  last_usec`
  - Previous documentation incorrectly showed: `start_sec, start_usec, last_sec, last_usec`

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
