### PR TITLE
doc/rules/internals: minor fixes - v1

### DIFF
--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -110,6 +110,7 @@ In the part [1:123], the first 1 is the gid (123 is the sid and 1 is the rev).
 
     07/12/2022-21:59:26.713297  [**] [:example-rule-emphasis:`1`:123:1] HTTP GET Request Containing Rule in URI [**] [Classification: Potentially Bad Traffic] [Priority: 2] {TCP} 192.168.225.121:12407 -> 172.16.105.84:80
 
+.. _classtype:
 
 classtype
 ---------

--- a/doc/userguide/rules/rules-internals.rst
+++ b/doc/userguide/rules/rules-internals.rst
@@ -72,6 +72,9 @@ had flowbits set and a rule action with higher priority, for instance.
    extra logic for prioritization. For example, considering flowbits, the
    priority is write (highest) > write + read > read (lowest) > no flowbits.
 
+.. note:: it is also possible to have a rule priority set implicitly, through
+   the `classtype` keyword. Check :ref:`classtype`.
+
 Another important element when considering rule parsing, processing and matching
 is that the ruleset is optimized into signature group heads based on the signature
 elements (thus, for instance, a TCP rule and an UDP rule would be loaded into
@@ -179,7 +182,7 @@ flow isn't flagged with ``pass``, it will be dropped with the third rule.
 
 .. Tip::
    A more straightforward way to achieve that in Suricata 8 is using the firewall
-   more. See :doc:`../firewall/firewall-design`.
+   mode. See :doc:`../firewall/firewall-design`.
 
 Alerts not seen
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fix typo and add a reference about the classtype keyword effect.

Related to
Task #5449

https://github.com/OISF/suricata/pull/13833 was merged with a couple of comments not addressed. This is an attempt to fix that.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
(still) https://redmine.openinfosecfoundation.org/issues/5449

Describe changes:
- s/more/mode (just where that belonged)
- add note about `classtype` keyword effect