### PR TITLE
dpdk: fix parsing of DPDK EAL argument options - v2

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -226,7 +226,7 @@ static char *AllocAndSetOption(const char *arg)
 
     ptr = AllocArgument(full_len);
     strlcpy(ptr, dash_prefix, full_len);
-    strlcat(ptr, arg, full_len);
+    strlcat(ptr, arg, full_len + 1);
     SCReturnPtr(ptr, "char *");
 }
 


### PR DESCRIPTION
Fix parsing of DPDK EAL argument options taken from suricata.yaml.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7856

Changes since the last PR:
- Add description and ticket number to commit

Previous PR: #13735