### PR TITLE
dpdk: fix assignment of pkt_mempools to ldev - v1

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -1835,10 +1835,8 @@ static void *ParseDpdkConfigAndConfigureDevice(const char *iface)
     if (ldev_instance == NULL) {
         FatalError("Device %s is not registered as a live device", iface);
     }
-    for (uint16_t i = 0; i < iconf->threads; i++) {
-        ldev_instance->dpdk_vars = iconf->pkt_mempools;
-        iconf->pkt_mempools = NULL;
-    }
+    ldev_instance->dpdk_vars = iconf->pkt_mempools;
+    iconf->pkt_mempools = NULL;
     return iconf;
 }
 


### PR DESCRIPTION
This PR changes how a pointer to pkt_mempools is assigned to LiveDevice instance ldev_instance.dpdk_vars.
When Suricata ran with multiple worker threads, the old method with a for-loop caused the pointer ldev_instance.dpdk_vars to be set to NULL.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7879

Describe changes:
- Remove unnecessary loop around assignment of iconf->pkt_mempool to ldev_instance->dpdk_vars.

