### PR TITLE
detect/from_base64: Support keyword w/no opts

### DIFF
--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -246,11 +246,15 @@ The option values must be ``,`` separated and can appear in any order.
 Format::
 
     from_base64: [[bytes <value>] [, offset <offset_value> [, mode: strict|rfc4648|rfc2045]]]
+    from_base64
 
 There are defaults for each of the options:
 - ``bytes`` defaults to the length of the input buffer
 - ``offset`` defaults to ``0`` and must be less than ``65536``
 - ``mode`` defaults to ``rfc4648``
+
+The second example shows the rule keyword only which will cause the default values for each option to
+be used.
 
 Note that both ``bytes`` and ``offset`` may be variables from `byte_extract` and/or `byte_math` in
 later versions of Suricata. They are not supported yet.

--- a/rust/src/detect/transforms/base64.rs
+++ b/rust/src/detect/transforms/base64.rs
@@ -191,7 +191,8 @@ fn parse_transform_base64(
 
 unsafe fn base64_parse(c_arg: *const c_char) -> *mut DetectTransformFromBase64Data {
     if c_arg.is_null() {
-        return std::ptr::null_mut();
+        let detect = DetectTransformFromBase64Data::default();
+        return Box::into_raw(Box::new(detect));
     }
 
     if let Ok(arg) = CStr::from_ptr(c_arg).to_str() {


### PR DESCRIPTION
Continuation of #13726 

Issue: 7853

Support the use of `from_base64` with no optional values. In this case, the default values for:
- mode RFC4648
- offset: 0
- bytes: buffer size will be used.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7853

Describe changes:
- Create a default set of values when a NULL is passed to setup

Updates:
- Emphasized that the rule keyword w/out options can be specified.
- 
### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2618
SU_REPO=
SU_BRANCH=
