### PR TITLE
pcap: refactor delete-when-done to support non-alerts

### DIFF
--- a/doc/userguide/capture-hardware/pcap-file.rst
+++ b/doc/userguide/capture-hardware/pcap-file.rst
@@ -15,6 +15,8 @@ Configuration
     checksum-checks: auto
     # buffer-size: 128 KiB
     # tenant-id: none
+    # Applies to file and directory. Options: false (no deletion), true (always delete),
+    #   "non-alerts" (delete only files with no alerts)
     # delete-when-done: false
     # recursive: false
     # continuous: false
@@ -85,9 +87,22 @@ Other options
 
 **delete-when-done**
 
-- If ``true``, Suricata deletes the PCAP file after processing.
-- The command-line option is
-  :ref:`--pcap-file-delete <cmdline-option-pcap-file-delete>`
+Controls when PCAP files are deleted after processing. Three values are supported:
+
+- ``false`` (default): Files are never deleted
+- ``true``: Files are always deleted after processing
+- ``"non-alerts"``: Files are deleted only if they didn't generate any alerts
+
+.. note::
+
+   The command-line option :ref:`--pcap-file-delete <cmdline-option-pcap-file-delete>`
+   overrides this configuration and forces "always delete" mode (``true``).
+
+.. warning::
+
+   When using ``"non-alerts"`` mode, file deletion is deferred until thread
+   cleanup to ensure alert counts are finalized. This may delay deletion
+   compared to other modes.
 
 **BPF filter**
 

--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -80,10 +80,23 @@
 
 .. option:: --pcap-file-delete
 
-   Used with the -r option to indicate that the mode should delete pcap files
-   after they have been processed. This is useful with pcap-file-continuous to
-   continuously feed files to a directory and have them cleaned up when done. If
-   this option is not set, pcap files will not be deleted after processing.
+   Used with the -r option to force deletion of pcap files after they have been
+   processed. This is useful with pcap-file-continuous to continuously feed files
+   to a directory and have them cleaned up when done.
+
+   **command-line vs Configuration**: This command-line option overrides the
+   ``pcap-file.delete-when-done`` configuration option in ``suricata.yaml`` and
+   forces "always delete" mode (equivalent to ``delete-when-done: true``).
+
+   **For more control**, use the ``pcap-file.delete-when-done`` configuration
+   option instead, which supports three values:
+   
+   - ``false`` (default): No files are deleted
+   - ``true``: All files are deleted after processing  
+   - ``"non-alerts"``: Only files that generated no alerts are deleted
+
+   If neither ``--pcap-file-delete`` nor ``delete-when-done`` is configured, 
+   pcap files will not be deleted after processing.
 
 .. _cmdline-option-pcap-file-buffer-size:
 

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -115,6 +115,7 @@
 #include "decode-vntag.h"
 #include "decode-vxlan.h"
 #include "decode-pppoe.h"
+#include "source-pcap-file-helper.h"
 
 #include "output-json-stats.h"
 
@@ -210,6 +211,7 @@ static void RegisterUnittests(void)
     StreamingBufferRegisterTests();
     MacSetRegisterTests();
     FlowRateRegisterTests();
+    SourcePcapFileHelperRegisterTests();
 #ifdef OS_WIN32
     Win32SyscallRegisterTests();
 #endif

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -23,9 +23,16 @@
 
 #include "suricata-common.h"
 #include "tm-threads.h"
+#include "util-atomic.h"
 
 #ifndef SURICATA_SOURCE_PCAP_FILE_HELPER_H
 #define SURICATA_SOURCE_PCAP_FILE_HELPER_H
