### PR TITLE
Detect integers 7889 v2

### DIFF
--- a/doc/userguide/rules/http2-keywords.rst
+++ b/doc/userguide/rules/http2-keywords.rst
@@ -36,6 +36,10 @@ http2.errorcode
 
 Match on the error code in a GOWAY or RST_STREAM frame
 
+http2.errorcode uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
+
+http2.errorcode is also a :ref:`multi-integer <multi-integers>`.
+
 Examples::
 
   http2.errorcode: NO_ERROR;

--- a/doc/userguide/rules/http2-keywords.rst
+++ b/doc/userguide/rules/http2-keywords.rst
@@ -20,6 +20,12 @@ http2.frametype
 
 Match on the frame type present in a transaction.
 
+http2.frametype uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+
+http2.frametype is also a :ref:`multi-integer <multi-integers>`.
+
+http2.frametype does not have any corresponding log output.
+
 Examples::
 
   http2.frametype:GOAWAY;
@@ -66,6 +72,8 @@ Match on the value of the HTTP2 value field present in a WINDOWUPDATE frame.
 http2.window uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
 http2.window is also a :ref:`multi-integer <multi-integers>`.
+
+http2.window does not have any corresponding log output.
 
 This keyword takes a numeric argument after a colon and supports additional qualifiers, such as:
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2269,7 +2269,12 @@
                             "minProperties": 1,
                             "properties": {
                                 "error_code": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "suricata": {
+                                        "keywords": [
+                                            "http2.errorcode"
+                                        ]
+                                    }
                                 },
                                 "has_multiple": {
                                     "type": "string"
@@ -2306,7 +2311,12 @@
                             "minProperties": 1,
                             "properties": {
                                 "error_code": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "suricata": {
+                                        "keywords": [
+                                            "http2.errorcode"
+                                        ]
+                                    }
                                 },
                                 "has_multiple": {
                                     "type": "string"

--- a/rust/derive/src/lib.rs
+++ b/rust/derive/src/lib.rs
@@ -59,7 +59,7 @@ pub fn derive_app_layer_state(input: TokenStream) -> TokenStream {
     applayerstate::derive_app_layer_state(input)
 }
 
-#[proc_macro_derive(EnumStringU8, attributes(name))]
+#[proc_macro_derive(EnumStringU8, attributes(name, suricata))]
 pub fn derive_enum_string_u8(input: TokenStream) -> TokenStream {
     stringenum::derive_enum_string::<u8>(input, "u8")
 }
@@ -69,7 +69,7 @@ pub fn derive_enum_string_u16(input: TokenStream) -> TokenStream {
     stringenum::derive_enum_string::<u16>(input, "u16")
 }
 
-#[proc_macro_derive(EnumStringU32, attributes(name))]
+#[proc_macro_derive(EnumStringU32, attributes(name, suricata))]
 pub fn derive_enum_string_u32(input: TokenStream) -> TokenStream {
     stringenum::derive_enum_string::<u32>(input, "u32")
 }

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -28,7 +28,6 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 use std::ffi::CStr;
 use std::os::raw::c_void;
 use std::rc::Rc;
-use std::str::FromStr;
 use suricata_sys::sys::DetectEngineThreadCtx;
 
 #[no_mangle]
@@ -65,64 +64,45 @@ pub unsafe extern "C" fn SCHttp2ParseFrametype(
     return std::ptr::null_mut();
 }
 
-fn http2_tx_has_errorcode(
-    tx: &HTTP2Transaction, direction: Direction, code: u32,
-) -> std::os::raw::c_int {
-    if direction == Direction::ToServer {
-        for i in 0..tx.frames_ts.len() {
-            match tx.frames_ts[i].data {
-                HTTP2FrameTypeData::GOAWAY(goaway) => {
-                    if goaway.errorcode == code {
-                        return 1;
-                    }
-                }
-                HTTP2FrameTypeData::RSTSTREAM(rst) => {
-                    if rst.errorcode == code {
-                        return 1;
-                    }
-                }
-                _ => {}
-            }
-        }
-    } else {
-        for i in 0..tx.frames_tc.len() {
-            match tx.frames_tc[i].data {
-                HTTP2FrameTypeData::GOAWAY(goaway) => {
-                    if goaway.errorcode == code {
-                        return 1;
-                    }
-                }
-                HTTP2FrameTypeData::RSTSTREAM(rst) => {
-                    if rst.errorcode == code {
-                        return 1;
-                    }
-                }
-                _ => {}
-            }
-        }
+fn http2_tx_get_errorcode(f: &HTTP2Frame) -> Option<u32> {
+    match &f.data {
+        HTTP2FrameTypeData::GOAWAY(goaway) => Some(goaway.errorcode),
+        HTTP2FrameTypeData::RSTSTREAM(rst) => Some(rst.errorcode),
+        _ => None,
     }
-    return 0;
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SCHttp2TxHasErrorCode(
-    tx: *mut std::os::raw::c_void, direction: u8, code: u32,
+    tx: *mut std::os::raw::c_void, direction: u8, ctx: *const std::os::raw::c_void,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
-    return http2_tx_has_errorcode(tx, direction.into(), code);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
+    let frames = if direction & Direction::ToServer as u8 != 0 {
+        &tx.frames_ts
+    } else {
+        &tx.frames_tc
+    };
+    return detect_uint_match_at_index::<HTTP2Frame, u32>(
+        frames,
+        ctx,
+        http2_tx_get_errorcode,
+        tx.state >= HTTP2TransactionState::HTTP2StateClosed,
+    );
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SCHttp2ParseErrorCode(
     str: *const std::os::raw::c_char,
-) -> std::os::raw::c_int {
+) -> *mut std::os::raw::c_void {
     let ft_name: &CStr = CStr::from_ptr(str); //unsafe
     if let Ok(s) = ft_name.to_str() {
-        if let Ok(x) = parser::HTTP2ErrorCode::from_str(s) {
-            return x as i32;
+        if let Some(ctx) = detect_parse_array_uint_enum::<u32, parser::HTTP2ErrorCode>(s) {
+            let boxed = Box::new(ctx);
+            return Box::into_raw(boxed) as *mut c_void;
         }
     }
-    return -1;
+    return std::ptr::null_mut();
 }
 
 fn get_http2_priority(frame: &HTTP2Frame) -> Option<u8> {

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -35,7 +35,10 @@ use std::rc::Rc;
 use base64::{Engine, engine::general_purpose::STANDARD_NO_PAD};
 
 #[repr(u8)]
+#[derive(EnumStringU8)]
 #[derive(Clone, Copy, PartialEq, Eq, FromPrimitive, Debug)]
+// parse GOAWAY, not GO_AWAY
+#[suricata(enum_string_style = "UPPERCASE")]
 pub enum HTTP2FrameType {
     Data = 0,
     Headers = 1,
@@ -47,34 +50,6 @@ pub enum HTTP2FrameType {
     GoAway = 7,
     WindowUpdate = 8,
     Continuation = 9,
-}
-
-impl fmt::Display for HTTP2FrameType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl std::str::FromStr for HTTP2FrameType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let su = s.to_uppercase();
-        let su_slice: &str = &su;
-        match su_slice {
-            "DATA" => Ok(HTTP2FrameType::Data),
-            "HEADERS" => Ok(HTTP2FrameType::Headers),
-            "PRIORITY" => Ok(HTTP2FrameType::Priority),
-            "RSTSTREAM" => Ok(HTTP2FrameType::RstStream),
-            "SETTINGS" => Ok(HTTP2FrameType::Settings),
-            "PUSHPROMISE" => Ok(HTTP2FrameType::PushPromise),
-            "PING" => Ok(HTTP2FrameType::Ping),
-            "GOAWAY" => Ok(HTTP2FrameType::GoAway),
-            "WINDOWUPDATE" => Ok(HTTP2FrameType::WindowUpdate),
-            "CONTINUATION" => Ok(HTTP2FrameType::Continuation),
-            _ => Err(format!("'{}' is not a valid value for HTTP2FrameType", s)),
-        }
-    }
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -81,7 +81,9 @@ pub fn http2_parse_frame_header(i: &[u8]) -> IResult<&[u8], HTTP2FrameHeader> {
 }
 
 #[repr(u32)]
+#[derive(EnumStringU32)]
 #[derive(Clone, Copy, PartialEq, Eq, FromPrimitive, Debug)]
+#[suricata(enum_string_style = "LOG_UPPERCASE")]
 pub enum HTTP2ErrorCode {
     NoError = 0,
     ProtocolError = 1,
@@ -97,37 +99,6 @@ pub enum HTTP2ErrorCode {
     EnhanceYourCalm = 11,
     InadequateSecurity = 12,
     Http11Required = 13,
-}
-
-impl fmt::Display for HTTP2ErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl std::str::FromStr for HTTP2ErrorCode {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let su = s.to_uppercase();
-        let su_slice: &str = &su;
-        match su_slice {
-            "NO_ERROR" => Ok(HTTP2ErrorCode::NoError),
-            "PROTOCOL_ERROR" => Ok(HTTP2ErrorCode::ProtocolError),
-            "FLOW_CONTROL_ERROR" => Ok(HTTP2ErrorCode::FlowControlError),
-            "SETTINGS_TIMEOUT" => Ok(HTTP2ErrorCode::SettingsTimeout),
-            "STREAM_CLOSED" => Ok(HTTP2ErrorCode::StreamClosed),
-            "FRAME_SIZE_ERROR" => Ok(HTTP2ErrorCode::FrameSizeError),
-            "REFUSED_STREAM" => Ok(HTTP2ErrorCode::RefusedStream),
-            "CANCEL" => Ok(HTTP2ErrorCode::Cancel),
-            "COMPRESSION_ERROR" => Ok(HTTP2ErrorCode::CompressionError),
-            "CONNECT_ERROR" => Ok(HTTP2ErrorCode::ConnectError),
-            "ENHANCE_YOUR_CALM" => Ok(HTTP2ErrorCode::EnhanceYourCalm),
-            "INADEQUATE_SECURITY" => Ok(HTTP2ErrorCode::InadequateSecurity),
-            "HTTP_1_1_REQUIRED" => Ok(HTTP2ErrorCode::Http11Required),
-            _ => Err(format!("'{}' is not a valid value for HTTP2ErrorCode", s)),
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/detect-engine-proto.c
+++ b/src/detect-engine-proto.c
@@ -100,26 +100,6 @@ int DetectProtoParse(DetectProto *dp, const char *str)
         SCLogDebug("IP protocol detected");
     } else {
         goto error;
-
-        /** \todo are numeric protocols even valid? */
-#if 0
-        uint8_t proto_u8; /* Used to avoid sign extension */
-
-        /* Extract out a 0-256 value with validation checks */
-        if (ByteExtractStringUint8(&proto_u8, 10, 0, str) == -1) {
-            // XXX
-            SCLogDebug("DetectProtoParse: Error in extracting byte string");
-            goto error;
-        }
-        proto = (int)proto_u8;
-
-        /* Proto 0 is the same as "ip" above */
-        if (proto == IPPROTO_IP) {
-            dp->flags |= DETECT_PROTO_ANY;
-        } else {
-            dp->proto[proto / 8] |= 1<<(proto % 8);
-        }
-#endif
     }
 
     return 0;

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -110,6 +110,8 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_FRAMETYPE].AppLayerTxMatch = DetectHTTP2frametypeMatch;
     sigmatch_table[DETECT_HTTP2_FRAMETYPE].Setup = DetectHTTP2frametypeSetup;
     sigmatch_table[DETECT_HTTP2_FRAMETYPE].Free = DetectHTTP2frametypeFree;
+    sigmatch_table[DETECT_HTTP2_FRAMETYPE].flags =
+            SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_HTTP2_FRAMETYPE].RegisterTests = DetectHTTP2frameTypeRegisterTests;
 #endif
@@ -132,8 +134,7 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_PRIORITY].AppLayerTxMatch = DetectHTTP2priorityMatch;
     sigmatch_table[DETECT_HTTP2_PRIORITY].Setup = DetectHTTP2prioritySetup;
     sigmatch_table[DETECT_HTTP2_PRIORITY].Free = DetectHTTP2priorityFree;
-    sigmatch_table[DETECT_HTTP2_PRIORITY].flags =
-            SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_MULTI_UINT;
+    sigmatch_table[DETECT_HTTP2_PRIORITY].flags = SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_HTTP2_PRIORITY].RegisterTests = DetectHTTP2priorityRegisterTests;
 #endif
@@ -216,26 +217,7 @@ static int DetectHTTP2frametypeMatch(DetectEngineThreadCtx *det_ctx,
                                const SigMatchCtx *ctx)
 
 {
-    uint8_t *detect = (uint8_t *)ctx;
-
-    return SCHttp2TxHasFrametype(txv, flags, *detect);
-}
-
-static int DetectHTTP2FuncParseFrameType(const char *str, uint8_t *ft)
-{
-    // first parse numeric value
-    if (ByteExtractStringUint8(ft, 10, (uint16_t)strlen(str), str) > 0) {
-        return 1;
-    }
-
-    // it it failed so far, parse string value from enumeration
-    int r = SCHttp2ParseFrametype(str);
-    if (r >= 0 && r <= UINT8_MAX) {
-        *ft = (uint8_t)r;
-        return 1;
-    }
-
-    return 0;
+    return SCHttp2TxHasFrametype(txv, flags, ctx);
 }
 
 /**
@@ -250,24 +232,16 @@ static int DetectHTTP2FuncParseFrameType(const char *str, uint8_t *ft)
  */
 static int DetectHTTP2frametypeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    uint8_t frame_type;
-
     if (SCDetectSignatureSetAppProto(s, ALPROTO_HTTP2) != 0)
         return -1;
 
-    if (!DetectHTTP2FuncParseFrameType(str, &frame_type)) {
-        SCLogError("Invalid argument \"%s\" supplied to http2.frametype keyword.", str);
+    void *dua8 = SCHttp2ParseFrametype(str);
+    if (dua8 == NULL)
         return -1;
-    }
 
-    uint8_t *http2ft = SCCalloc(1, sizeof(uint8_t));
-    if (http2ft == NULL)
-        return -1;
-    *http2ft = frame_type;
-
-    if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_FRAMETYPE, (SigMatchCtx *)http2ft,
+    if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_FRAMETYPE, (SigMatchCtx *)dua8,
                 g_http2_match_buffer_id) == NULL) {
-        DetectHTTP2frametypeFree(NULL, http2ft);
+        DetectHTTP2frametypeFree(NULL, dua8);
         return -1;
     }
 
@@ -281,7 +255,7 @@ static int DetectHTTP2frametypeSetup (DetectEngineCtx *de_ctx, Signature *s, con
  */
 void DetectHTTP2frametypeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    SCFree(ptr);
+    SCDetectU8ArrayFree(ptr);
 }
 
 /**

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -123,6 +123,8 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_ERRORCODE].AppLayerTxMatch = DetectHTTP2errorcodeMatch;
     sigmatch_table[DETECT_HTTP2_ERRORCODE].Setup = DetectHTTP2errorcodeSetup;
     sigmatch_table[DETECT_HTTP2_ERRORCODE].Free = DetectHTTP2errorcodeFree;
+    sigmatch_table[DETECT_HTTP2_ERRORCODE].flags =
+            SIGMATCH_INFO_UINT32 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_HTTP2_ERRORCODE].RegisterTests = DetectHTTP2errorCodeRegisterTests;
 #endif
@@ -236,8 +238,10 @@ static int DetectHTTP2frametypeSetup (DetectEngineCtx *de_ctx, Signature *s, con
         return -1;
 
     void *dua8 = SCHttp2ParseFrametype(str);
-    if (dua8 == NULL)
+    if (dua8 == NULL) {
+        SCLogError("Invalid http2.frametype: %s", str);
         return -1;
+    }
 
     if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_FRAMETYPE, (SigMatchCtx *)dua8,
                 g_http2_match_buffer_id) == NULL) {
@@ -269,27 +273,7 @@ static int DetectHTTP2errorcodeMatch(DetectEngineThreadCtx *det_ctx,
                                const SigMatchCtx *ctx)
 
 {
-    uint32_t *detect = (uint32_t *)ctx;
-
-    return SCHttp2TxHasErrorCode(txv, flags, *detect);
-    //TODOask handle negation rules
-}
-
-static int DetectHTTP2FuncParseErrorCode(const char *str, uint32_t *ec)
-{
-    // first parse numeric value
-    if (ByteExtractStringUint32(ec, 10, (uint16_t)strlen(str), str) > 0) {
-        return 1;
-    }
-
-    // it it failed so far, parse string value from enumeration
-    int r = SCHttp2ParseErrorCode(str);
-    if (r >= 0) {
-        *ec = r;
-        return 1;
-    }
-
-    return 0;
+    return SCHttp2TxHasErrorCode(txv, flags, ctx);
 }
 
 /**
@@ -304,24 +288,18 @@ static int DetectHTTP2FuncParseErrorCode(const char *str, uint32_t *ec)
  */
 static int DetectHTTP2errorcodeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    uint32_t error_code;
-
     if (SCDetectSignatureSetAppProto(s, ALPROTO_HTTP2) != 0)
         return -1;
 
-    if (!DetectHTTP2FuncParseErrorCode(str, &error_code)) {
-        SCLogError("Invalid argument \"%s\" supplied to http2.errorcode keyword.", str);
+    void *dua32 = SCHttp2ParseErrorCode(str);
+    if (dua32 == NULL) {
+        SCLogError("Invalid http2.frametype: %s", str);
         return -1;
     }
 
-    uint32_t *http2ec = SCCalloc(1, sizeof(uint32_t));
-    if (http2ec == NULL)
-        return -1;
-    *http2ec = error_code;
-
-    if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_ERRORCODE, (SigMatchCtx *)http2ec,
+    if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_ERRORCODE, (SigMatchCtx *)dua32,
                 g_http2_match_buffer_id) == NULL) {
-        DetectHTTP2errorcodeFree(NULL, http2ec);
+        DetectHTTP2errorcodeFree(NULL, dua32);
         return -1;
     }
 
@@ -335,7 +313,7 @@ static int DetectHTTP2errorcodeSetup (DetectEngineCtx *de_ctx, Signature *s, con
  */
 void DetectHTTP2errorcodeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    SCFree(ptr);
+    SCDetectU32ArrayFree(ptr);
 }
 
 /**


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7889

Describe changes:
- http2.frametype is now a generic integer
- http2.error_code  is now a generic integer (handling negation and other modes)
- rust EnumString derive accepts a enum_string_style parameter ("UPPERCASE" value accepted in addition to default "snake_case")

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2666

#13909 with tests fixed, error_code is logged as NOERROR, but parsed as NO_ERROR
