### PR TITLE
engine/mt: Ensure master lock held for reload

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2312,6 +2312,7 @@ static void InjectPackets(
  *
  *  If called in unix socket mode, it's possible that we don't have
  *  detect threads yet.
+ *  NOTE: master MUST be locked before calling this
  *
  *  \retval -1 error
  *  \retval 0 no detection threads
@@ -4865,8 +4866,13 @@ int DetectEngineReload(const SCInstance *suri)
     DetectEngineDeReference(&old_de_ctx);
 
     SCLogDebug("going to reload the threads to use new_de_ctx %p", new_de_ctx);
+
+    DetectEngineMasterCtx *master = &g_master_de_ctx;
+    SCMutexLock(&master->lock);
     /* update the threads */
     DetectEngineReloadThreads(new_de_ctx);
+    SCMutexUnlock(&master->lock);
+
     SCLogDebug("threads now run new_de_ctx %p", new_de_ctx);
 
     /* walk free list, freeing the old_de_ctx */


### PR DESCRIPTION
Issue: 7819

DetectEngineReload must hold the `master->lock`; recent changes changed the locking usages to avoid deadlock when registering/handling tenants. These changes added the presumption that the master lock is held at a higher level. Coverity highlighted that the lock is not held consistently.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7819

Describe changes:
- The recent fix for MT related deadlocks placed a new requirement that DetectEngineReload must be called w/the master->lock held.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
