### PR TITLE
Detect integers bitflags 6724 v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -681,6 +681,11 @@
                                 "type": "string"
                             }
                         }
+                    },
+                    "suricata": {
+                        "keywords": [
+                            "dnp3.iin"
+                        ]
                     }
                 },
                 "request": {
@@ -908,6 +913,11 @@
                                         "type": "string"
                                     }
                                 }
+                            },
+                            "suricata": {
+                                "keywords": [
+                                    "dnp3.iin"
+                                ]
                             }
                         },
                         "src": {

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -102,9 +102,11 @@ fn parse_uint_subslice(parts: &[&str]) -> Option<(i32, i32)> {
     }
     let (_, (start, end)) = parse_uint_subslice_aux(parts[2]).ok()?;
     if start > 0 && end > 0 && end <= start {
+        SCLogError!("subslice must end after start {} {}", start, end);
         return None;
     }
     if start < 0 && end < 0 && end <= start {
+        SCLogError!("subslice must end after start {} {}", start, end);
         return None;
     }
     return Some((start, end));
@@ -129,6 +131,7 @@ fn parse_uint_index(parts: &[&str]) -> Option<DetectUintIndex> {
 pub(crate) fn detect_parse_array_uint<T: DetectIntType>(s: &str) -> Option<DetectUintArrayData<T>> {
     let parts: Vec<&str> = s.split(',').collect();
     if parts.len() > 3 {
+        SCLogError!("Too many comma-separated parts in multi-integer");
         return None;
     }
 
@@ -149,6 +152,7 @@ pub(crate) fn detect_parse_array_uint_enum<T1: DetectIntType, T2: EnumString<T1>
 ) -> Option<DetectUintArrayData<T1>> {
     let parts: Vec<&str> = s.split(',').collect();
     if parts.len() > 3 {
+        SCLogError!("Too many comma-separated parts in multi-integer");
         return None;
     }
 
@@ -297,6 +301,7 @@ fn parse_flag_list_item<T1: DetectIntType, T2: EnumString<T1>>(
     let (s, vals) = take_while(|c| c != ' ' && c != ',')(s)?;
     let value = T2::from_str(vals);
     if value.is_none() {
+        SCLogError!("Bitflag unexpected value {}", vals);
         return Err(Err::Error(make_error(s, ErrorKind::Switch)));
     }
     let value = value.unwrap().into_u();
@@ -377,6 +382,7 @@ pub fn detect_parse_uint_enum<T1: DetectIntType, T2: EnumString<T1>>(
         };
         return Some(ctx);
     }
+    SCLogError!("Unexpected value for enumeration integer: {}", s);
     return None;
 }
 

--- a/rust/src/dnp3/detect.rs
+++ b/rust/src/dnp3/detect.rs
@@ -1,0 +1,84 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use crate::detect::uint::{detect_parse_uint_bitflags, DetectUintData};
+
+use std::ffi::CStr;
+
+#[repr(u16)]
+#[derive(EnumStringU16)]
+#[allow(non_camel_case_types)]
+pub enum Dnp3IndFlag {
+    Device_restart = 0x8000,
+    Device_trouble = 0x4000,
+    Local_control = 0x2000,
+    Need_time = 0x1000,
+    Class_3_events = 0x0800,
+    Class_2_events = 0x0400,
+    Class_1_events = 0x0200,
+    All_stations = 0x0100,
+    Reserved_1 = 0x0080,
+    Reserved_2 = 0x0040,
+    Config_corrupt = 0x0020,
+    Already_executing = 0x0010,
+    Event_buffer_overflow = 0x0008,
+    Parameter_error = 0x0004,
+    Object_unknown = 0x0002,
+    No_func_code_support = 0x0001,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDnp3DetectIndParse(
+    ustr: *const std::os::raw::c_char,
+) -> *mut DetectUintData<u16> {
+    let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
+    if let Ok(s) = ft_name.to_str() {
+        if let Some(ctx) = detect_parse_uint_bitflags::<u16, Dnp3IndFlag>(s) {
+            let boxed = Box::new(ctx);
+            return Box::into_raw(boxed) as *mut _;
+        }
+    }
+    return std::ptr::null_mut();
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn dnp3_ind_parse() {
+        let ctx = detect_parse_uint_bitflags::<u16, Dnp3IndFlag>("0").unwrap();
+        assert_eq!(ctx.arg1, 0);
+        let ctx = detect_parse_uint_bitflags::<u16, Dnp3IndFlag>("1").unwrap();
+        assert_eq!(ctx.arg1, 1);
+        let ctx = detect_parse_uint_bitflags::<u16, Dnp3IndFlag>("0x0").unwrap();
+        assert_eq!(ctx.arg1, 0);
+        let ctx = detect_parse_uint_bitflags::<u16, Dnp3IndFlag>("0x0000").unwrap();
+        assert_eq!(ctx.arg1, 0);
+        let ctx = detect_parse_uint_bitflags::<u16, Dnp3IndFlag>("0x0001").unwrap();
+        assert_eq!(ctx.arg1, 1);
+        let ctx = detect_parse_uint_bitflags::<u16, Dnp3IndFlag>("0x8421").unwrap();
+        assert_eq!(ctx.arg1, 0x8421);
+        assert!(detect_parse_uint_bitflags::<u16, Dnp3IndFlag>("a").is_none());
+        let ctx = detect_parse_uint_bitflags::<u16, Dnp3IndFlag>("all_stations").unwrap();
+        assert_eq!(ctx.arg1, 0x0100);
+        let ctx = detect_parse_uint_bitflags::<u16, Dnp3IndFlag>("class_1_events , class_2_events")
+            .unwrap();
+        assert_eq!(ctx.arg1, 0x600);
+        assert!(detect_parse_uint_bitflags::<u16, Dnp3IndFlag>("something").is_none());
+    }
+}

--- a/rust/src/dnp3/log.rs
+++ b/rust/src/dnp3/log.rs
@@ -1,0 +1,42 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use crate::detect::EnumString;
+use crate::jsonbuilder::{JsonBuilder, JsonError};
+
+use super::detect::Dnp3IndFlag;
+
+fn log_iin(js: &mut JsonBuilder, iin: u16) -> Result<(), JsonError> {
+    js.open_array("indicators")?;
+
+    for i in 0..16 {
+        if (iin & (1 << i)) != 0 {
+            let ind = Dnp3IndFlag::from_u(1 << i).unwrap();
+            js.append_string(ind.to_str())?;
+        }
+    }
+    js.close()?;
+    Ok(())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCJsonDNP3LogIin(js: &mut JsonBuilder, iin: u16) -> bool {
+    if iin == 0 {
+        return false;
+    }
+    log_iin(js, iin).is_ok()
+}

--- a/rust/src/dnp3/mod.rs
+++ b/rust/src/dnp3/mod.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015 Open Information Security Foundation
+/* Copyright (C) 2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,17 +15,7 @@
  * 02110-1301, USA.
  */
 
-#ifndef SURICATA_DETECT_DNP3_H
-#define SURICATA_DETECT_DNP3_H
+//! Application layer dnp3 detection.
 
-/**
- * Struct for mapping symbolic names to values.
- */
-typedef struct DNP3Mapping_ {
-    const char     *name;
-    uint16_t  value;
-} DNP3Mapping;
-
-void DetectDNP3Register(void);
-
-#endif /* SURICATA_DETECT_DNP3_H */
+pub mod detect;
+pub mod log;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -96,6 +96,7 @@ pub mod handshake;
 
 pub mod lua;
 
+pub mod dnp3;
 pub mod dns;
 pub mod mdns;
 pub mod nfs;

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -61,22 +61,6 @@ static void JsonDNP3LogLinkControl(SCJsonBuilder *js, uint8_t lc)
     SCJbSetUint(js, "function_code", DNP3_LINK_FC(lc));
 }
 
-static void JsonDNP3LogIin(SCJsonBuilder *js, uint16_t iin)
-{
-    if (iin) {
-        SCJbOpenArray(js, "indicators");
-
-        int mapping = 0;
-        do {
-            if (iin & DNP3IndicatorsMap[mapping].value) {
-                SCJbAppendString(js, DNP3IndicatorsMap[mapping].name);
-            }
-            mapping++;
-        } while (DNP3IndicatorsMap[mapping].name != NULL);
-        SCJbClose(js);
-    }
-}
-
 static void JsonDNP3LogApplicationControl(SCJsonBuilder *js, uint8_t ac)
 {
     SCJbSetBool(js, "fir", DNP3_APP_FIR(ac));
@@ -206,7 +190,7 @@ static void JsonDNP3LogResponse(SCJsonBuilder *js, DNP3Transaction *dnp3tx)
     SCJbClose(js);
 
     SCJbOpenObject(js, "iin");
-    JsonDNP3LogIin(js, (uint16_t)(dnp3tx->iin.iin1 << 8 | dnp3tx->iin.iin2));
+    SCJsonDNP3LogIin(js, (uint16_t)(dnp3tx->iin.iin1 << 8 | dnp3tx->iin.iin2));
     SCJbClose(js);
 }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6724

Describe changes:
- generalize/factorize the functions for bitflags
- move dnp3.ind a generic integer with bitflags

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2663

Still todo fragbits and tcp.flags to complete the ticket after that

#13900 with better error messages and `dnp3.ind` added as keyword in the schema