+
+typedef enum {
+    PCAP_FILE_DELETE_NONE = 0,
+    PCAP_FILE_DELETE_ALWAYS,
+    PCAP_FILE_DELETE_NON_ALERTS
+} PcapFileDeleteMode;
 
 typedef struct PcapFileGlobalVars_ {
     uint64_t cnt; /** packet counter */
@@ -46,7 +53,7 @@ typedef struct PcapFileSharedVars_
 
     struct timespec last_processed;
 
-    bool should_delete;
+    PcapFileDeleteMode delete_mode;
 
     ThreadVars *tv;
     TmSlot *slot;
@@ -75,6 +82,10 @@ typedef struct PcapFileFileVars_
     struct bpf_program filter;
 
     PcapFileSharedVars *shared;
+
+    SC_ATOMIC_DECLARE(uint64_t, alerts_count);
+    SC_ATOMIC_DECLARE(uint32_t, ref_cnt);
+    bool cleanup_requested;
 
     /* fields used to get the first packet's timestamp early,
      * so it can be used to setup the time subsys. */
@@ -120,5 +131,15 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv);
 TmEcode ValidateLinkType(int datalink, DecoderFunc *decoder);
 
 const char *PcapFileGetFilename(void);
+
+bool PcapFileShouldDeletePcapFile(PcapFileFileVars *pfv);
+
+void PcapFileFinalizePacket(PcapFileFileVars *pfv, uint16_t alert_count);
+
+PcapFileDeleteMode PcapFileParseDeleteMode(void);
+
+#ifdef UNITTESTS
+void SourcePcapFileHelperRegisterTests(void);
+#endif
 
 #endif /* SURICATA_SOURCE_PCAP_FILE_HELPER_H */

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -205,7 +205,6 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
     if(ptv->is_directory == 0) {
         SCLogInfo("Starting file run for %s", ptv->behavior.file->filename);
         status = PcapFileDispatch(ptv->behavior.file);
-        CleanupPcapFileFromThreadVars(ptv, ptv->behavior.file);
     } else {
         SCLogInfo("Starting directory run for %s", ptv->behavior.directory->filename);
         PcapDirectoryDispatch(ptv->behavior.directory);
@@ -261,11 +260,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         }
     }
 
-    int should_delete = 0;
-    ptv->shared.should_delete = false;
-    if (SCConfGetBool("pcap-file.delete-when-done", &should_delete) == 1) {
-        ptv->shared.should_delete = should_delete == 1;
-    }
+    ptv->shared.delete_mode = PcapFileParseDeleteMode();
 
     DIR *directory = NULL;
     SCLogDebug("checking file or directory %s", (char*)initdata);
@@ -422,6 +417,11 @@ TmEcode ReceivePcapFileThreadDeinit(ThreadVars *tv, void *data)
     SCEnter();
     if(data != NULL) {
         PcapFileThreadVars *ptv = (PcapFileThreadVars *) data;
+
+        if (!ptv->is_directory && ptv->behavior.file != NULL) {
+            CleanupPcapFileFromThreadVars(ptv, ptv->behavior.file);
+        }
+
         CleanupPcapFileThreadVars(ptv);
     }
     SCReturnInt(TM_ECODE_OK);

--- a/src/source-pcap.h
+++ b/src/source-pcap.h
@@ -24,6 +24,8 @@
 #ifndef SURICATA_SOURCE_PCAP_H
 #define SURICATA_SOURCE_PCAP_H
 
+typedef struct PcapFileFileVars_ PcapFileFileVars;
+
 void TmModuleReceivePcapRegister (void);
 void TmModuleDecodePcapRegister (void);
 void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
@@ -35,6 +37,7 @@ void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
 typedef struct PcapPacketVars_
 {
     uint32_t tenant_id;
+    PcapFileFileVars *pfv;
 } PcapPacketVars;
 
 /** needs to be able to contain Windows adapter id's, so

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -891,7 +891,9 @@ pcap-file:
   # buffer-size: 128 KiB
 
   # tenant-id: none # applies in multi-tenant environment with "direct" selector
-  # delete-when-done: false # applies to file and directory
+  # Applies to file and directory. Options: false (no deletion), true (always delete),
+  #   "non-alerts" (delete only files with no alerts)
+  # delete-when-done: false
 
   # PCAP Directory Processing options
   # recursive: false


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/issues/7786?next_issue_id=7785

Describe changes:
Allowing change the behaviour of --pcap-file-delete to only delete pcaps with no alerts via config.

Previous PR: https://github.com/OISF/suricata/pull/13682
Changes:
- Nit comments.
- UTs coverage

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2656
