### PR TITLE
Doc jsonschema v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -237,6 +237,9 @@ jobs:
       - name: Check EVE schema ordering
         run: ./scripts/schema-sort.py --check ./etc/schema.json
 
+      - name: Check EVE schema has all additionalProperties
+        run: test $(cat etc/schema.json | 'paths( objects | (.type == "object" and (has("additionalProperties") | not) )) | join(".")' | wc -l) = "0"
+
   almalinux-9:
     name: AlmaLinux 9 (schema)
     runs-on: ubuntu-latest

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -26,6 +26,7 @@
                 },
                 "metadata": {
                     "type": "object",
+                    "additionalProperties": true,
                     "properties": {
                         "affected_product": {
                             "type": "array",
@@ -309,24 +310,21 @@
                             "type": "array",
                             "items": {
                                 "type": "object",
-                                "items": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "required": [
-                                        "id",
-                                        "ip",
-                                        "port"
-                                    ],
-                                    "properties": {
-                                        "id": {
-                                            "type": "string"
-                                        },
-                                        "ip": {
-                                            "type": "string"
-                                        },
-                                        "port": {
-                                            "type": "number"
-                                        }
+                                "additionalProperties": false,
+                                "required": [
+                                    "id",
+                                    "ip",
+                                    "port"
+                                ],
+                                "properties": {
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "ip": {
+                                        "type": "string"
+                                    },
+                                    "port": {
+                                        "type": "number"
                                     }
                                 }
                             }
@@ -360,7 +358,16 @@
                         "values": {
                             "type": "array",
                             "items": {
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "ip": {
+                                        "type": "string"
+                                    },
+                                    "port": {
+                                        "type": "number"
+                                    }
+                                }
                             }
                         }
                     }
@@ -597,7 +604,8 @@
                                         "type": "array",
                                         "minItems": 1,
                                         "items": {
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": true
                                         }
                                     },
                                     "prefix_code": {
@@ -712,7 +720,8 @@
                                                 "type": "array",
                                                 "minItems": 1,
                                                 "items": {
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": true
                                                 }
                                             },
                                             "prefix_code": {
@@ -822,7 +831,8 @@
                                                 "type": "array",
                                                 "minItems": 1,
                                                 "items": {
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": true
                                                 }
                                             },
                                             "prefix_code": {
@@ -3207,6 +3217,7 @@
                     "minItems": 1,
                     "items": {
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "rrname": {
                                 "description": "Resource name being requested",
@@ -3249,6 +3260,7 @@
             "properties": {
                 "entropy": {
                     "type": "object",
+                    "additionalProperties": true,
                     "suricata": {
                         "keywords": [
                             "entropy"
@@ -3269,6 +3281,7 @@
                 },
                 "flowints": {
                     "type": "object",
+                    "additionalProperties": true,
                     "suricata": {
                         "keywords": [
                             "flowint"
@@ -3280,6 +3293,7 @@
                     "minItems": 1,
                     "items": {
                         "type": "object",
+                        "additionalProperties": true,
                         "properties": {
                             "gid": {
                                 "type": "string"
@@ -3503,7 +3517,8 @@
                             "type": "boolean"
                         },
                         "properties": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": true
                         },
                         "qos": {
                             "type": "integer"
@@ -3554,7 +3569,8 @@
                             "type": "string"
                         },
                         "properties": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": true
                         },
                         "protocol_string": {
                             "type": "string"
@@ -3579,7 +3595,8 @@
                                     "type": "string"
                                 },
                                 "properties": {
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": true
                                 },
                                 "topic": {
                                     "type": "string"
@@ -3596,7 +3613,8 @@
                             "type": "boolean"
                         },
                         "properties": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": true
                         },
                         "qos": {
                             "type": "integer"
@@ -3695,7 +3713,8 @@
                             "type": "integer"
                         },
                         "properties": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": true
                         },
                         "qos": {
                             "type": "integer"
@@ -3870,6 +3889,7 @@
         },
         "ndpi": {
             "type": "object",
+            "additionalProperties": true,
             "description": "nDPI plugin, contents provided by 3rd party library"
         },
         "netflow": {
@@ -4057,6 +4077,7 @@
                     "properties": {
                         "copy_data_in": {
                             "type": "object",
+                            "additionalProperties": false,
                             "description": "CopyData message from CopyIn mode",
                             "properties": {
                                 "data_size": {
@@ -4110,6 +4131,7 @@
                                     "minItems": 1,
                                     "items": {
                                         "type": "object",
+                                        "additionalProperties": true,
                                         "properties": {
                                             "application_name": {
                                                 "type": "string"
@@ -4160,6 +4182,7 @@
                         },
                         "copy_data_out": {
                             "type": "object",
+                            "additionalProperties": false,
                             "description": "CopyData message from CopyOut mode",
                             "properties": {
                                 "data_size": {
@@ -4174,6 +4197,7 @@
                         },
                         "copy_in_response": {
                             "type": "object",
+                            "additionalProperties": false,
                             "description": "Backend/server response accepting CopyIn mode",
                             "properties": {
                                 "columns": {
@@ -4184,6 +4208,7 @@
                         },
                         "copy_out_response": {
                             "type": "object",
+                            "additionalProperties": false,
                             "description": "Backend/server response accepting CopyOut mode",
                             "properties": {
                                 "columns": {
@@ -4215,6 +4240,7 @@
                             "minItems": 1,
                             "items": {
                                 "type": "object",
+                                "additionalProperties": true,
                                 "properties": {
                                     "application_name": {
                                         "type": "string"
@@ -4283,9 +4309,11 @@
         },
         "pop3": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "request": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "args": {
                             "type": "array",
@@ -4303,6 +4331,7 @@
                 },
                 "response": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "data": {
                             "type": "array",
@@ -5760,6 +5789,7 @@
                 },
                 "capture": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "kernel_drops": {
                             "type": "integer"
@@ -6738,6 +6768,7 @@
                 },
                 "exception_policy": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "app_layer": {
                             "type": "object",
@@ -7466,7 +7497,8 @@
             "type": "integer"
         },
         "stream_tcp": {
-            "type": "object"
+            "type": "object",
+            "additionalProperties": true
         },
         "suricata_version": {
             "type": "string"
@@ -7476,6 +7508,7 @@
         },
         "tcp": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "ack": {
                     "type": "boolean"
@@ -7701,6 +7734,7 @@
                 },
                 "client_handshake": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "ciphers": {
                             "description": "TLS client cipher(s)",
@@ -7847,6 +7881,7 @@
                 },
                 "server_handshake": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "cipher": {
                             "description": "TLS server's chosen cipher",
@@ -8162,6 +8197,7 @@
         },
         "verdict_type": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "action": {
                     "type": "string"
@@ -8196,6 +8232,7 @@
         },
         "exceptionPolicy": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "bypass": {
                     "type": "integer",

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -507,7 +507,12 @@
                     "type": "integer"
                 },
                 "lease_time": {
-                    "type": "integer"
+                    "type": "integer",
+                    "suricata": {
+                        "keywords": [
+                            "dhcp.leasetime"
+                        ]
+                    }
                 },
                 "next_server_ip": {
                     "type": "string"
@@ -520,13 +525,23 @@
                     }
                 },
                 "rebinding_time": {
-                    "type": "integer"
+                    "type": "integer",
+                    "suricata": {
+                        "keywords": [
+                            "dhcp.rebinding_time"
+                        ]
+                    }
                 },
                 "relay_ip": {
                     "type": "string"
                 },
                 "renewal_time": {
-                    "type": "integer"
+                    "type": "integer",
+                    "suricata": {
+                        "keywords": [
+                            "dhcp.renewal_time"
+                        ]
+                    }
                 },
                 "requested_ip": {
                     "type": "string"
@@ -1495,7 +1510,12 @@
                             "additionalProperties": false,
                             "properties": {
                                 "class_name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.cip_class"
+                                        ]
+                                    }
                                 },
                                 "multiple": {
                                     "type": "array",
@@ -1505,7 +1525,12 @@
                                         "additionalProperties": false,
                                         "properties": {
                                             "class_name": {
-                                                "type": "string"
+                                                "type": "string",
+                                                "suricata": {
+                                                    "keywords": [
+                                                        "enip.cip_class"
+                                                    ]
+                                                }
                                             },
                                             "path": {
                                                 "type": "array",
@@ -1518,7 +1543,14 @@
                                                             "type": "string"
                                                         },
                                                         "value": {
-                                                            "type": "integer"
+                                                            "type": "integer",
+                                                            "suricata": {
+                                                                "keywords": [
+                                                                    "enip.cip_attribute",
+                                                                    "enip.cip_class",
+                                                                    "enip.cip_instance"
+                                                                ]
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -1540,7 +1572,14 @@
                                                 "type": "string"
                                             },
                                             "value": {
-                                                "type": "integer"
+                                                "type": "integer",
+                                                "suricata": {
+                                                    "keywords": [
+                                                        "enip.cip_attribute",
+                                                        "enip.cip_class",
+                                                        "enip.cip_instance"
+                                                    ]
+                                                }
                                             }
                                         }
                                     }
@@ -1551,7 +1590,12 @@
                             }
                         },
                         "command": {
-                            "type": "string"
+                            "type": "string",
+                            "suricata": {
+                                "keywords": [
+                                    "enip.command"
+                                ]
+                            }
                         },
                         "register_session": {
                             "type": "object",
@@ -1561,12 +1605,22 @@
                                     "type": "integer"
                                 },
                                 "protocol_version": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.protocol_version"
+                                        ]
+                                    }
                                 }
                             }
                         },
                         "status": {
-                            "type": "string"
+                            "type": "string",
+                            "suricata": {
+                                "keywords": [
+                                    "enip.status"
+                                ]
+                            }
                         }
                     }
                 },
@@ -1589,10 +1643,20 @@
                                                 "type": "string"
                                             },
                                             "status": {
-                                                "type": "string"
+                                                "type": "string",
+                                                "suricata": {
+                                                    "keywords": [
+                                                        "enip.cip_status"
+                                                    ]
+                                                }
                                             },
                                             "status_extended": {
-                                                "type": "string"
+                                                "type": "string",
+                                                "suricata": {
+                                                    "keywords": [
+                                                        "enip.cip_extendedstatus"
+                                                    ]
+                                                }
                                             },
                                             "status_extended_meaning": {
                                                 "type": "string"
@@ -1604,10 +1668,20 @@
                                     "type": "string"
                                 },
                                 "status": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.cip_status"
+                                        ]
+                                    }
                                 },
                                 "status_extended": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.cip_extendedstatus"
+                                        ]
+                                    }
                                 },
                                 "status_extended_meaning": {
                                     "type": "string"
@@ -1615,38 +1689,83 @@
                             }
                         },
                         "command": {
-                            "type": "string"
+                            "type": "string",
+                            "suricata": {
+                                "keywords": [
+                                    "enip.command"
+                                ]
+                            }
                         },
                         "identity": {
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
                                 "device_type": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.device_type"
+                                        ]
+                                    }
                                 },
                                 "product_code": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.product_code"
+                                        ]
+                                    }
                                 },
                                 "product_name": {
                                     "type": "string"
                                 },
                                 "protocol_version": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.protocol_version"
+                                        ]
+                                    }
                                 },
                                 "revision": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.revision"
