### PR TITLE
redis: Add authentication support v1

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -76,6 +76,8 @@ Output types::
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
+      #  username: null ## ACL username; if null (default), no username is used
+      #  password: null ## AUTH password; if null (default), authentication is disabled
       #  async: true ## if redis replies are read asynchronously
       #  mode: list ## possible values: list|lpush (default), rpush, channel|publish, xadd|stream
       #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -21,6 +21,8 @@ outputs:
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
+      #  username: null ## ACL username; if null (default), no username is used
+      #  password: null ## AUTH password; if null (default), authentication is disabled
       #  async: true ## if redis replies are read asynchronously
       #  mode: list ## possible values: list|lpush (default), rpush, channel|publish, xadd|stream
       #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush

--- a/src/util-log-redis.h
+++ b/src/util-log-redis.h
@@ -41,6 +41,8 @@ typedef struct RedisSetup_ {
     const char *format;
     const char *command;
     const char *key;
+    const char *username;
+    const char *password;
     const char *server;
     uint16_t  port;
     int is_async;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -116,6 +116,8 @@ outputs:
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
+      #  username: null ## ACL username; if null (default), no username is used
+      #  password: null ## AUTH password; if null (default), authentication is disabled
       #  async: true ## if redis replies are read asynchronously
       #  mode: list ## possible values: list|lpush (default), rpush, channel|publish, xadd|stream
       #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7062

Describe changes:
- Add authentication support to the Redis logging output.
- Authentication configuration defaults to `null` for backward compatibility.
