### PR TITLE
output/alert-debug: do not return on app-layer

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -285,7 +285,7 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
             int ret;
             uint8_t flag;
             if (!(PacketIsTCP(p)) || p->flow == NULL || p->flow->protoctx == NULL) {
-                return TM_ECODE_OK;
+                continue;
             }
             /* IDS mode reverse the data */
             /** \todo improve the order selection policy */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4178

Describe changes:
- output/alert-debug: really write data for app-layer alerts
