### PR TITLE
Dpdk rte flow drop filter v3

### DIFF
--- a/doc/userguide/capture-hardware/dpdk.rst
+++ b/doc/userguide/capture-hardware/dpdk.rst
@@ -239,3 +239,56 @@ Encapsulation stripping
 Suricata supports stripping the hardware-offloaded encapsulation stripping on
 the supported NICs. Currently, VLAN encapsulation stripping is supported.
 VLAN encapsulation stripping can be enabled with `vlan-strip-offload`.
+
+Drop filter
+-----------------------------
+
+Drop filter can improve the performance of Suricata by filtering 
+used-predefined flows directly in the Network interface card. The user can 
+specify unwanted flows before the start of Suricata. These flows are not going to be 
+inspected by Suricata and will be ignored for the whole run of the program.
+
+The syntax for drop filter in Suricata is similar to the dpdk-testpmd application
+rule syntax, although in Suricata, only the "pattern" section is applicable. 
+The user can define multiple rules, either to match specific flow 
+or a range of flows (e.g. using ip or port masks).
+
+Patterns currently supported by this feature are listed in 
+"src/util-dpdk-rte-flow-pattern.c" in "enum index next_item[]" 
+and their corresponding attributes in "enum index item_<pattern>[]".
+
+This feature is supported and tested only on NICs wih mlx5, ice and i40e 
+drivers. The level of functionality varies between these cards, 
+the most versatile are cards with mlx5 drivers.
+
+ice does not support broad patterns; some pattern item has to have
+specification, e.g., "pattern eth / ipv4 / end" raises an error but
+"pattern eth / ipv4 src is x / end" or "eth / ipv4 / tcp src is x" works fine.
+
+i40e does not support different item sets on the same pattern item type,
+e.g., if the first rule is in the form "pattern eth / ipv4 src is x / end",
+then if any other rule contains an ipv4 pattern type, it needs to have
+exclusively attribute src.
+
+The configuration for the drop filter can be found and modified in the 
+DPDK section of the suricata.yaml file.
+
+Additionally, mlx5 and ice drivers are able to gather statistics about filtered flows.
+The number of filtered packets is stored in dpdk.rte_flow_filtered field in eve.json.
+ice driver gathers statistics only in the case when all of the rules match one specific flow
+(e.g. mask can not be used).
+
+Below is a sample configuration that demonstrates how to filter specific flow and a range of flows:
+
+::
+
+  ...
+  dpdk:
+      eal-params:
+        proc-type: primary
+
+      interfaces:
+        - interface: 0000:3b:00.0
+          drop-filter:
+            - rule: "pattern eth / ipv4 src is 192.11.120.50 / tcp / end"
+            - rule: "pattern eth / ipv4 src is 170.22.40.0 src mask 255.255.255.0 / tcp / end"

--- a/doc/userguide/capture-hardware/dpdk.rst
+++ b/doc/userguide/capture-hardware/dpdk.rst
@@ -243,42 +243,57 @@ VLAN encapsulation stripping can be enabled with `vlan-strip-offload`.
 Drop filter
 -----------------------------
 
-Drop filter can improve the performance of Suricata by filtering 
-used-predefined flows directly in the Network interface card. The user can 
-specify unwanted flows before the start of Suricata. These flows are not going to be 
-inspected by Suricata and will be ignored for the whole run of the program.
+The drop filter can improve Suricata's performance by filtering
+user-predefined traffic patterns directly in the NIC. The user can
+specify unwanted traffic patterns before starting Suricata. The specified 
+traffic is not going to be inspected by Suricata and will be ignored for the whole run of the program.
+On some PMDs, the statistics of matched rules are gathered and stored in eve.json.
 
-The syntax for drop filter in Suricata is similar to the dpdk-testpmd application
-rule syntax, although in Suricata, only the "pattern" section is applicable. 
-The user can define multiple rules, either to match specific flow 
-or a range of flows (e.g. using ip or port masks).
+The syntax for the drop filter in Suricata is similar to the dpdk-testpmd application
+rule syntax, although only the "pattern" section is applicable in Suricata.
+The user can define multiple rules, either to match a specific flow
+or a broad section of incoming network traffic (e.g., using ip and port masks, matching on specific protocols ...).
 
-Patterns currently supported by this feature are listed in 
-"src/util-dpdk-rte-flow-pattern.c" in "enum index next_item[]" 
+Patterns currently supported by this feature are listed in
+"src/util-dpdk-rte-flow-pattern.c" in "enum index next_item[]"
 and their corresponding attributes in "enum index item_<pattern>[]".
 
-This feature is supported and tested only on NICs wih mlx5, ice and i40e 
-drivers. The level of functionality varies between these cards, 
-the most versatile are cards with mlx5 drivers.
+.. literalinclude:: ../../../src/util-dpdk-rte-flow-pattern.c
+    :language: c
+    :start-at: /* --- start pattern enum --- */
+    :end-at: /* --- end pattern enum --- */
 
-ice does not support broad patterns; some pattern item has to have
-specification, e.g., "pattern eth / ipv4 / end" raises an error but
-"pattern eth / ipv4 src is x / end" or "eth / ipv4 / tcp src is x" works fine.
 
-i40e does not support different item sets on the same pattern item type,
-e.g., if the first rule is in the form "pattern eth / ipv4 src is x / end",
-then if any other rule contains an ipv4 pattern type, it needs to have
-exclusively attribute src.
+This feature is supported and tested only on NICs with mlx5, ice, and i40e drivers.
+Some of the drivers also support collecting statistics about dropped traffic
+(visible in dpdk.rte_flow_filtered in eve.json).
+The level of functionality varies between these cards, as specified below:
 
-The configuration for the drop filter can be found and modified in the 
-DPDK section of the suricata.yaml file.
+* ice:
 
-Additionally, mlx5 and ice drivers are able to gather statistics about filtered flows.
-The number of filtered packets is stored in dpdk.rte_flow_filtered field in eve.json.
-ice driver gathers statistics only in the case when all of the rules match one specific flow
-(e.g. mask can not be used).
+  The driver does not support broad (wildcard) patterns; some pattern item has to have
+  specification, e.g., ``pattern eth / ipv4 / end`` raises an error but
+  ``pattern eth / ipv4 src is x / end`` or ``pattern eth / ipv4 / tcp src is x`` works fine.
+  It also supports gathering statistics of the filtered packets, but only
+  when none of the rules use wildcard patterns (e.g., mask can not be used).
 
-Below is a sample configuration that demonstrates how to filter specific flow and a range of flows:
+* i40e:
+
+  The driver does not support different item sets on the same pattern item type,
+  e.g., if the first rule is in the form ``pattern eth / ipv4 src is x / end``,
+  then any other rule containing an ipv4 pattern type must exclusively use the src attribute.
+  Statistics of the filtered packets are not supported.
+
+* mlx5:
+
+  The driver is the most versatile PMD, supporting a wide range of patterns.
+  It also supports gathering statistics of the filtered packets without any other constraints.
+
+
+The configuration for the drop filter can be found and modified in the
+DPDK section of suricata.yaml file.
+
+Below is a sample configuration that demonstrates how to filter a specific flow and a range of flows:
 
 ::
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -508,6 +508,8 @@ noinst_HEADERS = \
 	util-dpdk-mlx5.h \
 	util-dpdk-rss.h \
 	util-dpdk.h \
+	util-dpdk-rte-flow.h \
+	util-dpdk-rte-flow-pattern.h \
 	util-ebpf.h \
 	util-enum.h \
 	util-error.h \
@@ -1090,6 +1092,8 @@ libsuricata_c_a_SOURCES = \
 	util-dpdk-mlx5.c \
 	util-dpdk-rss.c \
 	util-dpdk.c \
+	util-dpdk-rte-flow.c \
+	util-dpdk-rte-flow-pattern.c \
 	util-ebpf.c \
 	util-enum.c \
 	util-error.c \

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -47,6 +47,7 @@
 #include "util-dpdk-ice.h"
 #include "util-dpdk-ixgbe.h"
 #include "util-dpdk-rss.h"
+#include "util-dpdk-rte-flow.h"
 #include "util-time.h"
 #include "util-conf.h"
 #include "suricata.h"
