### PR TITLE
Flowbit ordering cyclic/v3

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -412,6 +412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +485,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -697,6 +709,15 @@ checksum = "2cf8413e5de78bcbc51880ff71f4b64105719abe6efb8b4b877d3c7dc494ddd1"
 dependencies = [
  "nom",
  "rusticata-macros",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1045,6 +1066,18 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "petgraph"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
+dependencies = [
+ "fixedbitset",
+ "hashbrown",
+ "indexmap",
+ "serde",
+]
 
 [[package]]
 name = "phf"
@@ -1524,6 +1557,7 @@ dependencies = [
  "hex",
  "hkdf",
  "ipsec-parser",
+ "itertools",
  "kerberos-parser",
  "lazy_static",
  "ldap-parser",
@@ -1537,6 +1571,7 @@ dependencies = [
  "num",
  "num-derive",
  "num-traits 0.2.19",
+ "petgraph",
  "psl",
  "regex",
  "sawp",

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -58,6 +58,9 @@ lru = "~0.12.5"
 der-parser = { version = "~9.0.0", default-features = false }
 kerberos-parser = { version = "~0.8.0", default-features = false }
 
+petgraph = "~0.8.2"
+itertools = "~0.14.0"
+
 sawp-modbus = "~0.13.1"
 sawp-pop3 = "~0.13.1"
 sawp = "~0.13.1"

--- a/rust/src/utils/flowbits_resolver.rs
+++ b/rust/src/utils/flowbits_resolver.rs
@@ -1,0 +1,256 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// Author: Shivani Bhardwaj <shivani@oisf.net>
+
+use itertools::iproduct;
+use petgraph::algo::is_cyclic_directed;
+use petgraph::graph::{GraphError, NodeIndex};
+use petgraph::stable_graph::StableDiGraph;
+use petgraph::visit::Bfs;
+use petgraph::Direction;
+use std::collections::HashMap;
+use std::os::raw::c_void;
+
+#[derive(Debug, Copy, Clone)]
+struct SCGNode {
+    iid: u32,        /* signature iid or flowbits iid */
+    ntype: bool,     /* node type: Signature (0), Flowbit (1) */
+    nidx: NodeIndex, /* Graph's internal node index */
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCCreateDirectedGraph() -> *mut c_void {
+    let graph: StableDiGraph<SCGNode, ()> = StableDiGraph::new();
+    let boxed_graph = Box::new(graph);
+    println!(
+        "sizeof(StableDiGraph): {:?}",
+        std::mem::size_of::<StableDiGraph<SCGNode, ()>>()
+    );
+    /* Make an opaque pointer for C as nothing is changed there */
+    return Box::into_raw(boxed_graph) as *mut c_void;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCFreeDirectedGraph(graph: *mut c_void) {
+    let _ = Box::from_raw(graph as *mut StableDiGraph<SCGNode, ()>);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCCreateNodeEdgeDirectedGraph(
+    graph: *mut c_void, iid: u32, ntype: bool, cmd: bool, sig_gid: u32,
+) -> i64 {
+    let g = &mut *(graph as *mut StableDiGraph<SCGNode, ()>);
+
+    let node_idx;
+    if let Some(nidx) = get_or_create_node(g, iid, ntype) {
+        node_idx = nidx;
+    } else {
+        SCLogError!("Error adding node; Graph is at full capacity");
+        return -2;
+    }
+
+    let sidx = NodeIndex::from(sig_gid);
+
+    if ntype {
+        /* flowbit type node */
+        if cmd {
+            /* WRITE command */
+            match g.try_update_edge(sidx, node_idx, ()) {
+                /* edge from signature to flowbit */
+                Ok(_) => {
+                    println!("Created an edge from {:?} -> {:?}", sidx, node_idx);
+                }
+                Err(GraphError::EdgeIxLimit) => {
+                    SCLogError!("Error adding edge; Graph is at full capacity");
+                    return -2;
+                }
+                Err(GraphError::NodeOutBounds) => {
+                    SCLogError!("Error adding edge; node does not exist");
+                    return -2;
+                }
+                Err(_) => {
+                    SCLogError!("Error adding edge to the Graph");
+                    return -2;
+                }
+            }
+        } else {
+            match g.try_update_edge(node_idx, sidx, ()) {
+                /* edge from flowbit to signature */
+                Ok(_) => {
+                    println!("Created an edge from {:?} -> {:?}", sidx, node_idx);
+                }
+                Err(GraphError::EdgeIxLimit) => {
+                    SCLogError!("Error adding edge; Graph is at full capacity");
+                    return -2;
+                }
+                Err(GraphError::NodeOutBounds) => {
+                    SCLogError!("Error adding edge; node does not exist");
+                    return -2;
+                }
+                Err(_) => {
+                    SCLogError!("Error adding edge to the Graph");
+                    return -2;
+                }
+            }
+        }
+    }
+
+    println!("node count: {:?}", g.node_count());
+    node_idx.index() as i64
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCResolveFlowbitDependencies(
+    graph: *mut c_void, sorted_sid_list: *mut u32, sorted_sid_list_len: u32,
+) {
+    let g = &mut *(graph as *mut StableDiGraph<SCGNode, ()>);
+
+    println!("Indices in the graph:");
+    for i in g.node_indices() {
+        println!("idx: {:?}", i);
+    }
+    for nd in g.node_weights() {
+        println!("The beginning node: {:?}", nd);
+    }
+
+    debug_validate_bug_on!(g.node_count() == 0);
+
+    normalize_graph(g);
+    let sorted_sid_list =
+        std::slice::from_raw_parts_mut(&mut *sorted_sid_list, sorted_sid_list_len as usize);
+
+    // No need for all the extra work if there's just one node
+    if g.node_count() == 1 {
+        debug_validate_bug_on!(sorted_sid_list_len != 1);
+        sorted_sid_list[0] = g[NodeIndex::from(0)].iid;
+        return;
+    }
+
+    if is_cyclic_directed(&g.clone()) {
+        println!("CYCLE");
+        return;
+    }
+    bfs_tree_dag(g, sorted_sid_list);
+}
+
+fn get_or_create_node(
+    g: &mut StableDiGraph<SCGNode, ()>, iid: u32, ntype: bool,
+) -> Option<NodeIndex> {
+    for node in g.node_weights() {
+        if node.iid == iid && node.ntype == ntype {
+            return Some(node.nidx);
+        }
+    }
+    let nd = SCGNode {
+        iid,
+        ntype,
+        nidx: NodeIndex::from(u32::MAX),
+    };
+    if let Ok(idx) = g.try_add_node(nd) {
+        g[idx].nidx = idx;
+        println!("Created node: {:?}", g[idx]);
+        return Some(idx);
+    }
+
+    None
+}
+
+fn normalize_graph(g: &mut StableDiGraph<SCGNode, ()>) {
+    let mut map_new_edges: Vec<(NodeIndex, NodeIndex)> = Vec::new();
+    let mut fb_nodes_list: Vec<SCGNode> = Vec::new();
+
+    for nd in g.node_weights() {
+        println!("Pre normalized node: {:?}", nd);
+    }
+
+    for nd in g.node_weights() {
+        if nd.ntype {
+            let in_edges: Vec<NodeIndex> =
+                g.neighbors_directed(nd.nidx, Direction::Incoming).collect();
+
+            let out_edges: Vec<NodeIndex> =
+                g.neighbors_directed(nd.nidx, Direction::Outgoing).collect();
+
+            let map_edges_curnode: Vec<(NodeIndex, NodeIndex)> =
+                iproduct!(in_edges, out_edges).collect();
+            map_new_edges.extend(map_edges_curnode);
+            fb_nodes_list.push(*nd);
+        }
+    }
+
+    for (from, to) in map_new_edges {
+        if from != to && g.find_edge(from, to).is_none() {
+            println!("map_new_edges -- from: {:?}; to: {:?}", from, to);
+            g.add_edge(from, to, ());
+        }
+    }
+
+    for node in fb_nodes_list {
+        println!("Removing node {:?}", node);
+        g.remove_node(node.nidx);
+    }
+}
+
+fn calculate_in_degree_nodes(
+    g: &mut StableDiGraph<SCGNode, ()>, in_degrees: &mut HashMap<NodeIndex, usize>,
+) {
+    for node_idx in g.node_indices() {
+        let in_degree = g.neighbors_directed(node_idx, Direction::Incoming).count();
+        println!("in_degree for node {:?}: {:?}", g[node_idx], in_degree);
+        in_degrees.insert(node_idx, in_degree);
+    }
+}
+
+fn bfs_tree_dag(g: &mut StableDiGraph<SCGNode, ()>, sorted_sid_list: &mut [u32]) {
+    let mut in_degrees: HashMap<NodeIndex, usize> = HashMap::new();
+    calculate_in_degree_nodes(g, &mut in_degrees);
+
+    let nidx;
+    if let Some(idx) = get_or_create_node(g, u32::MAX, false) {
+        nidx = idx;
+    } else {
+        SCLogError!("Error adding node; Graph is at full capacity");
+        return;
+    }
+
+    println!("node count: {:?}", g.node_count());
+    for node in g.node_weights() {
+        // There shouldn't be any flowbit nodes left at this point
+        debug_validate_bug_on!(node.ntype);
+        println!("FIN Node: {:?}", node);
+    }
+
+    for (node_idx, in_degree) in in_degrees {
+        if in_degree == 0 {
+            println!("added edge from {:?} -> {:?}", nidx, node_idx);
+            g.add_edge(nidx, node_idx, ());
+        }
+    }
+
+    let mut bfs = Bfs::new(&*g, nidx);
+    let mut i = 0;
+
+    println!("BFS of the graph:");
+    while let Some(idx) = bfs.next(&*g) {
+        if idx != nidx {
+            println!("[{:?}]: {:?}", i, g[idx]);
+            sorted_sid_list[i] = g[idx].iid;
+            i += 1;
+        }
+    }
+}

--- a/rust/src/utils/mod.rs
+++ b/rust/src/utils/mod.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2024 Open Information Security Foundation
+/* Copyright (C) 2024-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -17,3 +17,4 @@
 
 pub mod base64;
 pub mod datalink;
+pub mod flowbits_resolver;


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/13740

Changes since v2:
- fixed bug about preservation of signature order
- all existing tests pass
- \+ https://github.com/OISF/suricata/pull/13702

Known TODOs:
- a problem discovered with the current algorithm by the s-v test `firewall-01-tcp-pkt-state-flowbits` ⭐ 
For a given READ command (isset, isnotset) and a given WRITE command (set, unset, toggle)
current algorithm marks a combination of following signatures as cyclic -- which shall be rejected in the final rev of this work
```
flowbit:READ,A; flowbit:WRITE,B; sid:1;
flowbit:WRITE,A; flowbit:READ, B, sid:2;
```
However, there may exist such flowbit combinations that are not cyclic. From the test `firewall-01-tcp-pkt-state-flowbits`,
```
pass tcp any 443 -> any any (flags:SA; flow:not_established; flowbits:isset,syn; flowbits:set,synack; sid:2;)
pass tcp any any -> any 443 (flags:A; flow:not_established; flowbits:isset,synack; flowbits:unset,syn; flowbits:unset,synack; sid:3;)
```
- final leg of the solution to sort sigwrapper list per the order received from rust
- tests
- fn docs
- some code cleanups

Link to tickets:

- https://redmine.openinfosecfoundation.org/issues/7771
- https://redmine.openinfosecfoundation.org/issues/7638
- https://redmine.openinfosecfoundation.org/issues/7772
- https://redmine.openinfosecfoundation.org/issues/7773
- https://redmine.openinfosecfoundation.org/issues/7774
- https://redmine.openinfosecfoundation.org/issues/7817
- https://redmine.openinfosecfoundation.org/issues/7818