### PR TITLE
dpdk/rte_flow: dynamic bypass v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2422,10 +2422,10 @@ return 0;
 # get MAJOR_MINOR version for embedding in configuration file.
     MAJOR_MINOR=`expr "${PACKAGE_VERSION}" : "\([[0-9]]\+\.[[0-9]]\+\).*"`
 
-if test "${enable_ebpf}" = "yes" || test "${enable_unittests}" = "yes"; then
+if test "${enable_ebpf}" = "yes" || test "${enable_unittests}" = "yes" ||  test "${enable_dpdk}" = "yes"; then
   AC_DEFINE([CAPTURE_OFFLOAD_MANAGER], [1],[Building flow bypass manager code])
 fi
-if test "${enable_ebpf}" = "yes" || test "${enable_nfqueue}" = "yes" || test "${enable_pfring}" = "yes" || test "${enable_napatech}" = "yes"  || test "${enable_unittests}" = "yes"; then
+if test "${enable_ebpf}" = "yes" || test "${enable_nfqueue}" = "yes" || test "${enable_pfring}" = "yes" || test "${enable_napatech}" = "yes"  || test "${enable_unittests}" = "yes" || test "${enable_dpdk}" = "yes"; then
   AC_DEFINE([CAPTURE_OFFLOAD], [1],[Building flow capture bypass code])
 fi
 

--- a/doc/userguide/capture-hardware/dpdk.rst
+++ b/doc/userguide/capture-hardware/dpdk.rst
@@ -239,3 +239,56 @@ Encapsulation stripping
 Suricata supports stripping the hardware-offloaded encapsulation stripping on
 the supported NICs. Currently, VLAN encapsulation stripping is supported.
 VLAN encapsulation stripping can be enabled with `vlan-strip-offload`.
+
+Drop filter
+-----------------------------
+
+Drop filter can improve the performance of Suricata by filtering 
+used-predefined flows directly in the Network interface card. The user can 
+specify unwanted flows before the start of Suricata. These flows are not going to be 
+inspected by Suricata and will be ignored for the whole run of the program.
+
+The syntax for drop filter in Suricata is similar to the dpdk-testpmd application
+rule syntax, although in Suricata, only the "pattern" section is applicable. 
+The user can define multiple rules, either to match specific flow 
+or a range of flows (e.g. using ip or port masks).
+
+Patterns currently supported by this feature are listed in 
+"src/util-dpdk-rte-flow-pattern.c" in "enum index next_item[]" 
+and their corresponding attributes in "enum index item_<pattern>[]".
+
+This feature is supported and tested only on NICs wih mlx5, ice and i40e 
+drivers. The level of functionality varies between these cards, 
+the most versatile are cards with mlx5 drivers.
+
+ice does not support broad patterns; some pattern item has to have
+specification, e.g., "pattern eth / ipv4 / end" raises an error but
+"pattern eth / ipv4 src is x / end" or "eth / ipv4 / tcp src is x" works fine.
+
+i40e does not support different item sets on the same pattern item type,
+e.g., if the first rule is in the form "pattern eth / ipv4 src is x / end",
+then if any other rule contains an ipv4 pattern type, it needs to have
+exclusively attribute src.
+
+The configuration for the drop filter can be found and modified in the 
+DPDK section of the suricata.yaml file.
+
+Additionally, mlx5 and ice drivers are able to gather statistics about filtered flows.
+The number of filtered packets is stored in dpdk.rte_flow_filtered field in eve.json.
+ice driver gathers statistics only in the case when all of the rules match one specific flow
+(e.g. mask can not be used).
+
+Below is a sample configuration that demonstrates how to filter specific flow and a range of flows:
+
+::
+
+  ...
+  dpdk:
+      eal-params:
+        proc-type: primary
+
+      interfaces:
+        - interface: 0000:3b:00.0
+          drop-filter:
+            - rule: "pattern eth / ipv4 src is 192.11.120.50 / tcp / end"
+            - rule: "pattern eth / ipv4 src is 170.22.40.0 src mask 255.255.255.0 / tcp / end"

--- a/doc/userguide/capture-hardware/dpdk.rst
+++ b/doc/userguide/capture-hardware/dpdk.rst
@@ -243,40 +243,55 @@ VLAN encapsulation stripping can be enabled with `vlan-strip-offload`.
 Drop filter
 -----------------------------
 
-Drop filter can improve the performance of Suricata by filtering 
-used-predefined flows directly in the Network interface card. The user can 
-specify unwanted flows before the start of Suricata. These flows are not going to be 
+Drop filter can improve the performance of Suricata by filtering
+used-predefined flows directly in the Network interface card. The user can
+specify unwanted flows before the start of Suricata. These flows are not going to be
 inspected by Suricata and will be ignored for the whole run of the program.
+On some PMDs, the statistics of the dropped flows are gathered and stored in eve.json.
 
 The syntax for drop filter in Suricata is similar to the dpdk-testpmd application
-rule syntax, although in Suricata, only the "pattern" section is applicable. 
-The user can define multiple rules, either to match specific flow 
+rule syntax, although in Suricata, only the "pattern" section is applicable.
+The user can define multiple rules, either to match specific flow
 or a range of flows (e.g. using ip or port masks).
 
-Patterns currently supported by this feature are listed in 
-"src/util-dpdk-rte-flow-pattern.c" in "enum index next_item[]" 
+Patterns currently supported by this feature are listed in
+"src/util-dpdk-rte-flow-pattern.c" in "enum index next_item[]"
 and their corresponding attributes in "enum index item_<pattern>[]".
 
-This feature is supported and tested only on NICs wih mlx5, ice and i40e 
-drivers. The level of functionality varies between these cards, 
-the most versatile are cards with mlx5 drivers.
+.. literalinclude:: ../../../src/util-dpdk-rte-flow-pattern.c
+    :language: c
+    :start-at: /* --- start pattern enum --- */
+    :end-at: /* --- end pattern enum --- */
 
-ice does not support broad patterns; some pattern item has to have
-specification, e.g., "pattern eth / ipv4 / end" raises an error but
-"pattern eth / ipv4 src is x / end" or "eth / ipv4 / tcp src is x" works fine.
 
-i40e does not support different item sets on the same pattern item type,
-e.g., if the first rule is in the form "pattern eth / ipv4 src is x / end",
-then if any other rule contains an ipv4 pattern type, it needs to have
-exclusively attribute src.
+This feature is supported and tested only on NICs with mlx5, ice, and i40e drivers. 
+Some of the drivers also support collecting statistics about dropped flows 
+(visible in dpdk.rte_flow_filtered in eve.json). 
+The level of functionality varies between these cards, as specified below:
 
-The configuration for the drop filter can be found and modified in the 
+* ice:
+
+  The driver does not support broad patterns; some pattern item has to have
+  specification, e.g., ``pattern eth / ipv4 / end`` raises an error but
+  ``pattern eth / ipv4 src is x / end`` or ``pattern eth / ipv4 / tcp src is x`` works fine.
+  It also supports gathering statistics of the filtered packets, but only
+  when all of the rules match one specific flow (e.g. mask can not be used).
+
+* i40e:
+
+  The driver does not support different item sets on the same pattern item type,
+  e.g., if the first rule is in the form ``pattern eth / ipv4 src is x / end``,
+  then any other rule containing an ipv4 pattern type must exclusively use the src attribute.
+  Statistics of the filtered packets are not supported.
+
+* mlx5:
+
+  The driver is the most versatile PMD, supporting a wide range of patterns. 
+  It also supports gathering statistics of the filtered packets without any other constraints.
+
+
+The configuration for the drop filter can be found and modified in the
 DPDK section of the suricata.yaml file.
-
-Additionally, mlx5 and ice drivers are able to gather statistics about filtered flows.
-The number of filtered packets is stored in dpdk.rte_flow_filtered field in eve.json.
-ice driver gathers statistics only in the case when all of the rules match one specific flow
-(e.g. mask can not be used).
 
 Below is a sample configuration that demonstrates how to filter specific flow and a range of flows:
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -509,6 +509,8 @@ noinst_HEADERS = \
 	util-dpdk-mlx5.h \
 	util-dpdk-rss.h \
 	util-dpdk.h \
+	util-dpdk-rte-flow.h \
+	util-dpdk-rte-flow-pattern.h \
 	util-ebpf.h \
 	util-enum.h \
 	util-error.h \
@@ -1093,6 +1095,8 @@ libsuricata_c_a_SOURCES = \
 	util-dpdk-mlx5.c \
 	util-dpdk-rss.c \
 	util-dpdk.c \
+	util-dpdk-rte-flow.c \
+	util-dpdk-rte-flow-pattern.c \
 	util-ebpf.c \
 	util-enum.c \
 	util-error.c \

--- a/src/flow-bypass.c
+++ b/src/flow-bypass.c
@@ -31,7 +31,13 @@
 
 #ifdef CAPTURE_OFFLOAD_MANAGER
 
+#ifdef HAVE_DPDK
+#define FLOW_BYPASS_DELAY 0.001f
+#define FLOW_BYPASS_SLEEP 0.01f
+#else
 #define FLOW_BYPASS_DELAY       10
+#define FLOW_BYPASS_SLEEP       10
+#endif /* HAVE_DPDK */
 
 #ifndef TIMEVAL_TO_TIMESPEC
 #define TIMEVAL_TO_TIMESPEC(tv, ts) {                               \
@@ -123,7 +129,7 @@ static TmEcode BypassedFlowManager(ThreadVars *th_v, void *thread_data)
                 return TM_ECODE_OK;
             }
             StatsSyncCountersIfSignalled(th_v);
-            SleepMsec(10);
+            SleepMsec(FLOW_BYPASS_SLEEP);
         }
     }
     return TM_ECODE_OK;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -1059,7 +1059,7 @@ Flow *FlowGetExistingFlowFromFlowId(uint64_t flow_id)
  *  \param hash Value of the flow hash
  *  \retval f *LOCKED* flow or NULL
  */
-static Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash)
+Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash)
 {
     /* get our hash bucket and lock it */
     FlowBucket *fb = &flow_hash[hash % flow_config.hash_size];

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -80,7 +80,7 @@ typedef struct FlowBucket_ {
 /* prototypes */
 
 Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *tctx, Packet *, Flow **);
-
+Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash);
 Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t hash);
 Flow *FlowGetExistingFlowFromFlowId(uint64_t flow_id);
 uint32_t FlowKeyGetHash(FlowKey *flow_key);

--- a/src/flow-private.h
+++ b/src/flow-private.h
@@ -36,6 +36,12 @@
  *  flow engine with evaluate flows with lower timeout settings. */
 #define FLOW_EMERGENCY   0x01
 
+/** Flow engine is in shutdown mode. This means it will not accept new flows
+ *  and will only process existing flows.
+ * todo*/
+#define FLOW_SHUTDOWN     0x02
+#define FLOW_SHUTDOWN_END 0x04
+
 /* Flow Time out values */
 #define FLOW_DEFAULT_NEW_TIMEOUT 30
 #define FLOW_DEFAULT_EST_TIMEOUT           300

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2021-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -40,6 +40,7 @@ typedef struct DPDKIfaceConfigAttributes_ {
     const char *tx_descriptors;
     const char *copy_mode;
     const char *copy_iface;
+    const char *drop_filter;
 } DPDKIfaceConfigAttributes;
 
 int RunModeIdsDpdkWorkers(void);

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -36,6 +36,7 @@ typedef struct DPDKIfaceConfigAttributes_ {
     const char *linkup_timeout;
     const char *mempool_size;
     const char *mempool_cache_size;
+    const char *bypass_ring_size;
     const char *rx_descriptors;
     const char *tx_descriptors;
     const char *copy_mode;

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -42,6 +42,7 @@
 #include "tmqh-packetpool.h"
 #include "util-privs.h"
 #include "util-device-private.h"
+#include "util-dpdk-rte-flow.h"
 #include "action-globals.h"
 
 #ifndef HAVE_DPDK
@@ -191,7 +192,8 @@ static inline void DPDKFreeMbufArray(
     }
 }
 
-static void DevicePostStartPMDSpecificActions(DPDKThreadVars *ptv, const char *driver_name)
+static int DevicePostStartPMDSpecificActions(
+        DPDKThreadVars *ptv, DPDKIfaceConfig *dpdk_config, const char *driver_name)
 {
     if (strcmp(driver_name, "net_bonding") == 0)
         driver_name = BondingDeviceDriverGet(ptv->port_id);
@@ -203,6 +205,17 @@ static void DevicePostStartPMDSpecificActions(DPDKThreadVars *ptv, const char *d
         iceDeviceSetRSS(ptv->port_id, ptv->threads, ptv->livedev->dev);
     else if (strcmp(driver_name, "mlx5_pci") == 0)
         mlx5DeviceSetRSS(ptv->port_id, ptv->threads, ptv->livedev->dev);
+
+    if ((strcmp(driver_name, "mlx5_pci") == 0 || strcmp(driver_name, "net_ice") == 0 ||
+                strcmp(driver_name, "net_i40e") == 0)) {
+        int retval = RteFlowRulesCreate(
+                dpdk_config->iface, dpdk_config->port_id, &dpdk_config->drop_filter, driver_name);
+        if (retval != 0) {
+            SCLogError("%s: error when creating rte_flow rules", dpdk_config->iface);
+            SCReturnInt(retval);
+        }
+    }
+    SCReturnInt(0);
 }
 
 static void DevicePreClosePMDSpecificActions(DPDKThreadVars *ptv, const char *driver_name)
@@ -678,8 +691,10 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
             SCLogWarning("%s: link is down, trying to continue anyway", dpdk_config->iface);
         }
 