@@ -142,6 +143,7 @@ DPDKIfaceConfigAttributes dpdk_yaml = {
     .tx_descriptors = "tx-descriptors",
     .copy_mode = "copy-mode",
     .copy_iface = "copy-iface",
+    .drop_filter = "drop-filter",
 };
 
 /**
@@ -339,6 +341,7 @@ static void DPDKDerefConfig(void *conf)
 
     if (SC_ATOMIC_SUB(iconf->ref, 1) == 1) {
         DPDKDeviceResourcesDeinit(&iconf->pkt_mempools);
+        iconf->RteRulesFree(&iconf->drop_filter);
         SCFree(iconf);
     }
     SCReturn;
@@ -356,6 +359,7 @@ static void ConfigInit(DPDKIfaceConfig **iconf)
     SC_ATOMIC_INIT(ptr->ref);
     (void)SC_ATOMIC_ADD(ptr->ref, 1);
     ptr->DerefFunc = DPDKDerefConfig;
+    ptr->RteRulesFree = RteFlowRuleStorageFree;
     ptr->flags = 0;
 
     *iconf = ptr;
@@ -1024,6 +1028,10 @@ static int ConfigLoad(DPDKIfaceConfig *iconf, const char *iface)
     }
 
     retval = ConfigSetCopyIfaceSettings(iconf, copy_iface_str, copy_mode_str);
+    if (retval < 0)
+        SCReturnInt(retval);
+
+    retval = ConfigLoadRteFlowRules(if_root, dpdk_yaml.drop_filter, &iconf->drop_filter);
     if (retval < 0)
         SCReturnInt(retval);
 

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2021-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -40,6 +40,7 @@ typedef struct DPDKIfaceConfigAttributes_ {
     const char *tx_descriptors;
     const char *copy_mode;
     const char *copy_iface;
+    const char *drop_filter;
 } DPDKIfaceConfigAttributes;
 
 int RunModeIdsDpdkWorkers(void);

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -42,6 +42,7 @@
 #include "tmqh-packetpool.h"
 #include "util-privs.h"
 #include "util-device-private.h"
+#include "util-dpdk-rte-flow.h"
 #include "action-globals.h"
 
 #ifndef HAVE_DPDK
@@ -191,7 +192,8 @@ static inline void DPDKFreeMbufArray(
     }
 }
 
-static void DevicePostStartPMDSpecificActions(DPDKThreadVars *ptv, const char *driver_name)
+static int DevicePostStartPMDSpecificActions(
+        DPDKThreadVars *ptv, DPDKIfaceConfig *dpdk_config, const char *driver_name)
 {
     if (strcmp(driver_name, "net_bonding") == 0)
         driver_name = BondingDeviceDriverGet(ptv->port_id);
@@ -203,6 +205,15 @@ static void DevicePostStartPMDSpecificActions(DPDKThreadVars *ptv, const char *d
         iceDeviceSetRSS(ptv->port_id, ptv->threads, ptv->livedev->dev);
     else if (strcmp(driver_name, "mlx5_pci") == 0)
         mlx5DeviceSetRSS(ptv->port_id, ptv->threads, ptv->livedev->dev);
+
+    if ((strcmp(driver_name, "mlx5_pci") == 0 || strcmp(driver_name, "net_ice") == 0 ||
+                strcmp(driver_name, "net_i40e") == 0)) {
+        int retval =
+                RteFlowRulesCreate(dpdk_config->port_id, &dpdk_config->drop_filter, driver_name);
+        if (retval != 0)
+            SCReturnInt(retval);
+    }
+    SCReturnInt(0);
 }
 
 static void DevicePreClosePMDSpecificActions(DPDKThreadVars *ptv, const char *driver_name)
@@ -678,8 +689,11 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
             SCLogWarning("%s: link is down, trying to continue anyway", dpdk_config->iface);
         }
 
-        // some PMDs requires additional actions only after the device has started
-        DevicePostStartPMDSpecificActions(ptv, dev_info.driver_name);
+        /* some PMDs requires additional actions only after the device has started */
+        retval = DevicePostStartPMDSpecificActions(ptv, dpdk_config, dev_info.driver_name);
+        if (retval != 0) {
+            goto fail;
+        }
 
         uint16_t inconsistent_numa_cnt = SC_ATOMIC_GET(dpdk_config->inconsistent_numa_cnt);
         if (inconsistent_numa_cnt > 0 && ptv->port_socket_id != SOCKET_ID_ANY) {

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2021-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -26,6 +26,7 @@
 
 #include "suricata-common.h"
 #include "util-dpdk.h"
+#include "util-dpdk-rte-flow.h"
 
 #ifdef HAVE_DPDK
 #include <rte_ethdev.h>
@@ -75,12 +76,14 @@ typedef struct DPDKIfaceConfig_ {
     uint32_t mempool_cache_size;
     DPDKDeviceResources *pkt_mempools;
     uint16_t linkup_timeout; // in seconds how long to wait for link to come up
+    RteFlowRuleStorage drop_filter;
     SC_ATOMIC_DECLARE(uint16_t, ref);
     /* threads bind queue id one by one */
     SC_ATOMIC_DECLARE(uint16_t, queue_id);
     SC_ATOMIC_DECLARE(uint16_t, inconsistent_numa_cnt);
     DPDKWorkerSync *workers_sync;
     void (*DerefFunc)(void *);
+    void (*RteRulesFree)(RteFlowRuleStorage *);
 
     struct rte_flow *flow[100];
 #endif

--- a/src/util-dpdk-common.h
+++ b/src/util-dpdk-common.h
@@ -26,6 +26,7 @@
 
 #ifdef HAVE_DPDK
 
+#include "util-dpdk-rte-flow.h"
 #include <rte_eal.h>
 #include <rte_ethdev.h>
 #ifdef HAVE_DPDK_BOND
@@ -121,6 +122,7 @@ typedef struct {
     struct rte_mempool **pkt_mp;
     uint16_t pkt_mp_cnt;
     uint16_t pkt_mp_capa;
+    RteFlowRuleStorage *drop_filter;
 } DPDKDeviceResources;
 
 int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt);

--- a/src/util-dpdk-ice.c
+++ b/src/util-dpdk-ice.c
@@ -124,6 +124,26 @@ void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf)
     rss_conf->rss_key_len = 52;
 }
 
+/**
+ * \brief Check and log whether pattern is broad / not-specific
+ *        as ice does not support these patterns with counter
+ *        enabled
+ * \param items array of pattern items
+ * \return true if pattern is broad / wildcard, false otherwise
+ */
+bool iceDeviceRteFlowPatternError(struct rte_flow_item *items)
+{
+    SCEnter();
+    int i = 0;
+    while (items[i].type != RTE_FLOW_ITEM_TYPE_END) {
+        if (items[i].spec != NULL) {
+            SCReturnBool(false);
+        }
+        ++i;
+    }
+    SCReturnBool(true);
+}
+
 #endif /* HAVE_DPDK */
 /**
  * @}

--- a/src/util-dpdk-ice.c
+++ b/src/util-dpdk-ice.c
@@ -35,8 +35,10 @@
 #include "util-dpdk-rss.h"
 #include "util-debug.h"
 #include "util-dpdk-bonding.h"
+#include "util-dpdk-rte-flow.h"
 
 #ifdef HAVE_DPDK
+static bool RteFlowRulesContainPatternWildcard(RteFlowRuleStorage *);
 
 static void iceDeviceSetRSSHashFunction(uint64_t *rss_hf)
 {
@@ -142,6 +144,42 @@ bool iceDeviceRteFlowPatternError(struct rte_flow_item *items)
         ++i;
     }
     SCReturnBool(true);
+}
+
+/**
+ * \brief Checks whether at least one pattern contains wildcard matching
+ *
+ * \param patterns array of loaded rte_flow rule patterns from suricata.yaml
+ * \param rule_count number of loaded rte_flow rule patterns
+ * \return true if any pattern contains wildcard matching, false otherwise
+ */
+static bool RteFlowRulesContainPatternWildcard(RteFlowRuleStorage *rule_storage)
+{
+    for (size_t i = 0; i < rule_storage->rule_cnt; i++) {
+        char *pattern = rule_storage->rules[i];
+        if (strstr(pattern, " mask ") != NULL || (strstr(pattern, " last ") != NULL))
+            return true;
+    }
+    return false;
+}
+
+/**
+ * \brief Decide based on the pattern whether rte_flow rules should
+ *        support gathering statistic or not
+ * \param rule_storage struct contaning number of rules and their string instances
+ * \param port_name name of the port
+ * \return true if any pattern contains wildcard, false otherwise
+ */
+bool iceDeviceDecideRteFlowActionType(RteFlowRuleStorage *rule_storage, const char *port_name)
+{
+    if (RteFlowRulesContainPatternWildcard(rule_storage)) {
+        SCLogWarning(
+                "%s: gathering statistic for the rte_flow rule is disabled because of wildcard "
+                "pattern (ice PMD specific)",
+                port_name);
+        return false;
+    }
+    return true;
 }
 
 #endif /* HAVE_DPDK */

--- a/src/util-dpdk-ice.h
+++ b/src/util-dpdk-ice.h
@@ -29,10 +29,12 @@
 #ifdef HAVE_DPDK
 
 #include "util-dpdk.h"
+#include "util-dpdk-rte-flow.h"
 
 int iceDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
 void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf);
 bool iceDeviceRteFlowPatternError(struct rte_flow_item *items);
+bool iceDeviceDecideRteFlowActionType(RteFlowRuleStorage *rule_storage, const char *port_name);
 
 #endif /* HAVE_DPDK */
 