+                                        ]
+                                    }
                                 },
                                 "serial": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.serial"
+                                        ]
+                                    }
                                 },
                                 "state": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.state"
+                                        ]
+                                    }
                                 },
                                 "status": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.identity_status"
+                                        ]
+                                    }
                                 },
                                 "vendor_id": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.vendor_id"
+                                        ]
+                                    }
                                 }
                             }
                         },
@@ -1655,10 +1774,20 @@
                             "additionalProperties": false,
                             "properties": {
                                 "capabilities": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.capabilities"
+                                        ]
+                                    }
                                 },
                                 "protocol_version": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.protocol_version"
+                                        ]
+                                    }
                                 },
                                 "service_name": {
                                     "type": "string"
@@ -1673,12 +1802,22 @@
                                     "type": "integer"
                                 },
                                 "protocol_version": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "enip.protocol_version"
+                                        ]
+                                    }
                                 }
                             }
                         },
                         "status": {
-                            "type": "string"
+                            "type": "string",
+                            "suricata": {
+                                "keywords": [
+                                    "enip.status"
+                                ]
+                            }
                         }
                     }
                 }
@@ -1763,7 +1902,12 @@
                 },
                 "size": {
                     "type": "integer",
-                    "description": "The observed size fo the file, in bytes"
+                    "description": "The observed size fo the file, in bytes",
+                    "suricata": {
+                        "keywords": [
+                            "filesize"
+                        ]
+                    }
                 },
                 "start": {
                     "type": "integer",
@@ -2037,7 +2181,12 @@
                     }
                 },
                 "dynamic_port": {
-                    "type": "integer"
+                    "type": "integer",
+                    "suricata": {
+                        "keywords": [
+                            "ftp.dynamic_port"
+                        ]
+                    }
                 },
                 "mode": {
                     "type": "string"
@@ -2116,7 +2265,12 @@
                                     "type": "string"
                                 },
                                 "priority": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "http2.priority"
