### PR TITLE
Detect integers multi 7480 v4.2

### DIFF
--- a/doc/userguide/rules/dns-keywords.rst
+++ b/doc/userguide/rules/dns-keywords.rst
@@ -82,6 +82,8 @@ This keyword matches on the **rrtype** (integer) found in the DNS message.
 
 dns.rrtype uses an :ref:`unsigned 16-bit integer <rules-integer-keywords>`.
 
+dns.rrtype is also a :ref:`multi-integer <multi-integers>`.
+
 It can also be specified by text from the enumeration.
 
 Syntax

--- a/doc/userguide/rules/http2-keywords.rst
+++ b/doc/userguide/rules/http2-keywords.rst
@@ -63,6 +63,8 @@ Match on the value of the HTTP2 value field present in a WINDOWUPDATE frame.
 
 http2.window uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
+http2.window is also a :ref:`multi-integer <multi-integers>`.
+
 This keyword takes a numeric argument after a colon and supports additional qualifiers, such as:
 
 * ``>`` (greater than)

--- a/doc/userguide/rules/http2-keywords.rst
+++ b/doc/userguide/rules/http2-keywords.rst
@@ -41,6 +41,8 @@ Match on the value of the HTTP2 priority field present in a PRIORITY or HEADERS 
 
 http2.priority uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
 
+http2.priority is also a :ref:`multi-integer <multi-integers>`.
+
 This keyword takes a numeric argument after a colon and supports additional qualifiers, such as:
 
 * ``>`` (greater than)

--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -88,3 +88,26 @@ Examples::
 
     websocket.flags:fin,!comp;
     websocket.flags:&0xc0=0x80; # behaves the same
+
+.. _multi-integers:
+
+Multi-integers
+--------------
+
+As :ref:`multi-buffers <rules-multi-buffer-matching>` and sticky buffers,
+some integer keywords are also multi-integer.
+
+They expand the syntax of a single integer::
+ keyword: operation and value[,index];
+
+.. table:: **Index values for multi-integers keyword**
+
+    =========  ================================================
+    Value      Description
+    =========  ================================================
+    [default]  Match with any index
+    any        Match with any index
+    all        Match only if all indexes match
+    0>=        Match specific index
+    0<         Match specific index with back to front indexing
+    =========  ================================================

--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -109,6 +109,7 @@ They expand the syntax of a single integer::
     any        Match with any index
     all        Match only if all indexes match
     all1       Match only if all and at least one indexes match
+    nb         Matches a number of times
     0>=        Match specific index
     0<         Match specific index with back to front indexing
     =========  ================================================
@@ -116,3 +117,9 @@ They expand the syntax of a single integer::
 The index ``all`` will match if there is no value.
 The index ``all1`` will not match if there is no value and behaves
 like ``all`` if there is at least one value.
+These keywords will wait for transaction completion to run, to
+be sure to have the final number of elements.
+
+The index ``nb`` accepts all comparison modes as integer keywords.
+For example ``nb>3`` will match only if more than 3 integers in the
+array match the value.

--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -110,8 +110,10 @@ They expand the syntax of a single integer::
     all        Match only if all indexes match
     all1       Match only if all and at least one indexes match
     nb         Matches a number of times
+    or_absent  Match with any index or no values
     0>=        Match specific index
     0<         Match specific index with back to front indexing
+    oob_or     Match with specific index or index out of bounds
     =========  ================================================
 
 The index ``all`` will match if there is no value.

--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -98,7 +98,7 @@ As :ref:`multi-buffers <rules-multi-buffer-matching>` and sticky buffers,
 some integer keywords are also multi-integer.
 
 They expand the syntax of a single integer::
- keyword: operation and value[,index];
+ keyword: operation and value[,index,subslice];
 
 .. table:: **Index values for multi-integers keyword**
 
@@ -125,3 +125,12 @@ be sure to have the final number of elements.
 The index ``nb`` accepts all comparison modes as integer keywords.
 For example ``nb>3`` will match only if more than 3 integers in the
 array match the value.
+
+The subslice may use positive or negative indexing.
+For the array [1,2,3,4,5,6], here are some examples:
+* 2:4 will have subslice [3,4]
+* -4:-1 will have subslice [3,4,5]
+* 3:-1 will have subslice [4,5]
+* -4:4 will have subslice [3,4]
+
+If one index is out of bounds, an empty subslice is used.

--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -108,6 +108,11 @@ They expand the syntax of a single integer::
     [default]  Match with any index
     any        Match with any index
     all        Match only if all indexes match
+    all1       Match only if all and at least one indexes match
     0>=        Match specific index
     0<         Match specific index with back to front indexing
     =========  ================================================
+
+The index ``all`` will match if there is no value.
+The index ``all1`` will not match if there is no value and behaves
+like ``all`` if there is at least one value.

--- a/doc/userguide/rules/ldap-keywords.rst
+++ b/doc/userguide/rules/ldap-keywords.rst
@@ -79,6 +79,8 @@ Syntax::
 
 ldap.responses.operation uses :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
 
+ldap.responses.operation is also a :ref:`multi-integer <multi-integers>`.
+
 This keyword maps to the EVE field ``ldap.responses[].operation``
 
 An LDAP request operation can receive multiple responses. By default, the ldap.responses.operation
@@ -271,6 +273,8 @@ Syntax::
  ldap.responses.result_code: code[,index];
 
 ldap.responses.result_code uses :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
+
+ldap.responses.result_code is also a :ref:`multi-integer <multi-integers>`.
 
 This keyword maps to the following eve fields:
 

--- a/doc/userguide/rules/mqtt-keywords.rst
+++ b/doc/userguide/rules/mqtt-keywords.rst
@@ -48,6 +48,8 @@ where ``UNASSIGNED`` refers to message type code 0.
 
 mqtt.type uses an :ref:`unsigned 8-bits integer <rules-integer-keywords>`.
 
+mqtt.type is also a :ref:`multi-integer <multi-integers>`.
+
 Examples::
 
   mqtt.type:CONNECT;

--- a/doc/userguide/rules/multi-buffer-matching.rst
+++ b/doc/userguide/rules/multi-buffer-matching.rst
@@ -1,3 +1,5 @@
+.. _rules-multi-buffer-matching:
+
 Multiple Buffer Matching
 ========================
 

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -50,6 +50,13 @@ pub struct DetectUintData<T> {
     pub mode: DetectUintMode,
 }
 