--- a/src/util-dpdk-rss.c
+++ b/src/util-dpdk-rss.c
@@ -104,6 +104,7 @@ int DPDKCreateRSSFlowGeneric(
     rss_conf.types = RTE_ETH_RSS_IPV4 | RTE_ETH_RSS_IPV6;
 
     attr.ingress = 1;
+    attr.priority = 1;
     action[0].type = RTE_FLOW_ACTION_TYPE_RSS;
     action[0].conf = &rss_conf;
     action[1].type = RTE_FLOW_ACTION_TYPE_END;

--- a/src/util-dpdk-rte-flow-pattern.c
+++ b/src/util-dpdk-rte-flow-pattern.c
@@ -143,6 +143,7 @@ static const enum index item_param[] = {
     ZERO,
 };
 
+/* --- start pattern enum --- */
 static const enum index next_item[] = {
     ITEM_END,
     ITEM_VOID,
@@ -171,6 +172,7 @@ static const enum index next_item[] = {
     ITEM_VXLAN_GPE,
     ZERO,
 };
+/* --- end pattern enum --- */
 
 static const enum index item_any[] = {
     ITEM_NEXT,

--- a/src/util-dpdk-rte-flow-pattern.c
+++ b/src/util-dpdk-rte-flow-pattern.c
@@ -1,0 +1,1382 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2016 6WIND S.A.
+ * Copyright 2016 Mellanox Technologies, Ltd
+ *
+ *
+ * Modifications by Adam Kiripolsky:
+ * - The code is a modification of the parser for dpdk-testpmd application
+ *   located in DPDK 25.11 source code at  dpdk/app/testpmd/cmdline_flow.c
+ * - Simplified the parser and it's corresponding parts to parse only
+ *   pattern instead of the whole test-pmd commands
+ * - Add ParsePattern function to utilize the parser from outside
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+
+ * - Neither the name of the Qualys, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ *  \defgroup dpdk pattern parser
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK parser for pattern
+ *
+ */
+
+#include "util-debug.h"
+#include "util-dpdk.h"
+#include "util-dpdk-rte-flow-pattern.h"
+
+#ifdef HAVE_DPDK
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+
+#include <cmdline_parse_etheraddr.h>
+
+#define DATA_BUFFER_SIZE 1024
+
+enum index {
+    /* Special tokens. */
+    ZERO = 0,
+    END,
+
+    /* Create tokens */
+    CREATE,
+
+    /* Common tokens. */
+    COMMON_UNSIGNED,
+    COMMON_MAC_ADDR,
+    COMMON_IPV4_ADDR,
+    COMMON_IPV6_ADDR,
+
+    /* Validate/create pattern. */
+    ITEM_PATTERN,
+    ITEM_PARAM_IS,
+    ITEM_PARAM_SPEC,
+    ITEM_PARAM_LAST,
+    ITEM_PARAM_MASK,
+    ITEM_NEXT,
+    ITEM_END,
+    ITEM_VOID,
+    ITEM_ANY,
+    ITEM_PORT_ID,
+    ITEM_ETH,
+    ITEM_ETH_DST,
+    ITEM_ETH_SRC,
+    ITEM_ETH_TYPE,
+    ITEM_ETH_HAS_VLAN,
+    ITEM_RAW,
+    ITEM_VLAN,
+    ITEM_IPV4,
+    ITEM_IPV4_SRC,
+    ITEM_IPV4_DST,
+    ITEM_IPV6,
+    ITEM_IPV6_SRC,
+    ITEM_IPV6_DST,
+    ITEM_ICMP,
+    ITEM_ICMP_TYPE,
+    ITEM_ICMP_CODE,
+    ITEM_ICMP_IDENT,
+    ITEM_ICMP_SEQ,
+    ITEM_ICMP6,
+    ITEM_ICMP6_TYPE,
+    ITEM_ICMP6_CODE,
+    ITEM_UDP,
+    ITEM_UDP_SRC,
+    ITEM_UDP_DST,
+    ITEM_TCP,
+    ITEM_TCP_SRC,
+    ITEM_TCP_DST,
+    ITEM_TCP_FLAGS,
+    ITEM_SCTP,
+    ITEM_SCTP_SRC,
+    ITEM_SCTP_DST,
+    ITEM_SCTP_TAG,
+    ITEM_SCTP_CKSUM,
+    ITEM_VXLAN,
+    ITEM_E_TAG,
+    ITEM_NVGRE,
+    ITEM_MPLS,
+    ITEM_GRE,
+    ITEM_FUZZY,
+    ITEM_GTP,
+    ITEM_GTPC,
+    ITEM_GTPU,
+    ITEM_GENEVE,
+    ITEM_VXLAN_GPE,
+};
+
+static const enum index item_param[] = {
+    ITEM_PARAM_IS,
+    ITEM_PARAM_SPEC,
+    ITEM_PARAM_LAST,
+    ITEM_PARAM_MASK,
+    ZERO,
+};
+
+static const enum index next_item[] = {
+    ITEM_END,
+    ITEM_VOID,
+    ITEM_ANY,
+    ITEM_PORT_ID,
+    ITEM_ETH,
+    ITEM_RAW,
+    ITEM_VLAN,
+    ITEM_IPV4,
+    ITEM_IPV6,
+    ITEM_ICMP,
+    ITEM_ICMP6,
+    ITEM_UDP,
+    ITEM_TCP,
+    ITEM_SCTP,
+    ITEM_VXLAN,
+    ITEM_E_TAG,
+    ITEM_NVGRE,
+    ITEM_MPLS,
+    ITEM_GRE,
+    ITEM_FUZZY,
+    ITEM_GTP,
+    ITEM_GTPC,
+    ITEM_GTPU,
+    ITEM_GENEVE,
+    ITEM_VXLAN_GPE,
+    ZERO,
+};
+
+static const enum index item_any[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_port_id[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_eth[] = {
+    ITEM_ETH_DST,
+    ITEM_ETH_SRC,
+    ITEM_ETH_TYPE,
+    ITEM_ETH_HAS_VLAN,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_raw[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_vlan[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_ipv4[] = {
+    ITEM_IPV4_SRC,
+    ITEM_IPV4_DST,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_ipv6[] = {
+    ITEM_IPV6_SRC,
+    ITEM_IPV6_DST,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_icmp[] = {
+    ITEM_ICMP_TYPE,
+    ITEM_ICMP_CODE,
+    ITEM_ICMP_IDENT,
+    ITEM_ICMP_SEQ,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_icmp6[] = {
+    ITEM_ICMP6_TYPE,
+    ITEM_ICMP6_CODE,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_udp[] = {
+    ITEM_UDP_SRC,
+    ITEM_UDP_DST,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_tcp[] = {
+    ITEM_TCP_SRC,
+    ITEM_TCP_DST,
+    ITEM_TCP_FLAGS,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_sctp[] = {
+    ITEM_SCTP_SRC,
+    ITEM_SCTP_DST,
+    ITEM_SCTP_TAG,
+    ITEM_SCTP_CKSUM,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_vxlan[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_e_tag[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_nvgre[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_mpls[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gre[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gtp[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gtpc[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gtpu[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_geneve[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_fuzzy[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_vxlan_gpe[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index next_vc_attr[] = {
+    ITEM_PATTERN,
+    ZERO,
+};
+
+/** Maximum number of subsequent tokens and arguments on the stack. */
+#define CTX_STACK_SIZE 16
+
+/** Maximum size for pattern in struct rte_flow_item_raw. */
+#define ITEM_RAW_PATTERN_SIZE 512
+
+/** Static initializer for the args field. */
+#define ARGS(...)                                                                                  \
+    (const struct arg *const[])                                                                    \
+    {                                                                                              \
+        __VA_ARGS__, NULL,                                                                         \
+    }
+
+#define ARGS_ENTRY_HTON(s, f)                                                                      \
+    (&(const struct arg){                                                                          \
+            .hton = 1,                                                                             \
+            .offset = offsetof(s, f),                                                              \
+            .size = sizeof(((s *)0)->f),                                                           \
+    })
+
+#define PRIV_ITEM(t, s)                                                                            \
+    (&(const struct parse_item_priv){                                                              \
+            .type = RTE_FLOW_ITEM_TYPE_##t,                                                        \
+            .size = s,                                                                             \
+    })
+
+/** Static initializer for ARGS() to target a bit-field. */
+#define ARGS_ENTRY_BF(s, f, b)                                                                     \
+    (&(const struct arg){                                                                          \
+            .size = sizeof(s),                                                                     \
+            .mask = (const void *)&(const s){ .f = (1 << (b)) - 1 },                               \
+    })
+
+/** Static initializer for the next field. */
+#define NEXT(...)                                                                                  \
+    (const enum index *const[])                                                                    \
+    {                                                                                              \
+        __VA_ARGS__, NULL,                                                                         \
+    }
+
+/** Static initializer for a NEXT() entry. */
+#define NEXT_ENTRY(...)                                                                            \
+    (const enum index[])                                                                           \
+    {                                                                                              \
+        __VA_ARGS__, ZERO,                                                                         \
+    }
+
+/** Storage size for struct rte_flow_item_raw including pattern. */
+#define ITEM_RAW_SIZE (sizeof(struct rte_flow_item_raw) + ITEM_RAW_PATTERN_SIZE)
+
+/** Token argument. */
+struct arg {
+    uint32_t hton : 1;    /**< Use network byte ordering. */
+    uint32_t sign : 1;    /**< Value is signed. */
+    uint32_t bounded : 1; /**< Value is bounded. */
+    uintmax_t min;        /**< Minimum value if bounded. */
+    uintmax_t max;        /**< Maximum value if bounded. */
+    uint32_t offset;      /**< Relative offset from ctx->object. */
+    uint32_t size;        /**< Field size. */
+    const uint8_t *mask;  /**< Bit-mask to use instead of offset/size. */
+};
+
+struct buffer {
+    enum index command; /**< Flow command. */
+    union {
+        struct {
+            struct rte_flow_attr attr;
+            struct rte_flow_item *pattern;
+            uint32_t pattern_n;
+            uint8_t *data;
+        } vc; /**< Validate/create arguments. */
+
+    } args; /**< Command arguments. */
+};
+
+/** Parser context. */
+struct context {
+    /** Stack of subsequent token lists to process. */
+    const enum index *next[CTX_STACK_SIZE];
+    /** Arguments for stacked tokens. */
+    const void *args[CTX_STACK_SIZE];
+    enum index curr;   /**< Current token index. */
+    enum index prev;   /**< Index of the last token seen. */
+    int next_num;      /**< Number of entries in next[]. */
+    int args_num;      /**< Number of entries in args[]. */
+    uint32_t eol : 1;  /**< EOL has been detected. */
+    uint32_t last : 1; /**< No more arguments. */
+    uint16_t port;     /**< Current port ID (for completions). */
+    uint32_t objdata;  /**< Object-specific data. */
+    void *object;      /**< Address of current object for relative offsets. */
+    void *objmask;     /**< Object a full mask must be written to. */
+};
+
+static struct context cmd_flow_context;
+
+/** Initialize context. */
+static void cmd_flow_context_init(struct context *ctx)
+{
+    /* A full memset() is not necessary. */
+    ctx->curr = ZERO;
+    ctx->prev = ZERO;
+    ctx->next_num = 0;
+    ctx->args_num = 0;
+    ctx->eol = 0;
+    ctx->last = 0;
+    ctx->objdata = 0;
+    ctx->object = NULL;
+    ctx->objmask = NULL;
+}
+
+struct token {
+    /** Type displayed during completion (defaults to "TOKEN"). */
+    const char *type;
+    /** Private data used by parser functions. */
+    const void *priv;
+    /**
+     * Lists of subsequent tokens to push on the stack. Each call to the
+     * parser consumes the last entry of that stack.
+     */
+    const enum index *const *next;
+    /** Arguments stack for subsequent tokens that need them. */
+    const struct arg *const *args;
+    /**
+     * Token-processing callback, returns -1 in case of error, the
+     * length of the matched string otherwise. If NULL, attempts to
+     * match the token name.
+     *
+     * If buf is not NULL, the result should be stored in it according
+     * to context. An error is returned if not large enough.
+     */
+    int (*call)(struct context *ctx, const struct token *token, const char *str, unsigned int len,
+            void *buf, unsigned int size);
+    /** Mandatory token name, no default value. */
+    const char *name;
+};
+
+#if RTE_VERSION < RTE_VERSION_NUM(24, 0, 0, 0)
+/**
+ * Maximum IPv6 address size in bytes.
+ */
+#define RTE_IPV6_ADDR_SIZE 16
+
+/**
+ * IPv6 Address
+ */
+struct rte_ipv6_addr {
+    uint8_t a[RTE_IPV6_ADDR_SIZE];
+};
+#endif /* RTE_VERSION < RTE_VERSION_NUM(24, 0, 0, 0) */
+
+struct parse_item_priv {
+    enum rte_flow_item_type type; /**< Item type. */
+    uint32_t size;                /**< Size of item specification structure. */
+};
+
+static int parse_vc(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_vc_spec(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_init(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_int(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_mac_addr(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_ipv4_addr(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_ipv6_addr(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+
+static int parse_default(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size);
+
+static const struct token token_list[] = {
+
+    /* Starts parsing from ITEM_PATTERN */
+	[ZERO] = {
+		.name = "ZERO",
+		.next = NEXT(NEXT_ENTRY(ITEM_PATTERN)),
+	},
+	/* Create Token, not used directly */
+	[CREATE] = {
+		.name = "create",
+		.next = NEXT(next_vc_attr),
+		.call = parse_vc,
+	},
+    /* Common tokens. */
+	[COMMON_UNSIGNED] = {
+		.name = "{unsigned}",
+		.type = "UNSIGNED",
+		.call = parse_int,
+	},
+	[COMMON_MAC_ADDR] = {
+		.name = "{MAC address}",
+		.type = "MAC-48",
+		.call = parse_mac_addr,
+	},
+	[COMMON_IPV4_ADDR] = {
+		.name = "{IPv4 address}",
+		.type = "IPV4 ADDRESS",
+		.call = parse_ipv4_addr,
+	},
+	[COMMON_IPV6_ADDR] = {
+		.name = "{IPv6 address}",
+		.type = "IPV6 ADDRESS",
+		.call = parse_ipv6_addr,
+	},
+	/* Validate/create pattern. */
+	[ITEM_PATTERN] = {
+		.name = "pattern",
+		.next = NEXT(next_item),
+		.call = parse_init,
+	},
+	[ITEM_PARAM_IS] = {
+		.name = "is",
+		.call = parse_vc_spec,
+	},
+	[ITEM_PARAM_SPEC] = {
+		.name = "spec",
+		.call = parse_vc_spec,
+	},
+	[ITEM_PARAM_LAST] = {
+		.name = "last",
+		.call = parse_vc_spec,
+	},
+	[ITEM_PARAM_MASK] = {
+		.name = "mask",
+		.call = parse_vc_spec,
+	},
+	[ITEM_NEXT] = {
+		.name = "/",
+		.next = NEXT(next_item),
+	},
+    [ITEM_END] = {
+		.name = "end",
+		.priv = PRIV_ITEM(END, 0),
+		.next = NEXT(NEXT_ENTRY(END)),
+		.call = parse_vc,
+	},
+	[ITEM_VOID] = {
+		.name = "void",
+		.priv = PRIV_ITEM(VOID, 0),
+		.next = NEXT(NEXT_ENTRY(ITEM_NEXT)),
+		.call = parse_vc,
+	},
+	[ITEM_ANY] = {
+		.name = "any",
+		.priv = PRIV_ITEM(ANY, sizeof(struct rte_flow_item_any)),
+		.next = NEXT(item_any),
+		.call = parse_vc,
+	},
+	[ITEM_PORT_ID] = {
+		.name = "port_id",
+		.priv = PRIV_ITEM(PORT_ID,
+				  sizeof(struct rte_flow_item_port_id)),
+		.next = NEXT(item_port_id),
+		.call = parse_vc,
+	},
+	[ITEM_RAW] = {
+		.name = "raw",
+		.priv = PRIV_ITEM(RAW, ITEM_RAW_SIZE),
+		.next = NEXT(item_raw),
+		.call = parse_vc,
+	},
+	[ITEM_ETH] = {
+		.name = "eth",
+		.priv = PRIV_ITEM(ETH, sizeof(struct rte_flow_item_eth)),
+		.next = NEXT(item_eth),
+		.call = parse_vc,
+	},
+	[ITEM_ETH_SRC] = {
+		.name = "src",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_MAC_ADDR), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_eth, hdr.src_addr)),
+	},
+	[ITEM_ETH_DST] = {
+		.name = "dst",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_MAC_ADDR), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_eth, hdr.dst_addr)),
+	},
+	[ITEM_ETH_TYPE] = {
+		.name = "type",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_eth, hdr.ether_type)),
+	},
+	[ITEM_ETH_HAS_VLAN] = {
+		.name = "has_vlan",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_BF(struct rte_flow_item_eth,
+					   has_vlan, 1)),
+	},
+	[ITEM_VLAN] = {
+		.name = "vlan",
+		.priv = PRIV_ITEM(VLAN, sizeof(struct rte_flow_item_vlan)),
+		.next = NEXT(item_vlan),
+		.call = parse_vc,
+	},
+	[ITEM_IPV4] = {
+		.name = "ipv4",
+		.priv = PRIV_ITEM(IPV4, sizeof(struct rte_flow_item_ipv4)),
+		.next = NEXT(item_ipv4),
+		.call = parse_vc,
+	},
+	[ITEM_IPV4_SRC] = {
+		.name = "src",
+		.next = NEXT(item_ipv4, NEXT_ENTRY(COMMON_IPV4_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv4,
+					     hdr.src_addr)),
+	},
+	[ITEM_IPV4_DST] = {
+		.name = "dst",
+		.next = NEXT(item_ipv4, NEXT_ENTRY(COMMON_IPV4_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv4,
+					     hdr.dst_addr)),
+	},
+	[ITEM_IPV6] = {
+		.name = "ipv6",
+		.priv = PRIV_ITEM(IPV6, sizeof(struct rte_flow_item_ipv6)),
+		.next = NEXT(item_ipv6),
+		.call = parse_vc,
+	},
+	[ITEM_IPV6_SRC] = {
+		.name = "src",
+		.next = NEXT(item_ipv6, NEXT_ENTRY(COMMON_IPV6_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv6,
+					     hdr.src_addr)),
+	},
+	[ITEM_IPV6_DST] = {
+		.name = "dst",
+		.next = NEXT(item_ipv6, NEXT_ENTRY(COMMON_IPV6_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv6,
+					     hdr.dst_addr)),
+	},
+	[ITEM_ICMP] = {
+		.name = "icmp",
+		.priv = PRIV_ITEM(ICMP, sizeof(struct rte_flow_item_icmp)),
+		.next = NEXT(item_icmp),
+		.call = parse_vc,
+	},
+	[ITEM_ICMP_TYPE] = {
+		.name = "type",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_type)),
+	},
+	[ITEM_ICMP_CODE] = {
+		.name = "code",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_code)),
+	},
+	[ITEM_ICMP_IDENT] = {
+		.name = "ident",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_ident)),
+	},
+	[ITEM_ICMP_SEQ] = {
+		.name = "seq",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_seq_nb)),
+	},
+	[ITEM_UDP] = {
+		.name = "udp",
+		.priv = PRIV_ITEM(UDP, sizeof(struct rte_flow_item_udp)),
+		.next = NEXT(item_udp),
+		.call = parse_vc,
+	},
+	[ITEM_UDP_SRC] = {
+		.name = "src",
+		.next = NEXT(item_udp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_udp,
+					     hdr.src_port)),
+	},
+	[ITEM_UDP_DST] = {
+		.name = "dst",
+		.next = NEXT(item_udp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_udp,
+					     hdr.dst_port)),
+	},
+	[ITEM_TCP] = {
+		.name = "tcp",
+		.priv = PRIV_ITEM(TCP, sizeof(struct rte_flow_item_tcp)),
+		.next = NEXT(item_tcp),
+		.call = parse_vc,
+	},
+	[ITEM_TCP_SRC] = {
+		.name = "src",
+		.next = NEXT(item_tcp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_tcp,
+					     hdr.src_port)),
+	},
+	[ITEM_TCP_DST] = {
+		.name = "dst",
+		.next = NEXT(item_tcp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_tcp,
+					     hdr.dst_port)),
+	},
+	[ITEM_TCP_FLAGS] = {
+		.name = "flags",
+		.next = NEXT(item_tcp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_tcp,
+					     hdr.tcp_flags)),
+	},
+	[ITEM_SCTP] = {
+		.name = "sctp",
+		.priv = PRIV_ITEM(SCTP, sizeof(struct rte_flow_item_sctp)),
+		.next = NEXT(item_sctp),
+		.call = parse_vc,
+	},
+	[ITEM_SCTP_SRC] = {
+		.name = "src",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.src_port)),
+	},
+	[ITEM_SCTP_DST] = {
+		.name = "dst",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.dst_port)),
+	},
+	[ITEM_SCTP_TAG] = {
+		.name = "tag",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.tag)),
+	},
+	[ITEM_SCTP_CKSUM] = {
+		.name = "cksum",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.cksum)),
+	},
+	[ITEM_VXLAN] = {
+		.name = "vxlan",
+		.priv = PRIV_ITEM(VXLAN, sizeof(struct rte_flow_item_vxlan)),
+		.next = NEXT(item_vxlan),
+		.call = parse_vc,
+	},
+	[ITEM_E_TAG] = {
+		.name = "e_tag",
+		.priv = PRIV_ITEM(E_TAG, sizeof(struct rte_flow_item_e_tag)),
+		.next = NEXT(item_e_tag),
+		.call = parse_vc,
+	},
+	[ITEM_NVGRE] = {
+		.name = "nvgre",
+		.priv = PRIV_ITEM(NVGRE, sizeof(struct rte_flow_item_nvgre)),
+		.next = NEXT(item_nvgre),
+		.call = parse_vc,
+	},
+	[ITEM_MPLS] = {
+		.name = "mpls",
+		.priv = PRIV_ITEM(MPLS, sizeof(struct rte_flow_item_mpls)),
+		.next = NEXT(item_mpls),
+		.call = parse_vc,
+	},
+	[ITEM_GRE] = {
+		.name = "gre",
+		.priv = PRIV_ITEM(GRE, sizeof(struct rte_flow_item_gre)),
+		.next = NEXT(item_gre),
+		.call = parse_vc,
+	},
+	[ITEM_FUZZY] = {
+		.name = "fuzzy",
+		.priv = PRIV_ITEM(FUZZY,
+				sizeof(struct rte_flow_item_fuzzy)),
+		.next = NEXT(item_fuzzy),
+		.call = parse_vc,
+	},
+
+	[ITEM_GTP] = {
+		.name = "gtp",
+		.priv = PRIV_ITEM(GTP, sizeof(struct rte_flow_item_gtp)),
+		.next = NEXT(item_gtp),
+		.call = parse_vc,
+	},
+
+	[ITEM_GTPC] = {
+		.name = "gtpc",
+		.priv = PRIV_ITEM(GTPC, sizeof(struct rte_flow_item_gtp)),
+		.next = NEXT(item_gtpc),
+		.call = parse_vc,
+	},
+	[ITEM_GTPU] = {
+		.name = "gtpu",
+		.priv = PRIV_ITEM(GTPU, sizeof(struct rte_flow_item_gtp)),
+		.next = NEXT(item_gtpu),
+		.call = parse_vc,
+	},
+	[ITEM_GENEVE] = {
+		.name = "geneve",
+		.priv = PRIV_ITEM(GENEVE, sizeof(struct rte_flow_item_geneve)),
+		.next = NEXT(item_geneve),
+		.call = parse_vc,
+	},
+	[ITEM_VXLAN_GPE] = {
+		.name = "vxlan-gpe",
+		.priv = PRIV_ITEM(VXLAN_GPE,
+				  sizeof(struct rte_flow_item_vxlan_gpe)),
+		.next = NEXT(item_vxlan_gpe),
+		.call = parse_vc,
+	},
+
+	[ITEM_ICMP6] = {
+		.name = "icmp6",
+		.priv = PRIV_ITEM(ICMP6, sizeof(struct rte_flow_item_icmp6)),
+		.next = NEXT(item_icmp6),
+		.call = parse_vc,
+	},
+
+};
+
+/** Remove and return last entry from argument stack. */
+static const struct arg *pop_args(struct context *ctx)
+{
+    return ctx->args_num ? ctx->args[--ctx->args_num] : NULL;
+}
+
+/** Add entry on top of the argument stack. */
+static int push_args(struct context *ctx, const struct arg *arg)
+{
+    if (ctx->args_num == CTX_STACK_SIZE)
+        return -1;
+    ctx->args[ctx->args_num++] = arg;
+    return 0;
+}
+
+/** Spread value into buffer according to bit-mask. */
+static size_t arg_entry_bf_fill(void *dst, uintmax_t val, const struct arg *arg)
+{
+    uint32_t i = arg->size;
+    uint32_t end = 0;
+    int sub = 1;
+    int add = 0;
+    size_t len = 0;
+
+    if (!arg->mask)
+        return 0;
+#if RTE_BYTE_ORDER == RTE_LITTLE_ENDIAN
+    if (!arg->hton) {
+        i = 0;
+        end = arg->size;
+        sub = 0;
+        add = 1;
+    }
+#endif
+    while (i != end) {
+        unsigned int shift = 0;
+        uint8_t *buf = (uint8_t *)dst + arg->offset + (i -= sub);
+
+        for (shift = 0; arg->mask[i] >> shift; ++shift) {
+            if (!(arg->mask[i] & (1 << shift)))
+                continue;
+            ++len;
+            if (!dst)
+                continue;
+            *buf &= ~(1 << shift);
+            *buf |= (val & 1) << shift;
+            val >>= 1;
+        }
+        i += add;
+    }
+    return len;
+}
+
+/** Compare a string with a partial one of a given length. */
+static int strcmp_partial(const char *full, const char *partial, size_t partial_len)
+{
+    int r = strncmp(full, partial, partial_len);
+
+    if (r)
+        return r;
+    if (strlen(full) <= partial_len)
+        return 0;
+    return full[partial_len];
+}
+
+/** Parse flow command, initialize output buffer for subsequent tokens. */
+static int parse_init(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    struct buffer *out = buf;
+
+    /* Token name must match. */
+    if (parse_default(ctx, token, str, len, NULL, 0) < 0)
+        return -1;
+    /* Nothing else to do if there is no buffer. */
+    if (!out)
+        return len;
+    /* Make sure buffer is large enough. */
+    if (size < sizeof(*out))
+        return -1;
+    /* Initialize buffer. */
+    memset(out, 0x00, sizeof(*out));
+    memset((uint8_t *)out + sizeof(*out), 0x22, size - sizeof(*out));
+    ctx->objdata = 0;
+    ctx->object = out;
+    ctx->objmask = NULL;
+    parse_vc(ctx, token, str, len, buf, size);
+    return len;
+}
+
+/**
+ * Parse a MAC address.
+ *
+ * Last argument (ctx->args) is retrieved to determine storage size and
+ * location.
+ */
+static int parse_mac_addr(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    struct rte_ether_addr tmp;
+    int ret;
+
+    (void)token;
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    size = arg->size;
+    /* Bit-mask fill is not supported. */
+    if (arg->mask || size != sizeof(tmp))
+        goto error;
+    /* Only network endian is supported. */
+    if (!arg->hton)
+        goto error;
+    ret = cmdline_parse_etheraddr(NULL, str, &tmp, size);
+    if (ret < 0 || (unsigned int)ret != len)
+        goto error;
+    if (!ctx->object)
+        return len;
+    buf = (uint8_t *)ctx->object + arg->offset;
+    memcpy(buf, &tmp, size);
+    if (ctx->objmask)
+        memset((uint8_t *)ctx->objmask + arg->offset, 0xff, size);
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/**
+ * Parse an IPv4 address.
+ *
+ * Last argument (ctx->args) is retrieved to determine storage size and
+ * location.
+ */
+static int parse_ipv4_addr(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    char str2[len + 1];
+    struct in_addr tmp;
+    int ret;
+
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    size = arg->size;
+    /* Bit-mask fill is not supported. */
+    if (arg->mask || size != sizeof(tmp))
+        goto error;
+    /* Only network endian is supported. */
+    if (!arg->hton)
+        goto error;
+    memcpy(str2, str, len);
+    str2[len] = '\0';
+    ret = inet_pton(AF_INET, str2, &tmp);
+    if (ret != 1) {
+        /* Attempt integer parsing. */
+        push_args(ctx, arg);
+        return parse_int(ctx, token, str, len, buf, size);
+    }
+    if (!ctx->object)
+        return len;
+    buf = (uint8_t *)ctx->object + arg->offset;
+    memcpy(buf, &tmp, size);
+    if (ctx->objmask)
+        memset((uint8_t *)ctx->objmask + arg->offset, 0xff, size);
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/**
+ * Parse an IPv6 address.
+ *
+ * Last argument (ctx->args) is retrieved to determine storage size and
+ * location.
+ */
+static int parse_ipv6_addr(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    char str2[len + 1];
+    struct rte_ipv6_addr tmp;
+    int ret;
+
+    (void)token;
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    size = arg->size;
+    /* Bit-mask fill is not supported. */
+    if (arg->mask || size != sizeof(tmp))
+        goto error;
+    /* Only network endian is supported. */
+    if (!arg->hton)
+        goto error;
+    memcpy(str2, str, len);
+    str2[len] = '\0';
+    ret = inet_pton(AF_INET6, str2, &tmp);
+    if (ret != 1)
+        goto error;
+    if (!ctx->object)
+        return len;
+    buf = (uint8_t *)ctx->object + arg->offset;
+    memcpy(buf, &tmp, size);
+    if (ctx->objmask)
+        memset((uint8_t *)ctx->objmask + arg->offset, 0xff, size);
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/**
+ * Parse signed/unsigned integers 8 to 64-bit long.
+ *
+ * Last argument (ctx->args) is retrieved to determine integer type and
+ * storage location.
+ */
+static int parse_int(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    uintmax_t u;
+    char *end;
+
+    (void)token;
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    errno = 0;
+    u = arg->sign ? (uintmax_t)strtoimax(str, &end, 0) : strtoumax(str, &end, 0);
+    if (errno || (size_t)(end - str) != len)
+        goto error;
+    if (arg->bounded && ((arg->sign && ((intmax_t)u < (intmax_t)arg->min ||
+                                               (intmax_t)u > (intmax_t)arg->max)) ||
+                                (!arg->sign && (u < arg->min || u > arg->max))))
+        goto error;
+    if (!ctx->object)
+        return len;
+    if (arg->mask) {
+        if (!arg_entry_bf_fill(ctx->object, u, arg) || !arg_entry_bf_fill(ctx->objmask, -1, arg))
+            goto error;
+        return len;
+    }
+    buf = (uint8_t *)ctx->object + arg->offset;
+    size = arg->size;
+    if (u > RTE_LEN2MASK(size * CHAR_BIT, uint64_t))
+        return -1;
+objmask:
+    switch (size) {
+        case sizeof(uint8_t):
+            *(uint8_t *)buf = u;
+            break;
+        case sizeof(uint16_t):
+            *(uint16_t *)buf = arg->hton ? rte_cpu_to_be_16(u) : u;
+            break;
+        case sizeof(uint8_t[3]):
+#if RTE_BYTE_ORDER == RTE_LITTLE_ENDIAN
+            if (!arg->hton) {
+                ((uint8_t *)buf)[0] = u;
+                ((uint8_t *)buf)[1] = u >> 8;
+                ((uint8_t *)buf)[2] = u >> 16;
+                break;
+            }
+#endif
+            ((uint8_t *)buf)[0] = u >> 16;
+            ((uint8_t *)buf)[1] = u >> 8;
+            ((uint8_t *)buf)[2] = u;
+            break;
+        case sizeof(uint32_t):
+            *(uint32_t *)buf = arg->hton ? rte_cpu_to_be_32(u) : u;
+            break;
+        case sizeof(uint64_t):
+            *(uint64_t *)buf = arg->hton ? rte_cpu_to_be_64(u) : u;
+            break;
+        default:
+            goto error;
+    }
+    if (ctx->objmask && buf != (uint8_t *)ctx->objmask + arg->offset) {
+        u = -1;
+        buf = (uint8_t *)ctx->objmask + arg->offset;
+        goto objmask;
+    }
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/** Default parsing function for token name matching. */
+static int parse_default(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    (void)ctx;
+    (void)buf;
+    (void)size;
+    if (strcmp_partial(token->name, str, len))
+        return -1;
+    return len;
+}
+
+/** Parse tokens for validate/create commands. */
+static int parse_vc(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    struct buffer *out = buf;
+    uint8_t *data;
+    uint32_t data_size;
+
+    /* Token name must match. */
+    if (parse_default(ctx, token, str, len, NULL, 0) < 0)
+        return -1;
+    /* Nothing else to do if there is no buffer. */
+    if (!out)
+        return len;
+    if (!out->command) {
+        if (sizeof(*out) > size)
+            return -1;
+        out->command = CREATE;
+        ctx->objdata = 0;
+        ctx->object = out;
+        ctx->objmask = NULL;
+        out->args.vc.data = (uint8_t *)out + size;
+    }
+    ctx->objdata = 0;
+    ctx->object = &out->args.vc.attr;
+    ctx->objmask = NULL;
+    switch (ctx->curr) {
+        case ITEM_PATTERN:
+            out->args.vc.pattern = (void *)RTE_ALIGN_CEIL((uintptr_t)(out + 1), sizeof(double));
+            ctx->object = out->args.vc.pattern;
+            ctx->objmask = NULL;
+            return len;
+        default:
+            if (!token->priv)
+                return -1;
+            break;
+    }
+    const struct parse_item_priv *priv = token->priv;
+    struct rte_flow_item *item = out->args.vc.pattern + out->args.vc.pattern_n;
+
+    data_size = priv->size * 3; /* spec, last, mask */
+    data = (void *)RTE_ALIGN_FLOOR((uintptr_t)(out->args.vc.data - data_size), sizeof(double));
+    if ((uint8_t *)item + sizeof(*item) > data)
+        return -1;
+    *item = (struct rte_flow_item){
+        .type = priv->type,
+    };
+    ++out->args.vc.pattern_n;
+    ctx->object = item;
+    ctx->objmask = NULL;
+
+    memset(data, 0, data_size);
+    out->args.vc.data = data;
+    ctx->objdata = data_size;
+    return len;
+}
+
+/** Parse pattern item parameter type. */
+static int parse_vc_spec(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    struct buffer *out = buf;
+    struct rte_flow_item *item;
+    uint32_t data_size;
+    int index;
+    int objmask = 0;
+
+    (void)size;
+    /* Token name must match. */
+    if (parse_default(ctx, token, str, len, NULL, 0) < 0)
+        return -1;
+    /* Parse parameter types. */
+    switch (ctx->curr) {
+
+        case ITEM_PARAM_IS:
+            index = 0;
+            objmask = 1;
+            break;
+        case ITEM_PARAM_SPEC:
+            index = 0;
+            break;
+        case ITEM_PARAM_LAST:
+            index = 1;
+            break;
+        case ITEM_PARAM_MASK:
+            index = 2;
+            break;
+        default:
+            return -1;
+    }
+    /* Nothing else to do if there is no buffer. */
+    if (!out)
+        return len;
+    if (!out->args.vc.pattern_n)
+        return -1;
+    item = &out->args.vc.pattern[out->args.vc.pattern_n - 1];
+    data_size = ctx->objdata / 3; /* spec, last, mask */
+    /* Point to selected object. */
+    ctx->object = out->args.vc.data + (data_size * index);
+    if (objmask) {
+        ctx->objmask = out->args.vc.data + (data_size * 2); /* mask */
+        item->mask = ctx->objmask;
+    } else
+        ctx->objmask = NULL;
+    /* Update relevant item pointer. */
+    *((const void **[]){ &item->spec, &item->last, &item->mask })[index] = ctx->object;
+    return len;
+}
+
+/** Parse a token (cmdline API). */
+static int cmd_flow_parse(const char *src, void *result, unsigned int size)
+{
+    struct context *ctx = &cmd_flow_context;
+    const struct token *token;
+    const enum index *list;
+    int len;
+    int i;
+
+    token = &token_list[ctx->curr];
+    /* Check argument length. */
+    ctx->eol = 0;
+    ctx->last = 1;
+    for (len = 0; src[len]; ++len)
+        if (src[len] == '#' || isspace(src[len]))
+            break;
+    if (!len)
+        return -1;
+    /* Last argument and EOL detection. */
+    for (i = len; src[i]; ++i)
+        if (src[i] == '#' || src[i] == '\r' || src[i] == '\n')
+            break;
+        else if (!isspace(src[i])) {
+            ctx->last = 0;
+            break;
+        }
+    for (; src[i]; ++i)
+        if (src[i] == '\r' || src[i] == '\n') {
+            ctx->eol = 1;
+            break;
+        }
+    /* Initialize context if necessary. */
+    if (!ctx->next_num) {
+        if (!token->next)
+            return 0;
+        ctx->next[ctx->next_num++] = token->next[0];
+    }
+    /* Process argument through candidates. */
+    ctx->prev = ctx->curr;
+    list = ctx->next[ctx->next_num - 1];
+    for (i = 0; list[i]; ++i) {
+        const struct token *next = &token_list[list[i]];
+        int tmp;
+
+        ctx->curr = list[i];
+        if (next->call)
+            tmp = next->call(ctx, next, src, len, result, size);
+        else
+            tmp = parse_default(ctx, next, src, len, result, size);
+        if (tmp == -1 || tmp != len)
+            continue;
+        token = next;
+        break;
+    }
+    if (!list[i])
+        return -1;
+    --ctx->next_num;
+    /* Push subsequent tokens if any. */
+    if (token->next)
+        for (i = 0; token->next[i]; ++i) {
+            if (ctx->next_num == RTE_DIM(ctx->next))
+                return -1;
+            ctx->next[ctx->next_num++] = token->next[i];
+        }
+    /* Push arguments if any. */
+    if (token->args)
+        for (i = 0; token->args[i]; ++i) {
+            if (ctx->args_num == RTE_DIM(ctx->args))
+                return -1;
+            ctx->args[ctx->args_num++] = token->args[i];
+        }
+    return len;
+}
+
+static int flow_parse(
+        const char *src, void *result, unsigned int size, struct rte_flow_item **pattern)
+{
+    int ret;
+    struct context saved_flow_ctx = cmd_flow_context;
+
+    memset(result, 0x00, sizeof(*result));
+    memset((uint8_t *)result + sizeof(*result), 0x22, size - sizeof(*result));
+
+    cmd_flow_context_init(&cmd_flow_context);
+    do {
+        ret = cmd_flow_parse(src, result, size);
+        if (ret > 0) {
+            src += ret;
+            while (isspace(*src))
+                src++;
+        }
+    } while (ret > 0 && strlen(src));
+    cmd_flow_context = saved_flow_ctx;
+    *pattern = ((struct buffer *)result)->args.vc.pattern;
+
+    return (ret >= 0 && !strlen(src)) ? 0 : -1;
+}
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)*/
+
+/**
+ * \brief Parse rte_flow rule pattern and store individual pattern items in items and their
+ *        attributes in buffer data
+ *
+ * \param pattern rte_flow rule pattern to be parsed
+ * \param data buffer to store parsed pattern
+ * \param size size of buffer
+ * \param items parsed items used when creating rte_flow rules
+ * \return 0 on success, -1 on error
+ */
+int ParsePattern(char *pattern, struct rte_flow_item **items)
+{
+    SCEnter();
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+    static uint8_t items_data_buffer[DATA_BUFFER_SIZE] = { 0 };
+    SCReturnInt(flow_parse(pattern, (void *)items_data_buffer, sizeof(items_data_buffer), items));
+#else
+    SCReturnInt(0);
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)*/
+}
+
+#endif /* HAVE_DPDK */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow-pattern.h
+++ b/src/util-dpdk-rte-flow-pattern.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021-2025 Open Information Security Foundation
+/* Copyright (C) 2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -16,24 +16,31 @@
  */
 
 /**
- * \file
+ *  \defgroup dpdk DPDK rte_flow rules util functions
  *
- * \author Lukas Sismis <lukas.sismis@gmail.com>
+ *  @{
  */
 
-#ifndef UTIL_DPDK_ICE_H
-#define UTIL_DPDK_ICE_H
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
+ */
 
-#include "suricata-common.h"
+#ifndef SURICATA_RTE_FLOW_RULES_PATTERN_H
+#define SURICATA_RTE_FLOW_RULES_PATTERN_H
 
 #ifdef HAVE_DPDK
 
 #include "util-dpdk.h"
 
-int iceDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
-void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf);
-bool iceDeviceRteFlowPatternError(struct rte_flow_item *items);
+int ParsePattern(char *pattern, struct rte_flow_item **items);
 
 #endif /* HAVE_DPDK */
-
-#endif /* UTIL_DPDK_ICE_H */
+#endif /* SURICATA_RTE_FLOW_RULES_PATTERN_H */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.c
+++ b/src/util-dpdk-rte-flow.c
@@ -1,0 +1,288 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  \defgroup dpdk DPDK rte_flow rules util functions
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
+ */
+
+#include "decode.h"
+#include "runmode-dpdk.h"
+#include "util-debug.h"
+#include "util-dpdk.h"
+#include "util-dpdk-ice.h"
+#include "util-dpdk-rte-flow.h"
+#include "util-dpdk-rte-flow-pattern.h"
+
+#ifdef HAVE_DPDK
+
+#define RULE_STORAGE_INIT_SIZE 8
+#define RULE_STORAGE_SIZE_INC  16
+
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+
+static int RteFlowRuleStorageInit(RteFlowRuleStorage *);
+static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *, const char *);
+static int RteFlowRuleStorageExtendCapacity(RteFlowRuleStorage *, int);
+static char *DriverSpecificErrorMessage(const char *, struct rte_flow_item *);
+
+/**
+ * \brief Specify ambiguous error messages as some drivers have specific
+ *        behaviour when creating rte_flow rules.
+ *
+ * \param driver_name name of a driver
+ * \param items array of pattern items
+ * \return error message if error present, NULL otherwise
+ */
+static char *DriverSpecificErrorMessage(const char *driver_name, struct rte_flow_item *items)
+{
+    if (strcmp(driver_name, "net_ice") == 0) {
+        if (iceDeviceRteFlowPatternError(items) == true) {
+            char msg[] = "Driver specific errmsg: ice driver does not support broad patterns";
+            char *ret = SCCalloc((strlen(msg) + 1), sizeof(msg[0]));
+            strlcpy(ret, msg, sizeof(msg[0]) * (strlen(msg) + 1));
+            return ret;
+        }
+    }
+
+    return NULL;
+}
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
+
+static int RteFlowRuleStorageInit(RteFlowRuleStorage *rule_storage)
+{
+    SCEnter();
+    rule_storage->rule_cnt = 0;
+    rule_storage->rule_size = RULE_STORAGE_INIT_SIZE;
+    rule_storage->rules = SCCalloc(rule_storage->rule_size, sizeof(char *));
+
+    if (rule_storage->rules == NULL) {
+        SCLogError("Setup memory allocation for rte_flow rule storage failed");
+        SCReturnInt(-ENOMEM);
+    }
+    SCReturnInt(0);
+}
+
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *rule_storage, const char *rule)
+{
+    SCEnter();
+    if (rule_storage->rule_cnt == rule_storage->rule_size) {
+        int retval = RteFlowRuleStorageExtendCapacity(rule_storage, RULE_STORAGE_SIZE_INC);
+        if (retval != 0)
+            SCReturnInt(retval);
+    }
+
+    rule_storage->rules[rule_storage->rule_cnt] = SCCalloc(strlen(rule) + 1, sizeof(rule[0]));
+    if (rule_storage->rules[rule_storage->rule_cnt] == NULL) {
+        SCLogError("Memory allocation for rte_flow rule string failed");
+        SCReturnInt(-ENOMEM);
+    }
+
+    strlcpy(rule_storage->rules[rule_storage->rule_cnt], rule,
+            (strlen(rule) + 1) * sizeof(rule[0]));
+    rule_storage->rule_cnt++;
+    SCReturnInt(0);
+}
+
+static int RteFlowRuleStorageExtendCapacity(RteFlowRuleStorage *rule_storage, int inc)
+{
+    SCEnter();
+    char **tmp_rules;
+
+    rule_storage->rule_size += inc;
+    tmp_rules = SCRealloc(rule_storage->rules, rule_storage->rule_size * sizeof(char *));
+
+    if (tmp_rules == NULL) {
+        SCLogError("Memory reallocation for rte_flow rule storage failed");
+        SCReturnInt(-ENOMEM);
+    }
+
+    rule_storage->rules = tmp_rules;
+    SCReturnInt(0);
+}
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
+
+/**
+ * \brief Deallocation of memory containing user set rte_flow rules
+ *
+ * \param rule_storage rules loaded from suricata.yaml
+ */
+void RteFlowRuleStorageFree(RteFlowRuleStorage *rule_storage)
+{
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+
+    if (rule_storage->rules == NULL) {
+        SCReturn;
+    }
+    for (int i = 0; i < rule_storage->rule_cnt; i++) {
+        SCFree(rule_storage->rules[i]);
+    }
+    SCFree(rule_storage->rules);
+    rule_storage->rules = NULL;
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
+}
+
+/**
+ * \brief Load rte_flow rules patterns from suricata.yaml
+ *
+ * \param if_root root node in suricata.yaml
+ * \param if_default default value
+ * \param drop_filter_str value to look for in suricata.yaml
+ * \param rule_storage pointer to structure to load rte_flow rules into
+ * \return 0 on success, -1 on error
+ */
+int ConfigLoadRteFlowRules(
+        SCConfNode *if_root, const char *drop_filter_str, RteFlowRuleStorage *rule_storage)
+{
+    SCEnter();
+    SCConfNode *node = SCConfNodeLookupChild(if_root, drop_filter_str);
+    if (node == NULL) {
+        SCLogInfo("No configuration node found for %s", drop_filter_str);
+    } else {
+        SCConfNode *rule_node;
+        const char *rule = NULL;
+        /* Suppress unused variable warning in case of DPDK version < 21.11  */
+        (void)rule;
+        int retval = RteFlowRuleStorageInit(rule_storage);
+        if (retval != 0) {
+            SCReturnInt(retval);
+        }
+
+        TAILQ_FOREACH (rule_node, &node->head, next) {
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+            if (strcmp(rule_node->val, "rule") == 0) {
+                SCConfGetChildValue(rule_node, "rule", &rule);
+                retval = RteFlowRuleStorageAddRule(rule_storage, rule);
+                if (retval != 0) {
+                    RteFlowRuleStorageFree(rule_storage);
+                    SCReturnInt(retval);
+                }
+            } else {
+                SCLogError("DPDK .%s contains unrecognized key, only \"rule\" is supported",
+                        drop_filter_str);
+                SCReturnInt(-1);
+            }
+#else
+            if (strcmp(rule_node->val, "rule") == 0) {
+                SCLogError("DPDK .%s is supported from DPDK version 21.11 and higher, "
+                           "filter not applied",
+                        drop_filter_str);
+                RteFlowRuleStorageFree(rule_storage);
+                SCReturnInt(0);
+            }
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
+        }
+    }
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Create rte_flow drop rules with patterns stored in rule_storage on a port with id
+ *        port_id
+ *
+ * \param port_id identificator of a port
+ * \param rule_storage pointer to structure containing rte_flow rule patterns
+ * \param driver_name name of a driver
+ * \return 0 on success, -1 on error
+ */
+int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name)
+{
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+    SCEnter();
+    int failed_rule_count = 0;
+    struct rte_flow_error flush_error = { 0 };
+    struct rte_flow_attr attr = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+    const char *port_name = DPDKGetPortNameByPortID(port_id);
+
+    attr.ingress = 1;
+    action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+    rule_storage->rule_handlers = SCCalloc(rule_storage->rule_size, sizeof(struct rte_flow *));
+    if (rule_storage->rule_handlers == NULL) {
+        SCLogError("%s: Memory allocation for rte_flow rule string failed", port_name);
+        RteFlowRuleStorageFree(rule_storage);
+        SCReturnInt(-ENOMEM);
+    }
+
+    for (int i = 0; i < rule_storage->rule_cnt; i++) {
+        struct rte_flow_item *items = { 0 };
+        struct rte_flow_error flow_error = { 0 };
+
+        int retval = ParsePattern(rule_storage->rules[i], &items);
+        if (retval != 0) {
+            failed_rule_count++;
+            SCLogError("%s: Error when parsing rte_flow rule \"%s\"", port_name,
+                    rule_storage->rules[i]);
+            continue;
+        }
+
+        retval = rte_flow_validate(port_id, &attr, items, action, &flow_error);
+        if (retval != 0) {
+            failed_rule_count++;
+            char *driver_specific_err = DriverSpecificErrorMessage(driver_name, items);
+            SCLogError("%s: Error when validating rte_flow rule \"%s\": %s, errmsg: "
+                       "%s. %s",
+                    port_name, rule_storage->rules[i], rte_strerror(-retval), flow_error.message,
+                    driver_specific_err != NULL ? driver_specific_err : "");
+            if (driver_specific_err != NULL) {
+                SCFree(driver_specific_err);
+            }
+            continue;
+        }
+
+        struct rte_flow *flow_handler = rte_flow_create(port_id, &attr, items, action, &flow_error);
+        if (flow_handler == NULL) {
+            failed_rule_count++;
+            SCLogError("%s: Error when creating rte_flow rule \"%s\": %s", port_name,
+                    rule_storage->rules[i], flow_error.message);
+            continue;
+        }
+        rule_storage->rule_handlers[i] = flow_handler;
+        SCLogInfo("%s: rte_flow rule \"%s\" created", port_name, rule_storage->rules[i]);
+    }
+
+    if (failed_rule_count) {
+        SCLogError("%s: Error parsing/creating %i rte_flow rule(s), flushing rules", port_name,
+                failed_rule_count);
+        int retval = rte_flow_flush(port_id, &flush_error);
+        if (retval != 0) {
+            SCLogError("%s Unable to flush rte_flow rules: %s Flush error msg: %s", port_name,
+                    rte_strerror(-retval), flush_error.message);
+        }
+        SCReturnInt(-ENOTSUP);
+    }
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)*/
+    SCReturnInt(0);
+}
+
+#endif /* HAVE_DPDK */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.c
+++ b/src/util-dpdk-rte-flow.c
@@ -42,6 +42,7 @@
 
 #define RULE_STORAGE_INIT_SIZE 8
 #define RULE_STORAGE_SIZE_INC  16
+#define COUNT_ACTION_ID        1
 
 #if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
 
@@ -49,6 +50,10 @@ static int RteFlowRuleStorageInit(RteFlowRuleStorage *);
 static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *, const char *);
 static int RteFlowRuleStorageExtendCapacity(RteFlowRuleStorage *, int);
 static char *DriverSpecificErrorMessage(const char *, struct rte_flow_item *);