-        // some PMDs requires additional actions only after the device has started
-        DevicePostStartPMDSpecificActions(ptv, dev_info.driver_name);
+        retval = DevicePostStartPMDSpecificActions(ptv, dpdk_config, dev_info.driver_name);
+        if (retval != 0) {
+            goto fail;
+        }
 
         uint16_t inconsistent_numa_cnt = SC_ATOMIC_GET(dpdk_config->inconsistent_numa_cnt);
         if (inconsistent_numa_cnt > 0 && ptv->port_socket_id != SOCKET_ID_ANY) {

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -94,6 +94,7 @@ TmEcode NoDPDKSupportExit(ThreadVars *tv, const void *initdata, void **data)
 #include "util-dpdk-ixgbe.h"
 #include "util-dpdk-mlx5.h"
 #include "util-dpdk-bonding.h"
+#include <rte_flow.h>
 #include <numa.h>
 
 #define BURST_SIZE 32
@@ -116,6 +117,7 @@ typedef struct DPDKThreadVars_ {
     LiveDevice *livedev;
     ChecksumValidationMode checksum_mode;
     bool intr_enabled;
+    bool port_stopped;
     /* references to packet and drop counters */
     uint16_t capture_dpdk_packets;
     uint16_t capture_dpdk_rx_errs;
@@ -123,6 +125,7 @@ typedef struct DPDKThreadVars_ {
     uint16_t capture_dpdk_rx_no_mbufs;
     uint16_t capture_dpdk_ierrors;
     uint16_t capture_dpdk_tx_errs;
+    uint16_t capture_dpdk_rte_flow_filtered;
     unsigned int flags;
     uint16_t threads;
     /* for IPS */
@@ -210,8 +213,11 @@ static int DevicePostStartPMDSpecificActions(
                 strcmp(driver_name, "net_i40e") == 0)) {
         int retval = RteFlowRulesCreate(
                 dpdk_config->iface, dpdk_config->port_id, &dpdk_config->drop_filter, driver_name);
+        ptv->livedev->dpdk_vars->rte_flow_rule_handlers = dpdk_config->drop_filter.rule_handlers;
+        dpdk_config->drop_filter.rule_handlers = NULL;
+        ptv->livedev->dpdk_vars->rte_flow_rule_size = dpdk_config->drop_filter.rule_size;
+        ptv->livedev->dpdk_vars->rte_flow_rule_cnt = dpdk_config->drop_filter.rule_cnt;
         if (retval != 0) {
-            SCLogError("%s: error when creating rte_flow rules", dpdk_config->iface);
             SCReturnInt(retval);
         }
     }
@@ -294,14 +300,23 @@ void TmModuleDecodeDPDKRegister(void)
 static inline void DPDKDumpCounters(DPDKThreadVars *ptv)
 {
     /* Some NICs (e.g. Intel) do not support queue statistics and the drops can be fetched only on
-     * the port level. Therefore setting it to the first worker to have at least continuous update
+     * the port level. Therefore setting it to the last worker to have at least continuous update
      * on the dropped packets. */
-    if (ptv->queue_id == 0) {
+    if (ptv->queue_id == ptv->threads - 1) {
         struct rte_eth_stats eth_stats;
         int retval = rte_eth_stats_get(ptv->port_id, &eth_stats);
         if (unlikely(retval != 0)) {
             SCLogError("%s: failed to get stats: %s", ptv->livedev->dev, rte_strerror(-retval));
             return;
+        }
+
+        if (!ptv->port_stopped) {
+            uint64_t filtered_packets = 0;
+            retval = RteFlowFilteredPacketsQuery(ptv->livedev->dpdk_vars->rte_flow_rule_handlers,
+                    ptv->livedev->dpdk_vars->rte_flow_rule_cnt, ptv->livedev->dev, ptv->port_id,
+                    &filtered_packets);
+            if (retval == 0)
+                StatsSetUI64(ptv->tv, ptv->capture_dpdk_rte_flow_filtered, filtered_packets);
         }
 
         StatsSetUI64(ptv->tv, ptv->capture_dpdk_packets,
@@ -501,7 +516,9 @@ static void HandleShutdown(DPDKThreadVars *ptv)
     while (SC_ATOMIC_GET(ptv->workers_sync->worker_checked_in) < ptv->workers_sync->worker_cnt) {
         rte_delay_us(10);
     }
-    if (ptv->queue_id == 0) {
+
+    DPDKDumpCounters(ptv);
+    if (ptv->queue_id == ptv->threads - 1) {
         rte_delay_us(20); // wait for all threads to get out of the sync loop
         SC_ATOMIC_SET(ptv->workers_sync->worker_checked_in, 0);
         // If Suricata runs in peered mode, the peer threads might still want to send
@@ -513,8 +530,8 @@ static void HandleShutdown(DPDKThreadVars *ptv)
             // in IDS we stop our port - no peer threads are running
             rte_eth_dev_stop(ptv->port_id);
         }
+        ptv->port_stopped = true;
     }
-    DPDKDumpCounters(ptv);
 }
 
 static void PeriodicDPDKDumpCounters(DPDKThreadVars *ptv)
@@ -613,12 +630,15 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
     ptv->capture_dpdk_imissed = StatsRegisterCounter("capture.dpdk.imissed", ptv->tv);
     ptv->capture_dpdk_rx_no_mbufs = StatsRegisterCounter("capture.dpdk.no_mbufs", ptv->tv);
     ptv->capture_dpdk_ierrors = StatsRegisterCounter("capture.dpdk.ierrors", ptv->tv);
+    ptv->capture_dpdk_rte_flow_filtered =
+            StatsRegisterCounter("capture.dpdk.rte_flow_filtered", ptv->tv);
 
     ptv->copy_mode = dpdk_config->copy_mode;
     ptv->checksum_mode = dpdk_config->checksum_mode;
 
     ptv->threads = dpdk_config->threads;
     ptv->intr_enabled = (dpdk_config->flags & DPDK_IRQ_MODE) ? true : false;
+    ptv->port_stopped = false;
     ptv->port_id = dpdk_config->port_id;
     ptv->out_port_id = dpdk_config->out_port_id;
     ptv->port_socket_id = dpdk_config->socket_id;

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2021-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -50,6 +50,13 @@ typedef struct DPDKWorkerSync_ {
     SC_ATOMIC_DECLARE(uint16_t, worker_checked_in);
 } DPDKWorkerSync;
 
+typedef struct RteFlowRuleStorage_ {
+    uint16_t rule_cnt;
+    uint16_t rule_size;
+    char **rules;
+    struct rte_flow **rule_handlers;
+} RteFlowRuleStorage;
+
 typedef struct DPDKIfaceConfig_ {
 #ifdef HAVE_DPDK
     char iface[RTE_ETH_NAME_MAX_LEN];
@@ -75,12 +82,14 @@ typedef struct DPDKIfaceConfig_ {
     uint32_t mempool_cache_size;
     DPDKDeviceResources *pkt_mempools;
     uint16_t linkup_timeout; // in seconds how long to wait for link to come up
-    SC_ATOMIC_DECLARE(uint16_t, ref);
+    RteFlowRuleStorage drop_filter;
+    SC_ATOMIC_DECLARE(unsigned int, ref);
     /* threads bind queue id one by one */
     SC_ATOMIC_DECLARE(uint16_t, queue_id);
     SC_ATOMIC_DECLARE(uint16_t, inconsistent_numa_cnt);
     DPDKWorkerSync *workers_sync;
     void (*DerefFunc)(void *);
+    void (*RteRulesFree)(RteFlowRuleStorage *);
 
     struct rte_flow *flow[100];
 #endif

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -81,6 +81,7 @@ typedef struct DPDKIfaceConfig_ {
     uint32_t mempool_size;
     uint32_t mempool_cache_size;
     DPDKDeviceResources *pkt_mempools;
+    uint32_t bypass_ring_size;
     uint16_t linkup_timeout; // in seconds how long to wait for link to come up
     RteFlowRuleStorage drop_filter;
     SC_ATOMIC_DECLARE(unsigned int, ref);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2773,6 +2773,11 @@ int PostConfLoadedSetup(SCInstance *suri)
         LiveDevRegisterExtension();
     }
 #endif
+#ifdef HAVE_DPDK
+    if (suri->run_mode == RUNMODE_DPDK) {
+        LiveDevRegisterExtension();
+    }
+#endif
     RegisterFlowBypassInfo();
 
     MacSetRegisterFlowStorage();

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -258,11 +258,11 @@ static int LiveSafeDeviceName(const char *devname, char *newdevname, size_t dest
 }
 
 /**
- *  \brief Get a pointer to the device at idx
+ *  \brief Get a pointer to the device by name
  *
- *  \param number idx of the device in our list
+ *  \param str name of the device in our list
  *
- *  \retval ptr pointer to the string containing the device
+ *  \retval ptr pointer to the device instance
  *  \retval NULL on error
  */
 LiveDevice *LiveGetDevice(const char *name)
@@ -278,6 +278,30 @@ LiveDevice *LiveGetDevice(const char *name)
         if (!strcmp(name, pd->dev)) {
             return pd;
         }
+    }
+
+    return NULL;
+}
+
+/**
+ *  \brief Get a pointer to the device at idx
+ *
+ *  \param number idx of the device in our list
+ *
+ *  \retval ptr pointer to the device instance
+ *  \retval NULL on error
+ */
+LiveDevice *LiveGetDeviceByIdx(int number)
+{
+    int i = 0;
+    LiveDevice *pd;
+
+    TAILQ_FOREACH (pd, &live_devices, next) {
+        if (i == number) {
+            return pd;
+        }
+
+        i++;
     }
 
     return NULL;

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -366,6 +366,18 @@ int LiveDeviceListClean(void)
     }
     TAILQ_FOREACH_SAFE(pd, &live_devices, next, tpd) {
         if (live_devices_stats) {
+#ifdef CAPTURE_OFFLOAD
+            SCLogNotice("%s: packets: %" PRIu64 ", bypassed: %" PRIu64 ", drops: %" PRIu64
+                        " (%.2f%%), invalid chksum: %" PRIu64,
+                    pd->dev, SC_ATOMIC_GET(pd->pkts), SC_ATOMIC_GET(pd->bypassed),
+                    SC_ATOMIC_GET(pd->drop),
+                    SC_ATOMIC_GET(pd->pkts) > 0
+                            ? 100 * ((double)SC_ATOMIC_GET(pd->drop)) /
+                                      ((double)SC_ATOMIC_GET(pd->pkts) +
+                                              (double)SC_ATOMIC_GET(pd->bypassed))
+                            : 0,
+                    SC_ATOMIC_GET(pd->invalid_checksums));
+#else
             SCLogNotice("%s: packets: %" PRIu64 ", drops: %" PRIu64
                         " (%.2f%%), invalid chksum: %" PRIu64,
                     pd->dev, SC_ATOMIC_GET(pd->pkts), SC_ATOMIC_GET(pd->drop),
@@ -373,6 +385,7 @@ int LiveDeviceListClean(void)
                                                           (double)SC_ATOMIC_GET(pd->pkts)
                                                 : 0,
                     SC_ATOMIC_GET(pd->invalid_checksums));
+#endif
         }
 
         RestoreIfaceOffloading(pd);

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -56,6 +56,7 @@ int LiveGetDeviceCountWithoutAssignedThreading(void);
 int LiveGetDeviceCount(void);
 const char *LiveGetDeviceName(int number);
 LiveDevice *LiveGetDevice(const char *dev);
+LiveDevice *LiveGetDeviceByIdx(int number);
 const char *LiveGetShortName(const char *dev);
 int LiveBuildDeviceList(const char *base);
 void LiveDeviceHasNoStats(void);

--- a/src/util-dpdk-common.c
+++ b/src/util-dpdk-common.c
@@ -66,4 +66,27 @@ void DPDKDeviceResourcesDeinit(DPDKDeviceResources **dpdk_vars)
     }
 }
 
+/**
+ * \brief Input is a number of which we want to find the greatest divisor up to max_num (inclusive).
+ * The divisor is returned.
+ */
+static int GreatestDivisorUpTo(uint32_t num, uint32_t max_num)
+{
+    for (int i = max_num; i >= 2; i--) {
+        if (num % i == 0) {
+            return i;
+        }
+    }
+    return 1;
+}
+
+uint32_t MempoolCacheSizeCalculate(uint32_t mp_sz)
+{
+    // It is advised to have mempool cache size lower or equal to:
+    //   RTE_MEMPOOL_CACHE_MAX_SIZE (by default 512) and "mempool-size / 1.5"
+    // and at the same time "mempool-size modulo cache_size == 0".
+    uint32_t max_cache_size = MIN(RTE_MEMPOOL_CACHE_MAX_SIZE, mp_sz / 1.5);
+    return GreatestDivisorUpTo(mp_sz, max_cache_size);
+}
+
 #endif /* HAVE_DPDK */

--- a/src/util-dpdk-common.h
+++ b/src/util-dpdk-common.h
@@ -121,6 +121,9 @@ typedef struct {
     struct rte_mempool **pkt_mp;
     uint16_t pkt_mp_cnt;
     uint16_t pkt_mp_capa;
+    struct rte_flow **rte_flow_rule_handlers;
+    uint16_t rte_flow_rule_cnt;
+    uint16_t rte_flow_rule_size;
 } DPDKDeviceResources;
 
 int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt);

--- a/src/util-dpdk-common.h
+++ b/src/util-dpdk-common.h
@@ -117,6 +117,13 @@
 #define RTE_ETH_LINK_MAX_STR_LEN 40
 #endif
 
+typedef struct RteFlowBypassData_ {
+    struct rte_mempool *bypass_mp;
+    struct rte_ring *bypass_ring;
+    SC_ATOMIC_DECLARE(int32_t, rte_bypass_rules_active);
+    SC_ATOMIC_DECLARE(int32_t, rte_bypass_rules_created);
+} RteFlowBypassData;
+
 typedef struct {
     struct rte_mempool **pkt_mp;
     uint16_t pkt_mp_cnt;
@@ -124,10 +131,14 @@ typedef struct {
     struct rte_flow **rte_flow_rule_handlers;
     uint16_t rte_flow_rule_cnt;
     uint16_t rte_flow_rule_size;
+    RteFlowBypassData *rte_flow_bypass_data;
+    uint16_t port_id;
+    ;
 } DPDKDeviceResources;
 
 int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt);
 void DPDKDeviceResourcesDeinit(DPDKDeviceResources **dpdk_vars);
+uint32_t MempoolCacheSizeCalculate(uint32_t mp_sz);
 
 #endif /* HAVE_DPDK */
 

--- a/src/util-dpdk-ice.c
+++ b/src/util-dpdk-ice.c
@@ -124,6 +124,24 @@ void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf)
     rss_conf->rss_key_len = 52;
 }
 
+/**
+ * \brief Check and log whether pattern is broad / not-specific
+ *        as ice does not support these patterns
+ *
+ * \param items array of pattern items
+ */
+bool iceDeviceRteFlowPatternError(struct rte_flow_item *items)
+{
+    int i = 0;
+    while (items[i].type != RTE_FLOW_ITEM_TYPE_END) {
+        if (items[i].spec != NULL) {
+            SCReturnBool(false);
+        }
+        ++i;
+    }
+    SCReturnBool(true);
+}
+
 #endif /* HAVE_DPDK */
 /**
  * @}

--- a/src/util-dpdk-rss.c
+++ b/src/util-dpdk-rss.c
@@ -104,6 +104,7 @@ int DPDKCreateRSSFlowGeneric(
     rss_conf.types = RTE_ETH_RSS_IPV4 | RTE_ETH_RSS_IPV6;
 
     attr.ingress = 1;
+    attr.priority = 1;
     action[0].type = RTE_FLOW_ACTION_TYPE_RSS;
     action[0].conf = &rss_conf;
     action[1].type = RTE_FLOW_ACTION_TYPE_END;

--- a/src/util-dpdk-rte-flow-pattern.c
+++ b/src/util-dpdk-rte-flow-pattern.c
@@ -1,0 +1,1403 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2016 6WIND S.A.
+ * Copyright 2016 Mellanox Technologies, Ltd
+ *
+ *
+ * Modifications by Adam Kiripolsky:
+ * - The code is a modification of the parser for dpdk-testpmd application
+ *   located in DPDK 25.11 source code at  dpdk/app/testpmd/cmdline_flow.c
+ * - Simplified the parser and it's corresponding parts to parse only
+ *   pattern instead of the whole test-pmd commands
+ * - Add ParsePattern function to utilize the parser from outside
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+
+ * - Neither the name of the Qualys, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ *  \defgroup dpdk pattern parser
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK parser for pattern
+ *
+ */
+
+#include "util-debug.h"
+#include "util-dpdk.h"
+#include "util-dpdk-rte-flow-pattern.h"
+
+#ifdef HAVE_DPDK
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)
+
+#include <cmdline_parse_etheraddr.h>
+
+enum index {
+    /* Special tokens. */
+    ZERO = 0,
+    END,
+
+    /* Create tokens */
+    CREATE,
+
+    /* Common tokens. */
+    COMMON_UNSIGNED,
+    COMMON_MAC_ADDR,
+    COMMON_IPV4_ADDR,
+    COMMON_IPV6_ADDR,
+
+    /* Validate/create pattern. */
+    ITEM_PATTERN,
+    ITEM_PARAM_IS,
+    ITEM_PARAM_SPEC,
+    ITEM_PARAM_LAST,
+    ITEM_PARAM_MASK,
+    ITEM_NEXT,
+    ITEM_END,
+    ITEM_VOID,
+    ITEM_ANY,
+    ITEM_PORT_ID,
+    ITEM_ETH,
+    ITEM_ETH_DST,
+    ITEM_ETH_SRC,
+    ITEM_ETH_TYPE,
+    ITEM_ETH_HAS_VLAN,
+    ITEM_RAW,
+    ITEM_VLAN,
+    ITEM_IPV4,
+    ITEM_IPV4_SRC,
+    ITEM_IPV4_DST,
+    ITEM_IPV6,
+    ITEM_IPV6_SRC,
+    ITEM_IPV6_DST,
+    ITEM_ICMP,
+    ITEM_ICMP_TYPE,
+    ITEM_ICMP_CODE,
+    ITEM_ICMP_IDENT,
+    ITEM_ICMP_SEQ,
+    ITEM_ICMP6,
+    ITEM_ICMP6_TYPE,
+    ITEM_ICMP6_CODE,
+    ITEM_UDP,
+    ITEM_UDP_SRC,
+    ITEM_UDP_DST,
+    ITEM_TCP,
+    ITEM_TCP_SRC,
+    ITEM_TCP_DST,
+    ITEM_TCP_FLAGS,
+    ITEM_SCTP,
+    ITEM_SCTP_SRC,
+    ITEM_SCTP_DST,
+    ITEM_SCTP_TAG,
+    ITEM_SCTP_CKSUM,
+    ITEM_VXLAN,
+    ITEM_E_TAG,
+    ITEM_NVGRE,
+    ITEM_MPLS,
+    ITEM_GRE,
+    ITEM_FUZZY,
+    ITEM_GTP,
+    ITEM_GTPC,
+    ITEM_GTPU,
+    ITEM_GENEVE,
+    ITEM_VXLAN_GPE,
+};
+
+static const enum index item_param[] = {
+    ITEM_PARAM_IS,
+    ITEM_PARAM_SPEC,
+    ITEM_PARAM_LAST,
+    ITEM_PARAM_MASK,
+    ZERO,
+};
+
+static const enum index next_item[] = {
+    ITEM_END,
+    ITEM_VOID,
+    ITEM_ANY,
+    ITEM_PORT_ID,
+    ITEM_ETH,
+    ITEM_RAW,
+    ITEM_VLAN,
+    ITEM_IPV4,
+    ITEM_IPV6,
+    ITEM_ICMP,
+    ITEM_ICMP6,
+    ITEM_UDP,
+    ITEM_TCP,
+    ITEM_SCTP,
+    ITEM_VXLAN,
+    ITEM_E_TAG,
+    ITEM_NVGRE,
+    ITEM_MPLS,
+    ITEM_GRE,
+    ITEM_FUZZY,
+    ITEM_GTP,
+    ITEM_GTPC,
+    ITEM_GTPU,
+    ITEM_GENEVE,
+    ITEM_VXLAN_GPE,
+    ZERO,
+};
+
+static const enum index item_any[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_port_id[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_eth[] = {
+    ITEM_ETH_DST,
+    ITEM_ETH_SRC,
+    ITEM_ETH_TYPE,
+    ITEM_ETH_HAS_VLAN,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_raw[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_vlan[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_ipv4[] = {
+    ITEM_IPV4_SRC,
+    ITEM_IPV4_DST,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_ipv6[] = {
+    ITEM_IPV6_SRC,
+    ITEM_IPV6_DST,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_icmp[] = {
+    ITEM_ICMP_TYPE,
+    ITEM_ICMP_CODE,
+    ITEM_ICMP_IDENT,
+    ITEM_ICMP_SEQ,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_icmp6[] = {
+    ITEM_ICMP6_TYPE,
+    ITEM_ICMP6_CODE,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_udp[] = {
+    ITEM_UDP_SRC,
+    ITEM_UDP_DST,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_tcp[] = {
+    ITEM_TCP_SRC,
+    ITEM_TCP_DST,
+    ITEM_TCP_FLAGS,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_sctp[] = {
+    ITEM_SCTP_SRC,
+    ITEM_SCTP_DST,
+    ITEM_SCTP_TAG,
+    ITEM_SCTP_CKSUM,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_vxlan[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_e_tag[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_nvgre[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_mpls[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gre[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gtp[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gtpc[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gtpu[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_geneve[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_fuzzy[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_vxlan_gpe[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index next_vc_attr[] = {
+    ITEM_PATTERN,
+    ZERO,
+};
+
+/** Maximum number of subsequent tokens and arguments on the stack. */
+#define CTX_STACK_SIZE 16
+
+/** Maximum size for pattern in struct rte_flow_item_raw. */
+#define ITEM_RAW_PATTERN_SIZE 512
+
+/** Static initializer for the args field. */
+#define ARGS(...)                                                                                  \
+    (const struct arg *const[])                                                                    \
+    {                                                                                              \
+        __VA_ARGS__, NULL,                                                                         \
+    }
+
+/** Same as ARGS_ENTRY() using network byte ordering. */
+#define ARGS_ENTRY_HTON(s, f)                                                                      \
+    (&(const struct arg){                                                                          \
+            .hton = 1,                                                                             \
+            .offset = offsetof(s, f),                                                              \
+            .size = sizeof(((s *)0)->f),                                                           \
+    })
+
+/** Same as ARGS_ENTRY_HTON() for a single argument, without structure. */
+#define ARG_ENTRY_HTON(s)                                                                          \
+    (&(const struct arg){                                                                          \
+            .hton = 1,                                                                             \
+            .offset = 0,                                                                           \
+            .size = sizeof(s),                                                                     \
+    })
+
+#define PRIV_ITEM(t, s)                                                                            \
+    (&(const struct parse_item_priv){                                                              \
+            .type = RTE_FLOW_ITEM_TYPE_##t,                                                        \
+            .size = s,                                                                             \
+    })
+
+/** Static initializer for the args field. */
+#define ARGS(...)                                                                                  \
+    (const struct arg *const[])                                                                    \
+    {                                                                                              \
+        __VA_ARGS__, NULL,                                                                         \
+    }
+
+/** Static initializer for ARGS() to target a field. */
+#define ARGS_ENTRY(s, f)                                                                           \
+    (&(const struct arg){                                                                          \
+            .offset = offsetof(s, f),                                                              \
+            .size = sizeof(((s *)0)->f),                                                           \
+    })
+
+/** Static initializer for ARGS() to target a bit-field. */
+#define ARGS_ENTRY_BF(s, f, b)                                                                     \
+    (&(const struct arg){                                                                          \
+            .size = sizeof(s),                                                                     \
+            .mask = (const void *)&(const s){ .f = (1 << (b)) - 1 },                               \
+    })
+
+/** Static initializer for the next field. */
+#define NEXT(...)                                                                                  \
+    (const enum index *const[])                                                                    \
+    {                                                                                              \
+        __VA_ARGS__, NULL,                                                                         \
+    }
+
+/** Static initializer for a NEXT() entry. */
+#define NEXT_ENTRY(...)                                                                            \
+    (const enum index[])                                                                           \
+    {                                                                                              \
+        __VA_ARGS__, ZERO,                                                                         \
+    }
+
+/** Storage size for struct rte_flow_item_raw including pattern. */
+#define ITEM_RAW_SIZE (sizeof(struct rte_flow_item_raw) + ITEM_RAW_PATTERN_SIZE)
+
+/** Token argument. */
+struct arg {
+    uint32_t hton : 1;    /**< Use network byte ordering. */
+    uint32_t sign : 1;    /**< Value is signed. */
+    uint32_t bounded : 1; /**< Value is bounded. */
+    uintmax_t min;        /**< Minimum value if bounded. */
+    uintmax_t max;        /**< Maximum value if bounded. */
+    uint32_t offset;      /**< Relative offset from ctx->object. */
+    uint32_t size;        /**< Field size. */
+    const uint8_t *mask;  /**< Bit-mask to use instead of offset/size. */
+};
+
+struct buffer {
+    enum index command; /**< Flow command. */
+    union {
+        struct {
+            struct rte_flow_attr attr;
+            struct rte_flow_item *pattern;
+            uint32_t pattern_n;
+            uint8_t *data;
+        } vc; /**< Validate/create arguments. */
+
+    } args; /**< Command arguments. */
+};
+
+/** Parser context. */
+struct context {
+    /** Stack of subsequent token lists to process. */
+    const enum index *next[CTX_STACK_SIZE];
+    /** Arguments for stacked tokens. */
+    const void *args[CTX_STACK_SIZE];
+    enum index curr;   /**< Current token index. */
+    enum index prev;   /**< Index of the last token seen. */
+    int next_num;      /**< Number of entries in next[]. */
+    int args_num;      /**< Number of entries in args[]. */
+    uint32_t eol : 1;  /**< EOL has been detected. */
+    uint32_t last : 1; /**< No more arguments. */
+    uint16_t port;     /**< Current port ID (for completions). */
+    uint32_t objdata;  /**< Object-specific data. */
+    void *object;      /**< Address of current object for relative offsets. */
+    void *objmask;     /**< Object a full mask must be written to. */
+};
+
+static struct context cmd_flow_context;
+
+/** Initialize context. */
+static void cmd_flow_context_init(struct context *ctx)
+{
+    /* A full memset() is not necessary. */
+    ctx->curr = ZERO;
+    ctx->prev = ZERO;
+    ctx->next_num = 0;
+    ctx->args_num = 0;
+    ctx->eol = 0;
+    ctx->last = 0;
+    ctx->objdata = 0;
+    ctx->object = NULL;
+    ctx->objmask = NULL;
+}
+
+struct token {
+    /** Type displayed during completion (defaults to "TOKEN"). */
+    const char *type;
+    /** Private data used by parser functions. */
+    const void *priv;
+    /**
+     * Lists of subsequent tokens to push on the stack. Each call to the
+     * parser consumes the last entry of that stack.
+     */
+    const enum index *const *next;
+    /** Arguments stack for subsequent tokens that need them. */
+    const struct arg *const *args;
+    /**
+     * Token-processing callback, returns -1 in case of error, the
+     * length of the matched string otherwise. If NULL, attempts to
+     * match the token name.
+     *
+     * If buf is not NULL, the result should be stored in it according
+     * to context. An error is returned if not large enough.
+     */
+    int (*call)(struct context *ctx, const struct token *token, const char *str, unsigned int len,
+            void *buf, unsigned int size);
+    /** Mandatory token name, no default value. */
+    const char *name;
+};
+
+/**
+ * Maximum IPv6 address size in bytes.
+ */
+#define RTE_IPV6_ADDR_SIZE 16
+
+#if RTE_VERSION < RTE_VERSION_NUM(24, 0, 0, 0)
+/**
+ * IPv6 Address
+ */
+struct rte_ipv6_addr {
+    uint8_t a[RTE_IPV6_ADDR_SIZE];
+};
+#endif /* RTE_VERSION < RTE_VERSION_NUM(24, 0, 0, 0) */
+
+struct parse_item_priv {
+    enum rte_flow_item_type type; /**< Item type. */
+    uint32_t size;                /**< Size of item specification structure. */
+};
+
+static int parse_vc(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_vc_spec(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_init(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_int(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_mac_addr(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_ipv4_addr(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_ipv6_addr(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+
+static int parse_default(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size);
+
+static const struct token token_list[] = {
+
+    /* Starts parsing from ITEM_PATTERN */
+	[ZERO] = {
+		.name = "ZERO",
+		.next = NEXT(NEXT_ENTRY(ITEM_PATTERN)),
+	},
+	/* Create Token, not used directly */
+	[CREATE] = {
+		.name = "create",
+		.next = NEXT(next_vc_attr),
+		.call = parse_vc,
+	},	
+    /* Common tokens. */
+	[COMMON_UNSIGNED] = {
+		.name = "{unsigned}",
+		.type = "UNSIGNED",
+		.call = parse_int,
+	},
+	[COMMON_MAC_ADDR] = {
+		.name = "{MAC address}",
+		.type = "MAC-48",
+		.call = parse_mac_addr,
+	},
+	[COMMON_IPV4_ADDR] = {
+		.name = "{IPv4 address}",
+		.type = "IPV4 ADDRESS",
+		.call = parse_ipv4_addr,
+	},
+	[COMMON_IPV6_ADDR] = {
+		.name = "{IPv6 address}",
+		.type = "IPV6 ADDRESS",
+		.call = parse_ipv6_addr,
+	},
+	/* Validate/create pattern. */
+	[ITEM_PATTERN] = {
+		.name = "pattern",
+		.next = NEXT(next_item),
+		.call = parse_init,
+	},
+	[ITEM_PARAM_IS] = {
+		.name = "is",
+		.call = parse_vc_spec,
+	},
+	[ITEM_PARAM_SPEC] = {
+		.name = "spec",
+		.call = parse_vc_spec,
+	},
+	[ITEM_PARAM_LAST] = {
+		.name = "last",
+		.call = parse_vc_spec,
+	},
+	[ITEM_PARAM_MASK] = {
+		.name = "mask",
+		.call = parse_vc_spec,
+	},
+	[ITEM_NEXT] = {
+		.name = "/",
+		.next = NEXT(next_item),
+	},
+    [ITEM_END] = {
+		.name = "end",
+		.priv = PRIV_ITEM(END, 0),
+		.next = NEXT(NEXT_ENTRY(END)),
+		.call = parse_vc,
+	},
+	[ITEM_VOID] = {
+		.name = "void",
+		.priv = PRIV_ITEM(VOID, 0),
+		.next = NEXT(NEXT_ENTRY(ITEM_NEXT)),
+		.call = parse_vc,
+	},
+	[ITEM_ANY] = {
+		.name = "any",
+		.priv = PRIV_ITEM(ANY, sizeof(struct rte_flow_item_any)),
+		.next = NEXT(item_any),
+		.call = parse_vc,
+	},
+	[ITEM_PORT_ID] = {
+		.name = "port_id",
+		.priv = PRIV_ITEM(PORT_ID,
+				  sizeof(struct rte_flow_item_port_id)),
+		.next = NEXT(item_port_id),
+		.call = parse_vc,
+	},
+	[ITEM_RAW] = {
+		.name = "raw",
+		.priv = PRIV_ITEM(RAW, ITEM_RAW_SIZE),
+		.next = NEXT(item_raw),
+		.call = parse_vc,
+	},
+	[ITEM_ETH] = {
+		.name = "eth",
+		.priv = PRIV_ITEM(ETH, sizeof(struct rte_flow_item_eth)),
+		.next = NEXT(item_eth),
+		.call = parse_vc,
+	},
+	[ITEM_ETH_SRC] = {
+		.name = "src",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_MAC_ADDR), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_eth, hdr.src_addr)),
+	},
+	[ITEM_ETH_DST] = {
+		.name = "dst",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_MAC_ADDR), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_eth, hdr.dst_addr)),
+	},
+	[ITEM_ETH_TYPE] = {
+		.name = "type",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_eth, hdr.ether_type)),
+	},
+	[ITEM_ETH_HAS_VLAN] = {
+		.name = "has_vlan",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_BF(struct rte_flow_item_eth,
+					   has_vlan, 1)),
+	},
+	[ITEM_VLAN] = {
+		.name = "vlan",
+		.priv = PRIV_ITEM(VLAN, sizeof(struct rte_flow_item_vlan)),
+		.next = NEXT(item_vlan),
+		.call = parse_vc,
+	},
+	[ITEM_IPV4] = {
+		.name = "ipv4",
+		.priv = PRIV_ITEM(IPV4, sizeof(struct rte_flow_item_ipv4)),
+		.next = NEXT(item_ipv4),
+		.call = parse_vc,
+	},
+	[ITEM_IPV4_SRC] = {
+		.name = "src",
+		.next = NEXT(item_ipv4, NEXT_ENTRY(COMMON_IPV4_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv4,
+					     hdr.src_addr)),
+	},
+	[ITEM_IPV4_DST] = {
+		.name = "dst",
+		.next = NEXT(item_ipv4, NEXT_ENTRY(COMMON_IPV4_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv4,
+					     hdr.dst_addr)),
+	},
+	[ITEM_IPV6] = {
+		.name = "ipv6",
+		.priv = PRIV_ITEM(IPV6, sizeof(struct rte_flow_item_ipv6)),
+		.next = NEXT(item_ipv6),
+		.call = parse_vc,
+	},
+	[ITEM_IPV6_SRC] = {
+		.name = "src",
+		.next = NEXT(item_ipv6, NEXT_ENTRY(COMMON_IPV6_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv6,
+					     hdr.src_addr)),
+	},
+	[ITEM_IPV6_DST] = {
+		.name = "dst",
+		.next = NEXT(item_ipv6, NEXT_ENTRY(COMMON_IPV6_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv6,
+					     hdr.dst_addr)),
+	},
+	[ITEM_ICMP] = {
+		.name = "icmp",
+		.priv = PRIV_ITEM(ICMP, sizeof(struct rte_flow_item_icmp)),
+		.next = NEXT(item_icmp),
+		.call = parse_vc,
+	},
+	[ITEM_ICMP_TYPE] = {
+		.name = "type",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_type)),
+	},
+	[ITEM_ICMP_CODE] = {
+		.name = "code",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_code)),
+	},
+	[ITEM_ICMP_IDENT] = {
+		.name = "ident",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_ident)),
+	},
+	[ITEM_ICMP_SEQ] = {
+		.name = "seq",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_seq_nb)),
+	},
+	[ITEM_UDP] = {
+		.name = "udp",
+		.priv = PRIV_ITEM(UDP, sizeof(struct rte_flow_item_udp)),
+		.next = NEXT(item_udp),
+		.call = parse_vc,
+	},
+	[ITEM_UDP_SRC] = {
+		.name = "src",
+		.next = NEXT(item_udp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_udp,
+					     hdr.src_port)),
+	},
+	[ITEM_UDP_DST] = {
+		.name = "dst",
+		.next = NEXT(item_udp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_udp,
+					     hdr.dst_port)),
+	},
+	[ITEM_TCP] = {
+		.name = "tcp",
+		.priv = PRIV_ITEM(TCP, sizeof(struct rte_flow_item_tcp)),
+		.next = NEXT(item_tcp),
+		.call = parse_vc,
+	},
+	[ITEM_TCP_SRC] = {
+		.name = "src",
+		.next = NEXT(item_tcp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_tcp,
+					     hdr.src_port)),
+	},
+	[ITEM_TCP_DST] = {
+		.name = "dst",
+		.next = NEXT(item_tcp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_tcp,
+					     hdr.dst_port)),
+	},
+	[ITEM_TCP_FLAGS] = {
+		.name = "flags",
+		.next = NEXT(item_tcp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_tcp,
+					     hdr.tcp_flags)),
+	},
+	[ITEM_SCTP] = {
+		.name = "sctp",
+		.priv = PRIV_ITEM(SCTP, sizeof(struct rte_flow_item_sctp)),
+		.next = NEXT(item_sctp),
+		.call = parse_vc,
+	},
+	[ITEM_SCTP_SRC] = {
+		.name = "src",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.src_port)),
+	},
+	[ITEM_SCTP_DST] = {
+		.name = "dst",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.dst_port)),
+	},
+	[ITEM_SCTP_TAG] = {
+		.name = "tag",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.tag)),
+	},
+	[ITEM_SCTP_CKSUM] = {
+		.name = "cksum",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.cksum)),
+	},
+	[ITEM_VXLAN] = {
+		.name = "vxlan",
+		.priv = PRIV_ITEM(VXLAN, sizeof(struct rte_flow_item_vxlan)),
+		.next = NEXT(item_vxlan),
+		.call = parse_vc,
+	},
+	[ITEM_E_TAG] = {
+		.name = "e_tag",
+		.priv = PRIV_ITEM(E_TAG, sizeof(struct rte_flow_item_e_tag)),
+		.next = NEXT(item_e_tag),
+		.call = parse_vc,
+	},
+	[ITEM_NVGRE] = {
+		.name = "nvgre",
+		.priv = PRIV_ITEM(NVGRE, sizeof(struct rte_flow_item_nvgre)),
+		.next = NEXT(item_nvgre),
+		.call = parse_vc,
+	},
+	[ITEM_MPLS] = {
+		.name = "mpls",
+		.priv = PRIV_ITEM(MPLS, sizeof(struct rte_flow_item_mpls)),
+		.next = NEXT(item_mpls),
+		.call = parse_vc,
+	},
+	[ITEM_GRE] = {
+		.name = "gre",
+		.priv = PRIV_ITEM(GRE, sizeof(struct rte_flow_item_gre)),
+		.next = NEXT(item_gre),
+		.call = parse_vc,
+	},
+	[ITEM_FUZZY] = {
+		.name = "fuzzy",
+		.priv = PRIV_ITEM(FUZZY,
+				sizeof(struct rte_flow_item_fuzzy)),
+		.next = NEXT(item_fuzzy),
+		.call = parse_vc,
+	},
+
+	[ITEM_GTP] = {
+		.name = "gtp",
+		.priv = PRIV_ITEM(GTP, sizeof(struct rte_flow_item_gtp)),
+		.next = NEXT(item_gtp),
+		.call = parse_vc,
+	},
+
+	[ITEM_GTPC] = {
+		.name = "gtpc",
+		.priv = PRIV_ITEM(GTPC, sizeof(struct rte_flow_item_gtp)),
+		.next = NEXT(item_gtpc),
+		.call = parse_vc,
+	},
+	[ITEM_GTPU] = {
+		.name = "gtpu",
+		.priv = PRIV_ITEM(GTPU, sizeof(struct rte_flow_item_gtp)),
+		.next = NEXT(item_gtpu),
+		.call = parse_vc,
+	},
+	[ITEM_GENEVE] = {
+		.name = "geneve",
+		.priv = PRIV_ITEM(GENEVE, sizeof(struct rte_flow_item_geneve)),
+		.next = NEXT(item_geneve),
+		.call = parse_vc,
+	},
+	[ITEM_VXLAN_GPE] = {
+		.name = "vxlan-gpe",
+		.priv = PRIV_ITEM(VXLAN_GPE,
+				  sizeof(struct rte_flow_item_vxlan_gpe)),
+		.next = NEXT(item_vxlan_gpe),
+		.call = parse_vc,
+	},
+
+	[ITEM_ICMP6] = {
+		.name = "icmp6",
+		.priv = PRIV_ITEM(ICMP6, sizeof(struct rte_flow_item_icmp6)),
+		.next = NEXT(item_icmp6),
+		.call = parse_vc,
+	},
+
+};
+
+/** Remove and return last entry from argument stack. */
+static const struct arg *pop_args(struct context *ctx)
+{
+    return ctx->args_num ? ctx->args[--ctx->args_num] : NULL;
+}
+
+/** Add entry on top of the argument stack. */
+static int push_args(struct context *ctx, const struct arg *arg)
+{
+    if (ctx->args_num == CTX_STACK_SIZE)
+        return -1;
+    ctx->args[ctx->args_num++] = arg;
+    return 0;
+}
+
+/** Spread value into buffer according to bit-mask. */
+static size_t arg_entry_bf_fill(void *dst, uintmax_t val, const struct arg *arg)
+{
+    uint32_t i = arg->size;
+    uint32_t end = 0;
+    int sub = 1;
+    int add = 0;
+    size_t len = 0;
+
+    if (!arg->mask)
+        return 0;
+#if RTE_BYTE_ORDER == RTE_LITTLE_ENDIAN
+    if (!arg->hton) {
+        i = 0;
+        end = arg->size;
+        sub = 0;
+        add = 1;
+    }
+#endif
+    while (i != end) {
+        unsigned int shift = 0;
+        uint8_t *buf = (uint8_t *)dst + arg->offset + (i -= sub);
+
+        for (shift = 0; arg->mask[i] >> shift; ++shift) {
+            if (!(arg->mask[i] & (1 << shift)))
+                continue;
+            ++len;
+            if (!dst)
+                continue;
+            *buf &= ~(1 << shift);
+            *buf |= (val & 1) << shift;
+            val >>= 1;
+        }
+        i += add;
+    }
+    return len;
+}
+
+/** Compare a string with a partial one of a given length. */
+static int strcmp_partial(const char *full, const char *partial, size_t partial_len)
+{
+    int r = strncmp(full, partial, partial_len);
+
+    if (r)
+        return r;
+    if (strlen(full) <= partial_len)
+        return 0;
+    return full[partial_len];
+}
+
+/** Parse flow command, initialize output buffer for subsequent tokens. */
+static int parse_init(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    struct buffer *out = buf;
+
+    /* Token name must match. */
+    if (parse_default(ctx, token, str, len, NULL, 0) < 0)
+        return -1;
+    /* Nothing else to do if there is no buffer. */
+    if (!out)
+        return len;
+    /* Make sure buffer is large enough. */
+    if (size < sizeof(*out))
+        return -1;
+    /* Initialize buffer. */
+    memset(out, 0x00, sizeof(*out));
+    memset((uint8_t *)out + sizeof(*out), 0x22, size - sizeof(*out));
+    ctx->objdata = 0;
+    ctx->object = out;
+    ctx->objmask = NULL;
+    parse_vc(ctx, token, str, len, buf, size);
+    return len;
+}
+
+/**
+ * Parse a MAC address.
+ *
+ * Last argument (ctx->args) is retrieved to determine storage size and
+ * location.
+ */
+static int parse_mac_addr(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    struct rte_ether_addr tmp;
+    int ret;
+
+    (void)token;
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    size = arg->size;
+    /* Bit-mask fill is not supported. */
+    if (arg->mask || size != sizeof(tmp))
+        goto error;
+    /* Only network endian is supported. */
+    if (!arg->hton)
+        goto error;
+    ret = cmdline_parse_etheraddr(NULL, str, &tmp, size);
+    if (ret < 0 || (unsigned int)ret != len)
+        goto error;
+    if (!ctx->object)
+        return len;
+    buf = (uint8_t *)ctx->object + arg->offset;
+    memcpy(buf, &tmp, size);
+    if (ctx->objmask)
+        memset((uint8_t *)ctx->objmask + arg->offset, 0xff, size);
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/**
+ * Parse an IPv4 address.
+ *
+ * Last argument (ctx->args) is retrieved to determine storage size and
+ * location.
+ */
+static int parse_ipv4_addr(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    char str2[len + 1];
+    struct in_addr tmp;
+    int ret;
+
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    size = arg->size;
+    /* Bit-mask fill is not supported. */
+    if (arg->mask || size != sizeof(tmp))
+        goto error;
+    /* Only network endian is supported. */
+    if (!arg->hton)
+        goto error;
+    memcpy(str2, str, len);
+    str2[len] = '\0';
+    ret = inet_pton(AF_INET, str2, &tmp);
+    if (ret != 1) {
+        /* Attempt integer parsing. */
+        push_args(ctx, arg);
+        return parse_int(ctx, token, str, len, buf, size);
+    }
+    if (!ctx->object)
+        return len;
+    buf = (uint8_t *)ctx->object + arg->offset;
+    memcpy(buf, &tmp, size);
+    if (ctx->objmask)
+        memset((uint8_t *)ctx->objmask + arg->offset, 0xff, size);
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/**
+ * Parse an IPv6 address.
+ *
+ * Last argument (ctx->args) is retrieved to determine storage size and
+ * location.
+ */
+static int parse_ipv6_addr(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    char str2[len + 1];
+    struct rte_ipv6_addr tmp;
+    int ret;
+
+    (void)token;
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    size = arg->size;
+    /* Bit-mask fill is not supported. */
+    if (arg->mask || size != sizeof(tmp))
+        goto error;
+    /* Only network endian is supported. */
+    if (!arg->hton)
+        goto error;
+    memcpy(str2, str, len);
+    str2[len] = '\0';
+    ret = inet_pton(AF_INET6, str2, &tmp);
+    if (ret != 1)
+        goto error;
+    if (!ctx->object)
+        return len;
+    buf = (uint8_t *)ctx->object + arg->offset;
+    memcpy(buf, &tmp, size);
+    if (ctx->objmask)
+        memset((uint8_t *)ctx->objmask + arg->offset, 0xff, size);
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/**
+ * Parse signed/unsigned integers 8 to 64-bit long.
+ *
+ * Last argument (ctx->args) is retrieved to determine integer type and
+ * storage location.
+ */
+static int parse_int(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    uintmax_t u;
+    char *end;
+
+    (void)token;
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    errno = 0;
+    u = arg->sign ? (uintmax_t)strtoimax(str, &end, 0) : strtoumax(str, &end, 0);
+    if (errno || (size_t)(end - str) != len)
+        goto error;
+    if (arg->bounded && ((arg->sign && ((intmax_t)u < (intmax_t)arg->min ||
+                                               (intmax_t)u > (intmax_t)arg->max)) ||
+                                (!arg->sign && (u < arg->min || u > arg->max))))
+        goto error;
+    if (!ctx->object)
+        return len;
+    if (arg->mask) {
+        if (!arg_entry_bf_fill(ctx->object, u, arg) || !arg_entry_bf_fill(ctx->objmask, -1, arg))
+            goto error;
+        return len;
+    }
+    buf = (uint8_t *)ctx->object + arg->offset;
+    size = arg->size;
+    if (u > RTE_LEN2MASK(size * CHAR_BIT, uint64_t))
+        return -1;
+objmask:
+    switch (size) {
+        case sizeof(uint8_t):
+            *(uint8_t *)buf = u;
+            break;
+        case sizeof(uint16_t):
+            *(uint16_t *)buf = arg->hton ? rte_cpu_to_be_16(u) : u;
+            break;
+        case sizeof(uint8_t[3]):
+#if RTE_BYTE_ORDER == RTE_LITTLE_ENDIAN
+            if (!arg->hton) {
+                ((uint8_t *)buf)[0] = u;
+                ((uint8_t *)buf)[1] = u >> 8;
+                ((uint8_t *)buf)[2] = u >> 16;
+                break;
+            }
+#endif
+            ((uint8_t *)buf)[0] = u >> 16;
+            ((uint8_t *)buf)[1] = u >> 8;
+            ((uint8_t *)buf)[2] = u;
+            break;
+        case sizeof(uint32_t):
+            *(uint32_t *)buf = arg->hton ? rte_cpu_to_be_32(u) : u;
+            break;
+        case sizeof(uint64_t):
+            *(uint64_t *)buf = arg->hton ? rte_cpu_to_be_64(u) : u;
+            break;
+        default:
+            goto error;
+    }
+    if (ctx->objmask && buf != (uint8_t *)ctx->objmask + arg->offset) {
+        u = -1;
+        buf = (uint8_t *)ctx->objmask + arg->offset;
+        goto objmask;
+    }
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/** Default parsing function for token name matching. */
+static int parse_default(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    (void)ctx;
+    (void)buf;
+    (void)size;
+    if (strcmp_partial(token->name, str, len))
+        return -1;
+    return len;
+}
+
+/** Parse tokens for validate/create commands. */
+static int parse_vc(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    struct buffer *out = buf;
+    uint8_t *data;
+    uint32_t data_size;
+
+    /* Token name must match. */
+    if (parse_default(ctx, token, str, len, NULL, 0) < 0)
+        return -1;
+    /* Nothing else to do if there is no buffer. */
+    if (!out)
+        return len;
+    if (!out->command) {
+        if (sizeof(*out) > size)
+            return -1;
+        out->command = CREATE;
+        ctx->objdata = 0;
+        ctx->object = out;
+        ctx->objmask = NULL;
+        out->args.vc.data = (uint8_t *)out + size;
+    }
+    ctx->objdata = 0;
+    ctx->object = &out->args.vc.attr;
+    ctx->objmask = NULL;
+    switch (ctx->curr) {
+        case ITEM_PATTERN:
+            out->args.vc.pattern = (void *)RTE_ALIGN_CEIL((uintptr_t)(out + 1), sizeof(double));
+            ctx->object = out->args.vc.pattern;
+            ctx->objmask = NULL;
+            return len;
+        default:
+            if (!token->priv)
+                return -1;
+            break;
+    }
+    const struct parse_item_priv *priv = token->priv;
+    struct rte_flow_item *item = out->args.vc.pattern + out->args.vc.pattern_n;
+
+    data_size = priv->size * 3; /* spec, last, mask */
+    data = (void *)RTE_ALIGN_FLOOR((uintptr_t)(out->args.vc.data - data_size), sizeof(double));
+    if ((uint8_t *)item + sizeof(*item) > data)
+        return -1;
+    *item = (struct rte_flow_item){
+        .type = priv->type,
+    };
+    ++out->args.vc.pattern_n;
+    ctx->object = item;
+    ctx->objmask = NULL;
+
+    memset(data, 0, data_size);
+    out->args.vc.data = data;
+    ctx->objdata = data_size;
+    return len;
+}
+
+/** Parse pattern item parameter type. */
+static int parse_vc_spec(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    struct buffer *out = buf;
+    struct rte_flow_item *item;
+    uint32_t data_size;
+    int index;
+    int objmask = 0;
+
+    (void)size;
+    /* Token name must match. */
+    if (parse_default(ctx, token, str, len, NULL, 0) < 0)
+        return -1;
+    /* Parse parameter types. */
+    switch (ctx->curr) {
+
+        case ITEM_PARAM_IS:
+            index = 0;
+            objmask = 1;
+            break;
+        case ITEM_PARAM_SPEC:
+            index = 0;
+            break;
+        case ITEM_PARAM_LAST:
+            index = 1;
+            break;
+        case ITEM_PARAM_MASK:
+            index = 2;
+            break;
+        default:
+            return -1;
+    }
+    /* Nothing else to do if there is no buffer. */
+    if (!out)
+        return len;
+    if (!out->args.vc.pattern_n)
+        return -1;
+    item = &out->args.vc.pattern[out->args.vc.pattern_n - 1];
+    data_size = ctx->objdata / 3; /* spec, last, mask */
+    /* Point to selected object. */
+    ctx->object = out->args.vc.data + (data_size * index);
+    if (objmask) {
+        ctx->objmask = out->args.vc.data + (data_size * 2); /* mask */
+        item->mask = ctx->objmask;
+    } else
+        ctx->objmask = NULL;
+    /* Update relevant item pointer. */
+    *((const void **[]){ &item->spec, &item->last, &item->mask })[index] = ctx->object;
+    return len;
+}
+
+/** Parse a token (cmdline API). */
+static int cmd_flow_parse(const char *src, void *result, unsigned int size)
+{
+    struct context *ctx = &cmd_flow_context;
+    const struct token *token;
+    const enum index *list;
+    int len;
+    int i;
+
+    token = &token_list[ctx->curr];
+    /* Check argument length. */
+    ctx->eol = 0;
+    ctx->last = 1;
+    for (len = 0; src[len]; ++len)
+        if (src[len] == '#' || isspace(src[len]))
+            break;
+    if (!len)
+        return -1;
+    /* Last argument and EOL detection. */
+    for (i = len; src[i]; ++i)
+        if (src[i] == '#' || src[i] == '\r' || src[i] == '\n')
+            break;
+        else if (!isspace(src[i])) {
+            ctx->last = 0;
+            break;
+        }
+    for (; src[i]; ++i)
+        if (src[i] == '\r' || src[i] == '\n') {
+            ctx->eol = 1;
+            break;
+        }
+    /* Initialize context if necessary. */
+    if (!ctx->next_num) {
+        if (!token->next)
+            return 0;
+        ctx->next[ctx->next_num++] = token->next[0];
+    }
+    /* Process argument through candidates. */
+    ctx->prev = ctx->curr;
+    list = ctx->next[ctx->next_num - 1];
+    for (i = 0; list[i]; ++i) {
+        const struct token *next = &token_list[list[i]];
+        int tmp;
+
+        ctx->curr = list[i];
+        if (next->call)
+            tmp = next->call(ctx, next, src, len, result, size);
+        else
+            tmp = parse_default(ctx, next, src, len, result, size);
+        if (tmp == -1 || tmp != len)
+            continue;
+        token = next;
+        break;
+    }
+    if (!list[i])
+        return -1;
+    --ctx->next_num;
+    /* Push subsequent tokens if any. */
+    if (token->next)
+        for (i = 0; token->next[i]; ++i) {
+            if (ctx->next_num == RTE_DIM(ctx->next))
+                return -1;
+            ctx->next[ctx->next_num++] = token->next[i];
+        }
+    /* Push arguments if any. */
+    if (token->args)
+        for (i = 0; token->args[i]; ++i) {
+            if (ctx->args_num == RTE_DIM(ctx->args))
+                return -1;
+            ctx->args[ctx->args_num++] = token->args[i];
+        }
+    return len;
+}
+
+static int flow_parse(
+        const char *src, void *result, unsigned int size, struct rte_flow_item **pattern)
+{
+    int ret;
+    struct context saved_flow_ctx = cmd_flow_context;
+
+    memset(result, 0x00, sizeof(*result));
+    memset((uint8_t *)result + sizeof(*result), 0x22, size - sizeof(*result));
+
+    cmd_flow_context_init(&cmd_flow_context);
+    do {
+        ret = cmd_flow_parse(src, result, size);
+        if (ret > 0) {
+            src += ret;
+            while (isspace(*src))
+                src++;
+        }
+    } while (ret > 0 && strlen(src));
+    cmd_flow_context = saved_flow_ctx;
+    *pattern = ((struct buffer *)result)->args.vc.pattern;
+
+    return (ret >= 0 && !strlen(src)) ? 0 : -1;
+}
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)*/
+
+/**
+ * \brief Parse rte_flow rule pattern and store individual pattern items in items and their
+ *        attributes in buffer data
+ *
+ * \param pattern rte_flow rule pattern to be parsed
+ * \param data buffer to store parsed pattern
+ * \param size size of buffer
+ * \param items parsed items used when creating rte_flow rules
+ * \return int 0 on success, -1 on error
+ */
+int ParsePattern(
+        char *pattern, uint8_t *items_data_buffer, unsigned int size, struct rte_flow_item **items)
+{
+    SCEnter();
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)
+    SCReturnInt(flow_parse(pattern, (void *)items_data_buffer, size, items));
+#else
+    SCReturnInt(0);
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)*/
+}
+
+#endif /* HAVE_DPDK */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow-pattern.c
+++ b/src/util-dpdk-rte-flow-pattern.c
@@ -141,6 +141,7 @@ static const enum index item_param[] = {
     ZERO,
 };
 
+/* --- start pattern enum --- */
 static const enum index next_item[] = {
     ITEM_END,
     ITEM_VOID,
@@ -169,6 +170,7 @@ static const enum index next_item[] = {
     ITEM_VXLAN_GPE,
     ZERO,
 };
+/* --- end pattern enum --- */
 
 static const enum index item_any[] = {
     ITEM_NEXT,

--- a/src/util-dpdk-rte-flow-pattern.h
+++ b/src/util-dpdk-rte-flow-pattern.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021-2025 Open Information Security Foundation
+/* Copyright (C) 2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -16,24 +16,32 @@
  */
 
 /**
- * \file
+ *  \defgroup dpdk DPDK rte_flow rules util functions
  *
- * \author Lukas Sismis <lukas.sismis@gmail.com>
+ *  @{
  */
 
-#ifndef UTIL_DPDK_ICE_H
-#define UTIL_DPDK_ICE_H
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
+ */
 
-#include "suricata-common.h"
+#ifndef SURICATA_RTE_FLOW_RULES_PATTERN_H
+#define SURICATA_RTE_FLOW_RULES_PATTERN_H
 
 #ifdef HAVE_DPDK
 
 #include "util-dpdk.h"
+#include <rte_ethdev.h>
 
-int iceDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
-void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf);
-bool iceDeviceRteFlowPatternError(struct rte_flow_item *);
+int ParsePattern(char *pattern, uint8_t *data, unsigned int size, struct rte_flow_item **items);
 
 #endif /* HAVE_DPDK */
-
-#endif /* UTIL_DPDK_ICE_H */
+#endif /* SURICATA_RTE_FLOW_RULES_PATTERN_H */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.c
+++ b/src/util-dpdk-rte-flow.c
@@ -49,6 +49,9 @@ static int RteFlowRuleStorageInit(RteFlowRuleStorage *);
 static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *, const char *);
 static int RteFlowRuleStorageExtendCapacity(RteFlowRuleStorage *);
 static char *DriverSpecificErrorMessage(const char *, struct rte_flow_item *);
+static bool RteFlowRulesContainPatternWildcard(char **, uint32_t);
+static bool RteFlowDropFilterInit(uint32_t, char **, struct rte_flow_attr *,
+        struct rte_flow_action *, uint32_t *, const char *, const char *);
 
 /**
  * \brief Specify ambiguous error messages as some drivers have specific
@@ -69,6 +72,81 @@ static char *DriverSpecificErrorMessage(const char *driver_name, struct rte_flow
     }
 
     return NULL;
+}
+
+/**
+ * \brief Checks whether at least one pattern contains wildcard matching
+ *
+ * \param patterns array of loaded rte_flow rule patterns from suricata.yaml
+ * \param rule_count number of loaded rte_flow rule patterns
+ * \return true pattern contains wildcard matching
+ * \return false pattern does not contain wildcard matching
+ */
+static bool RteFlowRulesContainPatternWildcard(char **patterns, uint32_t rule_count)
+{
+    for (size_t i = 0; i < rule_count; i++) {
+        char *pattern = patterns[i];
+        if (strstr(pattern, " mask ") != NULL || (strstr(pattern, " last ") != NULL))
+            return true;
+    }
+    return false;
+}
+
+/**
+ * \brief Initializes rte_flow rules and decides whether statistics about the rule (count of
+ *        filtered packets) can be gathered or not
+ *
+ * \param rule_count number of rte_flow rules present
+ * \param patterns array of patterns for rte_flow rules
+ * \param attr out variable for initialized rte_flow attributes
+ * \param action out variable for initialized rte_flow action
+ * \param counter_id id of a rte_flow counter action
+ * \param driver_name name of the driver
+ * \param port_name name of the port
+ * \return true if statistics about rte_flow rules can be gathered
+ * \return false if statistics about rte_flow rules can not be gathered
+ */
+static bool RteFlowDropFilterInit(uint32_t rule_count, char **patterns, struct rte_flow_attr *attr,
+        struct rte_flow_action *action, uint32_t *counter_id, const char *driver_name,
+        const char *port_name)
+{
+    attr->ingress = 1;
+    attr->priority = 0;
+
+    /* ICE PMD does not support count action with wildcard pattern (mask and last pattern item
+     * types). The count action is omitted when wildcard pattern is detected */
+    if (strcmp(driver_name, "net_ice") == 0) {
+        if (RteFlowRulesContainPatternWildcard(patterns, rule_count) == true) {
+            action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
+            action[1].type = RTE_FLOW_ACTION_TYPE_END;
+            SCLogWarning(
+                    "%s: gathering statistic for the rte_flow rule is disabled because of wildcard "
+                    "pattern (ice PMD specific)",
+                    port_name);
+            return false;
+        }
+/* ICE PMD has to have attribute group set to 2 on DPDK 23.11 and higher for the count action to
+ * work properly */
+#if RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0)
+        attr->group = 2;
+#else
+        attr->group = 0;
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0) */
+    }
+
+    if (strcmp(driver_name, "net_ice") == 0 || strcmp(driver_name, "mlx5_pci") == 0) {
+
+        action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+        action[0].conf = counter_id;
+        action[1].type = RTE_FLOW_ACTION_TYPE_DROP;
+        action[2].type = RTE_FLOW_ACTION_TYPE_END;
+
+        return true;
+    }
+
+    action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+    return false;
 }
 
 static int RteFlowRuleStorageInit(RteFlowRuleStorage *rule_storage)
