### PR TITLE
output/alert-debug: do not return on app-layer (backport7)

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -288,7 +288,7 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
             uint8_t flag;
             if (!(PKT_IS_TCP(p)) || p->flow == NULL ||
                     p->flow->protoctx == NULL) {
-                return TM_ECODE_OK;
+                continue;
             }
             /* IDS mode reverse the data */
             /** \todo improve the order selection policy */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7874

Describe changes:
- backport of https://github.com/OISF/suricata/pull/13768 unclean cherry-pick just because of formatting