+                                        ]
+                                    }
                                 },
                                 "settings": {
                                     "type": "array",
@@ -2214,7 +2368,12 @@
                                 "type": "string"
                             },
                             "table_size_update": {
-                                "type": "integer"
+                                "type": "integer",
+                                "suricata": {
+                                    "keywords": [
+                                        "http2.size_update"
+                                    ]
+                                }
                             },
                             "value": {
                                 "type": "string"
@@ -2233,7 +2392,12 @@
                                 "type": "string"
                             },
                             "table_size_update": {
-                                "type": "integer"
+                                "type": "integer",
+                                "suricata": {
+                                    "keywords": [
+                                        "http2.size_update"
+                                    ]
+                                }
                             },
                             "value": {
                                 "type": "string"
@@ -2266,10 +2430,20 @@
             }
         },
         "icmp_code": {
-            "type": "integer"
+            "type": "integer",
+            "suricata": {
+                "keywords": [
+                    "icode"
+                ]
+            }
         },
         "icmp_type": {
-            "type": "integer"
+            "type": "integer",
+            "suricata": {
+                "keywords": [
+                    "itype"
+                ]
+            }
         },
         "ike": {
             "type": "object",
@@ -2300,7 +2474,12 @@
                     "type": "integer"
                 },
                 "exchange_type": {
-                    "type": "integer"
+                    "type": "integer",
+                    "suricata": {
+                        "keywords": [
+                            "ike.exchtype"
+                        ]
+                    }
                 },
                 "exchange_type_verbose": {
                     "type": "string"
@@ -2317,13 +2496,23 @@
                                     "type": "string"
                                 },
                                 "key_exchange_payload_length": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "ike.key_exchange_payload_length"