@@ -190,6 +268,44 @@ int ConfigLoadRteFlowRules(
 }
 
 /**
+ * \brief Query the number of packets filtered by rte_flow rules defined by user in suricata.yaml
+ *
+ * \param rules array of rte_flow rule handlers
+ * \param rule_count number of existing rules
+ * \param port_id id of a port
+ * \param filtered_packets out variable for the number of packets filtered by the rte_flow rules
+ * \return int 0 on success, a negative errno value otherwise and rte_errno is set
+ */
+uint64_t RteFlowFilteredPacketsQuery(struct rte_flow **rules, uint16_t rule_count,
+        char *device_name, int port_id, uint64_t *filtered_packets)
+{
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)
+    struct rte_flow_query_count query_count = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+    struct rte_flow_error flow_error = { 0 };
+    uint32_t counter_id = COUNT_ACTION_ID;
+    int retval = 0;
+
+    query_count.reset = 0;
+    action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+    action[0].conf = &counter_id;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+    for (uint16_t i = 0; i < rule_count; i++) {
+        retval +=
+                rte_flow_query(port_id, rules[i], &(action[0]), (void *)&query_count, &flow_error);
+        if (retval != 0) {
+            SCLogError("%s: rte_flow count query error %s errmsg: %s", device_name,
+                    rte_strerror(-retval), flow_error.message);
+            SCReturnInt(retval);
+        };
+        *filtered_packets += query_count.hits;
+    }
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0) */
+    SCReturnInt(0);
+}
+
+/**
  * \brief Create rte_flow drop rules with patterns stored in rule_storage on a port with id
  *        port_id
  *
@@ -205,13 +321,13 @@ int RteFlowRulesCreate(
 #if RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)
     SCEnter();
     int failed_rule_count = 0;
+    uint32_t counter_id = COUNT_ACTION_ID;
     struct rte_flow_error flush_error = { 0 };
     struct rte_flow_attr attr = { 0 };
     struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
 
-    attr.ingress = 1;
-    action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
-    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+    bool should_gather_stats = RteFlowDropFilterInit(rule_storage->rule_cnt, rule_storage->rules,
+            &attr, action, &counter_id, driver_name, port_name);
 
     rule_storage->rule_handlers = SCCalloc(rule_storage->rule_size, sizeof(struct rte_flow *));
     if (rule_storage->rule_handlers == NULL) {
@@ -269,6 +385,12 @@ int RteFlowRulesCreate(
         }
         SCReturnInt(-1);
     }
+
+    if (!should_gather_stats) {
+        SCFree(rule_storage->rule_handlers);
+        rule_storage->rule_cnt = 0;
+    }
+
 #endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)*/
     SCReturnInt(0);
 }

