### PR TITLE
HS: Prune stale cache files from disk v1.1

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -40,6 +40,7 @@
 #include "conf.h"
 #include "util-unittest.h"
 #include "util-debug.h"
+#include "util-misc.h"
 #include "util-path.h"
 #include "util-conf.h"
 
@@ -644,6 +645,37 @@ int SCConfGetFloat(const char *name, float *val)
         return 0;
 
     *val = tmpfl;
+    return 1;
+}
+
+/**
+ * \brief Retrieve a configuration value as a time duration in seconds.
+ *
+ * The configuration value is expected to be a string with a number
+ * followed by an optional unit.  Valid units are "s" for seconds,
+ * "m" for minutes, "h" for hours and "d" for days.  If no unit is
+ * specified seconds is assumed.
+ *
+ * \param name Name of configuration parameter to get.
+ * \param val Pointer to an uint64_t that will be set the
+ * configuration value in seconds.
+ *
+ * \retval 1 will be returned if the name is found and was properly
+ * converted to a time duration, otherwise 0 will be returned.
+ */
+int SCConfGetTime(const char *name, uint64_t *val)
+{
+    const char *strval = NULL;
+
+    if (SCConfGet(name, &strval) == 0)
+        return 0;
+
+    if (strval == NULL || strval[0] == '\0')
+        return 0;
+
+    if (ParseTimeStringU64(strval, val) != 0)
+        return 0;
+
     return 1;
 }
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -67,6 +67,7 @@ int SCConfGetInt(const char *name, intmax_t *val);
 int SCConfGetBool(const char *name, int *val);
 int SCConfGetDouble(const char *name, double *val);
 int SCConfGetFloat(const char *name, float *val);
+int SCConfGetTime(const char *name, uint64_t *val);
 int SCConfSet(const char *name, const char *val);
 int SCConfSetFromString(const char *input, int final);
 int SCConfSetFinal(const char *name, const char *val);

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -506,6 +506,10 @@ skip_regular_rules:
         mpm_table[de_ctx->mpm_matcher].CacheRuleset(de_ctx->mpm_cfg);
     }
 
+    if (mpm_table[de_ctx->mpm_matcher].CachePrune != NULL) {
+        mpm_table[de_ctx->mpm_matcher].CachePrune(de_ctx->mpm_cfg);
+    }
+
  end:
     gettimeofday(&de_ctx->last_reload, NULL);
     if (SCRunmodeGet() == RUNMODE_ENGINE_ANALYSIS) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2530,10 +2530,18 @@ static DetectEngineCtx *DetectEngineCtxInitReal(
         if (de_ctx->mpm_cfg == NULL) {
             goto error;
         }
-    }
-    if (DetectEngineMpmCachingEnabled() && mpm_table[de_ctx->mpm_matcher].ConfigCacheDirSet) {
-        mpm_table[de_ctx->mpm_matcher].ConfigCacheDirSet(
-                de_ctx->mpm_cfg, DetectEngineMpmCachingGetPath());
+
+        if (DetectEngineMpmCachingEnabled() && mpm_table[de_ctx->mpm_matcher].ConfigCacheDirSet) {
+            mpm_table[de_ctx->mpm_matcher].ConfigCacheDirSet(
+                    de_ctx->mpm_cfg, DetectEngineMpmCachingGetPath());
+
+            if (mpm_table[de_ctx->mpm_matcher].CachePrune) {
+                if (SCConfGetTime("detect.sgh-mpm-caching-max-age",
+                            &de_ctx->mpm_cfg->cache_max_age_seconds) != 1) {
+                    de_ctx->mpm_cfg->cache_max_age_seconds = 7ULL * 24ULL * 3600ULL;
+                }
+            }
+        }
     }
 
     de_ctx->spm_global_thread_ctx = SpmInitGlobalThreadCtx(de_ctx->spm_matcher);

--- a/src/util-misc.h
+++ b/src/util-misc.h
@@ -46,6 +46,18 @@ int ParseSizeStringU16(const char *, uint16_t *);
 int ParseSizeStringU32(const char *, uint32_t *);
 int ParseSizeStringU64(const char *, uint64_t *);
 