+                                        ]
+                                    }
                                 },
                                 "nonce_payload": {
                                     "type": "string"
                                 },
                                 "nonce_payload_length": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "ike.nonce_payload_length"
+                                        ]
+                                    }
                                 },
                                 "proposals": {
                                     "type": "array",
@@ -3508,13 +3697,23 @@
         "mqtt": {
             "type": "object",
             "additionalProperties": false,
+            "suricata": {
+                "keywords": [
+                    "mqtt.type"
+                ]
+            },
             "properties": {
                 "connack": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "properties": {
                             "type": "object",
@@ -3524,7 +3723,12 @@
                             "type": "integer"
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "return_code": {
                             "type": "integer"
@@ -3542,11 +3746,21 @@
                             "type": "string"
                         },
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "flags": {
                             "type": "object",
                             "additionalProperties": false,
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.connect.flags"
+                                ]
+                            },
                             "properties": {
                                 "clean_session": {
                                     "type": "boolean"
@@ -3576,13 +3790,23 @@
                             "type": "string"
                         },
                         "protocol_version": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.protocol_version"
+                                ]
+                            }
                         },
                         "qos": {
                             "type": "integer"
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "username": {
                             "type": "string"
@@ -3610,7 +3834,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "properties": {
                             "type": "object",
@@ -3620,10 +3849,20 @@
                             "type": "integer"
                         },
                         "reason_code": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.reason_code"
+                                ]
+                            }
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         }
                     }
                 },