+static void RteFlowDropFilterInitAttr(const char *, struct rte_flow_attr *);
+static void RteFlowDropFilterInitAction(
+        RteFlowRuleStorage *, const char *, const char *, struct rte_flow_action *);
+static bool RteFlowShouldGatherStats(RteFlowRuleStorage *, const char *, const char *);
 
 /**
  * \brief Specify ambiguous error messages as some drivers have specific
@@ -68,8 +73,79 @@ static char *DriverSpecificErrorMessage(const char *driver_name, struct rte_flow
             return ret;
         }
     }
-
     return NULL;
+}
+
+/**
+ * \brief Initializes the attributes of rte_flow rules
+ *
+ * \param driver_name name of the driver
+ * \param[out] attr attributes which configure how the rte_flow rules will behave
+ */
+static void RteFlowDropFilterInitAttr(const char *driver_name, struct rte_flow_attr *attr)
+{
+    attr->ingress = 1;
+    attr->priority = 0;
+    attr->group = 0;
+
+    /* ICE PMD has to have attribute group set to 2 on DPDK 23.11 and higher for the count action to
+     * work properly */
+    if (strcmp(driver_name, "net_ice") == 0) {
+#if RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0)
+        attr->group = 2;
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0) */
+    }
+}
+
+/**
+ * \brief Configures the action which will rte_flow rules perform and
+ *        decides whether statistic will be gathered or not
+ *
+ * \param rule_storage struct contaning number of rules and their string instances
+ * \param port_name name of the port
+ * \param driver_name name of the driver
+ * \param[out] action types of actions to be used in the rte_flow rules
+ */
+static void RteFlowDropFilterInitAction(RteFlowRuleStorage *rule_storage, const char *port_name,
+        const char *driver_name, struct rte_flow_action *action)
+{
+    /* ICE PMD does not support count action with wildcard pattern (mask and last pattern item
+     * types). The count action is omitted when wildcard pattern is detected */
+    if (strcmp(driver_name, "net_ice") == 0 &&
+            !iceDeviceDecideRteFlowActionType(rule_storage, port_name)) {
+        action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
+        action[1].type = RTE_FLOW_ACTION_TYPE_END;
+        return;
+    }
+    if (strcmp(driver_name, "net_ice") == 0 || strcmp(driver_name, "mlx5_pci") == 0) {
+        action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+        static uint32_t counter_id = COUNT_ACTION_ID;
+        action[0].conf = &counter_id;
+        action[1].type = RTE_FLOW_ACTION_TYPE_DROP;
+        action[2].type = RTE_FLOW_ACTION_TYPE_END;
+        return;
+    }
+    action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+    return;
+}
+
+/**
+ * \brief Function decides, based on the driver and type of rte_flow rules,
+ *        whether to gather statistics with counter in rte_flow rules or no.
+ *
+ * \param rule_storage rules loaded from suricata.yam
+ * \param driver_name name of the driver
+ * \param port_name name of the port
+ * \return true if gathering stats from rte_flow rules is possible, false otherwise
+ */
+static bool RteFlowShouldGatherStats(
+        RteFlowRuleStorage *rule_storage, const char *driver_name, const char *port_name)
+{
+    if (strcmp(driver_name, "net_ice") == 0 &&
+            !iceDeviceDecideRteFlowActionType(rule_storage, port_name))
+        return false;
+    return true;
 }
 #endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
 
