### PR TITLE
detect: remove flag SIGMATCH_DEONLY_COMPAT

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -365,7 +365,7 @@ static int SignatureIsDEOnly(DetectEngineCtx *de_ctx, const Signature *s)
     /* check for conflicting keywords */
     SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_MATCH];
     for ( ;sm != NULL; sm = sm->next) {
-        if ( !(sigmatch_table[sm->type].flags & SIGMATCH_DEONLY_COMPAT))
+        if (sm->type != DETECT_DECODE_EVENT)
             SCReturnInt(0);
     }
 

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -141,7 +141,6 @@ void DetectEngineEventRegister (void)
     sigmatch_table[DETECT_DECODE_EVENT].desc =
             "match on events triggered by structural or invalid values during packet decoding";
     sigmatch_table[DETECT_DECODE_EVENT].url = "/rules/decode-layer.html#decode-event";
-    sigmatch_table[DETECT_DECODE_EVENT].flags |= SIGMATCH_DEONLY_COMPAT;
     sigmatch_table[DETECT_DECODE_EVENT].SupportsPrefilter = PrefilterDecodeEventIsPrefilterable;
     sigmatch_table[DETECT_DECODE_EVENT].SetupPrefilter = PrefilterSetupDecodeEvent;
 

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -1488,13 +1488,6 @@ static const PrefilterStore *PrefilterStoreGetStore(const DetectEngineCtx *de_ct
     return store;
 }
 
-#ifdef PROFILING
-const char *PrefilterStoreGetName(const uint32_t id)
-{
-    return NULL;
-}
-#endif
-
 #include "util-print.h"
 
 typedef struct PrefilterMpmCtx {

--- a/src/detect-engine-prefilter.h
+++ b/src/detect-engine-prefilter.h
@@ -87,10 +87,6 @@ void PrefilterFreeEnginesList(PrefilterEngineList *list);
 int PrefilterSetupRuleGroup(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 void PrefilterCleanupRuleGroup(const DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 
-#ifdef PROFILING
-const char *PrefilterStoreGetName(const uint32_t id);
-#endif
-
 void PrefilterInit(DetectEngineCtx *de_ctx);
 void PrefilterDeinit(DetectEngineCtx *de_ctx);
 

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -305,12 +305,6 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
         printf("compatible with IP only rule");
         prev = 1;
     }
-    if (flags & SIGMATCH_DEONLY_COMPAT) {
-        if (prev == 1)
-            printf("%c", sep);
-        printf("compatible with decoder event only rule");
-        prev = 1;
-    }
     if (flags & SIGMATCH_INFO_CONTENT_MODIFIER) {
         if (prev == 1)
             printf("%c", sep);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1648,11 +1648,9 @@ typedef struct SigGroupHead_ {
 /** sigmatch has no options, so the parser shouldn't expect any */
 #define SIGMATCH_NOOPT                  BIT_U16(0)
 /** sigmatch is compatible with a ip only rule */
-#define SIGMATCH_IPONLY_COMPAT          BIT_U16(1)
-/** sigmatch is compatible with a decode event only rule */
-#define SIGMATCH_DEONLY_COMPAT          BIT_U16(2)
+#define SIGMATCH_IPONLY_COMPAT BIT_U16(1)
 
-// vacancy
+// vacancy (x2)
 
 /** sigmatch may have options, so the parser should be ready to
  *  deal with both cases */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None, just code clean-up with flag removal

Describe changes:
- detect: remove flag SIGMATCH_DEONLY_COMPAT
- detect: remove unused PrefilterStoreGetName