@@ -3632,13 +3871,23 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "qos": {
                             "type": "integer"
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         }
                     }
                 },
@@ -3647,13 +3896,23 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "qos": {
                             "type": "integer"
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         }
                     }
                 },
@@ -3662,7 +3921,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "message_id": {
                             "type": "integer"
@@ -3671,10 +3935,20 @@
                             "type": "integer"
                         },
                         "reason_code": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.reason_code"
+                                ]
+                            }
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         }
                     }
                 },
@@ -3683,7 +3957,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "message_id": {
                             "type": "integer"
@@ -3692,10 +3971,20 @@
                             "type": "integer"
                         },
                         "reason_code": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.reason_code"
+                                ]
+                            }
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         }
                     }
                 },
@@ -3704,7 +3993,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "message": {
                             "type": "string"
@@ -3720,7 +4014,12 @@
                             "type": "integer"
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "skipped_length": {
                             "type": "integer"
@@ -3738,7 +4037,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "message_id": {
                             "type": "integer"
@@ -3747,10 +4051,20 @@
                             "type": "integer"
                         },
                         "reason_code": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.reason_code"
+                                ]
+                            }
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         }
                     }
                 },
@@ -3759,7 +4073,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "message_id": {
                             "type": "integer"
@@ -3768,10 +4087,20 @@
                             "type": "integer"
                         },
                         "reason_code": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.reason_code"
+                                ]
+                            }
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         }
                     }
                 },
@@ -3780,7 +4109,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "message_id": {
                             "type": "integer"
@@ -3796,7 +4130,12 @@
                             }
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         }
                     }
                 },
@@ -3805,7 +4144,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "message_id": {
                             "type": "integer"
@@ -3814,7 +4158,12 @@
                             "type": "integer"
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "topics": {
                             "type": "array",
@@ -3839,7 +4188,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "message_id": {
                             "type": "integer"
@@ -3852,10 +4206,20 @@
                             "minItems": 1,
                             "items": {
                                 "type": "integer"
+                            },
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.reason_code"
+                                ]
                             }
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         }
                     }
                 },
@@ -3864,7 +4228,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "message_id": {
                             "type": "integer"
@@ -3873,7 +4242,12 @@
                             "type": "integer"
                         },
                         "retain": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "suricata": {
+                                "keywords": [
+                                    "mqtt.flags"
+                                ]
+                            }
                         },
                         "topics": {
                             "type": "array",
@@ -3967,7 +4341,12 @@
                     "type": "integer"
                 },
                 "procedure": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "nfs_procedure"
+                        ]
+                    }
                 },
                 "read": {
                     "type": "object",
@@ -4008,7 +4387,12 @@
                     "type": "string"
                 },
                 "version": {
-                    "type": "integer"
+                    "type": "integer",
+                    "suricata": {
+                        "keywords": [
+                            "nfs.version"
+                        ]
+                    }
                 },
                 "write": {
                     "type": "object",
@@ -4549,10 +4933,20 @@
                     "additionalProperties": false,
                     "properties": {
                         "security_result": {
-                            "type": "string"
+                            "type": "string",
+                            "suricata": {
+                                "keywords": [
+                                    "rfb.secresult"
+                                ]
+                            }
                         },
                         "security_type": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "rfb.sectype"
+                                ]
+                            }
                         },
                         "vnc": {
                             "type": "object",
@@ -5164,7 +5558,12 @@
                     "type": "string"
                 },
                 "pdu_type": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "snmp.pdu_type"