--- a/src/util-dpdk-rte-flow.c
+++ b/src/util-dpdk-rte-flow.c
@@ -1,0 +1,279 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  \defgroup dpdk DPDK rte_flow rules util functions
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
+ */
+
+#include "decode.h"
+#include "runmode-dpdk.h"
+#include "util-debug.h"
+#include "util-dpdk.h"
+#include "util-dpdk-ice.h"
+#include "util-dpdk-rte-flow.h"
+#include "util-dpdk-rte-flow-pattern.h"
+
+#ifdef HAVE_DPDK
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)
+
+#define INITIAL_RTE_FLOW_RULE_COUNT_CAPACITY 5
+#define DATA_BUFFER_SIZE                     1024
+#define COUNT_ACTION_ID                      128
+
+static int RteFlowRuleStorageInit(RteFlowRuleStorage *);
+static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *, const char *);
+static int RteFlowRuleStorageExtendCapacity(RteFlowRuleStorage *);
+static char *DriverSpecificErrorMessage(const char *, struct rte_flow_item *);
+
+/**
+ * \brief Specify ambiguous error messages as some drivers have specific
+ *        behaviour when creating rte_flow rules
+ *
+ * \param driver_name name of a driver
+ * \param items array of pattern items
+ */
+static char *DriverSpecificErrorMessage(const char *driver_name, struct rte_flow_item *items)
+{
+    if (strcmp(driver_name, "net_ice") == 0) {
+        if (iceDeviceRteFlowPatternError(items) == true) {
+            char msg[] = "Driver specific errmsg: ice driver does not support broad patterns";
+            char *ret = SCCalloc((strlen(msg) + 1), sizeof(char));
+            strlcpy(ret, msg, sizeof(char) * (strlen(msg) + 1));
+            return ret;
+        }
+    }
+
+    return NULL;
+}
+
+static int RteFlowRuleStorageInit(RteFlowRuleStorage *rule_storage)
+{
+    SCEnter();
+    rule_storage->rule_cnt = 0;
+    rule_storage->rule_size = INITIAL_RTE_FLOW_RULE_COUNT_CAPACITY;
+    rule_storage->rules = SCCalloc(rule_storage->rule_size, sizeof(char *));
+
+    if (rule_storage->rules == NULL) {
+        SCLogError("Setup memory allocation for rte_flow rule storage failed");
+        SCReturnInt(-1);
+    }
+    SCReturnInt(0);
+}
+
+static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *rule_storage, const char *rule)
+{
+    SCEnter();
+    rule_storage->rules[rule_storage->rule_cnt] = SCCalloc(strlen(rule) + 1, sizeof(char));
+    if (rule_storage->rules[rule_storage->rule_cnt] == NULL) {
+        SCLogError("Memory allocation for rte_flow rule string failed");
+        RteFlowRuleStorageFree(rule_storage);
+        SCReturnInt(-1);
+    }
+
+    strlcpy(rule_storage->rules[rule_storage->rule_cnt], rule, (strlen(rule) + 1) * sizeof(char));
+    rule_storage->rule_cnt++;
+
+    if (rule_storage->rule_cnt == rule_storage->rule_size) {
+        int retval = RteFlowRuleStorageExtendCapacity(rule_storage);
+        if (retval != 0) {
+            SCReturnInt(retval);
+        }
+    }
+    SCReturnInt(0);
+}
+
+static int RteFlowRuleStorageExtendCapacity(RteFlowRuleStorage *rule_storage)
+{
+    SCEnter();
+    char **tmp_rules;
+
+    rule_storage->rule_size = 2 * rule_storage->rule_size;
+    tmp_rules = SCRealloc(rule_storage->rules, rule_storage->rule_size * sizeof(char *));
+
+    if (tmp_rules == NULL) {
+        SCLogError("Memory reallocation for rte_flow rule storage failed");
+        RteFlowRuleStorageFree(rule_storage);
+        SCReturnInt(-1);
+    }
+
+    rule_storage->rules = tmp_rules;
+    SCReturnInt(0);
+}
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0) */
+
+/**
+ * \brief Deallocation of memory containing user set rte_flow rules
+ *
+ * \param rule_storage rules loaded from suricata.yaml
+ */
+void RteFlowRuleStorageFree(RteFlowRuleStorage *rule_storage)
+{
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)
+
+    if (rule_storage->rules == NULL) {
+        SCReturn;
+    }
+    for (int i = 0; i < rule_storage->rule_cnt; ++i) {
+        SCFree(rule_storage->rules[i]);
+    }
+    SCFree(rule_storage->rules);
+    rule_storage->rules = NULL;
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0) */
+}
+
+/**
+ * \brief Load rte_flow rules patterns from suricata.yaml
+ *
+ * \param if_root root node in suricata.yaml
+ * \param if_default default value
+ * \param filter_type type of rte_flow rules to be loaded, only drop_filter is supported
+ * \param rule_storage pointer to structure to load rte_flow rules into
+ * \return int 0 on success, -1 on error
+ */
+int ConfigLoadRteFlowRules(
+        SCConfNode *if_root, const char *filter_type, RteFlowRuleStorage *rule_storage)
+{
+    SCEnter();
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)
+    SCConfNode *node = SCConfNodeLookupChild(if_root, filter_type);
+    if (node == NULL) {
+        SCLogInfo("No configuration node found for %s", filter_type);
+    } else {
+        SCConfNode *rule_node;
+        const char *rule;
+        int retval = RteFlowRuleStorageInit(rule_storage);
+        if (retval != 0) {
+            SCReturnInt(retval);
+        }
+
+        TAILQ_FOREACH (rule_node, &node->head, next) {
+            if (strcmp(rule_node->val, "rule") == 0) {
+                SCConfGetChildValue(rule_node, "rule", &rule);
+                retval = RteFlowRuleStorageAddRule(rule_storage, rule);
+                if (retval != 0) {
+                    SCReturnInt(retval);
+                }
+            } else {
+                SCLogError("Found string that is not \"rule\" in dpdk dropfilter section in "
+                           "suricata.yaml");
+                SCReturnInt(-1);
+            }
+        }
+    }
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0) */
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Create rte_flow drop rules with patterns stored in rule_storage on a port with id
+ *        port_id
+ *
+ * \param port_name name of a port
+ * \param port_id identificator of a port
+ * \param rule_storage pointer to structure containing rte_flow rule patterns
+ * \param driver_name name of a driver
+ * \return int 0 on success, -1 on error
+ */
+int RteFlowRulesCreate(
+        char *port_name, int port_id, RteFlowRuleStorage *rule_storage, const char *driver_name)
+{
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)
+    SCEnter();
+    int failed_rule_count = 0;
+    struct rte_flow_error flush_error = { 0 };
+    struct rte_flow_attr attr = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+
+    attr.ingress = 1;
+    action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+    rule_storage->rule_handlers = SCCalloc(rule_storage->rule_size, sizeof(struct rte_flow *));
+    if (rule_storage->rule_handlers == NULL) {
+        SCLogError("%s: Memory allocation for rte_flow rule string failed", port_name);
+        RteFlowRuleStorageFree(rule_storage);
+        SCReturnInt(-1);
+    }
+
+    for (int i = 0; i < rule_storage->rule_cnt; i++) {
+        struct rte_flow_item *items = { 0 };
+        struct rte_flow_error flow_error = { 0 };
+        uint8_t items_data_buffer[DATA_BUFFER_SIZE] = { 0 };
+
+        int retval = ParsePattern(
+                rule_storage->rules[i], items_data_buffer, sizeof(items_data_buffer), &items);
+        if (retval != 0) {
+            failed_rule_count++;
+            SCLogError("%s: Error when parsing rte_flow rule \"%s\"", port_name,
+                    rule_storage->rules[i]);
+            continue;
+        }
+
+        retval = rte_flow_validate(port_id, &attr, items, action, &flow_error);
+        if (retval != 0) {
+            failed_rule_count++;
+            char *driver_specific_err = DriverSpecificErrorMessage(driver_name, items);
+            SCLogError("%s: Error when validating rte_flow rule \"%s\": %s, errmsg: "
+                       "%s. %s",
+                    port_name, rule_storage->rules[i], rte_strerror(-retval), flow_error.message,
+                    driver_specific_err != NULL ? driver_specific_err : "");
+            if (driver_specific_err != NULL) {
+                SCFree(driver_specific_err);
+            }
+            continue;
+        }
+
+        struct rte_flow *flow_handler = rte_flow_create(port_id, &attr, items, action, &flow_error);
+        if (flow_handler == NULL) {
+            failed_rule_count++;
+            SCLogError("%s: Error when creating rte_flow rule \"%s\": %s", port_name,
+                    rule_storage->rules[i], flow_error.message);
+            continue;
+        }
+        rule_storage->rule_handlers[i] = flow_handler;
+        SCLogInfo("%s: rte_flow rule \"%s\" created", port_name, rule_storage->rules[i]);
+    }
+
+    if (failed_rule_count) {
+        SCLogError("%s: Error parsing/creating %i rte_flow rule(s), flushing rules", port_name,
+                failed_rule_count);
+        int retval = rte_flow_flush(port_id, &flush_error);
+        if (retval != 0) {
+            SCLogError("%s Unable to flush rte_flow rules: %s Flush error msg: %s", port_name,
+                    rte_strerror(-retval), flush_error.message);
+        }
+        SCReturnInt(-1);
+    }
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)*/
+    SCReturnInt(0);
+}
+
+#endif /* HAVE_DPDK */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.c
+++ b/src/util-dpdk-rte-flow.c
@@ -31,19 +31,30 @@
  */
 
 #include "decode.h"
