### PR TITLE
Doc detect integer units 7190 v2

### DIFF
--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -13,6 +13,12 @@ Simple example::
 The integer value can be written as base-10 like ``100`` or as 
 an hexadecimal value like ``0x64``.
 
+The integer value can also have a unit/multiplier as a
+case-insensitive suffix:
+* kb : 1024
+* mb : 1048576
+* gb : 1073741824
+
 The most direct example is to match for equality, but there are
 different modes.
 

--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -15,9 +15,9 @@ an hexadecimal value like ``0x64``.
 
 The integer value can also have a unit/multiplier as a
 case-insensitive suffix:
-* kb : 1024
-* mb : 1048576
-* gb : 1073741824
+* kb/kib : 1024
+* mb/mib : 1048576
+* gb/gib : 1073741824
 
 The most direct example is to match for equality, but there are
 different modes.

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -104,8 +104,11 @@ impl<T> DetectIntType for T where
 
 pub fn detect_parse_uint_unit(i: &str) -> IResult<&str, u64> {
     let (i, unit) = alt((
+        value(1024, tag_no_case("kib")),
         value(1024, tag_no_case("kb")),
+        value(1024 * 1024, tag_no_case("mib")),
         value(1024 * 1024, tag_no_case("mb")),
+        value(1024 * 1024 * 1024, tag_no_case("gib")),
         value(1024 * 1024 * 1024, tag_no_case("gb")),
     ))(i)?;
     return Ok((i, unit));


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7190
https://redmine.openinfosecfoundation.org/issues/7869

Describe changes:
- detect/integers: document usage of units
- detect/integers: support kibibyte unit

https://github.com/OISF/suricata/pull/13749 with second commit for redmine 7869
