### PR TITLE
detect/dsize: define offset in edge case (backport7)

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -413,6 +413,8 @@ void SigParseRequiredContentSize(
 {
     int max_offset = 0, total_len = 0;
     bool first = true;
+    // define it first, and override it unless in DETECT_CONTENT_NEGATED edge case
+    *offset = 0;
     for (; sm != NULL; sm = sm->next) {
         if (sm->type != DETECT_CONTENT || sm->ctx == NULL) {
             continue;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7810

Describe changes:
- backport of https://github.com/OISF/suricata/pull/13769 clean cherry-pick
