### PR TITLE
Cifuzz faster v2

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/oss-fuzz-base/base-builder-rust
-RUN apt-get update && apt-get install -y build-essential autoconf automake libtool make pkg-config  python flex bison zlib1g-dev libpcre3-dev cmake tshark
+RUN apt-get update && apt-get install -y build-essential autoconf automake libtool make pkg-config flex bison zlib1g-dev libpcre3-dev cmake
 
 # TODO libmagic, liblzma and other optional libraries
 ADD https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.44/pcre2-10.44.tar.gz pcre2-10.44.tar.gz

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -14,8 +14,6 @@ ENV RUSTUP_TOOLCHAIN nightly
 RUN rustup toolchain install nightly-x86_64-unknown-linux-gnu
 RUN cargo install --force cbindgen
 
-RUN git clone --depth 1 https://github.com/OISF/libhtp.git libhtp
-
 COPY . $SRC/suricata
 WORKDIR $SRC/suricata
 COPY ./.clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -eu
 
+date
+
 cd $SRC/
 # build dependencies statically
 if [ "$SANITIZER" = "memory" ]
@@ -68,15 +70,21 @@ then
     export RUSTFLAGS="$RUSTFLAGS -Cdebug-assertions=yes"
 fi
 
+date
+
 rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
 
 # build project
+
+date
 
 cd suricata
 sh autogen.sh
 
 ./src/tests/fuzz/oss-fuzz-configure.sh
 make -j$(nproc)
+
+date
 
 ./src/suricata --list-app-layer-protos | tail -n +2 | while read i; do cp src/fuzz_applayerparserparse $OUT/fuzz_applayerparserparse""_$i; done
 
@@ -88,6 +96,9 @@ ls fuzz_* | while read i; do
     wget "https://storage.googleapis.com/suricata-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/suricata_$i/public.zip" --output-file=$OUT/"$i"_seed_corpus.zip || true
 done
 )
+
+date
+
 # dictionaries
 ./src/suricata --list-keywords | grep "\- " | sed 's/- //' | awk '{print "\""$0"\""}' > $OUT/fuzz_siginit.dict
 
@@ -101,3 +112,5 @@ cat generic.dict >> $OUT/fuzz_siginit.dict
 cat generic.dict >> $OUT/fuzz_applayerparserparse.dict
 cat generic.dict >> $OUT/fuzz_sigpcap.dict
 cat generic.dict >> $OUT/fuzz_sigpcap_aware.dict
+
+date

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -70,8 +70,6 @@ fi
 
 rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
 
-#we did not put libhtp there before so that cifuzz does not remove it
-cp -r libhtp suricata/
 # build project
 
 cd suricata

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -7,7 +7,6 @@ auto_ccs:
 sanitizers:
   - address
   - memory
-  - undefined
 fuzzing_engines:
   - afl
   - honggfuzz

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -18,7 +18,7 @@ jobs:
    strategy:
      fail-fast: false
      matrix:
-       sanitizer: [address, undefined]
+       sanitizer: [address]
    steps:
    - name: Clear unnecessary files
      run: |


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none, just CI

Describe changes:
- make clusterfuzzlite faster by removing the UBSAN build
