### PR TITLE
pcap: refactor delete-when-done to support non-alerts

### DIFF
--- a/doc/userguide/capture-hardware/pcap-file.rst
+++ b/doc/userguide/capture-hardware/pcap-file.rst
@@ -15,6 +15,8 @@ Configuration
     checksum-checks: auto
     # buffer-size: 128 KiB
     # tenant-id: none
+    # Applies to file and directory. Options: false (no deletion), true (always delete),
+    #   "non-alerts" (delete only files with no alerts)
     # delete-when-done: false
     # recursive: false
     # continuous: false
@@ -85,9 +87,22 @@ Other options
 
 **delete-when-done**
 
-- If ``true``, Suricata deletes the PCAP file after processing.
-- The command-line option is
-  :ref:`--pcap-file-delete <cmdline-option-pcap-file-delete>`
+Controls when PCAP files are deleted after processing. Three values are supported:
+
+- ``false`` (default): Files are never deleted
+- ``true``: Files are always deleted after processing
+- ``"non-alerts"``: Files are deleted only if they didn't generate any alerts
+
+.. note::
+
+   The command-line option :ref:`--pcap-file-delete <cmdline-option-pcap-file-delete>`
+   overrides this configuration and forces "always delete" mode (``true``).
+
+.. warning::
+
+   When using ``"non-alerts"`` mode, file deletion is deferred until thread
+   cleanup to ensure alert counts are finalized. This may delay deletion
+   compared to other modes.
 
 **BPF filter**
 

--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -80,10 +80,23 @@
 
 .. option:: --pcap-file-delete
 
-   Used with the -r option to indicate that the mode should delete pcap files
-   after they have been processed. This is useful with pcap-file-continuous to
-   continuously feed files to a directory and have them cleaned up when done. If
-   this option is not set, pcap files will not be deleted after processing.
+   Used with the -r option to force deletion of pcap files after they have been
+   processed. This is useful with pcap-file-continuous to continuously feed files
+   to a directory and have them cleaned up when done.
+
+   **command-line vs Configuration**: This command-line option overrides the
+   ``pcap-file.delete-when-done`` configuration option in ``suricata.yaml`` and
+   forces "always delete" mode (equivalent to ``delete-when-done: true``).
+
+   **For more control**, use the ``pcap-file.delete-when-done`` configuration
+   option instead, which supports three values:
+   
+   - ``false`` (default): No files are deleted
+   - ``true``: All files are deleted after processing  
+   - ``"non-alerts"``: Only files that generated no alerts are deleted
+
+   If neither ``--pcap-file-delete`` nor ``delete-when-done`` is configured, 
+   pcap files will not be deleted after processing.
 
 .. _cmdline-option-pcap-file-buffer-size:
 

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -115,6 +115,7 @@
 #include "decode-vntag.h"
 #include "decode-vxlan.h"
 #include "decode-pppoe.h"
+#include "source-pcap-file-helper.h"
 
 #include "output-json-stats.h"
 
@@ -210,6 +211,7 @@ static void RegisterUnittests(void)
     StreamingBufferRegisterTests();
     MacSetRegisterTests();
     FlowRateRegisterTests();
+    SourcePcapFileHelperRegisterTests();
 #ifdef OS_WIN32
     Win32SyscallRegisterTests();
 #endif

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -28,34 +28,59 @@
 #include "util-datalink.h"
 #include "util-checksum.h"
 #include "util-profiling.h"
-#include "source-pcap-file.h"
 #include "util-exception-policy.h"
+#include "conf-yaml-loader.h"
 
 extern uint32_t max_pending_packets;
 extern PcapFileGlobalVars pcap_g;
 
 static void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt);
 
