### PR TITLE
ci: do not run undefined for clusterfuzzlite backport7

### DIFF
--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -7,7 +7,6 @@ auto_ccs:
 sanitizers:
   - address
   - memory
-  - undefined
 fuzzing_engines:
   - afl
   - honggfuzz

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -17,7 +17,7 @@ jobs:
    strategy:
      fail-fast: false
      matrix:
-       sanitizer: [address, undefined]
+       sanitizer: [address]
    steps:
    - name: Clear unnecessary files
      run: |


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none, just ci improvements

Describe changes:
- ci: do not run undefined for clusterfuzzlite
