### PR TITLE
Flowbit ordering cyclic/v5

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -412,6 +412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +485,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -697,6 +709,15 @@ checksum = "2cf8413e5de78bcbc51880ff71f4b64105719abe6efb8b4b877d3c7dc494ddd1"
 dependencies = [
  "nom",
  "rusticata-macros",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1045,6 +1066,18 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "petgraph"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
+dependencies = [
+ "fixedbitset",
+ "hashbrown",
+ "indexmap",
+ "serde",
+]
 
 [[package]]
 name = "phf"
@@ -1524,6 +1557,7 @@ dependencies = [
  "hex",
  "hkdf",
  "ipsec-parser",
+ "itertools",
  "kerberos-parser",
  "lazy_static",
  "ldap-parser",
@@ -1537,6 +1571,7 @@ dependencies = [
  "num",
  "num-derive",
  "num-traits 0.2.19",
+ "petgraph",
  "psl",
  "regex",
  "sawp",

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -58,6 +58,9 @@ lru = "~0.12.5"
 der-parser = { version = "~9.0.0", default-features = false }
 kerberos-parser = { version = "~0.8.0", default-features = false }
 
+petgraph = "~0.8.2"
+itertools = "~0.14.0"
+
 sawp-modbus = "~0.13.1"
 sawp-pop3 = "~0.13.1"
 sawp = "~0.13.1"

--- a/rust/src/utils/flowbits_resolver.rs
+++ b/rust/src/utils/flowbits_resolver.rs
@@ -1,0 +1,257 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// Author: Shivani Bhardwaj <shivani@oisf.net>
+
+use itertools::iproduct;
+use petgraph::algo::is_cyclic_directed;
+use petgraph::graph::{GraphError, NodeIndex};
+use petgraph::stable_graph::StableDiGraph;
+use petgraph::visit::Bfs;
+use petgraph::Direction;
+use std::collections::HashMap;
+use std::os::raw::c_void;
+
+#[derive(Debug, Copy, Clone)]
+struct SCGNode {
+    iid: u32,        /* signature iid or flowbits iid */
+    ntype: bool,     /* node type: Signature (0), Flowbit (1) */
+    nidx: NodeIndex, /* Graph's internal node index */
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCCreateDirectedGraph() -> *mut c_void {
+    let graph: StableDiGraph<SCGNode, ()> = StableDiGraph::new();
+    let boxed_graph = Box::new(graph);
+    println!(
+        "sizeof(StableDiGraph): {:?}",
+        std::mem::size_of::<StableDiGraph<SCGNode, ()>>()
+    );
+    /* Make an opaque pointer for C as nothing is changed there */
+    return Box::into_raw(boxed_graph) as *mut c_void;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCFreeDirectedGraph(graph: *mut c_void) {
+    let _ = Box::from_raw(graph as *mut StableDiGraph<SCGNode, ()>);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCCreateNodeEdgeDirectedGraph(
+    graph: *mut c_void, iid: u32, ntype: bool, cmd: bool, sig_gid: u32,
+) -> i64 {
+    let g = &mut *(graph as *mut StableDiGraph<SCGNode, ()>);
+
+    let node_idx;
+    if let Some(nidx) = get_or_create_node(g, iid, ntype) {
+        node_idx = nidx;
+    } else {
+        SCLogError!("Error adding node; Graph is at full capacity");
+        return -2;
+    }
+
+    let sidx = NodeIndex::from(sig_gid);
+
+    if ntype {
+        /* flowbit type node */
+        if cmd {
+            /* WRITE command */
+            match g.try_update_edge(sidx, node_idx, ()) {
+                /* edge from signature to flowbit */
+                Ok(_) => {
+                    println!("Created an edge from {:?} -> {:?}", sidx, node_idx);
+                }
+                Err(GraphError::EdgeIxLimit) => {
+                    SCLogError!("Error adding edge; Graph is at full capacity");
+                    return -2;
+                }
+                Err(GraphError::NodeOutBounds) => {
+                    SCLogError!("Error adding edge; node does not exist");
+                    return -2;
+                }
+                Err(_) => {
+                    SCLogError!("Error adding edge to the Graph");
+                    return -2;
+                }
+            }
+        } else {
+            match g.try_update_edge(node_idx, sidx, ()) {
+                /* edge from flowbit to signature */
+                Ok(_) => {
+                    println!("Created an edge from {:?} -> {:?}", sidx, node_idx);
+                }
+                Err(GraphError::EdgeIxLimit) => {
+                    SCLogError!("Error adding edge; Graph is at full capacity");
+                    return -2;
+                }
+                Err(GraphError::NodeOutBounds) => {
+                    SCLogError!("Error adding edge; node does not exist");
+                    return -2;
+                }
+                Err(_) => {
+                    SCLogError!("Error adding edge to the Graph");
+                    return -2;
+                }
+            }
+        }
+    }
+
+    println!("node count: {:?}", g.node_count());
+    node_idx.index() as i64
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCResolveFlowbitDependencies(
+    graph: *mut c_void, sorted_sid_list: *mut u32, sorted_sid_list_len: u32,
+) -> i8 {
+    let g = &mut *(graph as *mut StableDiGraph<SCGNode, ()>);
+
+    println!("Indices in the graph:");
+    for i in g.node_indices() {
+        println!("idx: {:?}", i);
+    }
+    for nd in g.node_weights() {
+        println!("The beginning node: {:?}", nd);
+    }
+
+    debug_validate_bug_on!(g.node_count() == 0);
+
+    normalize_graph(g);
+    let sorted_sid_list =
+        std::slice::from_raw_parts_mut(&mut *sorted_sid_list, sorted_sid_list_len as usize);
+
+    // No need for all the extra work if there's just one node
+    if g.node_count() == 1 {
+        debug_validate_bug_on!(sorted_sid_list_len != 1);
+        sorted_sid_list[0] = g[NodeIndex::from(0)].iid;
+        return 0;
+    }
+
+    if is_cyclic_directed(&g.clone()) {
+        println!("CYCLE");
+        return -1;
+    }
+    bfs_tree_dag(g, sorted_sid_list);
+    return 0;
+}
+
+fn get_or_create_node(
+    g: &mut StableDiGraph<SCGNode, ()>, iid: u32, ntype: bool,
+) -> Option<NodeIndex> {
+    for node in g.node_weights() {
+        if node.iid == iid && node.ntype == ntype {
+            return Some(node.nidx);
+        }
+    }
+    let nd = SCGNode {
+        iid,
+        ntype,
+        nidx: NodeIndex::from(u32::MAX),
+    };
+    if let Ok(idx) = g.try_add_node(nd) {
+        g[idx].nidx = idx;
+        println!("Created node: {:?}", g[idx]);
+        return Some(idx);
+    }
+
+    None
+}
+
+fn normalize_graph(g: &mut StableDiGraph<SCGNode, ()>) {
+    let mut map_new_edges: Vec<(NodeIndex, NodeIndex)> = Vec::new();
+    let mut fb_nodes_list: Vec<SCGNode> = Vec::new();
+
+    for nd in g.node_weights() {
+        println!("Pre normalized node: {:?}", nd);
+    }
+
+    for nd in g.node_weights() {
+        if nd.ntype {
+            let in_edges: Vec<NodeIndex> =
+                g.neighbors_directed(nd.nidx, Direction::Incoming).collect();
+
+            let out_edges: Vec<NodeIndex> =
+                g.neighbors_directed(nd.nidx, Direction::Outgoing).collect();
+
+            let map_edges_curnode: Vec<(NodeIndex, NodeIndex)> =
+                iproduct!(in_edges, out_edges).collect();
+            map_new_edges.extend(map_edges_curnode);
+            fb_nodes_list.push(*nd);
+        }
+    }
+
+    for (from, to) in map_new_edges {
+        if from != to && g.find_edge(from, to).is_none() {
+            println!("map_new_edges -- from: {:?}; to: {:?}", from, to);
+            g.add_edge(from, to, ());
+        }
+    }
+
+    for node in fb_nodes_list {
+        println!("Removing node {:?}", node);
+        g.remove_node(node.nidx);
+    }
+}
+
+fn calculate_in_degree_nodes(
+    g: &mut StableDiGraph<SCGNode, ()>, in_degrees: &mut HashMap<NodeIndex, usize>,
+) {
+    for node_idx in g.node_indices() {
+        let in_degree = g.neighbors_directed(node_idx, Direction::Incoming).count();
+        println!("in_degree for node {:?}: {:?}", g[node_idx], in_degree);
+        in_degrees.insert(node_idx, in_degree);
+    }
+}
+
+fn bfs_tree_dag(g: &mut StableDiGraph<SCGNode, ()>, sorted_sid_list: &mut [u32]) {
+    let mut in_degrees: HashMap<NodeIndex, usize> = HashMap::new();
+    calculate_in_degree_nodes(g, &mut in_degrees);
+
+    let nidx;
+    if let Some(idx) = get_or_create_node(g, u32::MAX, false) {
+        nidx = idx;
+    } else {
+        SCLogError!("Error adding node; Graph is at full capacity");
+        return;
+    }
+
+    println!("node count: {:?}", g.node_count());
+    for node in g.node_weights() {
+        // There shouldn't be any flowbit nodes left at this point
+        debug_validate_bug_on!(node.ntype);
+        println!("FIN Node: {:?}", node);
+    }
+
+    for (node_idx, in_degree) in in_degrees {
+        if in_degree == 0 {
+            println!("added edge from {:?} -> {:?}", nidx, node_idx);
+            g.add_edge(nidx, node_idx, ());
+        }
+    }
+
+    let mut bfs = Bfs::new(&*g, nidx);
+    let mut i = 0;
+
+    println!("BFS of the graph:");
+    while let Some(idx) = bfs.next(&*g) {
+        if idx != nidx {
+            println!("[{:?}]: {:?}", i, g[idx]);
+            sorted_sid_list[i] = g[idx].iid;
+            i += 1;
+        }
+    }
+}

--- a/rust/src/utils/mod.rs
+++ b/rust/src/utils/mod.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2024 Open Information Security Foundation
+/* Copyright (C) 2024-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -17,3 +17,4 @@
 
 pub mod base64;
 pub mod datalink;
+pub mod flowbits_resolver;

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -40,6 +40,7 @@
 #include "action-globals.h"
 #include "flow-util.h"
 #include "util-validate.h"
+#include "rust.h"
 
 #define DETECT_FLOWVAR_NOT_USED      1
 #define DETECT_FLOWVAR_TYPE_READ     2
@@ -546,6 +547,13 @@ static int SCSigLessThan(SCSigSignatureWrapper *sw1,
 
         funcs = funcs->next;
     }
+
+    // Special handling for flowbits, do not touch the order if the comparison fn
+    // calculates two signatures to be equal
+    if ((sw1->user[DETECT_SIGORDER_FLOWBITS] > DETECT_FLOWBITS_NOT_USED) &&
+            (sw1->user[DETECT_SIGORDER_FLOWBITS] == sw2->user[DETECT_SIGORDER_FLOWBITS]))
+        return 0;
+
     // They are equal, so use sid as the final decider.
     return sw1->sig->id < sw2->sig->id;
 }
@@ -621,6 +629,113 @@ static SCSigSignatureWrapper *SCSigOrder(SCSigSignatureWrapper *sw,
     return result;
 }
 
+static SCSigSignatureWrapper *SCSigResolveFlowbitDependencies(SCSigSignatureWrapper *arg_sw)
+{
+    uint32_t sig_cnt = 0;
+    uint32_t *sorted_siids = NULL;
+    SCSigSignatureWrapper *sw = arg_sw;
+
+    void *graph = SCCreateDirectedGraph();
+
+    while (sw != NULL) {
+        Signature *s = sw->sig;
+        int64_t sidx = SCCreateNodeEdgeDirectedGraph(graph, s->iid, false /* Signature type node */,
+                false /* does not matter */, UINT32_MAX /* no signature index in graph yet */);
+        if (sidx < 0) {
+            goto error;
+        }
+        DEBUG_VALIDATE_BUG_ON(sidx > UINT32_MAX);
+        SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_MATCH];
+        DetectFlowbitsData *fbd = NULL;
+        int64_t nidx = 0;
+
+        while (sm != NULL) {
+            if (sm->type != DETECT_FLOWBITS) {
+                sm = sm->next;
+                continue;
+            }
+            fbd = (DetectFlowbitsData *)sm->ctx;
+            nidx = SCCreateNodeEdgeDirectedGraph(graph, fbd->idx, true /* Flowbit type node */,
+                    false /* READ cmd */, (uint32_t)sidx);
+            if (nidx < 0) {
+                goto error;
+            }
+            sm = sm->next;
+        }
+
+        sm = s->init_data->smlists[DETECT_SM_LIST_POSTMATCH];
+
+        while (sm != NULL) {
+            if (sm->type != DETECT_FLOWBITS) {
+                sm = sm->next;
+                continue;
+            }
+            fbd = (DetectFlowbitsData *)sm->ctx;
+            nidx = SCCreateNodeEdgeDirectedGraph(graph, fbd->idx, true /* Flowbit type node */,
+                    true /* WRITE cmd */, (uint32_t)sidx);
+            if (nidx < 0) {
+                goto error;
+            }
+            sm = sm->next;
+        }
+
+        sw = sw->next;
+        sig_cnt++;
+    }
+
+    DEBUG_VALIDATE_BUG_ON(sig_cnt == 0);
+
+    sorted_siids = SCCalloc(sig_cnt, sizeof(uint32_t));
+    if (sorted_siids == NULL) {
+        goto error;
+    }
+    if (SCResolveFlowbitDependencies(graph, sorted_siids, sig_cnt) < 0) {
+        goto error;
+    }
+
+    SCSigSignatureWrapper *fin = NULL;
+    SCSigSignatureWrapper *tmp = NULL;
+    SCSigSignatureWrapper *prev = NULL;
+
+    for (uint32_t i = 0; i < sig_cnt; i++) {
+        sw = arg_sw;
+        while (sw != NULL) {
+            if (sorted_siids[i] == sw->sig->iid) {
+                if (tmp) {
+                    prev->next = sw->next;
+                    sw->next = NULL;
+                    tmp->next = sw;
+                } else {
+                    tmp = sw;
+                    fin = tmp;
+                }
+            }
+            prev = sw;
+            sw = sw->next;
+        }
+    }
+
+#ifdef DEBUG
+    tmp = fin;
+    while (tmp != NULL) {
+        SCLogDebug("sid: %d, iid: %d", tmp->sig->id, tmp->sig->iid);
+        tmp = tmp->next;
+    }
+#endif
+
+    SCFree(sorted_siids); /* No longer needed */
+    SCFreeDirectedGraph(graph);
+    return fin;
+
+error:
+    SCLogError("Error resolving flowbit dependencies; rolling back to original order");
+    if (sorted_siids != NULL) {
+        SCFree(sorted_siids);
+    }
+    SCFreeDirectedGraph(graph);
+    return arg_sw;
+}
+
 /**
  * \brief Orders an incoming Signature based on its action
  *
@@ -631,6 +746,7 @@ static SCSigSignatureWrapper *SCSigOrder(SCSigSignatureWrapper *sw,
 static int SCSigOrderByActionCompare(SCSigSignatureWrapper *sw1,
                                      SCSigSignatureWrapper *sw2)
 {
+    SCLogDebug("Comparing by Action sid1: %d and sid2: %d", sw1->sig->id, sw2->sig->id);
     return ActionOrderVal(sw2->sig->action) - ActionOrderVal(sw1->sig->action);
 }
 
@@ -644,6 +760,7 @@ static int SCSigOrderByActionCompare(SCSigSignatureWrapper *sw1,
 static int SCSigOrderByFlowbitsCompare(SCSigSignatureWrapper *sw1,
                                        SCSigSignatureWrapper *sw2)
 {
+    SCLogDebug("Comparing by Flowbits sid1: %d and sid2: %d", sw1->sig->id, sw2->sig->id);
     return sw1->user[DETECT_SIGORDER_FLOWBITS] - sw2->user[DETECT_SIGORDER_FLOWBITS];
 }
 
@@ -657,6 +774,7 @@ static int SCSigOrderByFlowbitsCompare(SCSigSignatureWrapper *sw1,
 static int SCSigOrderByFlowvarCompare(SCSigSignatureWrapper *sw1,
                                       SCSigSignatureWrapper *sw2)
 {
+    SCLogDebug("Comparing by Flowvar sid1: %d and sid2: %d", sw1->sig->id, sw2->sig->id);
     return sw1->user[DETECT_SIGORDER_FLOWVAR] - sw2->user[DETECT_SIGORDER_FLOWVAR];
 }
 
@@ -670,12 +788,14 @@ static int SCSigOrderByFlowvarCompare(SCSigSignatureWrapper *sw1,
 static int SCSigOrderByPktvarCompare(SCSigSignatureWrapper *sw1,
                                      SCSigSignatureWrapper *sw2)
 {
+    SCLogDebug("Comparing by Pktvar sid1: %d and sid2: %d", sw1->sig->id, sw2->sig->id);
     return sw1->user[DETECT_SIGORDER_PKTVAR] - sw2->user[DETECT_SIGORDER_PKTVAR];
 }
 
 static int SCSigOrderByFlowintCompare(SCSigSignatureWrapper *sw1,
                                       SCSigSignatureWrapper *sw2)
 {
+    SCLogDebug("Comparing by Flowint sid1: %d and sid2: %d", sw1->sig->id, sw2->sig->id);
     return sw1->user[DETECT_SIGORDER_FLOWINT] - sw2->user[DETECT_SIGORDER_FLOWINT];
 }
 
@@ -689,6 +809,7 @@ static int SCSigOrderByFlowintCompare(SCSigSignatureWrapper *sw1,
 static int SCSigOrderByHostbitsCompare(SCSigSignatureWrapper *sw1,
                                        SCSigSignatureWrapper *sw2)
 {
+    SCLogDebug("Comparing by Hostbits sid1: %d and sid2: %d", sw1->sig->id, sw2->sig->id);
     return sw1->user[DETECT_SIGORDER_HOSTBITS] - sw2->user[DETECT_SIGORDER_HOSTBITS];
 }
 
@@ -702,6 +823,7 @@ static int SCSigOrderByHostbitsCompare(SCSigSignatureWrapper *sw1,
 static int SCSigOrderByIPPairbitsCompare(SCSigSignatureWrapper *sw1,
                                          SCSigSignatureWrapper *sw2)
 {
+    SCLogDebug("Comparing by IPPair sid1: %d and sid2: %d", sw1->sig->id, sw2->sig->id);
     return sw1->user[DETECT_SIGORDER_IPPAIRBITS] - sw2->user[DETECT_SIGORDER_IPPAIRBITS];
 }
 
@@ -715,6 +837,7 @@ static int SCSigOrderByIPPairbitsCompare(SCSigSignatureWrapper *sw1,
 static int SCSigOrderByPriorityCompare(SCSigSignatureWrapper *sw1,
                                        SCSigSignatureWrapper *sw2)
 {
+    SCLogDebug("Comparing by Priority sid1: %d and sid2: %d", sw1->sig->id, sw2->sig->id);
     if (sw1->sig->prio > sw2->sig->prio) {
         return -1;
     } else if (sw1->sig->prio < sw2->sig->prio) {
@@ -725,6 +848,7 @@ static int SCSigOrderByPriorityCompare(SCSigSignatureWrapper *sw1,
 
 static int SCSigOrderByIId(SCSigSignatureWrapper *sw1, SCSigSignatureWrapper *sw2)
 {
+    SCLogDebug("Comparing by IID sid1: %d and sid2: %d", sw1->sig->id, sw2->sig->id);
     if (sw1->sig->iid > sw2->sig->iid) {
         return -1;
     } else if (sw1->sig->iid < sw2->sig->iid) {
@@ -810,12 +934,29 @@ void SCSigOrderSignatures(DetectEngineCtx *de_ctx)
 
     SCLogDebug("ordering signatures in memory");
     SCSigSignatureWrapper *sigw = NULL;
-    SCSigSignatureWrapper *td_sigw_list = NULL; /* unified td list */
+    SCSigSignatureWrapper *td_sigw_list_start = NULL; /* unified td list */
+    SCSigSignatureWrapper *td_sigw_list_end = NULL;   /* unified td list */
+
+    SCSigSignatureWrapper *s_fb_sigw_list_start = NULL;  /* SET flowbits */
+    SCSigSignatureWrapper *r_fb_sigw_list_start = NULL;  /* READ flowbits */
+    SCSigSignatureWrapper *sr_fb_sigw_list_start = NULL; /* SET_READ flowbits */
+
+    SCSigSignatureWrapper *s_fb_sigw_list_end = NULL; /* SET flowbits */
+    //    SCSigSignatureWrapper *r_fb_sigw_list_end = NULL;  /* READ flowbits */
+    SCSigSignatureWrapper *sr_fb_sigw_list_end = NULL; /* SET_READ flowbits */
 
     SCSigSignatureWrapper *fw_pf_sigw_list = NULL; /* hook: packet_filter */
     SCSigSignatureWrapper *fw_af_sigw_list = NULL; /* hook: app_filter */
 
     Signature *sig = de_ctx->sig_list;
+
+#ifdef DEBUG
+    SCLogDebug(">>>>>>>>>>>>>>>BEGIN");
+    for (Signature *s = de_ctx->sig_list; s != NULL; s = s->next) {
+        SCLogDebug("sid: %d; iid: %d", s->id, s->iid);
+    }
+    SCLogDebug(">>>>>>>>>>>>>>>END");
+#endif
     while (sig != NULL) {
         sigw = SCSigAllocSignatureWrapper(sig);
         /* Push signature wrapper onto a list, order doesn't matter here. */
@@ -829,8 +970,25 @@ void SCSigOrderSignatures(DetectEngineCtx *de_ctx)
                 fw_af_sigw_list = sigw;
             }
         } else {
-            sigw->next = td_sigw_list;
-            td_sigw_list = sigw;
+            if (sigw->user[DETECT_SIGORDER_FLOWBITS] != DETECT_FLOWBITS_NOT_USED) {
+                if (sigw->user[DETECT_SIGORDER_FLOWBITS] == DETECT_FLOWBITS_TYPE_SET_READ) {
+                    sigw->next = sr_fb_sigw_list_start;
+                    sr_fb_sigw_list_start = sigw;
+                } else if (sigw->user[DETECT_SIGORDER_FLOWBITS] == DETECT_FLOWBITS_TYPE_READ) {
+                    sigw->next = r_fb_sigw_list_start;
+                    r_fb_sigw_list_start = sigw;
+                } else if (sigw->user[DETECT_SIGORDER_FLOWBITS] == DETECT_FLOWBITS_TYPE_SET) {
+                    sigw->next = s_fb_sigw_list_start;
+                    if (!s_fb_sigw_list_end)
+                        s_fb_sigw_list_end = sigw;
+                    s_fb_sigw_list_start = sigw;
+                }
+            } else {
+                sigw->next = td_sigw_list_start;
+                if (!td_sigw_list_end)
+                    td_sigw_list_end = sigw;
+                td_sigw_list_start = sigw;
+            }
         }
         sig = sig->next;
     }
@@ -846,10 +1004,64 @@ void SCSigOrderSignatures(DetectEngineCtx *de_ctx)
         SCSigOrderFunc OrderFn = { .SWCompare = SCSigOrderByAppFirewall, .next = NULL };
         fw_af_sigw_list = SCSigOrder(fw_af_sigw_list, &OrderFn);
     }