+static void PcapFileReleasePacket(Packet *p)
+{
+    PcapFileFileVars *pfv = p->pcap_v.pfv;
+    if (pfv != NULL) {
+        /* Count alerts per pcap file for "non-alerts" deletion mode.
+         * Global alert statistics are still maintained in DetectRunPostRules
+         * for all capture modes. */
+        PcapFileFinalizePacket(pfv, p->alerts.cnt);
+    }
+
+    PacketFreeOrRelease(p);
+}
+
 void CleanupPcapFileFileVars(PcapFileFileVars *pfv)
 {
-    if (pfv != NULL) {
-        if (pfv->pcap_handle != NULL) {
-            pcap_close(pfv->pcap_handle);
-            pfv->pcap_handle = NULL;
-        }
-        if (pfv->filename != NULL) {
-            if (pfv->shared != NULL && pfv->shared->should_delete) {
-                SCLogDebug("Deleting pcap file %s", pfv->filename);
-                if (unlink(pfv->filename) != 0) {
-                    SCLogWarning("Failed to delete %s: %s", pfv->filename, strerror(errno));
-                }
-            }
-            SCFree(pfv->filename);
-            pfv->filename = NULL;
-        }
-        pfv->shared = NULL;
-        SCFree(pfv);
+    if (pfv == NULL) {
+        return;
     }
+
+    /* If there are still packets in flight, defer ALL cleanup actions, including
+     * the deletion decision, until the last packet completes. */
+    if (SC_ATOMIC_GET(pfv->ref_cnt) != 0) {
+        pfv->cleanup_requested = true;
+        return;
+    }
+
+    /* No packets in flight anymore: it's now safe to close, decide, and delete. */
+    if (pfv->pcap_handle != NULL) {
+        pcap_close(pfv->pcap_handle);
+        pfv->pcap_handle = NULL;
+    }
+
+    if (pfv->filename != NULL) {
+        if (PcapFileShouldDeletePcapFile(pfv)) {
+            SCLogDebug("Deleting pcap file %s", pfv->filename);
+            if (unlink(pfv->filename) != 0) {
+                SCLogWarning("Failed to delete %s: %s", pfv->filename, strerror(errno));
+            }
+        }
+        SCFree(pfv->filename);
+        pfv->filename = NULL;
+    }
+
+    pfv->shared = NULL;
+    SCFree(pfv);
 }
 
 void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
@@ -74,6 +99,8 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     if (unlikely(p == NULL)) {
         SCReturn;
     }
+    SC_ATOMIC_ADD(ptv->ref_cnt, 1);
+
     PACKET_PROFILING_TMM_START(p, TMM_RECEIVEPCAPFILE);
 
     PKT_SET_SRC(p, PKT_SRC_WIRE);
@@ -83,8 +110,11 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     p->pcap_cnt = ++pcap_g.cnt;
 
     p->pcap_v.tenant_id = ptv->shared->tenant_id;
+    p->pcap_v.pfv = ptv;
     ptv->shared->pkts++;
     ptv->shared->bytes += h->caplen;
+
+    p->ReleasePacket = PcapFileReleasePacket;
 
     if (unlikely(PacketCopyData(p, pkt, h->caplen))) {
         TmqhOutputPacketpool(ptv->shared->tv, p);
@@ -236,6 +266,14 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
         pcap_freecode(&pfv->filter);
     }
 
+    SC_ATOMIC_INIT(pfv->alerts_count);
+    SC_ATOMIC_SET(pfv->alerts_count, 0);
+
+    SC_ATOMIC_INIT(pfv->ref_cnt);
+    SC_ATOMIC_SET(pfv->ref_cnt, 0);
+
+    pfv->cleanup_requested = false;
+
     pfv->datalink = pcap_datalink(pfv->pcap_handle);
     SCLogDebug("datalink %" PRId32 "", pfv->datalink);
     DatalinkSetGlobalType(pfv->datalink);
@@ -285,3 +323,507 @@ TmEcode ValidateLinkType(int datalink, DecoderFunc *DecoderFn)
 
     SCReturnInt(TM_ECODE_OK);
 }