@@ -202,6 +278,45 @@ int ConfigLoadRteFlowRules(
 }
 
 /**
+ * \brief Query the number of packets filtered by rte_flow rules defined by user in suricata.yaml
+ *
+ * \param rules array of rte_flow rule handlers
+ * \param rule_count number of existing rules
+ * \param port_id id of a port
+ * \return 0 on success, a negative errno value otherwise and rte_errno is set
+ */
+uint64_t RteFlowFilteredPacketsQuery(
+        struct rte_flow **rules, uint16_t rule_count, const char *device_name, int port_id)
+{
+    uint64_t retval = 0;
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+    struct rte_flow_query_count query_count = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+    struct rte_flow_error flow_error = { 0 };
+    uint32_t counter_id = COUNT_ACTION_ID;
+    bool err = false;
+    int query_retval = 0;
+
+    query_count.reset = 0;
+    action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+    action[0].conf = &counter_id;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+    for (uint16_t i = 0; i < rule_count; i++) {
+        query_retval =
+                rte_flow_query(port_id, rules[i], &(action[0]), (void *)&query_count, &flow_error);
+        if (query_retval != 0 && !err) {
+            err = true;
+            SCLogError("%s: rte_flow count query error %s errmsg: %s", device_name,
+                    rte_strerror(-retval), flow_error.message);
+        } else
+            retval += query_count.hits;
+    }
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
+    SCReturnInt(retval);
+}
+
+/**
  * \brief Create rte_flow drop rules with patterns stored in rule_storage on a port with id
  *        port_id
  *
@@ -220,9 +335,8 @@ int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const
     struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
     const char *port_name = DPDKGetPortNameByPortID(port_id);
 
-    attr.ingress = 1;
-    action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
-    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+    RteFlowDropFilterInitAttr(driver_name, &attr);
+    RteFlowDropFilterInitAction(rule_storage, port_name, driver_name, action);
 
     rule_storage->rule_handlers = SCCalloc(rule_storage->rule_size, sizeof(struct rte_flow *));
     if (rule_storage->rule_handlers == NULL) {
@@ -278,6 +392,12 @@ int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const
         }
         SCReturnInt(-ENOTSUP);
     }
+
+    if (RteFlowShouldGatherStats(rule_storage, driver_name, port_name)) {
+        SCFree(rule_storage->rule_handlers);
+        rule_storage->rule_cnt = 0;
+    }
+
 #endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)*/
     SCReturnInt(0);
 }

