### PR TITLE
Detect sigmatch flags removal v2

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -365,7 +365,7 @@ static int SignatureIsDEOnly(DetectEngineCtx *de_ctx, const Signature *s)
     /* check for conflicting keywords */
     SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_MATCH];
     for ( ;sm != NULL; sm = sm->next) {
-        if ( !(sigmatch_table[sm->type].flags & SIGMATCH_DEONLY_COMPAT))
+        if (sm->type != DETECT_DECODE_EVENT)
             SCReturnInt(0);
     }
 

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -141,7 +141,6 @@ void DetectEngineEventRegister (void)
     sigmatch_table[DETECT_DECODE_EVENT].desc =
             "match on events triggered by structural or invalid values during packet decoding";
     sigmatch_table[DETECT_DECODE_EVENT].url = "/rules/decode-layer.html#decode-event";
-    sigmatch_table[DETECT_DECODE_EVENT].flags |= SIGMATCH_DEONLY_COMPAT;
     sigmatch_table[DETECT_DECODE_EVENT].SupportsPrefilter = PrefilterDecodeEventIsPrefilterable;
     sigmatch_table[DETECT_DECODE_EVENT].SetupPrefilter = PrefilterSetupDecodeEvent;
 

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -1488,13 +1488,6 @@ static const PrefilterStore *PrefilterStoreGetStore(const DetectEngineCtx *de_ct
     return store;
 }
 
-#ifdef PROFILING
-const char *PrefilterStoreGetName(const uint32_t id)
-{
-    return NULL;
-}
-#endif
-
 #include "util-print.h"
 
 typedef struct PrefilterMpmCtx {

--- a/src/detect-engine-prefilter.h
+++ b/src/detect-engine-prefilter.h
@@ -87,10 +87,6 @@ void PrefilterFreeEnginesList(PrefilterEngineList *list);
 int PrefilterSetupRuleGroup(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 void PrefilterCleanupRuleGroup(const DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 
-#ifdef PROFILING
-const char *PrefilterStoreGetName(const uint32_t id);
-#endif
-
 void PrefilterInit(DetectEngineCtx *de_ctx);
 void PrefilterDeinit(DetectEngineCtx *de_ctx);
 

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -305,12 +305,6 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
         printf("compatible with IP only rule");
         prev = 1;
     }
-    if (flags & SIGMATCH_DEONLY_COMPAT) {
-        if (prev == 1)
-            printf("%c", sep);
-        printf("compatible with decoder event only rule");
-        prev = 1;
-    }
     if (flags & SIGMATCH_INFO_CONTENT_MODIFIER) {
         if (prev == 1)
             printf("%c", sep);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1392,15 +1392,6 @@ const char *DetectEngineBufferTypeGetDescriptionById(const DetectEngineCtx *de_c
     return exists->description;
 }
 
-const char *DetectBufferTypeGetDescriptionByName(const char *name)
-{
-    const DetectBufferType *exists = DetectBufferTypeLookupByName(name);
-    if (!exists) {
-        return NULL;
-    }
-    return exists->description;
-}
-
 void DetectEngineBufferTypeSupportsFrames(DetectEngineCtx *de_ctx, const char *name)
 {
     DetectBufferType *exists = DetectEngineBufferTypeLookupByName(de_ctx, name);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -41,7 +41,6 @@ void DetectBufferTypeSupportsMultiInstance(const char *name);
 int DetectBufferTypeMaxId(void);
 void DetectBufferTypeCloseRegistration(void);
 void DetectBufferTypeSetDescriptionByName(const char *name, const char *desc);
-const char *DetectBufferTypeGetDescriptionByName(const char *name);
 void DetectBufferTypeRegisterSetupCallback(const char *name,
         void (*Callback)(const DetectEngineCtx *, Signature *));
 void DetectBufferTypeRegisterValidateCallback(

--- a/src/detect.h
+++ b/src/detect.h
@@ -1648,11 +1648,9 @@ typedef struct SigGroupHead_ {
 /** sigmatch has no options, so the parser shouldn't expect any */
 #define SIGMATCH_NOOPT                  BIT_U16(0)
 /** sigmatch is compatible with a ip only rule */
-#define SIGMATCH_IPONLY_COMPAT          BIT_U16(1)
-/** sigmatch is compatible with a decode event only rule */
-#define SIGMATCH_DEONLY_COMPAT          BIT_U16(2)
+#define SIGMATCH_IPONLY_COMPAT BIT_U16(1)
 
-// vacancy
+// vacancy (x2)
 
 /** sigmatch may have options, so the parser should be ready to
  *  deal with both cases */

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -7150,13 +7150,6 @@ const char *StreamTcpStateAsString(const enum TcpState state)
     return tcp_state;
 }
 
-const char *StreamTcpSsnStateAsString(const TcpSession *ssn)
-{
-    if (ssn == NULL)
-        return NULL;
-    return StreamTcpStateAsString(ssn->state);
-}
-
 #ifdef UNITTESTS
 #include "tests/stream-tcp.c"
 #endif

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -156,7 +156,6 @@ void StreamReassembleRawUpdateProgress(TcpSession *ssn, Packet *p, const uint64_
 void StreamTcpDetectLogFlush(ThreadVars *tv, StreamTcpThread *stt, Flow *f, Packet *p, PacketQueueNoLock *pq);
 
 const char *StreamTcpStateAsString(const enum TcpState);
-const char *StreamTcpSsnStateAsString(const TcpSession *ssn);
 
 enum ExceptionPolicy StreamTcpSsnMemcapGetExceptionPolicy(void);
 enum ExceptionPolicy StreamTcpReassemblyMemcapGetExceptionPolicy(void);

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -29,28 +29,3 @@
 #include "util-error.h"
 
 thread_local SCError sc_errno = SC_OK;
-#define CASE_CODE(E)  case E: return #E
-
-/**
- * \brief Maps the error code, to its string equivalent
- *
- * \param The error code
- *
- * \retval The string equivalent for the error code
- */
-const char * SCErrorToString(SCError err)
-{
-    switch (err) {
-        CASE_CODE (SC_OK);
-
-        CASE_CODE(SC_ENOMEM);
-        CASE_CODE(SC_EINVAL);
-        CASE_CODE(SC_ELIMIT);
-        CASE_CODE(SC_EEXIST);
-        CASE_CODE(SC_ENOENT);
-
-        CASE_CODE (SC_ERR_MAX);
-    }
-
-    return "UNKNOWN_ERROR";
-}

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -35,8 +35,6 @@ typedef enum {
     SC_ERR_MAX
 } SCError;
 
-const char *SCErrorToString(SCError);
-
 #include "threads.h"
 
 extern thread_local SCError sc_errno;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None, just code clean-up with flag removal

Describe changes:
- detect: remove flag SIGMATCH_DEONLY_COMPAT
- src: remove some unused functions like PrefilterStoreGetName

Found with `git grep "^const" src/*.h | cut -d\( -f1 | cut -d\* -f2 | sort | while read i; do echo -n $i; git grep $i | wc -l ; done | awk '$2 == 2'`