+
+bool PcapFileShouldDeletePcapFile(PcapFileFileVars *pfv)
+{
+    if (pfv == NULL || pfv->shared == NULL) {
+        return false;
+    }
+
+    if (pfv->shared->delete_mode == PCAP_FILE_DELETE_NONE) {
+        return false;
+    }
+
+    if (pfv->shared->delete_mode == PCAP_FILE_DELETE_ALWAYS) {
+        return true;
+    }
+
+    /* PCAP_FILE_DELETE_NON_ALERTS mode */
+    uint64_t file_alerts = SC_ATOMIC_GET(pfv->alerts_count);
+
+    if (file_alerts != 0) {
+        SCLogDebug("Skipping deletion of %s due to %" PRIu64 " alert(s) generated.", pfv->filename,
+                file_alerts);
+        return false;
+    }
+
+    return true;
+}
+
+void PcapFileFinalizePacket(PcapFileFileVars *pfv, uint16_t alert_count)
+{
+    if (pfv != NULL) {
+        if (alert_count > 0) {
+            SC_ATOMIC_ADD(pfv->alerts_count, alert_count);
+        }
+        /* decrease ref count as packet is done */
+        /* if this was the last reference, and cleanup was requested, free now */
+        if (SC_ATOMIC_SUB(pfv->ref_cnt, 1) == 1) {
+            if (pfv->cleanup_requested) {
+                CleanupPcapFileFileVars(pfv);
+            }
+        }
+    }
+}
+
+PcapFileDeleteMode PcapFileParseDeleteMode(void)
+{
+    PcapFileDeleteMode delete_mode = PCAP_FILE_DELETE_NONE;
+    const char *delete_when_done_str = NULL;
+
+    if (SCConfGet("pcap-file.delete-when-done", &delete_when_done_str) == 1) {
+        if (strcmp(delete_when_done_str, "non-alerts") == 0) {
+            delete_mode = PCAP_FILE_DELETE_NON_ALERTS;
+        } else {
+            int delete_always = 0;
+            if (SCConfGetBool("pcap-file.delete-when-done", &delete_always) == 1) {
+                if (delete_always == 1) {
+                    delete_mode = PCAP_FILE_DELETE_ALWAYS;
+                }
+            }
+        }
+    }
+
+    return delete_mode;
+}
+
+#ifdef UNITTESTS
+#include "util-unittest-helper.h"
+/**
+ * \test Tests that the PcapFileShouldDeletePcapFile function correctly applies the
+ * delete mode configuration.
+ */
+static int SourcePcapFileHelperTest01(void)
+{
+    PcapFileSharedVars shared;
+    memset(&shared, 0, sizeof(shared));
+    shared.delete_mode = PCAP_FILE_DELETE_ALWAYS;
+
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    pfv.shared = &shared;
+    pfv.filename = SCStrdup("test.pcap");
+    SC_ATOMIC_INIT(pfv.alerts_count);
+    SC_ATOMIC_SET(pfv.alerts_count, 0);
+
+    /* Test case 1: Always delete mode */
+    int result1 = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF_NOT(result1);
+
+    /* Test case 2: Non-alerts mode with no alerts */
+    shared.delete_mode = PCAP_FILE_DELETE_NON_ALERTS;
+    int result2 = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF_NOT(result2);
+
+    /* Test case 3: Non-alerts mode with alerts */
+    SC_ATOMIC_ADD(pfv.alerts_count, 1);
+    int result3 = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(result3);
+
+    /* Test case 4: Always delete mode with alerts */
+    shared.delete_mode = PCAP_FILE_DELETE_ALWAYS;
+    int result4 = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF_NOT(result4);
+
+    /* Test case 5: No delete mode */
+    shared.delete_mode = PCAP_FILE_DELETE_NONE;
+    int result5 = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(result5);
+
+    SCFree(pfv.filename);
+
+    PASS;
+}
+
+/**
+ * \test Test PcapFileFinalizePacket function with reference counting
+ */
+static int SourcePcapFileHelperTest02(void)
+{
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    SC_ATOMIC_INIT(pfv.alerts_count);
+    SC_ATOMIC_SET(pfv.alerts_count, 0);
+    SC_ATOMIC_INIT(pfv.ref_cnt);
+    SC_ATOMIC_SET(pfv.ref_cnt, 0);
+    pfv.cleanup_requested = false;
+
+    /* Test adding alerts with reference counting */
+    SC_ATOMIC_ADD(pfv.ref_cnt, 1); /* simulate packet in flight */
+    PcapFileFinalizePacket(&pfv, 5);
+    uint64_t count = SC_ATOMIC_GET(pfv.alerts_count);
+    FAIL_IF_NOT(count == 5);
+    FAIL_IF_NOT(SC_ATOMIC_GET(pfv.ref_cnt) == 0); /* should be decremented */
+
+    /* Test adding more alerts */
+    SC_ATOMIC_ADD(pfv.ref_cnt, 1);
+    PcapFileFinalizePacket(&pfv, 3);
+    count = SC_ATOMIC_GET(pfv.alerts_count);
+    FAIL_IF_NOT(count == 8);
+
+    /* Test with zero alerts (should not increment count) */
+    SC_ATOMIC_ADD(pfv.ref_cnt, 1);
+    PcapFileFinalizePacket(&pfv, 0);
+    count = SC_ATOMIC_GET(pfv.alerts_count);
+    FAIL_IF_NOT(count == 8);
+
+    /* Test with NULL pfv (should not crash) */
+    PcapFileFinalizePacket(NULL, 10);
+
+    PASS;
+}
+
+/* Mock for configuration testing */
+static int SetupYamlConf(const char *conf_string)
+{
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    return SCConfYamlLoadString(conf_string, strlen(conf_string));
+}
+
+static void CleanupYamlConf(void)
+{
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+}
+
+/**
+ * \test Test PcapFileParseDeleteMode with all configuration combinations
+ */
+static int SourcePcapFileHelperTest03(void)
+{
+    /* Test 1: No configuration (should default to NONE) */
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    PcapFileDeleteMode result = PcapFileParseDeleteMode();
+    FAIL_IF_NOT(result == PCAP_FILE_DELETE_NONE);
+
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+
+    /* Test 2: "false" configuration */
+    const char *conf_false = "%YAML 1.1\n"
+                             "---\n"
+                             "pcap-file:\n"
+                             "  delete-when-done: false\n";
+
+    SetupYamlConf(conf_false);
+    result = PcapFileParseDeleteMode();
+    FAIL_IF_NOT(result == PCAP_FILE_DELETE_NONE);
+    CleanupYamlConf();
+
+    /* Test 3: "true" configuration */
+    const char *conf_true = "%YAML 1.1\n"
+                            "---\n"
+                            "pcap-file:\n"
+                            "  delete-when-done: true\n";
+
+    SetupYamlConf(conf_true);
+    result = PcapFileParseDeleteMode();
+    FAIL_IF_NOT(result == PCAP_FILE_DELETE_ALWAYS);
+    CleanupYamlConf();
+
+    /* Test 4: "non-alerts" configuration */
+    const char *conf_non_alerts = "%YAML 1.1\n"
+                                  "---\n"
+                                  "pcap-file:\n"
+                                  "  delete-when-done: \"non-alerts\"\n";
+
+    SetupYamlConf(conf_non_alerts);
+    result = PcapFileParseDeleteMode();
+    FAIL_IF_NOT(result == PCAP_FILE_DELETE_NON_ALERTS);
+    CleanupYamlConf();
+
+    /* Test 5: Invalid configuration (should default to NONE) */
+    const char *conf_invalid = "%YAML 1.1\n"
+                               "---\n"
+                               "pcap-file:\n"
+                               "  delete-when-done: \"invalid-value\"\n";
+
+    SetupYamlConf(conf_invalid);
+    result = PcapFileParseDeleteMode();
+    FAIL_IF_NOT(result == PCAP_FILE_DELETE_NONE);
+    CleanupYamlConf();
+
+    PASS;
+}
+
+/**
+ * \test pfv is NULL.
+ */
+static int SourcePcapFileHelperTest04(void)
+{
+    int rc = PcapFileShouldDeletePcapFile(NULL);
+    FAIL_IF(rc);
+    PASS;
+}
+
+/**
+ * \test pfv->shared is NULL.
+ */
+static int SourcePcapFileHelperTest05(void)
+{
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+
+    int rc = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(rc);
+    PASS;
+}
+
+/**
+ * \test Test cleanup with reference counting and deferred deletion
+ */
+static int SourcePcapFileHelperTest06(void)
+{
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    SC_ATOMIC_INIT(pfv.alerts_count);
+    SC_ATOMIC_SET(pfv.alerts_count, 0);
+    SC_ATOMIC_INIT(pfv.ref_cnt);
+    SC_ATOMIC_SET(pfv.ref_cnt, 2); /* simulate 2 packets in flight */
+    pfv.cleanup_requested = false;
+
+    /* Simulate first packet completion - should not cleanup yet */
+    SC_ATOMIC_SUB(pfv.ref_cnt, 1);
+    FAIL_IF_NOT(SC_ATOMIC_GET(pfv.ref_cnt) == 1);
+
+    /* Request cleanup while packets are still in flight */
+    pfv.cleanup_requested = true;
+
+    /* Simulate second packet completion - should trigger cleanup */
+    if (SC_ATOMIC_SUB(pfv.ref_cnt, 1) == 1) {
+        FAIL_IF_NOT(pfv.cleanup_requested); /* cleanup should have been requested */
+        /* In real code, CleanupPcapFileFileVars would be called here */
+    }
+
+    PASS;
+}
+
+/**
+ * \test Test edge cases and error conditions
+ */
+static int SourcePcapFileHelperTest07(void)
+{
+    /* Test 1: PcapFileShouldDeletePcapFile with very high alert count */
+    PcapFileSharedVars shared;
+    memset(&shared, 0, sizeof(shared));
+    shared.delete_mode = PCAP_FILE_DELETE_NON_ALERTS;
+
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    pfv.shared = &shared;
+    pfv.filename = SCStrdup("test.pcap");
+    SC_ATOMIC_INIT(pfv.alerts_count);
+    SC_ATOMIC_SET(pfv.alerts_count, UINT64_MAX); /* max value */
+
+    int result = PcapFileShouldDeletePcapFile(&pfv);
+    FAIL_IF(result); /* should not delete with max alerts */
+
+    /* Test 2: PcapFileFinalizePacket with max alert count */
+    SC_ATOMIC_INIT(pfv.ref_cnt);
+    SC_ATOMIC_ADD(pfv.ref_cnt, 1);
+    PcapFileFinalizePacket(&pfv, UINT16_MAX); /* max uint16_t */
+    /* Should not overflow or crash */
+
+    SCFree(pfv.filename);
+    PASS;
+}
+
+/**
+ * \test Test command-line --pcap-file-delete override behavior
+ */
+static int SourcePcapFileHelperTest08(void)
+{
+    /* Test 1: Command line overrides YAML "false" */
+    const char *conf_false = "%YAML 1.1\n"
+                             "---\n"
+                             "pcap-file:\n"
+                             "  delete-when-done: false\n";
+
+    SetupYamlConf(conf_false);
+
+    /* Simulate --pcap-file-delete command line option */
+    int set_result = SCConfSetFinal("pcap-file.delete-when-done", "true");
+    FAIL_IF_NOT(set_result == 1);
+
+    PcapFileDeleteMode result = PcapFileParseDeleteMode();
+    FAIL_IF_NOT(result == PCAP_FILE_DELETE_ALWAYS); /* Should override YAML false */
+    CleanupYamlConf();
+
+    /* Test 2: Command line overrides YAML "non-alerts" */
+    const char *conf_non_alerts = "%YAML 1.1\n"
+                                  "---\n"
+                                  "pcap-file:\n"
+                                  "  delete-when-done: \"non-alerts\"\n";
+
+    SetupYamlConf(conf_non_alerts);
+
+    /* Simulate --pcap-file-delete command line option */
+    set_result = SCConfSetFinal("pcap-file.delete-when-done", "true");
+    FAIL_IF_NOT(set_result == 1);
+
+    result = PcapFileParseDeleteMode();
+    FAIL_IF_NOT(result == PCAP_FILE_DELETE_ALWAYS); /* Should override YAML "non-alerts" */
+    CleanupYamlConf();
+
+    /* Test 3: Command line overrides no YAML config */
+    SCConfCreateContextBackup();
+    SCConfInit();
+
+    /* Simulate --pcap-file-delete command line option with no YAML config */
+    set_result = SCConfSetFinal("pcap-file.delete-when-done", "true");
+    FAIL_IF_NOT(set_result == 1);
+
+    result = PcapFileParseDeleteMode();
+    FAIL_IF_NOT(result == PCAP_FILE_DELETE_ALWAYS); /* Should set to always delete */
+
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+
+    PASS;
+}
+
+/**
+ * \test Test that cleanup defers while packets are in flight and that a file
+ * with alerts is not deleted in NON_ALERTS mode.
+ */
+static int SourcePcapFileHelperTest09(void)
+{
+    PcapFileSharedVars *shared = SCCalloc(1, sizeof(*shared));
+    FAIL_IF_NULL(shared);
+    shared->delete_mode = PCAP_FILE_DELETE_NON_ALERTS;
+
+    PcapFileFileVars *pfv = SCCalloc(1, sizeof(*pfv));
+    FAIL_IF_NULL(pfv);
+    pfv->shared = shared;
+    pfv->filename = SCStrdup("unit_del_test.pcap");
+    FAIL_IF_NULL(pfv->filename);
+
+    SC_ATOMIC_INIT(pfv->alerts_count);
+    SC_ATOMIC_SET(pfv->alerts_count, 0);
+    SC_ATOMIC_INIT(pfv->ref_cnt);
+    SC_ATOMIC_SET(pfv->ref_cnt, 2); /* two packets in flight */
+    pfv->cleanup_requested = false;
+
+    /* Request cleanup while packets still in flight: should defer. */
+    CleanupPcapFileFileVars(pfv);
+    FAIL_IF_NOT(pfv->cleanup_requested);
+    FAIL_IF_NULL(pfv->filename); /* not freed yet */
+
+    /* First packet completes and generates an alert. */
+    PcapFileFinalizePacket(pfv, 1);
+    FAIL_IF_NOT(SC_ATOMIC_GET(pfv->alerts_count) == 1);
+
+    /* Second (last) packet completes: triggers final cleanup. */
+    PcapFileFinalizePacket(pfv, 0);
+
+    /* pfv memory is freed at this point; only free shared. */
+    SCFree(shared);
+
+    PASS;
+}
+
+/**
+ * \test Cover unlink-on-ALWAYS branch (ref_cnt == 0) and deferred deletion when ref_cnt > 0
+ */
+static int SourcePcapFileHelperTest10(void)
+{
+    /* Create a temporary file that we expect to be deleted. */
+    const char *tmpname = "suri_ut_delete_always.pcap";
+    const uint8_t dummy[] = { 0x00 };
+    int rc = TestHelperBufferToFile(tmpname, dummy, sizeof(dummy));
+    FAIL_IF_NOT(rc >= 0);
+
+    /* Case 1: delete ALWAYS with no packets in flight -> file unlinked immediately */
+    PcapFileSharedVars *shared1 = SCCalloc(1, sizeof(*shared1));
+    FAIL_IF_NULL(shared1);
+    shared1->delete_mode = PCAP_FILE_DELETE_ALWAYS;
+
+    PcapFileFileVars *pfv1 = SCCalloc(1, sizeof(*pfv1));
+    FAIL_IF_NULL(pfv1);
+    pfv1->shared = shared1;
+    pfv1->filename = SCStrdup(tmpname);
+    FAIL_IF_NULL(pfv1->filename);
+
+    SC_ATOMIC_INIT(pfv1->alerts_count);
+    SC_ATOMIC_SET(pfv1->alerts_count, 0);
+    SC_ATOMIC_INIT(pfv1->ref_cnt);
+    SC_ATOMIC_SET(pfv1->ref_cnt, 0);
+
+    /* Provide a closable handle to cover close path. */
+    pfv1->pcap_handle = pcap_open_dead(DLT_EN10MB, 65535);
+    FAIL_IF_NULL(pfv1->pcap_handle);
+
+    CleanupPcapFileFileVars(pfv1);
+
+    /* File should be gone. */
+    FILE *f = fopen(tmpname, "rb");
+    FAIL_IF_NOT_NULL(f);
+    if (f != NULL)
+        fclose(f);
+
+    /* Case 2: delete ALWAYS but ref_cnt > 0 -> defer until finalize. */
+    /* Recreate the file. */
+    rc = TestHelperBufferToFile(tmpname, dummy, sizeof(dummy));
+    FAIL_IF_NOT(rc >= 0);
+
+    PcapFileSharedVars *shared2 = SCCalloc(1, sizeof(*shared2));
+    FAIL_IF_NULL(shared2);
+    shared2->delete_mode = PCAP_FILE_DELETE_ALWAYS;
+
+    PcapFileFileVars *pfv2 = SCCalloc(1, sizeof(*pfv2));
+    FAIL_IF_NULL(pfv2);
+    pfv2->shared = shared2;
+    pfv2->filename = SCStrdup(tmpname);
+    FAIL_IF_NULL(pfv2->filename);
+
+    SC_ATOMIC_INIT(pfv2->alerts_count);
+    SC_ATOMIC_SET(pfv2->alerts_count, 0);
+    SC_ATOMIC_INIT(pfv2->ref_cnt);
+    SC_ATOMIC_SET(pfv2->ref_cnt, 1);
+    pfv2->pcap_handle = pcap_open_dead(DLT_EN10MB, 65535);
+    FAIL_IF_NULL(pfv2->pcap_handle);
+
+    CleanupPcapFileFileVars(pfv2);
+
+    /* Still exists now because deletion should be deferred. */
+    f = fopen(tmpname, "rb");
+    FAIL_IF_NULL(f);
+    if (f != NULL)
+        fclose(f);
+
+    /* Finalize the last packet which should trigger final cleanup & unlink. */
+    PcapFileFinalizePacket(pfv2, 0);
+
+    /* Now the file should be gone. */
+    f = fopen(tmpname, "rb");
+    FAIL_IF_NOT_NULL(f);
+    if (f != NULL)
+        fclose(f);
+
+    SCFree(shared1);
+    SCFree(shared2);
+
+    PASS;
+}
+
+/**
+ * \brief Register unit tests for pcap file helper
+ */
+void SourcePcapFileHelperRegisterTests(void)
+{
+    UtRegisterTest("SourcePcapFileHelperTest01", SourcePcapFileHelperTest01);
+    UtRegisterTest("SourcePcapFileHelperTest02", SourcePcapFileHelperTest02);
+    UtRegisterTest("SourcePcapFileHelperTest03", SourcePcapFileHelperTest03);
+    UtRegisterTest("SourcePcapFileHelperTest04", SourcePcapFileHelperTest04);
+    UtRegisterTest("SourcePcapFileHelperTest05", SourcePcapFileHelperTest05);
+    UtRegisterTest("SourcePcapFileHelperTest06", SourcePcapFileHelperTest06);
+    UtRegisterTest("SourcePcapFileHelperTest07", SourcePcapFileHelperTest07);
+    UtRegisterTest("SourcePcapFileHelperTest08", SourcePcapFileHelperTest08);
+    UtRegisterTest("SourcePcapFileHelperTest09", SourcePcapFileHelperTest09);
+    UtRegisterTest("SourcePcapFileHelperTest10", SourcePcapFileHelperTest10);
+}
+#endif /* UNITTESTS */

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -23,9 +23,16 @@
 
 #include "suricata-common.h"
 #include "tm-threads.h"