-    if (td_sigw_list) {
-        /* Sort the list */
-        td_sigw_list = SCSigOrder(td_sigw_list, de_ctx->sc_sig_order_funcs);
+    if (sr_fb_sigw_list_start) {
+        /* Resolve any complex dependencies, if possible, or error out early on */
+        sr_fb_sigw_list_start = SCSigResolveFlowbitDependencies(sr_fb_sigw_list_start);
+        SCSigSignatureWrapper *tmp = sr_fb_sigw_list_start;
+        while (tmp != NULL) {
+            sr_fb_sigw_list_end = tmp;
+            tmp = tmp->next;
+        }
     }
+    /* Merge the flowbit lists into the generic thread detection list */
+    SCSigSignatureWrapper *tmp = NULL;
+    if (s_fb_sigw_list_end) {
+        s_fb_sigw_list_end->next = sr_fb_sigw_list_start;
+        tmp = s_fb_sigw_list_start;
+    }
+    if (sr_fb_sigw_list_end) {
+        sr_fb_sigw_list_end->next = r_fb_sigw_list_start;
+        if (!tmp)
+            tmp = sr_fb_sigw_list_start;
+    }
+    if (r_fb_sigw_list_start) {
+        if (!sr_fb_sigw_list_start && s_fb_sigw_list_end)
+            s_fb_sigw_list_end->next = r_fb_sigw_list_start;
+        if (!tmp)
+            tmp = r_fb_sigw_list_start;
+    }
+
+#ifdef DEBUG
+    SCSigSignatureWrapper *tmp2 = tmp;
+    SCLogDebug(">>>>>>>>>>>>>>>BEGIN");
+    while (tmp2 != NULL) {
+        SCLogDebug("tmp sid: %d, iid: %d", tmp2->sig->id, tmp2->sig->iid);
+        tmp2 = tmp2->next;
+    }
+    SCLogDebug(">>>>>>>>>>>>>>>END");
+#endif
+
+    if (td_sigw_list_end) {
+        td_sigw_list_end->next = tmp;
+        /* Sort the list */
+        td_sigw_list_start = SCSigOrder(td_sigw_list_start, de_ctx->sc_sig_order_funcs);
+    } else if (tmp) {
+        td_sigw_list_start = tmp;
+        /* Sort the list */
+        td_sigw_list_start = SCSigOrder(td_sigw_list_start, de_ctx->sc_sig_order_funcs);
+    }
+
+#ifdef DEBUG
+    SCLogDebug("POST MERGE SORT");
+    tmp2 = td_sigw_list_start;
+    SCLogDebug(">>>>>>>>>>>>>>>BEGIN");
+    while (tmp2 != NULL) {
+        SCLogDebug("tmp sid: %d, iid: %d", tmp2->sig->id, tmp2->sig->iid);
+        tmp2 = tmp2->next;
+    }
+    SCLogDebug(">>>>>>>>>>>>>>>END");
+#endif
+
     /* Recreate the sig list in order */
     de_ctx->sig_list = NULL;
 
@@ -888,7 +1100,7 @@ void SCSigOrderSignatures(DetectEngineCtx *de_ctx)
         SCFree(sigw_to_free);
     }
     /* threat detect list for hook app_td */
