### PR TITLE
doc: upgrade note about keyword tls.cert_subject

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -199,6 +199,8 @@ Keyword changes
 ~~~~~~~~~~~~~~~
 - ``ja3.hash`` and ``ja3s.hash`` no longer accept contents with non hexadecimal
   characters, as they will never match.
+- Usage of multiple ``tls.cert_subject`` in a rule will print a warning
+  as this keyword was not and is not implemented as a multi-buffer.
 
 Logging changes
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7890

Describe changes:
- doc: upgrade note about keyword tls.cert_subject