+#include "util-atomic.h"
 
 #ifndef SURICATA_SOURCE_PCAP_FILE_HELPER_H
 #define SURICATA_SOURCE_PCAP_FILE_HELPER_H
+
+typedef enum {
+    PCAP_FILE_DELETE_NONE = 0,
+    PCAP_FILE_DELETE_ALWAYS,
+    PCAP_FILE_DELETE_NON_ALERTS
+} PcapFileDeleteMode;
 
 typedef struct PcapFileGlobalVars_ {
     uint64_t cnt; /** packet counter */
@@ -46,7 +53,7 @@ typedef struct PcapFileSharedVars_
 
     struct timespec last_processed;
 
-    bool should_delete;
+    PcapFileDeleteMode delete_mode;
 
     ThreadVars *tv;
     TmSlot *slot;
@@ -75,6 +82,10 @@ typedef struct PcapFileFileVars_
     struct bpf_program filter;
 
     PcapFileSharedVars *shared;
+
+    SC_ATOMIC_DECLARE(uint64_t, alerts_count);
+    SC_ATOMIC_DECLARE(uint32_t, ref_cnt);
+    bool cleanup_requested;
 
     /* fields used to get the first packet's timestamp early,
      * so it can be used to setup the time subsys. */
@@ -120,5 +131,15 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv);
 TmEcode ValidateLinkType(int datalink, DecoderFunc *decoder);
 
 const char *PcapFileGetFilename(void);
