### PR TITLE
ike: log attributes as objects - v2


### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -34,6 +34,15 @@ also check all the new features that have been added but are not covered by
 this guide. Those features are either not enabled by default or require
 dedicated new configuration.
 
+Upgrading to 9.0.0
+------------------
+
+Logging Changes
+~~~~~~~~~~~~~~~
+- The format of IKEv1 proposal attributes has been changed to handle
+  duplicate attribute types. See :ref:`IKE logging changes
+  <9.0-ike-logging-changes>`
+
 Upgrading to 8.0.1
 ------------------
 

--- a/doc/userguide/upgrade/9.0-logging-changes.rst
+++ b/doc/userguide/upgrade/9.0-logging-changes.rst
@@ -1,0 +1,139 @@
+:orphan: Referenced from upgrade notes, not a toctree
+
+Suricata 9.0 Logging Changes
+############################
+
+.. _9.0-ike-logging-changes:
+
+IKE
+***
+
+IKE attributes are now logged as an array of objects instead of a map
+keyed by the attribute type. This allows for multiple attributes of
+the same type to be logged.
+
+The affected field names include:
+
+* alg_auth
+* alg_auth_raw
+* alg_dh
+* alf_dh_raw
+* alg_enc
+* alg_enc_raw
+* alg_hash
+* alg_hash_raw
+* sa_key_length
+* sa_key_length_raw
+* sa_life_duration
+* sa_life_duration_raw
+* sa_life_type
+* sa_life_type_raw
+
+Example - Attributes in "ike" object
+====================================
+
+**Suricata 8.0**
+
+.. code-block:: json
+
+   "ike": {
+     "alg_enc": "EncAesCbc",
+     "alg_enc_raw": 7,
+     "sa_key_length": "Unknown",
+     "sa_key_length_raw": 128
+   }
+
+**Suricata 9.0**
+
+.. code-block:: json
+
+   "ike": {
+     "attributes": [
+       {
+         "key": "alg_enc",
+         "value": "EncAesCbc",
+         "raw": 7
+       },
+       {
+         "key": "sa_key_length",
+         "value": "Unknown",
+         "raw": 128
+       }
+     ]
+   }
+
+Example - Client Proposal
+=========================
+
+**Suricata 8.0**
+
+.. code-block:: json
+
+        "ikev1": {
+           "client": {
+             "proposals": [
+               {
+                 "alg_enc": "EncAesCbc",
+                 "alg_enc_raw": 7,
+                 "sa_key_length": "Unknown",
+                 "sa_key_length_raw": 128,
+                 "alg_hash": "HashSha",
+                 "alg_hash_raw": 2,
+                 "alg_dh": "GroupAlternate1024BitModpGroup",
+                 "alg_dh_raw": 2,
+                 "alg_auth": "AuthPreSharedKey",
+                 "alg_auth_raw": 1,
+                 "sa_life_type": "LifeTypeSeconds",
+                 "sa_life_type_raw": 1,
+                 "sa_life_duration": "Unknown",
+                 "sa_life_duration_raw": 86400
+               }
+             ]
+           }
+         }
+
+**Suricata 9.0**
+
+.. code-block:: json
+
+          "ikev1": {
+            "client": {
+              "proposals": [
+                {
+                  "key": "alg_enc",
+                  "value": "EncAesCbc",
+                  "raw": 7
+                },
+                {
+                  "key": "sa_key_length",
+                  "value": "Unknown",
+                  "raw": 128
+                },
+                {
+                  "key": "alg_hash",
+                  "value": "HashSha",
+                  "raw": 2
+                },
+                {
+                  "key": "alg_dh",
+                  "value": "GroupAlternate1024BitModpGroup",
+                  "raw": 2
+                },
+                {
+                  "key": "alg_auth",
+                  "value": "AuthPreSharedKey",
+                  "raw": 1
+                },
+                {
+                  "key": "sa_life_type",
+                  "value": "LifeTypeSeconds",
+                  "raw": 1
+                },
+                {
+                  "key": "sa_life_duration",
+                  "value": "Unknown",
+                  "raw": 86400
+                }
+              ]
+            }
+          }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2567,6 +2567,7 @@
                         "server": {
                             "type": "object",
                             "additionalProperties": false,
+                            "minProperties": 1,
                             "properties": {
                                 "key_exchange_payload": {
                                     "type": "string"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2459,29 +2459,33 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "alg_auth": {
-                    "type": "string"
-                },
-                "alg_auth_raw": {
-                    "type": "integer"
-                },
-                "alg_dh": {
-                    "type": "string"
-                },
-                "alg_dh_raw": {
-                    "type": "integer"
-                },
-                "alg_enc": {
-                    "type": "string"
-                },
-                "alg_enc_raw": {
-                    "type": "integer"
-                },
-                "alg_hash": {
-                    "type": "string"
-                },
-                "alg_hash_raw": {
-                    "type": "integer"
+                "attributes": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": [
+                                    "alg_auth",
+                                    "alg_dh",
+                                    "alg_enc",
+                                    "alg_hash",
+                                    "sa_key_length",
+                                    "sa_life_duration",
+                                    "sa_life_type"
+                                ]
+                            },
+                            "raw": {
+                                "type": ["string", "number"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 },
                 "exchange_type": {
                     "type": "integer",
@@ -2531,47 +2535,23 @@
                                         "type": "object",
                                         "additionalProperties": false,
                                         "properties": {
-                                            "alg_auth": {
+                                            "key": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "alg_auth",
+                                                    "alg_dh",
+                                                    "alg_enc",
+                                                    "alg_hash",
+                                                    "sa_key_length",
+                                                    "sa_life_duration",
+                                                    "sa_life_type"
+                                                ]
+                                            },
+                                            "raw": {
+                                                "type": ["string", "number"]
+                                            },
+                                            "value": {
                                                 "type": "string"
-                                            },
-                                            "alg_auth_raw": {
-                                                "type": "integer"
-                                            },
-                                            "alg_dh": {
-                                                "type": "string"
-                                            },
-                                            "alg_dh_raw": {
-                                                "type": "integer"
-                                            },
-                                            "alg_enc": {
-                                                "type": "string"
-                                            },
-                                            "alg_enc_raw": {
-                                                "type": "integer"
-                                            },
-                                            "alg_hash": {
-                                                "type": "string"
-                                            },
-                                            "alg_hash_raw": {
-                                                "type": "integer"
-                                            },
-                                            "sa_key_length": {
-                                                "type": "string"
-                                            },
-                                            "sa_key_length_raw": {
-                                                "type": "integer"
-                                            },
-                                            "sa_life_duration": {
-                                                "type": "string"
-                                            },
-                                            "sa_life_duration_raw": {
-                                                "type": "integer"
-                                            },
-                                            "sa_life_type": {
-                                                "type": "string"
-                                            },
-                                            "sa_life_type_raw": {
-                                                "type": "integer"
                                             }
                                         }
                                     }
@@ -2642,22 +2622,8 @@
                 "role": {
                     "type": "string"
                 },
-                "sa_key_length": {
-                    "type": "string"
-                },
-                "sa_key_length_raw": {
-                    "type": "integer"
-                },
-                "sa_life_duration": {
-                    "type": "string"
-                },
-                "sa_life_duration_raw": {
-                    "type": "integer"
-                },
-                "sa_life_type": {
-                    "type": "string"
-                },
-                "sa_life_type_raw": {
+                "version": {
+                    "desription": "The version of the IKE log record (not IKE version)",
                     "type": "integer"
                 },
                 "version_major": {

--- a/rust/src/ike/detect.rs
+++ b/rust/src/ike/detect.rs
@@ -145,7 +145,7 @@ pub extern "C" fn SCIkeStateGetSaAttribute(
     let sa_type_s: Result<_, _>;
 
     unsafe { sa_type_s = CStr::from_ptr(sa_type).to_str() }
-    SCLogInfo!("{:#?}", sa_type_s);
+    SCLogDebug!("{:#?}", sa_type_s);
 
     if let Ok(sa) = sa_type_s {
         if tx.ike_version == 1 {

--- a/rust/src/ike/logger.rs
+++ b/rust/src/ike/logger.rs
@@ -173,26 +173,31 @@ fn log_ikev1(state: &IKEState, tx: &IKETransaction, jb: &mut JsonBuilder) -> Res
         jb.close()?; // client
 
         // server data
-        jb.open_object("server")?;
-        if !state.ikev1_container.server.key_exchange.is_empty() {
-            jb.set_string(
-                "key_exchange_payload",
-                &state.ikev1_container.server.key_exchange,
-            )?;
-            if let Ok(server_key_length) =
-                u64::try_from(state.ikev1_container.server.key_exchange.len())
-            {
-                jb.set_uint("key_exchange_payload_length", server_key_length / 2)?;
+        if !state.ikev1_container.server.key_exchange.is_empty()
+            || !state.ikev1_container.server.nonce.is_empty()
+        {
+            jb.open_object("server")?;
+            if !state.ikev1_container.server.key_exchange.is_empty() {
+                jb.set_string(
+                    "key_exchange_payload",
+                    &state.ikev1_container.server.key_exchange,
+                )?;
+                if let Ok(server_key_length) =
+                    u64::try_from(state.ikev1_container.server.key_exchange.len())
+                {
+                    jb.set_uint("key_exchange_payload_length", server_key_length / 2)?;
+                }
             }
-        }
-        if !state.ikev1_container.server.nonce.is_empty() {
-            jb.set_string("nonce_payload", &state.ikev1_container.server.nonce)?;
-            if let Ok(server_nonce_length) = u64::try_from(state.ikev1_container.server.nonce.len())
-            {
-                jb.set_uint("nonce_payload_length", server_nonce_length / 2)?;
+            if !state.ikev1_container.server.nonce.is_empty() {
+                jb.set_string("nonce_payload", &state.ikev1_container.server.nonce)?;
+                if let Ok(server_nonce_length) =
+                    u64::try_from(state.ikev1_container.server.nonce.len())
+                {
+                    jb.set_uint("nonce_payload_length", server_nonce_length / 2)?;
+                }
             }
+            jb.close()?; // server
         }
-        jb.close()?; // server
 
         if !tx.hdr.ikev1_header.vendor_ids.is_empty() {
             jb.open_array("vendor_ids")?;


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/7902

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2665

Also:
- Don't log empty "ike" server objects

Previous PR: https://github.com/OISF/suricata/pull/13907

Changes:
- Add ike log record version specifier