--- a/src/util-dpdk-rte-flow.h
+++ b/src/util-dpdk-rte-flow.h
@@ -1,0 +1,58 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  \defgroup dpdk DPDK rte_flow rules util functions
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
+ */
+
+#ifndef SURICATA_RTE_FLOW_RULES_H
+#define SURICATA_RTE_FLOW_RULES_H
+
+#ifdef HAVE_DPDK
+
+#include "conf.h"
+#include "util-dpdk.h"
+
+typedef struct RteFlowRuleStorage_ {
+    uint16_t rule_cnt;
+    uint16_t rule_size;
+    char **rules;
+    struct rte_flow **rule_handlers;
+} RteFlowRuleStorage;
+
+void RteFlowRuleStorageFree(RteFlowRuleStorage *rule_storage);
+int ConfigLoadRteFlowRules(
+        SCConfNode *if_root, const char *drop_filter_str, RteFlowRuleStorage *rule_storage);
+int RteFlowRulesCreate(
+        uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name);
+
+#endif /* HAVE_DPDK */
+#endif /* SURICATA_RTE_FLOW_RULES_H */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.h
+++ b/src/util-dpdk-rte-flow.h
@@ -48,8 +48,9 @@ typedef struct RteFlowRuleStorage_ {
 void RteFlowRuleStorageFree(RteFlowRuleStorage *rule_storage);
 int ConfigLoadRteFlowRules(
         SCConfNode *if_root, const char *drop_filter_str, RteFlowRuleStorage *rule_storage);
-int RteFlowRulesCreate(
-        uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name);
+int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name);
+uint64_t RteFlowFilteredPacketsQuery(
+        struct rte_flow **rules, uint16_t rule_count, const char *device_name, int port_id);
 
 #endif /* HAVE_DPDK */
 #endif /* SURICATA_RTE_FLOW_RULES_H */

