### PR TITLE
detect: count keywords for multi-buffer

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -90,6 +90,7 @@ include = [
     "FtpDataStateValues",
     "HTTP2TransactionState",
     "DataRepType",
+    "DETECT_COUNT_INDEX",
 ]
 
 # A list of items to not include in the generated bindings

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -119,6 +119,8 @@ pub(crate) const SIGMATCH_OPTIONAL_OPT: u16 = 0x10; // BIT_U16(4) in detect.h
 pub(crate) const SIGMATCH_QUOTES_MANDATORY: u16 = 0x40; // BIT_U16(6) in detect.h
 pub const SIGMATCH_INFO_STICKY_BUFFER: u16 = 0x200; // BIT_U16(9)
 
+pub const DETECT_COUNT_INDEX: u32 = 0xFFFFFFFF;
+
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 // endian <big|little|dce>

--- a/rust/src/mime/detect.rs
+++ b/rust/src/mime/detect.rs
@@ -65,6 +65,26 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetUrl(
 /// for array header fields.
 /// The hname parameter determines which data will be returned.
 #[no_mangle]
+pub unsafe extern "C" fn SCDetectMimeEmailGetCount(
+    ctx: &MimeStateSMTP, hname: *const std::os::raw::c_char,
+) -> u32{
+    let c_str = CStr::from_ptr(hname); //unsafe
+    let str = c_str.to_str().unwrap_or("");
+
+    let mut r = 0u32;
+    for h in &ctx.headers[..ctx.main_headers_nb] {
+        if mime::slice_equals_lowercase(&h.name, str.as_bytes()) {
+            r += 1;
+        }
+    }
+
+    return r;
+}
+
+/// Intermediary function used in detect-email.c to access data from the MimeStateSMTP structure
+/// for array header fields.
+/// The hname parameter determines which data will be returned.
+#[no_mangle]
 pub unsafe extern "C" fn SCDetectMimeEmailGetDataArray(
     ctx: &MimeStateSMTP, buffer: *mut *const u8, buffer_len: *mut u32,
     hname: *const std::os::raw::c_char, idx: u32,

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -111,6 +111,7 @@ noinst_HEADERS = \
 	detect-classtype.h \
 	detect-config.h \
 	detect-content.h \
+	detect-count.h \
 	detect-csum.h \
 	detect-datarep.h \
 	detect-dataset.h \
@@ -712,6 +713,7 @@ libsuricata_c_a_SOURCES = \
 	detect-classtype.c \
 	detect-config.c \
 	detect-content.c \
+	detect-count.c \
 	detect-csum.c \
 	detect-datarep.c \
 	detect-dataset.c \

--- a/src/detect-count.c
+++ b/src/detect-count.c
@@ -1,0 +1,83 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "rust.h"
+
+#include "detect-count.h"
+#include "detect-engine-buffer.h"
+#include "detect-engine-uint.h"
+#include "detect-parse.h"
+
+#include "util-validate.h"
+
+static void DetectCountFree(DetectEngineCtx *de_ctx, void *ptr)
+{
+    SCDetectU32Free(ptr);
+}
+
+static int DetectCountSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
+{
+    int sm_list = DETECT_SM_LIST_PMATCH;
+    if (s->init_data->list == DETECT_SM_LIST_NOTSET) {
+        SCLogError("count must be applied on a multi-buffer");
+        return -1;
+    }
+    if (DetectBufferGetActiveList(de_ctx, s) == -1) {
+        SCLogError("count must be applied on a multi-buffer");
+        return -1;
+    }
+
+    sm_list = s->init_data->list;
+    // TODO check it is a multi buffer and not a single buffer
+
+    DetectU32Data *du32 = SCDetectU32Parse(arg);
+    if (du32 == NULL) {
+        SCLogError("invalid count argument");
+        return -1;
+    }
+
+    if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_COUNT, (SigMatchCtx *)du32, sm_list) != NULL) {
+        return 0;
+    }
+    SCLogError("error during count setup");
+    DetectCountFree(de_ctx, du32);
+    return -1;
+}
+
+bool DetectCountDoMatch(DetectEngineThreadCtx *det_ctx, Flow *f, const uint8_t flow_flags,
+        void *txv, InspectionMultiBufferGetDataPtr GetBuf, const SigMatchCtx *ctx)
+{
+    uint32_t count = 0;
+    if (!GetBuf(det_ctx, txv, flow_flags, DETECT_COUNT_INDEX, NULL, &count)) {
+        DEBUG_VALIDATE_BUG_ON(1);
+        return false;
+    }
+    DetectU32Data *du32 = (DetectU32Data *)ctx;
+
+    return DetectU32Match(count, du32);
+}
+
+void DetectCountRegister(void)
+{
+    sigmatch_table[DETECT_COUNT].name = "count";
+    sigmatch_table[DETECT_COUNT].desc = "count number of buffers in a multi-buffer";
+    // TODO doc
+    sigmatch_table[DETECT_COUNT].url = "/rules/payload-keywords.html#count";
+    sigmatch_table[DETECT_COUNT].Free = DetectCountFree;
+    sigmatch_table[DETECT_COUNT].Setup = DetectCountSetup;
+}