-    for (sigw = td_sigw_list; sigw != NULL;) {
+    for (sigw = td_sigw_list_start; sigw != NULL;) {
         sigw->sig->next = NULL;
         if (de_ctx->sig_list == NULL) {
             /* First entry on the list */


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/13756

Changes since v4:
- fixed initialization of an array causing CI failures

Known TODOs:
- a problem discovered with the current algorithm by the s-v test `firewall-01-tcp-pkt-state-flowbits` ⭐ 
For a given READ command (isset, isnotset) and a given WRITE command (set, unset, toggle)
current algorithm marks a combination of following signatures as cyclic -- which shall be rejected in the final rev of this work
```
flowbit:READ,A; flowbit:WRITE,B; sid:1;
flowbit:WRITE,A; flowbit:READ, B, sid:2;
```
However, there may exist such flowbit combinations that are not cyclic. From the test `firewall-01-tcp-pkt-state-flowbits`,
```
pass tcp any 443 -> any any (flags:SA; flow:not_established; flowbits:isset,syn; flowbits:set,synack; sid:2;)
pass tcp any any -> any 443 (flags:A; flow:not_established; flowbits:isset,synack; flowbits:unset,syn; flowbits:unset,synack; sid:3;)
```
- fn docs
- code + commit segregation cleanups

Link to tickets:

- https://redmine.openinfosecfoundation.org/issues/7771
- https://redmine.openinfosecfoundation.org/issues/7638
- https://redmine.openinfosecfoundation.org/issues/7772
- https://redmine.openinfosecfoundation.org/issues/7773
- https://redmine.openinfosecfoundation.org/issues/7774
- https://redmine.openinfosecfoundation.org/issues/7817
- https://redmine.openinfosecfoundation.org/issues/7818

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2627

**Question**: What shall be done with signatures which contain a cyclic dependency? Current PR's behavior is to restore the original signature ordering in such a case.