### PR TITLE
doc/lualib: fix flow timestamps return value order and wrong tuple section markdown in flowlib

### DIFF
--- a/doc/userguide/lua/libs/flowlib.rst
+++ b/doc/userguide/lua/libs/flowlib.rst
@@ -29,7 +29,7 @@ Get timestamps of the first and the last packets from the flow, as seconds and
 microseconds since `1970-01-01 00:00:00` UTC, returning 4 numbers::
 
     f = flow.get()
-    local start_sec, start_usec, last_sec, last_usec = f:timestamps()
+    local start_sec, last_sec, start_usec, last_usec = f:timestamps()
 
 ``timestring_legacy``
 ^^^^^^^^^^^^^^^^^^^^^

--- a/doc/userguide/lua/libs/flowlib.rst
+++ b/doc/userguide/lua/libs/flowlib.rst
@@ -58,7 +58,7 @@ Ports and Addresses
 ~~~~~~~~~~~~~~~~~~~
 
 ``tuple``
-~~~~~~~~~
+^^^^^^^^^
 
 Using the `tuple` method, the IP version (4 or 6), src IP and dest IP (as
 string), IP protocol (int), and ports (ints) are retrieved.


### PR DESCRIPTION
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7854

Previous PR https://github.com/OISF/suricata/pull/13728

Describe changes:

1. Fixed incorrect return value order in flow timestamps documentation
    - According to `LuaFlowTimestamps()` in <a href='https://github.com/OISF/suricata/blob/master/src/util-lua-flowlib.c#L149'>src/util-lua-flowlib.c</a>, the function returns values in this order:
      1. start_sec (SCTIME_SECS(f->startts))
      2. last_sec (SCTIME_SECS(f->lastts))
      3. start_usec (SCTIME_USECS(f->startts))
      4. last_usec (SCTIME_USECS(f->lastts))
    - Updated documentation in <a href='https://github.com/OISF/suricata/blob/b93a27722c29e10f69ff32eadbd2964aa254000e/doc/userguide/lua/libs/flowlib.rst?plain=1#L32'>doc/userguide/lua/libs/flowlib.rst</a> to reflect the correct order: `start_sec, last_sec, start_usec,
    last_usec`
    - Previous documentation incorrectly showed: `start_sec, start_usec, last_sec, last_usec`
 2.  fix wrong tuple section markdown in flowlib 