### PR TITLE
ci: use CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback

### DIFF
--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -155,5 +155,5 @@ jobs:
       - name: Cargo Update and Build
         working-directory: rust
         run: |
-          cargo update
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
           cargo build --all-features --all-targets


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
no ticket, just ci fix

Describe changes:
- ci: use `CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback`

 see https://doc.rust-lang.org/cargo/reference/config.html#resolverincompatible-rust-versions