### PR TITLE
doc: fix some small typos in the documentation v2

### DIFF
--- a/doc/userguide/configuration/global-thresholds.rst
+++ b/doc/userguide/configuration/global-thresholds.rst
@@ -32,7 +32,7 @@ Rate filters allow changing of a rule action when a rule matches.
 
 Syntax::
 
-  rate_filter: rate_filter gen_id <gid>, sig_id <sid>, track <tracker>, \
+  rate_filter gen_id <gid>, sig_id <sid>, track <tracker>, \
     count <c>, seconds <s>, new_action <action>, timeout <timeout>
 
 Example::

--- a/doc/userguide/rules/ssh-keywords.rst
+++ b/doc/userguide/rules/ssh-keywords.rst
@@ -88,7 +88,7 @@ The example above matches on SSH connections where the software string contains
 ssh.hassh
 ---------
 
-Match on hassh (md5 of of hassh algorithms of client).
+Match on hassh (md5 of hassh algorithms of client).
 
 Example::
 
@@ -136,6 +136,7 @@ ssh.hassh.server.string
 Match on hassh string (hassh algorithms of server).
 
 Example::
+
   alert ssh any any -> any any (msg:"match SSH hash-server-string"; \
       ssh.hassh.server.string; content:"umac-64-etm@openssh.com,umac-128-etm@openssh.com"; \
       sid:1000040;)

--- a/doc/userguide/security.rst
+++ b/doc/userguide/security.rst
@@ -83,7 +83,7 @@ The following commands will setup the correct permissions:
     chgrp -R suricata /var/lib/suricata
     chmod -R g+srw /var/lib/suricata
 
-* ``/var/lib/suricata``::
+* ``/var/run/suricata``::
 
     chgrp -R suricata /var/run/suricata
     chmod -R g+srw /var/run/suricata

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -93,7 +93,7 @@ typedef struct ThreadVars_ {
 
     SC_ATOMIC_DECLARE(uint32_t, flags);
 
-    /** list of of TmSlot objects together forming the packet pipeline. */
+    /** list of TmSlot objects together forming the packet pipeline. */
     struct TmSlot_ *tm_slots;
 
     /** pointer to the flowworker in the pipeline. Used as starting point


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made -> Yes, this PR contains only fixes in the documentation :)
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions) -> not applicable
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues -> Not yet, because these are just some small typos. Please tell me if you need a ticket though.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/ -> No ticket

Describe changes:
- Follow-up to https://github.com/OISF/suricata/pull/13861
- doc/userguide/configuration/global-thresholds.rst: Fix doc syntax error in rate_filter example. In the 'threshold.config' it is wrong to name `rate_filter` twice.
- doc/userguide/rules/ssh-keywords.rst: Fix typo and missing newline. Duplicate use of word `of`. Missing newline after `Example::` causes rendering to be incorrect, but I did not test the correct rendering.
- doc/userguide/security.rst: Section describes `/var/run/suricata` and not `/var/lib/suricata `, probably a copy-paste-typo from the section above.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=

Thanks for reviewing :)