+#include "flow-bypass.h"
+#include "flow-hash.h"
+#include "flow-storage.h"
 #include "runmode-dpdk.h"
 #include "util-debug.h"
 #include "util-dpdk.h"
 #include "util-dpdk-ice.h"
 #include "util-dpdk-rte-flow.h"
 #include "util-dpdk-rte-flow-pattern.h"
+#include "util-device-private.h"
+#include "runmodes.h"
+#include "tm-threads.h"
+#include "suricata.h"
 
 #ifdef HAVE_DPDK
+#include <rte_ring.h>
+
 #if RTE_VERSION >= RTE_VERSION_NUM(21, 0, 0, 0)
 
 #define INITIAL_RTE_FLOW_RULE_COUNT_CAPACITY 5
 #define DATA_BUFFER_SIZE                     1024
 #define COUNT_ACTION_ID                      128
+#define RTE_BYPASS_RING_NAME                 "rte_bypass_ring"
+#define RTE_BYPASS_MEMPOOL_NAME              "rte_bypass_mempool"
 
 static int RteFlowRuleStorageInit(RteFlowRuleStorage *);
 static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *, const char *);
@@ -52,6 +63,9 @@ static char *DriverSpecificErrorMessage(const char *, struct rte_flow_item *);
 static bool RteFlowRulesContainPatternWildcard(char **, uint32_t);
 static bool RteFlowDropFilterInit(uint32_t, char **, struct rte_flow_attr *,
         struct rte_flow_action *, uint32_t *, const char *, const char *);