+
+bool PcapFileShouldDeletePcapFile(PcapFileFileVars *pfv);
+
+void PcapFileFinalizePacket(PcapFileFileVars *pfv, uint16_t alert_count);
+
+PcapFileDeleteMode PcapFileParseDeleteMode(void);
+
+#ifdef UNITTESTS
+void SourcePcapFileHelperRegisterTests(void);
+#endif
 
 #endif /* SURICATA_SOURCE_PCAP_FILE_HELPER_H */

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -205,7 +205,6 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
     if(ptv->is_directory == 0) {
         SCLogInfo("Starting file run for %s", ptv->behavior.file->filename);
         status = PcapFileDispatch(ptv->behavior.file);
-        CleanupPcapFileFromThreadVars(ptv, ptv->behavior.file);
     } else {
         SCLogInfo("Starting directory run for %s", ptv->behavior.directory->filename);
         PcapDirectoryDispatch(ptv->behavior.directory);
@@ -261,11 +260,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         }
     }
 
-    int should_delete = 0;
-    ptv->shared.should_delete = false;
-    if (SCConfGetBool("pcap-file.delete-when-done", &should_delete) == 1) {
-        ptv->shared.should_delete = should_delete == 1;
-    }
+    ptv->shared.delete_mode = PcapFileParseDeleteMode();
 
     DIR *directory = NULL;
     SCLogDebug("checking file or directory %s", (char*)initdata);