+                        ]
+                    }
                 },
                 "usm": {
                     "type": "string"
@@ -5177,7 +5576,12 @@
                     }
                 },
                 "version": {
-                    "type": "integer"
+                    "type": "integer",
+                    "suricata": {
+                        "keywords": [
+                            "snmp.version"
+                        ]
+                    }
                 }
             },
             "optional": true
@@ -8009,9 +8413,19 @@
         },
         "vlan": {
             "type": "array",
+            "suricata": {
+                "keywords": [
+                    "vlan.layers"
+                ]
+            },
             "minItems": 1,
             "items": {
-                "type": "number"
+                "type": "number",
+                "suricata": {
+                    "keywords": [
+                        "vlan.id"
+                    ]
+                }
             }
         },
         "websocket": {
@@ -8019,13 +8433,28 @@
             "additionalProperties": false,
             "properties": {
                 "fin": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "suricata": {
+                        "keywords": [
+                            "websocket.flags"
+                        ]
+                    }
                 },
                 "mask": {
-                    "type": "integer"
+                    "type": "integer",
+                    "suricata": {
+                        "keywords": [
+                            "websocket.mask"
+                        ]
+                    }
                 },
                 "opcode": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "websocket.opcode"
+                        ]
+                    }
                 },
                 "payload_base64": {
                     "type": "string"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2558,6 +2558,7 @@
         },
         "ldap": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "request": {
                     "type": "object",
@@ -2565,6 +2566,7 @@
                     "properties": {
                         "abandon_request": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "message_id": {
                                     "type": "integer"
@@ -2574,12 +2576,14 @@
                         },
                         "add_request": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "attributes": {
                                     "type": "array",
                                     "minItems": 1,
                                     "items": {
                                         "type": "object",
+                                        "additionalProperties": false,
                                         "properties": {
                                             "name": {
                                                 "type": "string"
@@ -2602,12 +2606,14 @@
                         },
                         "bind_request": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "name": {
                                     "type": "string"
                                 },
                                 "sasl": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "credentials": {
                                             "type": "string",
@@ -2627,9 +2633,11 @@
                         },
                         "compare_request": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "attribute_value_assertion": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "description": {
                                             "type": "string"
@@ -2647,6 +2655,7 @@
                         },
                         "del_request": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "dn": {
                                     "type": "string"
@@ -2656,6 +2665,7 @@
                         },
                         "extended_request": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "name": {
                                     "type": "string"
@@ -2672,6 +2682,7 @@
                         },
                         "mod_dn_request": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "delete_old_rdn": {
                                     "type": "boolean"
@@ -2691,15 +2702,18 @@
                         },
                         "modify_request": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "changes": {
                                     "type": "array",
                                     "minItems": 1,
                                     "items": {
                                         "type": "object",
+                                        "additionalProperties": false,
                                         "properties": {
                                             "modification": {
                                                 "type": "object",
+                                                "additionalProperties": false,
                                                 "properties": {
                                                     "attribute_type": {
                                                         "type": "string"
@@ -2726,10 +2740,16 @@
                             "optional": "true"
                         },
                         "operation": {
-                            "type": "string"
+                            "type": "string",
+                            "suricata": {
+                                "keywords": [
+                                    "ldap.request.operation"
+                                ]
+                            }
                         },
                         "search_request": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "attributes": {
                                     "type": "array",
@@ -2755,6 +2775,9 @@
                                 },
                                 "types_online": {
                                     "type": "boolean"
+                                },
+                                "types_only": {
+                                    "type": "boolean"
                                 }
                             },
                             "optional": "true"
@@ -2765,11 +2788,18 @@
                     "type": "array",
                     "optional": "true",
                     "minItems": 1,
+                    "suricata": {
+                        "keywords": [
+                            "ldap.responses.count"
+                        ]
+                    },
                     "items": {
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "add_response": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "matched_dn": {
                                         "type": "string"
@@ -2778,13 +2808,19 @@
                                         "type": "string"
                                     },
                                     "result_code": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "suricata": {
+                                            "keywords": [
+                                                "ldap.responses.result_code"
+                                            ]
+                                        }
                                     }
                                 },
                                 "optional": "true"
                             },
                             "bind_response": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "matched_dn": {
                                         "type": "string"
@@ -2793,7 +2829,12 @@
                                         "type": "string"
                                     },
                                     "result_code": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "suricata": {
+                                            "keywords": [
+                                                "ldap.responses.result_code"
+                                            ]
+                                        }
                                     },
                                     "server_sasl_creds": {
                                         "type": "string",
@@ -2804,6 +2845,7 @@
                             },
                             "compare_response": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "matched_dn": {
                                         "type": "string"
@@ -2812,13 +2854,19 @@
                                         "type": "string"
                                     },
                                     "result_code": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "suricata": {
+                                            "keywords": [
+                                                "ldap.responses.result_code"
+                                            ]
+                                        }
                                     }
                                 },
                                 "optional": "true"
                             },
                             "del_response": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "matched_dn": {
                                         "type": "string"
@@ -2827,13 +2875,19 @@
                                         "type": "string"
                                     },
                                     "result_code": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "suricata": {
+                                            "keywords": [
+                                                "ldap.responses.result_code"
+                                            ]
+                                        }
                                     }
                                 },
                                 "optional": "true"
                             },
                             "extended_response": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "matched_dn": {
                                         "type": "string"
@@ -2845,7 +2899,12 @@
                                         "type": "string"
                                     },
                                     "result_code": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "suricata": {
+                                            "keywords": [
+                                                "ldap.responses.result_code"
+                                            ]
+                                        }
                                     },
                                     "value": {
                                         "type": "string"
@@ -2855,6 +2914,7 @@
                             },
                             "intermediate_response": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "name": {
                                         "type": "string"
@@ -2865,8 +2925,12 @@
                                 },
                                 "optional": "true"
                             },