+static int RteFlowBypassRuleCreate(struct rte_flow_item *, int, struct rte_flow **);
+static int RteFlowUpdateStats(FlowBypassInfo *, uint16_t, struct rte_flow *, struct rte_flow *);
+static int RteFlowSetFlowBypassInfo(Flow *, struct rte_flow *, struct rte_flow *, int);
 
 /**
  * \brief Specify ambiguous error messages as some drivers have specific
@@ -395,7 +409,523 @@ int RteFlowRulesCreate(
     SCReturnInt(0);
 }
 
-#endif /* HAVE_DPDK */
+/**
+ * \brief Enable and register functions for BypassManager,
+ *        initialize rte_ring data structure and store in global
+ *        variable
+ *
+ * \param port_name name of a port
+ * \param port_id identificator of a port
+ * \return int 0 on success, negative value on error
+ */
+int RteBypassInit(DPDKDeviceResources *dpdk_resources, uint32_t bypass_ring_size,
+        const char *port_name, int port_id)
+{
+    SCEnter();
+    LiveDevice *livedev = LiveGetDevice(port_name);
+    LiveDevUseBypass(livedev);
+    RunModeEnablesBypassManager();
+
+    RteFlowBypassData *rte_flow_bypass_data = SCCalloc(1, sizeof(RteFlowBypassData));
+    if (rte_flow_bypass_data == NULL) {
+        SCLogError("%s: Memory allocation for RteFlowBypassData failed", port_name);
+        SCReturnInt(-1);
+    }
+
+    struct rte_ring *bypass_ring =
+            rte_ring_create(RTE_BYPASS_RING_NAME, bypass_ring_size, rte_socket_id(), RING_F_SC_DEQ);
+    if (bypass_ring == NULL) {
+        SCLogError("%s: rte_ring_create failed with code %d (ring: %s): %s", port_name, rte_errno,
+                RTE_BYPASS_RING_NAME, rte_strerror(rte_errno));
+        SCReturnInt(-1);
+    }
+    rte_flow_bypass_data->bypass_ring = bypass_ring;
+
+    uint32_t mempool_size = (bypass_ring_size * 2) - 1;
+    struct rte_mempool *bypass_mp = rte_mempool_create(RTE_BYPASS_MEMPOOL_NAME, mempool_size,
+            sizeof(FlowKey), MempoolCacheSizeCalculate(mempool_size), 0, NULL, NULL, NULL, NULL,
+            rte_socket_id(), 0);
+    if (bypass_mp == NULL) {
+        SCLogError("%s: rte_mempool_create failed with code %d (mempool: %s): %s", port_name,
+                rte_errno, RTE_BYPASS_MEMPOOL_NAME, rte_strerror(rte_errno));
+        SCReturnInt(-1);
+    }
+    BypassedFlowManagerRegisterCheckFunc(
+            RteFlowBypassRuleLoad, RteFlowBypassCheckFlowInit, (void *)rte_flow_bypass_data);
+
+    rte_flow_bypass_data->bypass_mp = bypass_mp;
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_rules_active);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_rules_created);
+
+    dpdk_resources->rte_flow_bypass_data = rte_flow_bypass_data;
+
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Decides whether the rte_flow rule should be removed from the table
+ *
+ * \param port_id identificator of a port
+ * \param src_rule_handler rte_flow rule handler for specific flow in one direction
+ * \param dst_rule_handler rte_flow rule handler for specific flow in other direction
+ * \param flow flow to be possibly removed from the table
+ * \return int 1 if the rte_flow rule is active, 0 if it should be removed
+ */
+static int RteFlowUpdateStats(FlowBypassInfo *fc, uint16_t port_id,
+        struct rte_flow *src_rule_handler, struct rte_flow *dst_rule_handler)
+{
+    SCEnter();
+    struct rte_flow_query_count query_count = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+    struct rte_flow_error flow_error = { 0 };
+    uint32_t counter_id = COUNT_ACTION_ID;
+    int retval = 0;
+
+    query_count.reset = 1;
+    action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+    action[0].conf = &counter_id;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+    retval = rte_flow_query(
+            port_id, src_rule_handler, &(action[0]), (void *)&query_count, &flow_error);
+    if (retval != 0) {
+        SCLogError("rte_flow dynamic bypass: count query error %s errmsg: %s",
+                rte_strerror(-retval), flow_error.message);
+    };
+
+    uint32_t src_packets = query_count.hits;
+    uint32_t src_bytes = query_count.bytes;
+
+    memset(&query_count, 0, sizeof(struct rte_flow_query_count));
+    query_count.reset = 1;
+    retval = rte_flow_query(
+            port_id, dst_rule_handler, &(action[0]), (void *)&query_count, &flow_error);
+    if (retval != 0) {
+        SCLogError("rte_flow dynamic bypass: count query error %s errmsg: %s",
+                rte_strerror(-retval), flow_error.message);
+    };
+
+    uint32_t dst_packets = query_count.hits;
+    uint32_t dst_bytes = query_count.bytes;
+
+    /* Proceed only if there are new filtered packets in the flow */
+    if (src_packets || dst_packets) {
+        fc->tosrcpktcnt += src_packets;
+        fc->tosrcbytecnt += src_bytes;
+        fc->todstpktcnt += dst_packets;
+        fc->todstbytecnt += dst_bytes;
+        SCReturnInt(1);
+    }
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Create rte_flow drop rule for dynamic bypass
+ *
+ * \param items array of pattern items
+ * \param port_id identificator of a port
+ * \param flow_handler rte_flow rule handler
+ * \return int 0 on success, negative value on error
+ */
+static int RteFlowBypassRuleCreate(
+        struct rte_flow_item *items, int port_id, struct rte_flow **flow_handler)
+{
+    struct rte_flow_error flow_error = { 0 };
+    struct rte_flow_attr attr = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+
+    attr.ingress = 1;
+    attr.priority = 0;
+    attr.group = 0;
+
+    uint32_t counter_id = COUNT_ACTION_ID;
+
+    action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+    action[0].conf = &counter_id;
+    action[1].type = RTE_FLOW_ACTION_TYPE_DROP;
+    action[2].type = RTE_FLOW_ACTION_TYPE_END;
+
+    int retval = rte_flow_validate(port_id, &attr, items, action, &flow_error);
+    if (retval != 0) {
+        SCReturnInt(retval);
+    }
+
+    *flow_handler = rte_flow_create(port_id, &attr, items, action, &flow_error);
+    if (*flow_handler == NULL) {
+        SCReturnInt(-1);
+    }
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Placeholder function for BypassManager
+ *
+ * \param th_v Ignored
+ * \param curtime Ignored
+ * \param data Ignored
+ * \return 0
+ */
+int RteFlowBypassCheckFlowInit(ThreadVars *th_v, struct timespec *curtime, void *data)
+{
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Poll flow data from rte_flow_ring structure and create rte_flow bypass rule to bypass flow
+ *        from both directions
+ *
+ * \param th_v Ignored
+ * \param bypassstats Ignored
+ * \param curtime Ignored
+ * \param data table of flows and rte_flow rule handlers
+ * \return int number of successfully created rte_flow rules
+ */
+int RteFlowBypassRuleLoad(
+        ThreadVars *th_v, struct flows_stats *bypassstats, struct timespec *curtime, void *data)
+{
+    SCEnter();
+    RteFlowBypassData *rte_flow_bypass_data = (RteFlowBypassData *)data;
+    struct rte_ring *bypass_ring = rte_flow_bypass_data->bypass_ring;
+    struct rte_mempool *bypass_mp = rte_flow_bypass_data->bypass_mp;
+    struct rte_flow_item items[] = { { 0 }, { 0 }, { 0 }, { 0 }, { 0 } };
+    uint16_t L2_INDEX = 0, L3_INDEX = 1, L4_INDEX = 2, END_INDEX = 3;
+    uint16_t ring_dequeue_num = 20;
+    uint32_t success_count = 0;
+    FlowKey *ring_data[ring_dequeue_num];
+
+    /* Initialize the reusable part of rte_flow rules */
+    items[L2_INDEX].type = RTE_FLOW_ITEM_TYPE_ETH;
+    items[END_INDEX].type = RTE_FLOW_ITEM_TYPE_END;
+
+    uint32_t to_bypass_packets =
+            rte_ring_dequeue_burst(bypass_ring, (void **)ring_data, ring_dequeue_num, NULL);
+    for (uint16_t i = 0; i < to_bypass_packets; i++) {
+        if (unlikely(suricata_ctl_flags != 0)) {
+            SCReturnInt(success_count);
+        }
+        struct rte_flow_item_ipv4 ipv4_spec = { 0 }, ipv4_mask = { 0 };
+        struct rte_flow_item_ipv6 ipv6_spec = { 0 }, ipv6_mask = { 0 };
+        struct rte_flow_item_tcp tcp_spec = { 0 }, tcp_mask = { 0 };
+        struct rte_flow_item_udp udp_spec = { 0 }, udp_mask = { 0 };
+        void *ip_spec = NULL, *ip_mask = NULL, *l4_spec = NULL, *l4_mask = NULL;
+
+        FlowKey *flow_key = ring_data[i];
+        LiveDevice *livedev = LiveGetDeviceByIdx(flow_key->livedev_id);
+        uint16_t port_id = livedev->dpdk_vars->port_id;
+
+        /* Create rte_flow rule for original direction */
+        if (flow_key->src.family == AF_INET) {
+            SCLogDebug("Add an IPv4 rte_flow bypass rule");
+            ipv4_spec.hdr.src_addr = flow_key->src.address.address_un_data32[0];
+            ipv4_mask.hdr.src_addr = 0xFFFFFFFF;
+            ipv4_spec.hdr.dst_addr = flow_key->dst.address.address_un_data32[0];
+            ipv4_mask.hdr.dst_addr = 0xFFFFFFFF;
+            ip_spec = &ipv4_spec;
+            ip_mask = &ipv4_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV4;
+        } else {
+            SCLogDebug("Add an IPv6 rte_flow bypass rule");
+            memcpy(ipv6_spec.hdr.src_addr, flow_key->src.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.src_addr, 0xFF, 16);
+            memcpy(ipv6_spec.hdr.dst_addr, flow_key->dst.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.dst_addr, 0xFF, 16);
+            ip_spec = &ipv6_spec;
+            ip_mask = &ipv6_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV6;
+        }
+
+        if (flow_key->proto == IPPROTO_TCP) {
+            tcp_spec.hdr.src_port = htons(flow_key->sp);
+            tcp_mask.hdr.src_port = 0xFFFF;
+            tcp_spec.hdr.dst_port = htons(flow_key->dp);
+            tcp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &tcp_spec;
+            l4_mask = &tcp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_TCP;
+        } else {
+            udp_spec.hdr.src_port = htons(flow_key->sp);
+            udp_mask.hdr.src_port = 0xFFFF;
+            udp_spec.hdr.dst_port = htons(flow_key->dp);
+            udp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &udp_spec;
+            l4_mask = &udp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_UDP;
+        }
+
+        items[L3_INDEX].spec = ip_spec;
+        items[L3_INDEX].mask = ip_mask;
+        items[L4_INDEX].spec = l4_spec;
+        items[L4_INDEX].mask = l4_mask;
+
+        struct rte_flow *src_rule_handler = NULL;
+        int retval = RteFlowBypassRuleCreate(items, port_id, &src_rule_handler);
+
+        /* Create rte_flow rule for the opposite direction */
+        if (flow_key->src.family == AF_INET) {
+            SCLogDebug("Add an IPv4 rte_flow bypass rule in other direction");
+            ipv4_spec.hdr.src_addr = flow_key->dst.address.address_un_data32[0];
+            ipv4_mask.hdr.src_addr = 0xFFFFFFFF;
+            ipv4_spec.hdr.dst_addr = flow_key->src.address.address_un_data32[0];
+            ipv4_mask.hdr.dst_addr = 0xFFFFFFFF;
+            ip_spec = &ipv4_spec;
+            ip_mask = &ipv4_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV4;
+        } else {
+            SCLogDebug("Add an IPv6 rte_flow bypass rule");
+            memcpy(ipv6_spec.hdr.src_addr, flow_key->dst.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.src_addr, 0xFF, 16);
+            memcpy(ipv6_spec.hdr.dst_addr, flow_key->src.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.dst_addr, 0xFF, 16);
+            ip_spec = &ipv6_spec;
+            ip_mask = &ipv6_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV6;
+        }
+
+        if (flow_key->proto == IPPROTO_TCP) {
+            tcp_spec.hdr.src_port = htons(flow_key->dp);
+            tcp_mask.hdr.src_port = 0xFFFF;
+            tcp_spec.hdr.dst_port = htons(flow_key->sp);
+            tcp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &tcp_spec;
+            l4_mask = &tcp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_TCP;
+        } else {
+            udp_spec.hdr.src_port = htons(flow_key->dp);
+            udp_mask.hdr.src_port = 0xFFFF;
+            udp_spec.hdr.dst_port = htons(flow_key->sp);
+            udp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &udp_spec;
+            l4_mask = &udp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_UDP;
+        }
+
+        items[L3_INDEX].spec = ip_spec;
+        items[L3_INDEX].mask = ip_mask;
+        items[L4_INDEX].spec = l4_spec;
+        items[L4_INDEX].mask = l4_mask;
+
+        struct rte_flow *dst_rule_handler = NULL;
+        retval += RteFlowBypassRuleCreate(items, port_id, &dst_rule_handler);
+
+        uint32_t flow_hash = FlowKeyGetHash(flow_key);
+        Flow *flow = FlowGetExistingFlowFromHash(flow_key, flow_hash);
+        rte_mempool_put(bypass_mp, flow_key);
+        /* If error, destroy the rule for flow in original direction and set flow state to local
+         * bypass*/
+        if (retval != 0 || flow == NULL) {
+            struct rte_flow_error flow_error = { 0 };
+            if (src_rule_handler != NULL) {
+                retval = rte_flow_destroy(port_id, src_rule_handler, &flow_error);
+                if (retval != 0) {
+                    SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                            rte_strerror(-retval), flow_error.message);
+                }
+            }
+            if (dst_rule_handler != NULL) {
+                retval = rte_flow_destroy(port_id, dst_rule_handler, &flow_error);
+                if (retval != 0) {
+                    SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                            rte_strerror(-retval), flow_error.message);
+                }
+            }
+            if (flow != NULL) {
+                FlowUpdateState(flow, FLOW_STATE_LOCAL_BYPASSED);
+                FLOWLOCK_UNLOCK(flow);
+            }
+            continue;
+        }
+
+        int inet_family;
+        if (FLOW_IS_IPV4(flow))
+            inet_family = AF_INET;
+        else
+            inet_family = AF_INET6;
+        retval = RteFlowSetFlowBypassInfo(flow, src_rule_handler, dst_rule_handler, inet_family);
+        if (retval != 0) {
+            SC_ATOMIC_ADD(
+                    flow->livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_rules_active, 1);
+            SC_ATOMIC_ADD(
+                    flow->livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_rules_created, 1);
+            bypassstats->count++;
+            success_count++;
+        }
+        FLOWLOCK_UNLOCK(flow);
+    }
+    SCReturnInt(success_count);
+}
+
+bool RteBypassUpdate(Flow *flow, void *data, time_t tsec)
+{
+    RteFlowHandlerToFlow *flow_handler_info = (RteFlowHandlerToFlow *)data;
+    if (flow_handler_info == NULL) {
+        SCLogError("rte_flow dynamic bypass: flow_handler_info is NULL");
+        return false;
+    }
+    FlowBypassInfo *fc = FlowGetStorageById(flow, GetFlowBypassInfoID());
+    if (fc == NULL) {
+        SCLogError("rte_flow dynamic bypass: flow bypass info is NULL");
+        return false;
+    }
+    if (flow_handler_info->src_handler == NULL || flow_handler_info->dst_handler == NULL) {
+        return false;
+    }
+    bool activity = RteFlowUpdateStats(fc, flow->livedev->dpdk_vars->port_id,
+            flow_handler_info->src_handler, flow_handler_info->dst_handler);
+    if (activity)
+        flow->lastts = SCTIME_FROM_SECS(tsec);
+    if (!activity || unlikely(suricata_ctl_flags != 0)) {
+        if (flow_handler_info->src_handler != NULL && flow_handler_info->dst_handler != NULL) {
+            struct rte_flow_error flow_error = { 0 };
+            int retval = rte_flow_destroy(flow_handler_info->dpdk_vars->port_id,
+                    flow_handler_info->src_handler, &flow_error);
+            if (retval != 0) {
+                SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                        rte_strerror(-retval), flow_error.message);
+            }
+            flow_handler_info->src_handler = NULL;
+            retval = rte_flow_destroy(flow_handler_info->dpdk_vars->port_id,
+                    flow_handler_info->dst_handler, &flow_error);
+            if (retval != 0) {
+                SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                        rte_strerror(-retval), flow_error.message);
+            }
+            flow_handler_info->dst_handler = NULL;
+            SC_ATOMIC_SUB(
+                    flow_handler_info->dpdk_vars->rte_flow_bypass_data->rte_bypass_rules_active, 1);
+        }
+    }
+    SCReturnBool(activity);
+}
+
+void RteBypassFree(void *data)
+{
+    RteFlowHandlerToFlow *flow_handler_info = (RteFlowHandlerToFlow *)data;
+    struct rte_flow_error flow_error = { 0 };
+    if (flow_handler_info->src_handler != NULL && flow_handler_info->dst_handler != NULL) {
+        FlowBypassInfo *fc = FlowGetStorageById(flow_handler_info->flow, GetFlowBypassInfoID());
+        if (fc == NULL) {
+            SCLogError("rte_flow dynamic bypass: flow_bypass_info is NULL");
+            return;
+        }
+        RteFlowUpdateStats(fc, flow_handler_info->flow->livedev->dpdk_vars->port_id,
+                flow_handler_info->src_handler, flow_handler_info->dst_handler);
+        int retval = rte_flow_destroy(
+                flow_handler_info->dpdk_vars->port_id, flow_handler_info->src_handler, &flow_error);
+        if (retval != 0) {
+            SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                    rte_strerror(-retval), flow_error.message);
+        }
+        flow_handler_info->src_handler = NULL;
+        retval = rte_flow_destroy(
+                flow_handler_info->dpdk_vars->port_id, flow_handler_info->dst_handler, &flow_error);
+        if (retval != 0) {
+            SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                    rte_strerror(-retval), flow_error.message);
+        }
+        flow_handler_info->dst_handler = NULL;
+        SC_ATOMIC_SUB(
+                flow_handler_info->dpdk_vars->rte_flow_bypass_data->rte_bypass_rules_active, 1);
+    }
+    if (flow_handler_info != NULL) {
+        SCFree(flow_handler_info);
+    }
+}
+
+static int RteFlowSetFlowBypassInfo(
+        Flow *flow, struct rte_flow *src_handler, struct rte_flow *dst_handler, int family)
+{
+    FlowBypassInfo *fc = FlowGetStorageById(flow, GetFlowBypassInfoID());
+    if (fc) {
+        if (fc->bypass_data != NULL) {
+            SCReturnInt(0);
+        }
+        RteFlowHandlerToFlow *flow_handler_info = SCCalloc(1, sizeof(RteFlowHandlerToFlow));
+        if (flow_handler_info == NULL) {
+            goto bypass_fail;
+        }
+        flow_handler_info->flow = flow;
+        flow_handler_info->src_handler = src_handler;
+        flow_handler_info->dst_handler = dst_handler;
+        flow_handler_info->dpdk_vars = flow->livedev->dpdk_vars;
+        fc->bypass_data = flow_handler_info;
+        fc->BypassUpdate = RteBypassUpdate;
+        fc->BypassFree = RteBypassFree;
+        LiveDevAddBypassStats(flow->livedev, 1, family);
+        LiveDevAddBypassSuccess(flow->livedev, 1, family);
+        SCReturnInt(1);
+    }
+
+bypass_fail:;
+    struct rte_flow_error flow_error = { 0 };
+    int retval = rte_flow_destroy(flow->livedev->dpdk_vars->port_id, src_handler, &flow_error);
+    if (retval != 0) {
+        SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                rte_strerror(-retval), flow_error.message);
+    }
+
+    retval = rte_flow_destroy(flow->livedev->dpdk_vars->port_id, dst_handler, &flow_error);
+    if (retval != 0) {
+        SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                rte_strerror(-retval), flow_error.message);
+    }
+    LiveDevAddBypassFail(flow->livedev, 1, family);
+    SCReturnInt(0);
+}
+
+int RteFlowBypassCallback(Packet *p)
+{
+    if (p == NULL || p->flow == NULL) {
+        SCReturnInt(0);
+    }
+
+    /* Only bypass TCP and UDP */
+    if (!(PacketIsTCP(p) || PacketIsUDP(p))) {
+        SCReturnInt(0);
+    }
+
+    FlowKey *flow_key = NULL;
+    RteFlowBypassData *rte_flow_bypass_data = p->livedev->dpdk_vars->rte_flow_bypass_data;
+    if (rte_mempool_get(rte_flow_bypass_data->bypass_mp, (void **)&flow_key) < 0) {
+        SCLogError("Memory allocation for rte_flow bypass data failed");
+        SCReturnInt(0);
+    }
+
+    if (PacketIsIPv4(p)) {
+        flow_key->src.family = AF_INET;
+        flow_key->src.address.address_un_data32[0] = (GET_IPV4_SRC_ADDR_U32(p));
+        flow_key->dst.family = AF_INET;
+        flow_key->dst.address.address_un_data32[0] = (GET_IPV4_DST_ADDR_U32(p));
+    } else if (PacketIsIPv6(p)) {
+        flow_key->src.family = AF_INET6;
+        memcpy(flow_key->src.address.address_un_data8, GET_IPV6_SRC_ADDR(p), 16 * sizeof(uint8_t));
+        flow_key->dst.family = AF_INET6;
+        memcpy(flow_key->dst.address.address_un_data8, GET_IPV6_DST_ADDR(p), 16 * sizeof(uint8_t));
+    }
+    if (p->proto == IPPROTO_TCP) {
+        flow_key->proto = IPPROTO_TCP;
+    } else {
+        flow_key->proto = IPPROTO_UDP;
+    }
+    flow_key->sp = p->sp;
+    flow_key->dp = p->dp;
+    flow_key->livedev_id = p->livedev->id;
+    flow_key->vlan_id[0] = p->vlan_id[0];
+    flow_key->vlan_id[1] = p->vlan_id[1];
+    flow_key->vlan_id[2] = p->vlan_id[2];
+    flow_key->recursion_level = 0;
+
+    int retval = rte_ring_mp_enqueue(rte_flow_bypass_data->bypass_ring, flow_key);
+    /* If ring is full, continue with local bypass */
+    if (retval < 0) {
+        rte_mempool_put(rte_flow_bypass_data->bypass_mp, flow_key);
+        SCReturnInt(0);
+    }
+    retval = retval == 0 ? 1 : 0;
+    SCReturnInt(retval);
+}
+
 /**
  * @}
  */
