### PR TITLE
lua: fix null dereference in tx HTTP accessor functions - v1

### DIFF
--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -23,7 +23,6 @@
  */
 
 #include "suricata-common.h"
-
 #include "app-layer-htp.h"
 #include "util-lua.h"
 #include "util-lua-common.h"
@@ -65,9 +64,13 @@ static int LuaHttpGetRequestHost(lua_State *luastate)
         lua_pushnil(luastate);
         return 1;
     }
+    const struct bstr *host = htp_tx_request_hostname(tx->tx);
+    if (host == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
 
-    return LuaPushStringBuffer(luastate, bstr_ptr(htp_tx_request_hostname(tx->tx)),
-            bstr_len(htp_tx_request_hostname(tx->tx)));
+    return LuaPushStringBuffer(luastate, bstr_ptr(host), bstr_len(host));
 }
 
 static int LuaHttpGetRequestUriRaw(lua_State *luastate)
@@ -77,9 +80,13 @@ static int LuaHttpGetRequestUriRaw(lua_State *luastate)
         lua_pushnil(luastate);
         return 1;
     }
+    const struct bstr *uri = htp_tx_request_uri(tx->tx);
+    if (uri == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
 
-    return LuaPushStringBuffer(
-            luastate, bstr_ptr(htp_tx_request_uri(tx->tx)), bstr_len(htp_tx_request_uri(tx->tx)));
+    return LuaPushStringBuffer(luastate, bstr_ptr(uri), bstr_len(uri));
 }
 
 static int LuaHttpGetRequestUriNormalized(lua_State *luastate)
@@ -107,8 +114,13 @@ static int LuaHttpGetRequestLine(lua_State *luastate)
         return 1;
     }
 
-    return LuaPushStringBuffer(
-            luastate, bstr_ptr(htp_tx_request_line(tx->tx)), bstr_len(htp_tx_request_line(tx->tx)));
+    const struct bstr *line = htp_tx_request_line(tx->tx);
+    if (line == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+
+    return LuaPushStringBuffer(luastate, bstr_ptr(line), bstr_len(line));
 }
 
 static int LuaHttpGetResponseLine(lua_State *luastate)
@@ -119,8 +131,13 @@ static int LuaHttpGetResponseLine(lua_State *luastate)
         return 1;
     }
 
-    return LuaPushStringBuffer(luastate, bstr_ptr(htp_tx_response_line(tx->tx)),
-            bstr_len(htp_tx_response_line(tx->tx)));
+    const struct bstr *line = htp_tx_response_line(tx->tx);
+    if (line == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+
+    return LuaPushStringBuffer(luastate, bstr_ptr(line), bstr_len(line));
 }
 
 static int LuaHttpGetHeader(lua_State *luastate, int dir)


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/7829

Fix crashes in Lua when calling tx:response_line(), tx:request_line(),
tx:request_uri_raw(), or tx:request_host() on incomplete or malformed
HTTP transactions.

These functions return bstr pointers which may be NULL. Add NULL
checks before calling bstr_ptr() and bstr_len() to avoid segfaults.

Minor cleanups from previous PR: https://github.com/OISF/suricata/pull/13669
- Commit message/author
- Remove htp_rs include, does not appear to be needed