+#[derive(Debug, PartialEq)]
+pub(crate) enum DetectUintIndex {
+    Any,
+    All,
+    Index(i32),
+}
+
 /// Parses a string for detection with integers, using enumeration strings
 ///
 /// Needs to specify T1 the integer type (like u8)

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -57,6 +57,12 @@ pub(crate) enum DetectUintIndex {
     Index(i32),
 }
 
+#[derive(Debug, PartialEq)]
+pub(crate) struct DetectUintArrayData<T> {
+    pub du: DetectUintData<T>,
+    pub index: DetectUintIndex,
+}
+
 /// Parses a string for detection with integers, using enumeration strings
 ///
 /// Needs to specify T1 the integer type (like u8)

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -25,7 +25,7 @@ use nom7::IResult;
 
 use super::EnumString;
 
-use std::ffi::CStr;
+use std::ffi::{c_int, CStr};
 use std::str::FromStr;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -92,6 +92,48 @@ pub(crate) fn detect_parse_array_uint_enum<T1: DetectIntType, T2: EnumString<T1>
     let du = detect_parse_uint_enum::<T1, T2>(parts[0])?;
 
     Some(DetectUintArrayData { du, index })
+}
+
+pub(crate) fn detect_uint_match_at_index<T, U: DetectIntType>(
+    array: &[T], ctx: &DetectUintArrayData<U>, get_value: impl Fn(&T) -> Option<U>,
+) -> c_int {
+    match ctx.index {
+        DetectUintIndex::Any => {
+            for response in array {
+                if let Some(code) = get_value(response) {
+                    if detect_match_uint::<U>(&ctx.du, code) {
+                        return 1;
+                    }
+                }
+            }
+            return 0;
+        }
+        DetectUintIndex::All => {
+            for response in array {
+                if let Some(code) = get_value(response) {
+                    if !detect_match_uint::<U>(&ctx.du, code) {
+                        return 0;
+                    }
+                }
+            }
+            return 1;
+        }
+        DetectUintIndex::Index(idx) => {
+            let index = if idx < 0 {
+                // negative values for backward indexing.
+                ((array.len() as i32) + idx) as usize
+            } else {
+                idx as usize
+            };
+            if array.len() <= index {
+                return 0;
+            }
+            if let Some(code) = get_value(&array[index]) {
+                return detect_match_uint::<U>(&ctx.du, code) as c_int;
+            }
+            return 0;
+        }
+    }
 }
 
 /// Parses a string for detection with integers, using enumeration strings

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -17,7 +17,7 @@
 
 use nom7::branch::alt;
 use nom7::bytes::complete::{is_a, tag, tag_no_case, take_while};
-use nom7::character::complete::{char, digit1, hex_digit1};
+use nom7::character::complete::{char, digit1, hex_digit1, i32 as nom_i32};
 use nom7::combinator::{all_consuming, map_opt, opt, value, verify};
 use nom7::error::{make_error, Error, ErrorKind};
 use nom7::Err;
@@ -26,7 +26,6 @@ use nom7::IResult;
 use super::EnumString;
 
 use std::ffi::{c_int, c_void, CStr};
