### PR TITLE
http: generate no anomaly for identity encoding

### DIFF
--- a/rust/htp/src/response.rs
+++ b/rust/htp/src/response.rs
@@ -1229,6 +1229,7 @@ impl ConnectionParser {
                                 HtpContentEncoding::Lzma
                             } else if encoding.cmp_slice(b"inflate") == Ordering::Equal
                                 || encoding.cmp_slice(b"none") == Ordering::Equal
+                                || encoding.cmp_slice(b"identity") == Ordering::Equal
                             {
                                 HtpContentEncoding::None
                             } else {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7843

Describe changes:
- http: generate no anomaly for identity encoding

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2624
