### PR TITLE
htp: use transactions right get function

### DIFF
--- a/rust/htp/src/transactions.rs
+++ b/rust/htp/src/transactions.rs
@@ -33,7 +33,7 @@ impl Transactions {
         // that transaction is started), or zero if neither
         // request or response transaction exist yet
         let tx_to_check = std::cmp::max(self.request, self.response);
-        match self.transactions.get(tx_to_check) {
+        match self.get(tx_to_check) {
             // Transaction is created, check if it is started
             Some(tx) => tx.index.wrapping_add(tx.is_started() as usize),
             // Transaction doesn't exist yet, so the index is the size


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7803

Describe changes:
- htp: use transactions right get function

use our own function (checking `index` field) instead of the VecDequeue one 