### PR TITLE
unix-socket: fix memory leak on client disconnect

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -519,7 +519,7 @@ static int UnixCommandExecute(UnixCommand * this, char *command, UnixClient *cli
     }
 
     if (UnixCommandSendJSONToClient(client, server_msg) != 0) {
-        goto error;
+        goto error_cmd;
     }
 
     json_decref(jsoncmd);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -252,9 +252,10 @@ static void UnixClientFree(UnixClient *c)
 static void UnixCommandClose(UnixCommand  *this, int fd)
 {
     UnixClient *item;
+    UnixClient *safe = NULL;
     int found = 0;
 
-    TAILQ_FOREACH(item, &this->clients, next) {
+    TAILQ_FOREACH_SAFE (item, &this->clients, next, safe) {
         if (item->fd == fd) {
             found = 1;
             break;


### PR DESCRIPTION
If a client loses the connection during a reload it initiated there is a small memory leak.

Bug: #7891.
