### PR TITLE
7.0.x: dpdk: avoid mbuf leak on failed packet acquisition v1

### DIFF
--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -416,6 +416,7 @@ static TmEcode ReceiveDPDKLoop(ThreadVars *tv, void *data, void *slot)
         for (uint16_t i = 0; i < nb_rx; i++) {
             p = PacketGetFromQueueOrAlloc();
             if (unlikely(p == NULL)) {
+                rte_pktmbuf_free(ptv->received_mbufs[i]);
                 continue;
             }
             PKT_SET_SRC(p, PKT_SRC_WIRE);


### PR DESCRIPTION
When the Suricata packet structure cannot be initialized (packet mempool is depleted and there is no more memory to allocate), a NULL is returned. While the capture loop detects the NULL, it only continues and does not free the current mbuf back to the DPDK mempool.

Ticket: [7872](https://redmine.openinfosecfoundation.org/issues/7872) -- https://redmine.openinfosecfoundation.org/issues/7872