-use std::str::FromStr;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[repr(u8)]
@@ -57,6 +56,7 @@ pub enum DetectUintIndex {
     All,
     All1,
     Index(i32),
+    NumberMatches(DetectUintData<u32>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -65,16 +65,30 @@ pub struct DetectUintArrayData<T> {
     pub index: DetectUintIndex,
 }
 
+fn parse_uint_index_precise(s: &str) -> IResult<&str, DetectUintIndex> {
+    let (s, i32_index) = nom_i32(s)?;
+    Ok((s, DetectUintIndex::Index(i32_index)))
+}
+
+fn parse_uint_index_nb(s: &str) -> IResult<&str, DetectUintIndex> {
+    let (s, _) = tag("nb")(s)?;
+    let (s, du32) = detect_parse_uint::<u32>(s)?;
+    Ok((s, DetectUintIndex::NumberMatches(du32)))
+}
+
+fn parse_uint_index_val(s: &str) -> Option<DetectUintIndex> {
+    let (_s, arg1) = alt((parse_uint_index_precise, parse_uint_index_nb))(s).ok()?;
+    Some(arg1)
+}
+
 fn parse_uint_index(parts: &[&str]) -> Option<DetectUintIndex> {
     let index = if parts.len() == 2 {
         match parts[1] {
             "all" => DetectUintIndex::All,
             "all1" => DetectUintIndex::All1,
             "any" => DetectUintIndex::Any,
-            _ => {
-                let i32_index = i32::from_str(parts[1]).ok()?;
-                DetectUintIndex::Index(i32_index)
-            }
+            // not only a literal, but some numeric value
+            _ => return parse_uint_index_val(parts[1]),
         }
     } else {
         DetectUintIndex::Any
@@ -111,7 +125,7 @@ pub(crate) fn detect_parse_array_uint_enum<T1: DetectIntType, T2: EnumString<T1>
 pub(crate) fn detect_uint_match_at_index<T, U: DetectIntType>(
     array: &[T], ctx: &DetectUintArrayData<U>, get_value: impl Fn(&T) -> Option<U>, eof: bool,
 ) -> c_int {
-    match ctx.index {
+    match &ctx.index {
         DetectUintIndex::Any => {
             for response in array {
                 if let Some(code) = get_value(response) {
@@ -119,6 +133,28 @@ pub(crate) fn detect_uint_match_at_index<T, U: DetectIntType>(
                         return 1;
                     }
                 }
+            }
+            return 0;
+        }
+        DetectUintIndex::NumberMatches(du32) => {
+            if !eof {
+                match du32.mode {
+                    DetectUintMode::DetectUintModeGt | DetectUintMode::DetectUintModeGte => {}
+                    _ => {
+                        return 0;
+                    }
+                }
+            }
+            let mut nb = 0u32;
+            for response in array {
+                if let Some(code) = get_value(response) {
+                    if detect_match_uint::<U>(&ctx.du, code) {
+                        nb += 1;
+                    }
+                }
+            }
+            if detect_match_uint(du32, nb) {
+                return 1;
             }
             return 0;
         }
@@ -154,11 +190,11 @@ pub(crate) fn detect_uint_match_at_index<T, U: DetectIntType>(
             return 0;
         }
         DetectUintIndex::Index(idx) => {
-            let index = if idx < 0 {
+            let index = if *idx < 0 {
                 // negative values for backward indexing.
                 ((array.len() as i32) + idx) as usize
             } else {
-                idx as usize
+                *idx as usize
             };
             if array.len() <= index {
                 return 0;

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -55,6 +55,7 @@ pub struct DetectUintData<T> {
 pub enum DetectUintIndex {
     Any,
     All,
+    All1,
     Index(i32),
 }
 
@@ -68,6 +69,7 @@ fn parse_uint_index(parts: &[&str]) -> Option<DetectUintIndex> {
     let index = if parts.len() == 2 {
         match parts[1] {
             "all" => DetectUintIndex::All,
+            "all1" => DetectUintIndex::All1,
             "any" => DetectUintIndex::Any,
             _ => {
                 let i32_index = i32::from_str(parts[1]).ok()?;
@@ -132,6 +134,24 @@ pub(crate) fn detect_uint_match_at_index<T, U: DetectIntType>(
                 }
             }
             return 1;
+        }
+        DetectUintIndex::All1 => {
+            if !eof {
+                return 0;
+            }
+            let mut has_elem = false;
+            for response in array {
+                if let Some(code) = get_value(response) {
+                    if !detect_match_uint::<U>(&ctx.du, code) {
+                        return 0;
+                    }
+                    has_elem = true;
+                }
+            }
+            if has_elem {
+                return 1;
+            }
+            return 0;
         }
         DetectUintIndex::Index(idx) => {
             let index = if idx < 0 {

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -584,6 +584,24 @@ pub unsafe extern "C" fn SCDetectU8ArrayFree(ctx: &mut DetectUintArrayData<u8>) 
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn SCDetectU32ArrayParse(ustr: *const std::os::raw::c_char) -> *mut c_void {
+    let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
+    if let Ok(s) = ft_name.to_str() {
+        if let Some(ctx) = detect_parse_array_uint::<u32>(s) {
+            let boxed = Box::new(ctx);
+            return Box::into_raw(boxed) as *mut c_void;
+        }
+    }
+    return std::ptr::null_mut();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectU32ArrayFree(ctx: &mut DetectUintData<u32>) {
+    // Just unbox...
+    std::mem::drop(Box::from_raw(ctx));
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn SCDetectU16Parse(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectUintData<u16> {

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -124,10 +124,7 @@ pub fn detect_parse_uint_value_hex<T: DetectIntType>(i: &str) -> IResult<&str, T
 }
 
 pub fn detect_parse_uint_value<T: DetectIntType>(i: &str) -> IResult<&str, T> {
-    let (i, arg1) = alt((
-        detect_parse_uint_value_hex,
-        detect_parse_uint_with_unit,
-    ))(i)?;
+    let (i, arg1) = alt((detect_parse_uint_value_hex, detect_parse_uint_with_unit))(i)?;
     Ok((i, arg1))
 }
 
@@ -178,19 +175,10 @@ pub fn detect_parse_uint_start_interval<T: DetectIntType>(
     } else {
         DetectUintMode::DetectUintModeRange
     };
-    Ok((
-        i,
-        DetectUintData {
-            arg1,
-            arg2,
-            mode,
-        },
-    ))
+    Ok((i, DetectUintData { arg1, arg2, mode }))
 }
 
-pub fn detect_parse_uint_bitmask<T: DetectIntType>(
-    i: &str,
-) -> IResult<&str, DetectUintData<T>> {
+pub fn detect_parse_uint_bitmask<T: DetectIntType>(i: &str) -> IResult<&str, DetectUintData<T>> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = tag("&")(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
@@ -209,23 +197,14 @@ pub fn detect_parse_uint_bitmask<T: DetectIntType>(
     } else {
         DetectUintMode::DetectUintModeNegBitmask
     };
-    Ok((
-        i,
-        DetectUintData {
-            arg1,
-            arg2,
-            mode,
-        },
-    ))
+    Ok((i, DetectUintData { arg1, arg2, mode }))
 }
 
 fn detect_parse_uint_start_interval_inclusive<T: DetectIntType>(
     i: &str,
 ) -> IResult<&str, DetectUintData<T>> {
     let (i, neg) = opt(char('!'))(i)?;
-    let (i, arg1) = verify(detect_parse_uint_value::<T>, |x| {
-        *x > T::min_value()
-    })(i)?;
+    let (i, arg1) = verify(detect_parse_uint_value::<T>, |x| *x > T::min_value())(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = alt((tag("-"), tag("<>")))(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
@@ -475,9 +454,7 @@ pub unsafe extern "C" fn SCDetectU8Parse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCDetectU8Match(
-    arg: u8, ctx: &DetectUintData<u8>,
-) -> std::os::raw::c_int {
+pub unsafe extern "C" fn SCDetectU8Match(arg: u8, ctx: &DetectUintData<u8>) -> std::os::raw::c_int {
     if detect_match_uint(ctx, arg) {
         return 1;
     }

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -107,7 +107,7 @@ pub(crate) fn detect_parse_array_uint_enum<T1: DetectIntType, T2: EnumString<T1>
 }
 
 pub(crate) fn detect_uint_match_at_index<T, U: DetectIntType>(
-    array: &[T], ctx: &DetectUintArrayData<U>, get_value: impl Fn(&T) -> Option<U>,
+    array: &[T], ctx: &DetectUintArrayData<U>, get_value: impl Fn(&T) -> Option<U>, eof: bool,
 ) -> c_int {
     match ctx.index {
         DetectUintIndex::Any => {
@@ -121,6 +121,9 @@ pub(crate) fn detect_uint_match_at_index<T, U: DetectIntType>(
             return 0;
         }
         DetectUintIndex::All => {
+            if !eof {
+                return 0;
+            }
             for response in array {
                 if let Some(code) = get_value(response) {
                     if !detect_match_uint::<U>(&ctx.du, code) {

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -15,11 +15,14 @@
  * 02110-1301, USA.
  */
 
-use super::dns::{DNSRcode, DNSRecordType, DNSTransaction, ALPROTO_DNS};
+use super::dns::{
+    DNSAnswerEntry, DNSQueryEntry, DNSRcode, DNSRecordType, DNSTransaction, ALPROTO_DNS,
+};
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
-    detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU16Free, SCDetectU8Free,
-    SCDetectU8Parse,
+    detect_match_uint, detect_parse_array_uint_enum, detect_parse_uint_enum,
+    detect_uint_match_at_index, DetectUintArrayData, DetectUintData, SCDetectU16Free,
+    SCDetectU8Free, SCDetectU8Parse,
 };
 use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer};
 use crate::direction::Direction;
@@ -102,23 +105,21 @@ unsafe extern "C" fn dns_rrtype_match(
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
     let tx = cast_pointer!(tx, DNSTransaction);
-    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u16>);
 
     if flags & Direction::ToServer as u8 != 0 {
         if let Some(request) = &tx.request {
-            for i in 0..request.queries.len() {
-                if detect_match_uint(ctx, request.queries[i].rrtype) {
-                    return 1;
-                }
-            }
+            return detect_uint_match_at_index::<DNSQueryEntry, u16>(&request.queries, ctx, |q| {
+                Some(q.rrtype)
+            });
         }
     } else if flags & Direction::ToClient as u8 != 0 {
         if let Some(response) = &tx.response {
-            for i in 0..response.answers.len() {
-                if detect_match_uint(ctx, response.answers[i].rrtype) {
-                    return 1;
-                }
-            }
+            return detect_uint_match_at_index::<DNSAnswerEntry, u16>(
+                &response.answers,
+                ctx,
+                |a| Some(a.rrtype),
+            );
         }
     }
     return 0;
@@ -209,10 +210,10 @@ unsafe extern "C" fn dns_rcode_free(_de: *mut DetectEngineCtx, ctx: *mut c_void)
 
 unsafe extern "C" fn dns_rrtype_parse(
     ustr: *const std::os::raw::c_char,
-) -> *mut DetectUintData<u8> {
+) -> *mut DetectUintArrayData<u16> {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
     if let Ok(s) = ft_name.to_str() {
-        if let Some(ctx) = detect_parse_uint_enum::<u16, DNSRecordType>(s) {
+        if let Some(ctx) = detect_parse_array_uint_enum::<u16, DNSRecordType>(s) {
             let boxed = Box::new(ctx);
             return Box::into_raw(boxed) as *mut _;
         }
@@ -246,9 +247,8 @@ unsafe extern "C" fn dns_rrtype_setup(
 }
 
 unsafe extern "C" fn dns_rrtype_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
-    // Just unbox...
-    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
-    SCDetectU16Free(ctx);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u16>);
+    std::mem::drop(Box::from_raw(ctx));
 }
 
 unsafe extern "C" fn dns_detect_answer_name_setup(

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -109,9 +109,12 @@ unsafe extern "C" fn dns_rrtype_match(
 
     if flags & Direction::ToServer as u8 != 0 {
         if let Some(request) = &tx.request {
-            return detect_uint_match_at_index::<DNSQueryEntry, u16>(&request.queries, ctx, |q| {
-                Some(q.rrtype)
-            });
+            return detect_uint_match_at_index::<DNSQueryEntry, u16>(
+                &request.queries,
+                ctx,
+                |q| Some(q.rrtype),
+                true,
+            );
         }
     } else if flags & Direction::ToClient as u8 != 0 {
         if let Some(response) = &tx.response {
@@ -119,6 +122,7 @@ unsafe extern "C" fn dns_rrtype_match(
                 &response.answers,
                 ctx,
                 |a| Some(a.rrtype),
+                true,
             );
         }
     }

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -151,8 +151,8 @@ fn http2_match_priority(
     } else {
         &tx.frames_tc
     };
-
-    return detect_uint_match_at_index::<HTTP2Frame, u8>(frames, ctx, get_http2_priority);
+    let eof = tx.state >= HTTP2TransactionState::HTTP2StateClosed;
+    return detect_uint_match_at_index::<HTTP2Frame, u8>(frames, ctx, get_http2_priority, eof);
 }
 
 #[no_mangle]
@@ -179,7 +179,8 @@ fn http2_match_window(
     } else {
         &tx.frames_tc
     };
-    return detect_uint_match_at_index::<HTTP2Frame, u32>(frames, ctx, get_http2_window);
+    let eof = tx.state >= HTTP2TransactionState::HTTP2StateClosed;
+    return detect_uint_match_at_index::<HTTP2Frame, u32>(frames, ctx, get_http2_window, eof);
 }
 
 #[no_mangle]

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -37,7 +37,7 @@ use std::os::raw::{c_int, c_void};
 use std::str::FromStr;
 
 #[derive(Debug, PartialEq)]
-enum LdapIndex {
+enum DetectUintIndex {
     Any,
     All,
     Index(i32),
@@ -50,7 +50,7 @@ struct DetectLdapRespOpData {
     /// Index can be Any to match with any responses index,
     /// All to match if all indices, or an i32 integer
     /// Negative values represent back to front indexing.
-    pub index: LdapIndex,
+    pub index: DetectUintIndex,
 }
 
 struct DetectLdapRespResultData {
@@ -59,7 +59,7 @@ struct DetectLdapRespResultData {
     /// Index can be Any to match with any responses index,
     /// All to match if all indices, or an i32 integer
     /// Negative values represent back to front indexing.
-    pub index: LdapIndex,
+    pub index: DetectUintIndex,
 }
 
 static mut G_LDAP_REQUEST_OPERATION_KW_ID: u16 = 0;
@@ -133,18 +133,18 @@ unsafe extern "C" fn ldap_detect_request_free(_de: *mut DetectEngineCtx, ctx: *m
     SCDetectU8Free(ctx);
 }
 
-fn parse_ldap_index(parts: &[&str]) -> Option<LdapIndex> {
+fn parse_ldap_index(parts: &[&str]) -> Option<DetectUintIndex> {
     let index = if parts.len() == 2 {
         match parts[1] {
-            "all" => LdapIndex::All,
-            "any" => LdapIndex::Any,
+            "all" => DetectUintIndex::All,
+            "any" => DetectUintIndex::Any,
             _ => {
                 let i32_index = i32::from_str(parts[1]).ok()?;
-                LdapIndex::Index(i32_index)
+                DetectUintIndex::Index(i32_index)
             }
         }
     } else {
-        LdapIndex::Any
+        DetectUintIndex::Any
     };
     return Some(index);
 }
@@ -201,10 +201,10 @@ unsafe extern "C" fn ldap_detect_responses_operation_setup(
 
 fn match_at_index<T, U>(
     array: &VecDeque<T>, ctx_value: &DetectUintData<U>, get_value: impl Fn(&T) -> Option<U>,
-    detect_match: impl Fn(U, &DetectUintData<U>) -> c_int, index: &LdapIndex,
+    detect_match: impl Fn(U, &DetectUintData<U>) -> c_int, index: &DetectUintIndex,
 ) -> c_int {
     match index {
-        LdapIndex::Any => {
+        DetectUintIndex::Any => {
             for response in array {
                 if let Some(code) = get_value(response) {
                     if detect_match(code, ctx_value) == 1 {
@@ -214,7 +214,7 @@ fn match_at_index<T, U>(
             }
             return 0;
         }
-        LdapIndex::All => {
+        DetectUintIndex::All => {
             for response in array {
                 if let Some(code) = get_value(response) {
                     if detect_match(code, ctx_value) == 0 {
@@ -224,7 +224,7 @@ fn match_at_index<T, U>(
             }
             return 1;
         }
-        LdapIndex::Index(idx) => {
+        DetectUintIndex::Index(idx) => {
             let index = if *idx < 0 {
                 // negative values for backward indexing.
                 ((array.len() as i32) + idx) as usize

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -19,7 +19,7 @@ use super::ldap::{LdapTransaction, ALPROTO_LDAP};
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, DetectUintIndex, SCDetectU32Free,
-    SCDetectU32Parse, SCDetectU8Free,
+    SCDetectU32Parse, SCDetectU8Free, DetectUintArrayData,
 };
 use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer};
 use crate::ldap::types::*;
@@ -35,25 +35,6 @@ use std::collections::VecDeque;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use std::str::FromStr;
-
-#[derive(Debug, PartialEq)]
-struct DetectLdapRespOpData {
-    /// Ldap response operation code
-    pub du8: DetectUintData<u8>,
-    /// Index can be Any to match with any responses index,
-    /// All to match if all indices, or an i32 integer
-    /// Negative values represent back to front indexing.
-    pub index: DetectUintIndex,
-}
-
-struct DetectLdapRespResultData {
-    /// Ldap result code
-    pub du32: DetectUintData<u32>,
-    /// Index can be Any to match with any responses index,
-    /// All to match if all indices, or an i32 integer
-    /// Negative values represent back to front indexing.
-    pub index: DetectUintIndex,
-}
 
 static mut G_LDAP_REQUEST_OPERATION_KW_ID: u16 = 0;
 static mut G_LDAP_REQUEST_OPERATION_BUFFER_ID: c_int = 0;
@@ -142,16 +123,16 @@ fn parse_ldap_index(parts: &[&str]) -> Option<DetectUintIndex> {
     return Some(index);
 }
 
-fn aux_ldap_parse_protocol_resp_op(s: &str) -> Option<DetectLdapRespOpData> {
+fn aux_ldap_parse_protocol_resp_op(s: &str) -> Option<DetectUintArrayData<u8>> {
     let parts: Vec<&str> = s.split(',').collect();
     if parts.len() > 2 {
         return None;
     }
 
     let index = parse_ldap_index(&parts)?;
-    let du8 = detect_parse_uint_enum::<u8, ProtocolOpCode>(parts[0])?;
+    let du = detect_parse_uint_enum::<u8, ProtocolOpCode>(parts[0])?;
 
-    Some(DetectLdapRespOpData { du8, index })
+    Some(DetectUintArrayData{ du, index })
 }
 
 unsafe extern "C" fn ldap_parse_protocol_resp_op(
@@ -240,11 +221,11 @@ unsafe extern "C" fn ldap_detect_responses_operation_match(
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
     let tx = cast_pointer!(tx, LdapTransaction);
-    let ctx = cast_pointer!(ctx, DetectLdapRespOpData);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u8>);
 
     return match_at_index::<LdapMessage, u8>(
         &tx.responses,
-        &ctx.du8,
+        &ctx.du,
         |response| Some(response.protocol_op.tag().0 as u8),
         |code, ctx_value| detect_match_uint(ctx_value, code) as c_int,
         &ctx.index,
@@ -253,7 +234,7 @@ unsafe extern "C" fn ldap_detect_responses_operation_match(
 
 unsafe extern "C" fn ldap_detect_responses_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     // Just unbox...
-    let ctx = cast_pointer!(ctx, DetectLdapRespOpData);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u8>);
     std::mem::drop(Box::from_raw(ctx));
 }
 
@@ -382,16 +363,16 @@ unsafe extern "C" fn ldap_tx_get_responses_dn(
     return true;
 }
 
-fn aux_ldap_parse_resp_result_code(s: &str) -> Option<DetectLdapRespResultData> {
+fn aux_ldap_parse_resp_result_code(s: &str) -> Option<DetectUintArrayData<u32>> {
     let parts: Vec<&str> = s.split(',').collect();
     if parts.len() > 2 {
         return None;
     }
 
     let index = parse_ldap_index(&parts)?;
-    let du32 = detect_parse_uint_enum::<u32, LdapResultCode>(parts[0])?;
+    let du = detect_parse_uint_enum::<u32, LdapResultCode>(parts[0])?;
 
-    Some(DetectLdapRespResultData { du32, index })
+    Some(DetectUintArrayData { du, index })
 }
 
 unsafe extern "C" fn ldap_parse_responses_result_code(
@@ -451,11 +432,11 @@ unsafe extern "C" fn ldap_detect_responses_result_code_match(
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
     let tx = cast_pointer!(tx, LdapTransaction);
-    let ctx = cast_pointer!(ctx, DetectLdapRespResultData);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
 
     return match_at_index::<LdapMessage, u32>(
         &tx.responses,
-        &ctx.du32,
+        &ctx.du,
         get_ldap_result_code,
         |code, ctx_value| detect_match_uint(ctx_value, code) as c_int,
         &ctx.index,
@@ -466,7 +447,7 @@ unsafe extern "C" fn ldap_detect_responses_result_code_free(
     _de: *mut DetectEngineCtx, ctx: *mut c_void,
 ) {
     // Just unbox...
-    let ctx = cast_pointer!(ctx, DetectLdapRespResultData);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
     std::mem::drop(Box::from_raw(ctx));
 }
 

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -151,9 +151,12 @@ unsafe extern "C" fn ldap_detect_responses_operation_match(
     let tx = cast_pointer!(tx, LdapTransaction);
     let ctx = cast_pointer!(ctx, DetectUintArrayData<u8>);
 
-    return detect_uint_match_at_index::<LdapMessage, u8>(&tx.responses, ctx, |response| {
-        Some(response.protocol_op.tag().0 as u8)
-    });
+    return detect_uint_match_at_index::<LdapMessage, u8>(
+        &tx.responses,
+        ctx,
+        |response| Some(response.protocol_op.tag().0 as u8),
+        tx.complete,
+    );
 }
 
 unsafe extern "C" fn ldap_detect_responses_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
@@ -350,6 +353,7 @@ unsafe extern "C" fn ldap_detect_responses_result_code_match(
         &tx.responses,
         ctx,
         get_ldap_result_code,
+        tx.complete,
     );
 }
 

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -18,8 +18,8 @@
 use super::ldap::{LdapTransaction, ALPROTO_LDAP};
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
-    detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Parse,
-    SCDetectU8Free,
+    detect_match_uint, detect_parse_uint_enum, DetectUintData, DetectUintIndex, SCDetectU32Free,
+    SCDetectU32Parse, SCDetectU8Free,
 };
 use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer};
 use crate::ldap::types::*;
@@ -35,13 +35,6 @@ use std::collections::VecDeque;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use std::str::FromStr;
-
-#[derive(Debug, PartialEq)]
-enum DetectUintIndex {
-    Any,
-    All,
-    Index(i32),
-}
 
 #[derive(Debug, PartialEq)]
 struct DetectLdapRespOpData {

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -31,7 +31,6 @@ use suricata_sys::sys::{
     SCSigTableAppLiteElmt, SigMatchCtx, Signature,
 };
 
-use std::collections::VecDeque;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 
@@ -145,7 +144,7 @@ unsafe extern "C" fn ldap_detect_responses_operation_setup(
 }
 
 fn match_at_index<T, U>(
-    array: &VecDeque<T>, ctx_value: &DetectUintData<U>, get_value: impl Fn(&T) -> Option<U>,
+    array: &[T], ctx_value: &DetectUintData<U>, get_value: impl Fn(&T) -> Option<U>,
     detect_match: impl Fn(U, &DetectUintData<U>) -> c_int, index: &DetectUintIndex,
 ) -> c_int {
     match index {

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -18,8 +18,8 @@
 use super::ldap::{LdapTransaction, ALPROTO_LDAP};
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
-    detect_match_uint, detect_parse_uint_enum, DetectUintData, DetectUintIndex, SCDetectU32Free,
-    SCDetectU32Parse, SCDetectU8Free, DetectUintArrayData,
+    detect_match_uint, detect_parse_array_uint_enum, detect_parse_uint_enum, DetectUintArrayData,
+    DetectUintData, DetectUintIndex, SCDetectU32Free, SCDetectU32Parse, SCDetectU8Free,
 };
 use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer};
 use crate::ldap::types::*;
@@ -34,7 +34,6 @@ use suricata_sys::sys::{
 use std::collections::VecDeque;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
-use std::str::FromStr;
 
 static mut G_LDAP_REQUEST_OPERATION_KW_ID: u16 = 0;
 static mut G_LDAP_REQUEST_OPERATION_BUFFER_ID: c_int = 0;
@@ -107,40 +106,12 @@ unsafe extern "C" fn ldap_detect_request_free(_de: *mut DetectEngineCtx, ctx: *m
     SCDetectU8Free(ctx);
 }
 
-fn parse_ldap_index(parts: &[&str]) -> Option<DetectUintIndex> {
-    let index = if parts.len() == 2 {
-        match parts[1] {
-            "all" => DetectUintIndex::All,
-            "any" => DetectUintIndex::Any,
-            _ => {
-                let i32_index = i32::from_str(parts[1]).ok()?;
-                DetectUintIndex::Index(i32_index)
-            }
-        }
-    } else {
-        DetectUintIndex::Any
-    };
-    return Some(index);
-}
-
-fn aux_ldap_parse_protocol_resp_op(s: &str) -> Option<DetectUintArrayData<u8>> {
-    let parts: Vec<&str> = s.split(',').collect();
-    if parts.len() > 2 {
-        return None;
-    }
-
-    let index = parse_ldap_index(&parts)?;
-    let du = detect_parse_uint_enum::<u8, ProtocolOpCode>(parts[0])?;
-
-    Some(DetectUintArrayData{ du, index })
-}
-
 unsafe extern "C" fn ldap_parse_protocol_resp_op(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectUintData<u8> {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
     if let Ok(s) = ft_name.to_str() {
-        if let Some(ctx) = aux_ldap_parse_protocol_resp_op(s) {
+        if let Some(ctx) = detect_parse_array_uint_enum::<u8, ProtocolOpCode>(s) {
             let boxed = Box::new(ctx);
             return Box::into_raw(boxed) as *mut _;
         }
@@ -363,24 +334,12 @@ unsafe extern "C" fn ldap_tx_get_responses_dn(
     return true;
 }
 
-fn aux_ldap_parse_resp_result_code(s: &str) -> Option<DetectUintArrayData<u32>> {
-    let parts: Vec<&str> = s.split(',').collect();
-    if parts.len() > 2 {
-        return None;
-    }
-
-    let index = parse_ldap_index(&parts)?;
-    let du = detect_parse_uint_enum::<u32, LdapResultCode>(parts[0])?;
-
-    Some(DetectUintArrayData { du, index })
-}
-
 unsafe extern "C" fn ldap_parse_responses_result_code(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectUintData<u32> {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
     if let Ok(s) = ft_name.to_str() {
-        if let Some(ctx) = aux_ldap_parse_resp_result_code(s) {
+        if let Some(ctx) = detect_parse_array_uint_enum::<u32, LdapResultCode>(s) {
             let boxed = Box::new(ctx);
             return Box::into_raw(boxed) as *mut _;
         }

--- a/rust/src/ldap/ldap.rs
+++ b/rust/src/ldap/ldap.rs
@@ -64,7 +64,7 @@ enum LdapEvent {
 pub struct LdapTransaction {
     pub tx_id: u64,
     pub request: Option<LdapMessage<'static>>,
-    pub responses: VecDeque<LdapMessage<'static>>,
+    pub responses: Vec<LdapMessage<'static>>,
     complete: bool,
 
     tx_data: AppLayerTxData,
@@ -81,7 +81,7 @@ impl LdapTransaction {
         Self {
             tx_id: 0,
             request: None,
-            responses: VecDeque::new(),
+            responses: Vec::new(),
             complete: false,
             tx_data: AppLayerTxData::new(),
         }
@@ -312,7 +312,7 @@ impl LdapState {
                         tx.complete |= tx_is_complete(&response.protocol_op, Direction::ToClient);
                         let tx_id = tx.id();
                         tx.tx_data.updated_tc = true;
-                        tx.responses.push_back(response.to_static());
+                        tx.responses.push(response.to_static());
                         sc_app_layer_parser_trigger_raw_stream_inspection(
                             flow,
                             Direction::ToClient as i32,
@@ -329,7 +329,7 @@ impl LdapState {
                         let mut tx = tx.unwrap();
                         let tx_id = tx.id();
                         tx.complete = true;
-                        tx.responses.push_back(response.to_static());
+                        tx.responses.push(response.to_static());
                         self.transactions.push_back(tx);
                         sc_app_layer_parser_trigger_raw_stream_inspection(
                             flow,
@@ -345,7 +345,7 @@ impl LdapState {
                         let mut tx = tx.unwrap();
                         tx.complete = true;
                         let tx_id = tx.id();
-                        tx.responses.push_back(response.to_static());
+                        tx.responses.push(response.to_static());
                         self.transactions.push_back(tx);
                         sc_app_layer_parser_trigger_raw_stream_inspection(
                             flow,
@@ -436,7 +436,7 @@ impl LdapState {
                     if let Some(tx) = self.find_request(response.message_id) {
                         tx.complete |= tx_is_complete(&response.protocol_op, Direction::ToClient);
                         let tx_id = tx.id();
-                        tx.responses.push_back(response.to_static());
+                        tx.responses.push(response.to_static());
                         let consumed = start.len() - rem.len();
                         self.set_frame_tc(flow, tx_id, consumed as i64);
                     } else if let ProtocolOp::ExtendedResponse(_) = response.protocol_op {
@@ -449,7 +449,7 @@ impl LdapState {
                         let mut tx = tx.unwrap();
                         tx.complete = true;
                         let tx_id = tx.id();
-                        tx.responses.push_back(response.to_static());
+                        tx.responses.push(response.to_static());
                         self.transactions.push_back(tx);
                         let consumed = start.len() - rem.len();
                         self.set_frame_tc(flow, tx_id, consumed as i64);
@@ -461,7 +461,7 @@ impl LdapState {
                         let mut tx = tx.unwrap();
                         tx.complete = true;
                         let tx_id = tx.id();
-                        tx.responses.push_back(response.to_static());
+                        tx.responses.push(response.to_static());
                         self.transactions.push_back(tx);
                         self.set_event(LdapEvent::RequestNotFound);
                         let consumed = start.len() - rem.len();

--- a/rust/src/ldap/ldap.rs
+++ b/rust/src/ldap/ldap.rs
@@ -65,7 +65,7 @@ pub struct LdapTransaction {
     pub tx_id: u64,
     pub request: Option<LdapMessage<'static>>,
     pub responses: Vec<LdapMessage<'static>>,
-    complete: bool,
+    pub complete: bool,
 
     tx_data: AppLayerTxData,
 }

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -45,9 +45,12 @@ use std::ptr;
 use std::str::FromStr;
 
 fn mqtt_tx_has_type(tx: &MQTTTransaction, ctx: &DetectUintArrayData<u8>) -> c_int {
-    return detect_uint_match_at_index::<MQTTMessage, u8>(&tx.msg, ctx, |msg| {
-        Some(msg.header.message_type as u8)
-    });
+    return detect_uint_match_at_index::<MQTTMessage, u8>(
+        &tx.msg,
+        ctx,
+        |msg| Some(msg.header.message_type as u8),
+        tx.complete,
+    );
 }
 
 unsafe extern "C" fn mqtt_conn_clientid_get_data(

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -19,8 +19,8 @@
 
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
-    detect_match_uint, detect_parse_uint, detect_parse_uint_enum, DetectUintData, DetectUintMode,
-    SCDetectU8Free, SCDetectU8Parse,
+    detect_match_uint, detect_parse_array_uint_enum, detect_parse_uint, detect_uint_match_at_index,
+    DetectUintArrayData, DetectUintData, DetectUintMode, SCDetectU8Free, SCDetectU8Parse,
 };
 use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer};
 use suricata_sys::sys::{
@@ -38,19 +38,16 @@ use nom7::IResult;
 
 use super::mqtt::{MQTTState, MQTTTransaction, ALPROTO_MQTT};
 use crate::conf::conf_get;
-use crate::mqtt::mqtt_message::{MQTTOperation, MQTTTypeCode};
+use crate::mqtt::mqtt_message::{MQTTMessage, MQTTOperation, MQTTTypeCode};
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use std::ptr;
 use std::str::FromStr;
 
-fn mqtt_tx_has_type(tx: &MQTTTransaction, mtype: &DetectUintData<u8>) -> c_int {
-    for msg in tx.msg.iter() {
-        if detect_match_uint(mtype, msg.header.message_type as u8) {
-            return 1;
-        }
-    }
-    return 0;
+fn mqtt_tx_has_type(tx: &MQTTTransaction, ctx: &DetectUintArrayData<u8>) -> c_int {
+    return detect_uint_match_at_index::<MQTTMessage, u8>(&tx.msg, ctx, |msg| {
+        Some(msg.header.message_type as u8)
+    });
 }
 
 unsafe extern "C" fn mqtt_conn_clientid_get_data(
@@ -382,10 +379,12 @@ unsafe extern "C" fn sub_topic_setup(
     return 0;
 }
 
-unsafe extern "C" fn mqtt_parse_type(ustr: *const std::os::raw::c_char) -> *mut DetectUintData<u8> {
+unsafe extern "C" fn mqtt_parse_type(
+    ustr: *const std::os::raw::c_char,
+) -> *mut DetectUintArrayData<u8> {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
     if let Ok(s) = ft_name.to_str() {
-        if let Some(ctx) = detect_parse_uint_enum::<u8, MQTTTypeCode>(s) {
+        if let Some(ctx) = detect_parse_array_uint_enum::<u8, MQTTTypeCode>(s) {
             let boxed = Box::new(ctx);
             return Box::into_raw(boxed) as *mut _;
         }
@@ -423,14 +422,14 @@ unsafe extern "C" fn mqtt_type_match(
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
     let tx = cast_pointer!(tx, MQTTTransaction);
-    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u8>);
     return mqtt_tx_has_type(tx, ctx);
 }
 
 unsafe extern "C" fn mqtt_type_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     // Just unbox...
-    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
-    SCDetectU8Free(ctx);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u8>);
+    std::mem::drop(Box::from_raw(ctx));
 }
 
 unsafe extern "C" fn mqtt_reason_code_setup(
@@ -1324,19 +1323,19 @@ mod test {
 
     #[test]
     fn mqtt_type_test_parse() {
-        let ctx = detect_parse_uint_enum::<u8, MQTTTypeCode>("CONNECT").unwrap();
-        assert_eq!(ctx.arg1, 1);
-        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
-        let ctx = detect_parse_uint_enum::<u8, MQTTTypeCode>("PINGRESP").unwrap();
-        assert_eq!(ctx.arg1, 13);
-        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
-        let ctx = detect_parse_uint_enum::<u8, MQTTTypeCode>("auth").unwrap();
-        assert_eq!(ctx.arg1, 15);
-        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
-        assert!(detect_parse_uint_enum::<u8, MQTTTypeCode>("invalidopt").is_none());
-        let ctx = detect_parse_uint_enum::<u8, MQTTTypeCode>("unassigned").unwrap();
-        assert_eq!(ctx.arg1, 0);
-        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
+        let ctx = detect_parse_array_uint_enum::<u8, MQTTTypeCode>("CONNECT").unwrap();
+        assert_eq!(ctx.du.arg1, 1);
+        assert_eq!(ctx.du.mode, DetectUintMode::DetectUintModeEqual);
+        let ctx = detect_parse_array_uint_enum::<u8, MQTTTypeCode>("PINGRESP").unwrap();
+        assert_eq!(ctx.du.arg1, 13);
+        assert_eq!(ctx.du.mode, DetectUintMode::DetectUintModeEqual);
+        let ctx = detect_parse_array_uint_enum::<u8, MQTTTypeCode>("auth").unwrap();
+        assert_eq!(ctx.du.arg1, 15);
+        assert_eq!(ctx.du.mode, DetectUintMode::DetectUintModeEqual);
+        assert!(detect_parse_array_uint_enum::<u8, MQTTTypeCode>("invalidopt").is_none());
+        let ctx = detect_parse_array_uint_enum::<u8, MQTTTypeCode>("unassigned").unwrap();
+        assert_eq!(ctx.du.arg1, 0);
+        assert_eq!(ctx.du.mode, DetectUintMode::DetectUintModeEqual);
     }
 
     #[test]

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -75,7 +75,7 @@ pub struct MQTTTransaction {
     tx_id: u64,
     pkt_id: Option<u32>,
     pub msg: Vec<MQTTMessage>,
-    complete: bool,
+    pub complete: bool,
     toclient: bool,
     toserver: bool,
 

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -362,17 +362,7 @@ static int DetectHTTP2priorityMatch(DetectEngineThreadCtx *det_ctx,
                                const SigMatchCtx *ctx)
 
 {
-    uint32_t nb = 0;
-    int value = SCHttp2TxGetNextPriority(txv, flags, nb);
-    const DetectU8Data *du8 = (const DetectU8Data *)ctx;
-    while (value >= 0) {
-        if (DetectU8Match((uint8_t)value, du8)) {
-            return 1;
-        }
-        nb++;
-        value = SCHttp2TxGetNextPriority(txv, flags, nb);
-    }
-    return 0;
+    return SCHttp2PriorityMatch(txv, flags, ctx);
 }
 
 /**
@@ -390,7 +380,7 @@ static int DetectHTTP2prioritySetup (DetectEngineCtx *de_ctx, Signature *s, cons
     if (SCDetectSignatureSetAppProto(s, ALPROTO_HTTP2) != 0)
         return -1;
 
-    DetectU8Data *prio = DetectU8Parse(str);
+    DetectU8Data *prio = SCDetectU8ArrayParse(str);
     if (prio == NULL)
         return -1;
 
@@ -410,7 +400,7 @@ static int DetectHTTP2prioritySetup (DetectEngineCtx *de_ctx, Signature *s, cons
  */
 void DetectHTTP2priorityFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    SCDetectU8Free(ptr);
+    SCDetectU8ArrayFree(ptr);
 }
 
 /**


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7480

Describe changes:
- detect/integers: generalize multi-integers

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2653

#13872 with better rustfmt and negative index parsing fix

@victorjulien should I do a first PR with commits up to `rust/detect: generic detect_uint_match_at_index` ? 

More TODOs:
- need to do all keywords
- think about `count` feature in relation to https://github.com/OISF/suricata/pull/13783 and Victor wanting a new keyword `vlan.layers` instead of a count option to `vlan.id`

List of keywords to do : `./src/suricata --list-keywords=csv | grep uint | grep multi | cut -d\; -f1`
- nfs_procedure (first cherry-pick https://github.com/OISF/suricata/pull/13831/commits/da81b7e99ea7496b79f5ec199555edff2c29cbc5)
- filesize (file iterator)
- vlan.id (c prefilter)
- enip.cip_attribute (array of arrays)
- enip.cip_class (array of arrays)
- enip.cip_status (array of arrays)
- enip.cip_instance (array of arrays)
- enip.cip_extendedstatus (array of arrays)
- mqtt.reason_code (2 arrays ...)
- mqtt.flags (bitflags)
- mqtt.connect.flags (bitflags)