### PR TITLE
dpdk: fix parsing of DPDK EAL argument options

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -226,7 +226,7 @@ static char *AllocAndSetOption(const char *arg)
 
     ptr = AllocArgument(full_len);
     strlcpy(ptr, dash_prefix, full_len);
-    strlcat(ptr, arg, full_len);
+    strlcat(ptr, arg, full_len + 1);
     SCReturnPtr(ptr, "char *");
 }
 


### PR DESCRIPTION
The commit [4dfd44d](https://github.com/OISF/suricata/pull/13383/commits/4dfd44d350717476f435a0c49bd41c61ccc4bc1b) changed how the EAL options are parsed and effectively disabled passing the parameters to the rte_eal_init() function. Reverted this back to the previous version.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7856

Describe changes:
- increase the size argument of strlcat in AllocAndSetOption() function in src/runmode-dpdk.c to fix argument option parsing