@@ -422,6 +417,11 @@ TmEcode ReceivePcapFileThreadDeinit(ThreadVars *tv, void *data)
     SCEnter();
     if(data != NULL) {
         PcapFileThreadVars *ptv = (PcapFileThreadVars *) data;
+
+        if (!ptv->is_directory && ptv->behavior.file != NULL) {
+            CleanupPcapFileFromThreadVars(ptv, ptv->behavior.file);
+        }
+
         CleanupPcapFileThreadVars(ptv);
     }
     SCReturnInt(TM_ECODE_OK);

--- a/src/source-pcap.h
+++ b/src/source-pcap.h
@@ -24,6 +24,8 @@
 #ifndef SURICATA_SOURCE_PCAP_H
 #define SURICATA_SOURCE_PCAP_H
 
+typedef struct PcapFileFileVars_ PcapFileFileVars;
+
 void TmModuleReceivePcapRegister (void);
 void TmModuleDecodePcapRegister (void);
 void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
@@ -35,6 +37,7 @@ void PcapTranslateIPToDevice(char *pcap_dev, size_t len);
 typedef struct PcapPacketVars_
 {
     uint32_t tenant_id;
+    PcapFileFileVars *pfv;
 } PcapPacketVars;
 
 /** needs to be able to contain Windows adapter id's, so

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -891,7 +891,9 @@ pcap-file:
   # buffer-size: 128 KiB
 
   # tenant-id: none # applies in multi-tenant environment with "direct" selector
-  # delete-when-done: false # applies to file and directory
+  # Applies to file and directory. Options: false (no deletion), true (always delete),
+  #   "non-alerts" (delete only files with no alerts)
+  # delete-when-done: false
 
   # PCAP Directory Processing options
   # recursive: false


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/issues/7786?next_issue_id=7785

Describe changes:
Allowing change the behaviour of --pcap-file-delete to only delete pcaps with no alerts via config.

Previous PR: https://github.com/OISF/suricata/pull/13881
Changes:
- nit fixes for tests.
- fix tests for cross platform.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2656