+/* time string parsing API (to seconds) */
+/* Supported units (case-insensitive, singular/plural & common abbreviations):
+ *  s, sec, secs, second, seconds
+ *  m, min, mins, minute, minutes
+ *  h, hr, hrs, hour, hours
+ *  d, day, days
+ *  w, week, weeks
+ *  y, year, years (365 days)
+ * If unit omitted value is interpreted as seconds.
+ */
+int ParseTimeStringU64(const char *str, uint64_t *res);
+
 #ifdef UNITTESTS
 void UtilMiscRegisterTests(void);
 #endif /* UNITTESTS */

--- a/src/util-mpm-hs-cache.c
+++ b/src/util-mpm-hs-cache.c
@@ -150,6 +150,10 @@ int HSLoadCache(hs_database_t **hs_db, uint64_t hs_db_hash, const char *dirpath)
         }
 
         ret = 0;
+        /* Touch file to update modification time so active caches are retained. */
+        if (SCTouchFile(hash_file_static) != 0) {
+            SCLogDebug("Failed to update mtime for %s", hash_file_static);
+        }
         goto freeup;
     }
 

--- a/src/util-mpm-hs-cache.c
+++ b/src/util-mpm-hs-cache.c
@@ -20,7 +20,7 @@
  *
  * \author Lukas Sismis <lsismis@oisf.net>
  *
- * MPM pattern matcher that calls the Hyperscan regex matcher.
+ * Hyperscan cache helper utilities for MPM cache files.
  */
 
 #include "suricata-common.h"

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -838,7 +838,7 @@ static int SCHSCacheRuleset(MpmConfig *mpm_conf)
     SCLogDebug("Caching the loaded ruleset to %s", mpm_conf->cache_dir_path);
     if (SCCreateDirectoryTree(mpm_conf->cache_dir_path, true) != 0) {
         SCLogWarning("Failed to create Hyperscan cache folder, make sure "
-                     "the  parent folder is writeable "
+                     "the parent folder is writeable "
                      "or adjust sgh-mpm-caching-path setting (%s)",
                 mpm_conf->cache_dir_path);
         return -1;

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -88,6 +88,7 @@ typedef struct MpmPattern_ {
 
 typedef struct MpmConfig_ {
     const char *cache_dir_path;
+    uint64_t cache_max_age_seconds; /* 0 means disabled/no pruning policy */
 } MpmConfig;
 
 typedef struct MpmCtx_ {
@@ -174,6 +175,7 @@ typedef struct MpmTableElmt_ {
             uint32_t, SigIntId, uint8_t);
     int (*Prepare)(MpmConfig *, struct MpmCtx_ *);
     int (*CacheRuleset)(MpmConfig *);
+    int (*CachePrune)(MpmConfig *);
     /** \retval cnt number of patterns that matches: once per pattern max. */
     uint32_t (*Search)(const struct MpmCtx_ *, struct MpmThreadCtx_ *, PrefilterRuleStore *, const uint8_t *, uint32_t);
     void (*PrintCtx)(struct MpmCtx_ *);

--- a/src/util-path.h
+++ b/src/util-path.h
@@ -59,5 +59,6 @@ bool SCIsRegularFile(const struct dirent *const dir_entry);
 char *SCRealPath(const char *path, char *resolved_path);
 const char *SCBasename(const char *path);
 bool SCPathContainsTraversal(const char *path);
+int SCTouchFile(const char *path);
 
 #endif /* SURICATA_UTIL_PATH_H */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1792,6 +1792,9 @@ detect:
   # Cache files are created in the standard library directory.
   sgh-mpm-caching: yes
   sgh-mpm-caching-path: @e_sghcachedir@
+  # Maximum age for cached MPM databases before they are pruned.
+  # Accepts time units (s,m,h,d,w,y). Omit to use the default of 7d, 0 to disable.
+  # sgh-mpm-caching-max-age: 7d
   # inspection-recursion-limit: 3000
   # maximum number of times a tx will get logged for rules without app-layer keywords
   # stream-tx-log-limit: 4


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7830

Describe changes:
- time parsing function from config,
- "touch" files to signal actively used files,
- pruning function to remove the HS MPM cache files older than the age specified in the config.

The logic to determine a stale file is currently based on the modification timestamp in the file systems. The accessed time stamp was not used as it may be switched off. Alternatively, we could use a local DB/notekeeping file of the last used files/caches but this approach seemed simpler. 

I can also add GitHub CI tests, I thought of some scenarios. 