--- a/src/util-dpdk.c
+++ b/src/util-dpdk.c
@@ -61,6 +61,12 @@ void DPDKFreeDevice(LiveDevice *ldev)
     (void)ldev; // avoid warnings of unused variable
 #ifdef HAVE_DPDK
     if (SCRunmodeGet() == RUNMODE_DPDK) {
+        if (ldev->dpdk_vars->drop_filter->rule_handlers != NULL &&
+                ldev->dpdk_vars->drop_filter->rule_cnt != 0) {
+            SCLogDebug("%s: releasing rte_flow rule handlers", ldev->dev);
+            SCFree(ldev->dpdk_vars->drop_filter->rule_handlers);
+            SCFree(ldev->dpdk_vars->drop_filter);
+        }
         SCLogDebug("%s: releasing packet mempools", ldev->dev);
         DPDKDeviceResourcesDeinit(&ldev->dpdk_vars);
     }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -827,6 +827,11 @@ dpdk:
       # - ips: the same as tap mode but it also drops packets that are flagged by rules to be dropped
       copy-mode: none
       copy-iface: none # or PCIe address of the second interface
+      # Flow patterns in dpdk-testpmd syntax for flows that are supposed to be dropped directly in the NIC.
+      # If the pattern is invalid or unsupported, Suricata will not start.
+      # Example: "rule: pattern eth / ipv4 src is 16.0.25.0 / udp / end"
+      #          "rule: pattern eth / ipv4 dst is 19.1.2.15 / tcp / end" 
+      drop-filter: none 
 
     - interface: default
       threads: auto
