### PR TITLE
requirements: use libhtp 0.5.x for devel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 # Format:
 #
 #   name {repo} {branch|tag}
-libhtp https://github.com/OISF/libhtp 0.5.51
+libhtp https://github.com/OISF/libhtp 0.5.x
 suricata-update https://github.com/OISF/suricata-update 1.3.6


### PR DESCRIPTION
With the recent change in the release process of not updating requirements post release to point to dev version, libhtp was pinned to `0.5.51` causing build failures in CI because `0.5.x` has moved ahead with a breaking change for an s-v test.

Manually updated now but I think we'll be sticking to changing requirements for libhtp at least per release. We'll leave suricata-update out of it.