+                            "message_id": {
+                                "type": "integer"
+                            },
                             "mod_dn_response": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "matched_dn": {
                                         "type": "string"
@@ -2875,13 +2939,19 @@
                                         "type": "string"
                                     },
                                     "result_code": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "suricata": {
+                                            "keywords": [
+                                                "ldap.responses.result_code"
+                                            ]
+                                        }
                                     }
                                 },
                                 "optional": "true"
                             },
                             "modify_response": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "matched_dn": {
                                         "type": "string"
@@ -2890,13 +2960,27 @@
                                         "type": "string"
                                     },
                                     "result_code": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "suricata": {
+                                            "keywords": [
+                                                "ldap.responses.result_code"
+                                            ]
+                                        }
                                     }
                                 },
                                 "optional": "true"
                             },
+                            "operation": {
+                                "type": "string",
+                                "suricata": {
+                                    "keywords": [
+                                        "ldap.responses.operation"
+                                    ]
+                                }
+                            },
                             "search_result_done": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "matched_dn": {
                                         "type": "string"
@@ -2905,6 +2989,41 @@
                                         "type": "string"
                                     },
                                     "result_code": {
+                                        "type": "string",
+                                        "suricata": {
+                                            "keywords": [
+                                                "ldap.responses.result_code"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "optional": "true"
+                            },
+                            "search_result_entry": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "attributes": {
+                                        "type": "array",
+                                        "minItems": 1,
+                                        "items": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string"
+                                                },
+                                                "values": {
+                                                    "type": "array",
+                                                    "minItems": 1,
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "base_object": {
                                         "type": "string"
                                     }
                                 },


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None so far, should I make one or more ?

Describe changes:
- doc/jsonschema: complete ldap (responses.operation)
- doc/jsonschema: fix and complete bittorrent
- doc/jsonschema: document every integer keyword
- ci : enforce the use of `additionalProperties` in json schema to avoid missing stuff like ldap and feeling ok next time

https://github.com/OISF/suricata/pull/13816 clean rebase

Still the question about 
- What should we do about keyword like `http2.window` or tcp.wscale that do not have a log output ?
- @jufajardini were the pgsql fields meant to be complete ? (where I put additionalProperties: true because SV was failing otherwise)