+
+#endif /* HAVE_DPDK */

--- a/src/util-dpdk-rte-flow.h
+++ b/src/util-dpdk-rte-flow.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021-2025 Open Information Security Foundation
+/* Copyright (C) 2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -16,24 +16,36 @@
  */
 
 /**
- * \file
+ *  \defgroup dpdk DPDK rte_flow rules util functions
  *
- * \author Lukas Sismis <lukas.sismis@gmail.com>
+ *  @{
  */
 
-#ifndef UTIL_DPDK_ICE_H
-#define UTIL_DPDK_ICE_H
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
+ */
 
-#include "suricata-common.h"
+#ifndef SURICATA_RTE_FLOW_RULES_H
+#define SURICATA_RTE_FLOW_RULES_H
 
 #ifdef HAVE_DPDK
 
+#include "conf.h"
 #include "util-dpdk.h"
 
-int iceDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
-void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf);
-bool iceDeviceRteFlowPatternError(struct rte_flow_item *);
+void RteFlowRuleStorageFree(RteFlowRuleStorage *rte_flow_rule_storage);
+int ConfigLoadRteFlowRules(
+        SCConfNode *if_root, const char *filter_type, RteFlowRuleStorage *rte_flow_rule_storage);
+int RteFlowRulesCreate(char *port_name, int port_id, RteFlowRuleStorage *rte_flow_rule_storage,
+        const char *driver_name);
 
 #endif /* HAVE_DPDK */