--- a/src/detect-count.h
+++ b/src/detect-count.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef SURICATA_DETECT_COUNT_H
+#define SURICATA_DETECT_COUNT_H
+
+void DetectCountRegister(void);
+bool DetectCountDoMatch(DetectEngineThreadCtx *det_ctx, Flow *f, const uint8_t flow_flags,
+        void *txv, InspectionMultiBufferGetDataPtr GetBuf, const SigMatchCtx *ctx);
+
+#endif

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -219,6 +219,11 @@ static bool GetMimeEmailReceivedData(DetectEngineThreadCtx *det_ctx, const void 
         return false;
     }
 
+    if (idx == DETECT_COUNT_INDEX) {
+        *buf_len = SCDetectMimeEmailGetCount(tx->mime_state, "received");
+        return true;
+    }
+
     if (SCDetectMimeEmailGetDataArray(tx->mime_state, buf, buf_len, "received", idx) != 1) {
         return false;
     }
@@ -307,6 +312,6 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailReceivedSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_received_buffer_id = SCDetectHelperMultiBufferMpmRegister("email.received",
-            "MIME EMAIL RECEIVED", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailReceivedData);
+    g_mime_email_received_buffer_id = SCDetectHelperMultiBufferProgressMpmRegister("email.received",
+            "MIME EMAIL RECEIVED", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailReceivedData, 1);
 }

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -212,6 +212,7 @@
 #include "detect-ja4-hash.h"
 #include "detect-ftp-command.h"
 #include "detect-entropy.h"
+#include "detect-count.h"
 #include "detect-ftp-command-data.h"
 #include "detect-ftp-completion-code.h"
 #include "detect-ftp-reply.h"
@@ -617,6 +618,7 @@ void SigTableSetup(void)
     DetectBytejumpRegister();
     DetectBytemathRegister();
     DetectEntropyRegister();
+    DetectCountRegister();
     DetectSameipRegister();
     DetectGeoipRegister();
     DetectL3ProtoRegister();

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -94,6 +94,7 @@ enum DetectKeywordId {
     DETECT_URILEN,
     DETECT_ABSENT,
     DETECT_ENTROPY,
+    DETECT_COUNT,
     /* end of content inspection */
 
     DETECT_METADATA,


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5044

Describe changes:
- detect: count keywords for multi-buffer

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2634

Draft :
- see TODOs in the code
- see if this can be used for integers https://redmine.openinfosecfoundation.org/issues/7211
- other idea for expressivity : add another keyword `match_count`, so we can test a dns request has 3 names, including 2 that match content "toto" see https://github.com/OISF/suricata/pull/13475 with DETECT_ENGINE_INSPECT_SIG_MATCH_MORE_BUF
- next ticket : handle maps https://redmine.openinfosecfoundation.org/issues/5775

Feedback about design is welcome