### PR TITLE
detect/integer: support missing modes for u8 prefilter

### DIFF
--- a/src/detect-engine-prefilter-common.c
+++ b/src/detect-engine-prefilter-common.c
@@ -168,7 +168,16 @@ static void ApplyToU8Hash(PrefilterPacketU8HashCtx *ctx, PrefilterPacketHeaderVa
                 } while (x--);
 
                 break;
-            }
+        }
+        case DetectUintModeLte: {
+            uint8_t x = v.u8[1];
+            do {
+                SigsArray *sa = ctx->array[x];
+                sa->sigs[sa->offset++] = s->iid;
+            } while (x--);
+
+            break;
+        }
         case PREFILTER_U8HASH_MODE_GT:
             {
                 int x = v.u8[1] + 1;
@@ -178,7 +187,16 @@ static void ApplyToU8Hash(PrefilterPacketU8HashCtx *ctx, PrefilterPacketHeaderVa
                 } while (++x < 256);
 
                 break;
-            }
+        }
+        case DetectUintModeGte: {
+            int x = v.u8[1];
+            do {
+                SigsArray *sa = ctx->array[x];
+                sa->sigs[sa->offset++] = s->iid;
+            } while (++x < 256);
+
+            break;
+        }
         case PREFILTER_U8HASH_MODE_RA:
             {
                 int x = v.u8[1] + 1;
@@ -188,7 +206,20 @@ static void ApplyToU8Hash(PrefilterPacketU8HashCtx *ctx, PrefilterPacketHeaderVa
                 } while (++x < v.u8[2]);
 
                 break;
+        }
+        case DetectUintModeNe: {
+            for (uint8_t i = 0; i < UINT8_MAX; i++) {
+                if (i != v.u8[1]) {
+                    SigsArray *sa = ctx->array[i];
+                    sa->sigs[sa->offset++] = s->iid;
+                }
             }
+            if (UINT8_MAX != v.u8[1]) {
+                SigsArray *sa = ctx->array[UINT8_MAX];
+                sa->sigs[sa->offset++] = s->iid;
+            }
+            break;
+        }
     }
 }
 
@@ -299,9 +330,29 @@ static void SetupU8Hash(DetectEngineCtx *de_ctx, HashListTable *hash_table, SigG
 
                 break;
             }
+            case DetectUintModeLte: {
+                uint8_t v = ctx->v1.u8[1];
+                counts[v] += ctx->cnt;
+                while (v > 0) {
+                    v--;
+                    counts[v] += ctx->cnt;
+                }
+
+                break;
+            }
             case PREFILTER_U8HASH_MODE_GT:
             {
                 uint8_t v = ctx->v1.u8[1];
+                while (v < UINT8_MAX) {
+                    v++;
+                    counts[v] += ctx->cnt;
+                }
+
+                break;
+            }
+            case DetectUintModeGte: {
+                uint8_t v = ctx->v1.u8[1];
+                counts[v] += ctx->cnt;
                 while (v < UINT8_MAX) {
                     v++;
                     counts[v] += ctx->cnt;
@@ -321,6 +372,19 @@ static void SetupU8Hash(DetectEngineCtx *de_ctx, HashListTable *hash_table, SigG
                 }
                 break;
             }
+            case DetectUintModeNe: {
+                for (uint8_t i = 0; i < UINT8_MAX; i++) {
+                    if (i != ctx->v1.u8[1]) {
+                        counts[i] += ctx->cnt;
+                    }
+                }
+                if (UINT8_MAX != ctx->v1.u8[1]) {
+                    counts[UINT8_MAX] += ctx->cnt;
+                }
+                break;
+            }
+            default:
+                SCLogWarning("Prefilter not implemented for mode 0x%x", ctx->v1.u8[0]);
         }
     }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7865

Describe changes:
- detect/integer: support more (all) modes for u8 prefilter

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2625

#13751 with better commit message