@@ -844,6 +849,7 @@ dpdk:
       tx-descriptors: auto
       copy-mode: none
       copy-iface: none
+      drop-filter: none
 
 
 # Cross platform libpcap capture support


### PR DESCRIPTION
Followup of [#13891](https://github.com/OISF/suricata/pull/13891)

## Changes:

v3:
- integrated changes based on the previous PR
- changed DPDK version number in #ifdef in  util-dpdk-rte-flow-pattern.c from 21.00 to 21.11

v2:
- integrated feedback from previous PR
- integrated feedback related to this feature from draft PR [#13760](https://github.com/OISF/suricata/pull/13760)
- rebased
- removed unused macros
- added an explanation for the chosen syntax used for this feature and an expanded PR description

Ticket: [#7629](https://redmine.openinfosecfoundation.org/issues/7629)

## Motivation

This feature brings a new approach to filter unwanted network traffic in hardware in Suricata's DPDK runmode, even before it reaches Suricata. The main benefit is the ability to offload the processing of unwanted traffic from the software, thus reducing the load on both the PCIe bus and the CPU and increasing Suricata throughput. This is achieved via DPDK's rte\_flow API, which provides flow rules that define the behaviour of matched flows in the hardware.

The rules and their relationships work similarly to Suricata rules, as the individual pattern parts inside one rule are connected with an AND operation, and the whole rules are connected with an OR operation. For example, if a rule in [dpdk-testpmd syntax](https://doc.dpdk.org/guides/testpmd_app_ug/testpmd_funcs.html#flow-syntax) looks like `flow create 0 ingress pattern eth / ipv4 src is 192.11.11.12 / tcp src is 10 / end actions drop / end`, then matching pattern parts (`eth`, `ipv4,` and `tcp`) are combined with an AND operation. If there is another rule with a different pattern, then the first rule and the second rule would be connected with an OR operation, meaning that the incoming traffic will either match the first rule, match the second rule or it will be passed to Suricata.

## Explored options

### Rule syntax

#### dpdk-testpmd-like syntax

dpdk-testpmd syntax offers a wide range of different patterns and adjustments, which are well documented in the DPDK documentation. This means that the drop-filter is limited only by the capabilities of the used NIC. Another advantage is that Suricata operators can easily test and adjust the rules they want to apply in the [dpdk-testpmd application](https://doc.dpdk.org/guides/testpmd_app_ug/), with the possibility of copying the tested patterns into suricata.yaml.

The whole rule, as could be applied in dpdk-testpmd application, would, for example, look like `flow create 0 ingress pattern eth /  ipv4 src is 199.11.23.5 / tcp src is 42 / end actions drop end / end`. However, only the pattern part is important when defining rte\_flow rules for Suricata, so only `pattern eth /  ipv4 src is 199.11.23.5 / tcp src is 42 / end` would be present in suricata.yaml.

This example shows how the rules are defined in suricata.yaml:

```yaml
drop-filter:

    - rule: 'pattern eth / ipv4 src is 199.11.23.5 / tcp src is 42 / end'

    - rule: 'pattern eth / vlan vid is 15'
```

If supported by the NIC, this syntax also offers the ability to adjust the matched range (of IP addresses, ports, …) with two keywords, `mask` and `last`. For example, rules including these keywords could look as follows:

```yaml
drop-filter:

    - rule: 'pattern eth / ipv4 src is 199.11.23.0 src mask 255.255.255.0 / tcp src is 42 / end'

    - rule: 'pattern eth / ipv4 src is 192.11.23.10 src last 192.11.11.20 / tcp / end' 
```

#### BPF syntax

One of the reasons why I did not choose the BPF syntax is that both BPF and rte\_flow offer multiple distinct features that the other does not. For example, BPF syntax provides the capability to use an OR operand inside the pattern (`tcp dst port 80 or 8000`), which would require two distinct rte\_flow rules. Another difference is the lack of negation operand and exact-byte reading in rte\_flow rules.

A disadvantage of BPF in this case is the lack of an existing parser to convert BPF syntax into rte\_flow rules. In contrast, the dpdk-testpmd syntax already has a usable parser implementation that transforms the dpdk-testpmd string rules into rte\_flow rules. With some modifications, it is suitable for our use case.

#### Simple filter

Another considered option to define what traffic should be filtered is to declare a simple list of IP addresses and ports, which will then be parsed into rte\_flow rules. However, this way we lose a substantial part of the available matching power, as we can match only specific flows and we can not utilize the various supported protocols, such as matching on VLAN or other encapsulation protocols. 

This method is not implemented, but could serve as an alternative/support mode for the dpdk-testpmd rule-based filter. It could be present in an exclusive mode, meaning only one of the options will be available at a time, or it could work as an additional way to declare what traffic to discard.

A concept of how such a filter could be defined in suricata.yaml:

```yaml
drop-filter:

    - rule: ip src 199.1.2.5 and ip dst 10.10.1.1 and tcp src 80

    - rule: ip src 200.1.2.0/24 and ip dst 10.10.1.1 and tcp src 80
```

### Allow-filter

The allow-filter was expected to work as the exact opposite of the drop-filter, with Suricata receiving only traffic defined by rte\_flow rules. This filter would behave similarly to a BPF program that passes only specified traffic and drops everything else.

This filter could be implemented via DPDK's [isolated mode](https://doc.dpdk.org/guides-24.07/prog_guide/rte_flow.html#flow-isolated-mode), which restricts the NIC to accept only traffic defined via some rte\_flow rule. Unfortunately, this filter would currently work only on Mellanox NICs (among the ones we tested), as isolated mode is not supported on Intel NICs.

If this hypothetical allow-filter were implemented, it could serve as an alternative/exclusive mode to the drop-filter, as its implicit behavior is to drop all unwanted traffic.

## NIC limitations and more detailed description

Limitations of supported NICs, as well as a more expanded description of the feature, can be found in the file `/doc/userguide/capture-hardware/dpdk.rst`.