-
-#endif /* UTIL_DPDK_ICE_H */
+#endif /* SURICATA_RTE_FLOW_RULES_H */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.h
+++ b/src/util-dpdk-rte-flow.h
@@ -43,6 +43,8 @@ int ConfigLoadRteFlowRules(
         SCConfNode *if_root, const char *filter_type, RteFlowRuleStorage *rte_flow_rule_storage);
 int RteFlowRulesCreate(char *port_name, int port_id, RteFlowRuleStorage *rte_flow_rule_storage,
         const char *driver_name);
+uint64_t RteFlowFilteredPacketsQuery(struct rte_flow **rte_flow_rules, uint16_t rule_count,
+        char *device_name, int port_id, uint64_t *filtered_packets);
 
 #endif /* HAVE_DPDK */
 #endif /* SURICATA_RTE_FLOW_RULES_H */

--- a/src/util-dpdk.c
+++ b/src/util-dpdk.c
@@ -66,6 +66,10 @@ void DPDKFreeDevice(LiveDevice *ldev)
             SCLogDebug("%s: releasing rte_flow rule handlers", ldev->dev);
             SCFree(ldev->dpdk_vars->rte_flow_rule_handlers);
         }
+        if (ldev->dpdk_vars->rte_flow_bypass_data->bypass_mp != NULL) {
+            rte_mempool_free(ldev->dpdk_vars->rte_flow_bypass_data->bypass_mp);
+            ldev->dpdk_vars->rte_flow_bypass_data->bypass_mp = NULL;
+        }
         SCLogDebug("%s: releasing packet mempools", ldev->dev);
         DPDKDeviceResourcesDeinit(&ldev->dpdk_vars);
     }

--- a/src/util-dpdk.c
+++ b/src/util-dpdk.c
@@ -61,6 +61,11 @@ void DPDKFreeDevice(LiveDevice *ldev)
     (void)ldev; // avoid warnings of unused variable
 #ifdef HAVE_DPDK
     if (SCRunmodeGet() == RUNMODE_DPDK) {
+        if (ldev->dpdk_vars->rte_flow_rule_handlers != NULL &&
+                ldev->dpdk_vars->rte_flow_rule_cnt != 0) {
+            SCLogDebug("%s: releasing rte_flow rule handlers", ldev->dev);
+            SCFree(ldev->dpdk_vars->rte_flow_rule_handlers);
+        }
         SCLogDebug("%s: releasing packet mempools", ldev->dev);
         DPDKDeviceResourcesDeinit(&ldev->dpdk_vars);
     }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -827,6 +827,11 @@ dpdk:
       # - ips: the same as tap mode but it also drops packets that are flagged by rules to be dropped
       copy-mode: none
       copy-iface: none # or PCIe address of the second interface
+      # Flow patterns in dpdk-testpmd syntax for flows that are supposed to be dropped directly in the NIC.
+      # If the pattern is invalid or unsupported, Suricata will not start.
+      # Example: "rule: pattern eth / ipv4 src is 16.0.25.0 / udp / end"
+      #          "rule: pattern eth / ipv4 dst is 19.1.2.15 / tcp / end" 
+      drop-filter: none 
 
     - interface: default
       threads: auto
@@ -844,6 +849,7 @@ dpdk:
       tx-descriptors: auto
       copy-mode: none
       copy-iface: none
+      drop-filter: none
 
 
 # Cross platform libpcap capture support


### PR DESCRIPTION
This is a draft of a new feauture that enables Suricata to use capture bypass in DPDK 
runmode utilizing features available on modern SmartNICs. 
The offload is based on the DPDK's rte_flow rules, mainly the drop
and count actions. The bypass utilizes the BypassManager thread and API.

The number of flows offloaded to the NIC differs based on the used NIC,
the current version was tested only with Mellanox ConnectX-6 and
supports offload of around 32 768 flows. The real number of rte_flow
rules inserted into the NIC is double of the offloaded flows (so around
65 536 rules in this case), because rte_flow needs 2 separate rules
to match both directions of a flow. All of the flows that cannot be
bypassed in the NIC are offloaded locally in Suricata.

The process of applying the bypass is as follows: the workers enqueue  a
flow_key created from the bypassed flow into a rte_ring,
the BypassManager constantly polls the ring, tries to create and insert
the respective rte_flow rule into the NIC. The Flow Manager is in the
meantime responsible for checking the activity of the flows,
performed by reading the counters attached to the rte_flow rules, and
potentially destroying the rules in the case the flow timeouts.

The statistics from the flows are collected periodically (managed by
Flow Manager) and in the shutdown stage.

This branch is branched from a different unmerged feature branch,
https://github.com/adaki4/suricata/tree/dpdk-rte-flow-drop-filter-v2

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7871

Describe changes:
- Add function LiveGetDeviceByIdx() to retrieve LiveDev instance by numerical index
- Add capture bypass for Suricata in DPDK runmode
