### PR TITLE
8.0.x: ike: handle duplicate attributes - v1

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -315,6 +315,17 @@ YAML::
             # Default: all.
             #types: [a, aaaa, cname, mx, ns, ptr, txt]
 
+IKE
+~~~
+
+YAML::
+
+  - ike:
+      # Enable logging attributes as objects instead of
+      # giving duplicates an index suffix. This will be
+      # the default in Suricata 9.0.
+      #object-attributes: false
+
 TLS
 ~~~
 

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -34,6 +34,21 @@ also check all the new features that have been added but are not covered by
 this guide. Those features are either not enabled by default or require
 dedicated new configuration.
 
+Upgrading to 8.0.2
+------------------
+
+Logging Changes
+~~~~~~~~~~~~~~~
+
+- Duplicate field names in IKE attributes has been removed. Before 8.0
+  it was possible to see duplicate field names like
+  ``sa_life_duration``, while some parsers ignore the duplicates,
+  strict parsers will fail on duplicates. To address this, duplicates
+  will now be given an index suffix, for example: `sa_life_duration`,
+  `sa_life_duration_1`. See
+  https://redmine.openinfosecfoundation.org/issues/7902 for more
+  information.
+
 Upgrading to 8.0.1
 ------------------
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2563,6 +2563,14 @@
                                             "sa_life_type_raw": {
                                                 "type": "integer"
                                             }
+                                        },
+                                        "patternProperties": {
+                                            "^sa_life_duration_[0-9]+$": {
+                                                "type": "string"
+                                            },
+                                            "^sa_life_duration_[0-9]+_raw$": {
+                                                "type": "integer"
+                                            }
                                         }
                                     }
                                 }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2473,6 +2473,38 @@
                 "alg_hash_raw": {
                     "type": "integer"
                 },
+                "attributes": {
+                    "description": "When object-attributes = true",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": [
+                                    "alg_auth",
+                                    "alg_dh",
+                                    "alg_enc",
+                                    "alg_hash",
+                                    "sa_key_length",
+                                    "sa_life_duration",
+                                    "sa_life_type"
+                                ]
+                            },
+                            "raw": {
+                                "type": [
+                                    "string",
+                                    "number"
+                                ]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "exchange_type": {
                     "type": "integer",
                     "suricata": {
@@ -2545,6 +2577,26 @@
                                             "alg_hash_raw": {
                                                 "type": "integer"
                                             },
+                                            "key": {
+                                                "description": "When object-attributes = true",
+                                                "type": "string",
+                                                "enum": [
+                                                    "alg_auth",
+                                                    "alg_dh",
+                                                    "alg_enc",
+                                                    "alg_hash",
+                                                    "sa_key_length",
+                                                    "sa_life_duration",
+                                                    "sa_life_type"
+                                                ]
+                                            },
+                                            "raw": {
+                                                "description": "When object-attributes = true",
+                                                "type": [
+                                                    "string",
+                                                    "number"
+                                                ]
+                                            },
                                             "sa_key_length": {
                                                 "type": "string"
                                             },
@@ -2562,6 +2614,10 @@
                                             },
                                             "sa_life_type_raw": {
                                                 "type": "integer"
+                                            },
+                                            "value": {
+                                                "description": "When object-attributes = true",
+                                                "type": "string"
                                             }
                                         },
                                         "patternProperties": {

--- a/rust/src/ike/detect.rs
+++ b/rust/src/ike/detect.rs
@@ -145,7 +145,7 @@ pub extern "C" fn SCIkeStateGetSaAttribute(
     let sa_type_s: Result<_, _>;
 
     unsafe { sa_type_s = CStr::from_ptr(sa_type).to_str() }
-    SCLogInfo!("{:#?}", sa_type_s);
+    SCLogDebug!("{:#?}", sa_type_s);
 
     if let Ok(sa) = sa_type_s {
         if tx.ike_version == 1 {

--- a/src/output-json-ike.c
+++ b/src/output-json-ike.c
@@ -49,8 +49,9 @@
 
 #include "rust.h"
 
-#define LOG_IKE_DEFAULT  0
-#define LOG_IKE_EXTENDED (1 << 0)
+#define LOG_IKE_DEFAULT           BIT_U32(0)
+#define LOG_IKE_EXTENDED          BIT_U32(1)
+#define LOG_IKE_ATTRIBUTE_OBJECTS BIT_U32(2)
 
 typedef struct LogIKEFileCtx_ {
     uint32_t flags;
@@ -130,6 +131,11 @@ static OutputInitResult OutputIKELogInitSub(SCConfNode *conf, OutputCtx *parent_
         if (SCConfValIsTrue(extended)) {
             ikelog_ctx->flags = LOG_IKE_EXTENDED;
         }
+    }
+
+    const char *objects = SCConfNodeLookupChildValue(conf, "object-attributes");
+    if (objects && SCConfValIsTrue(objects)) {
+        ikelog_ctx->flags |= LOG_IKE_ATTRIBUTE_OBJECTS;
     }
 
     output_ctx->data = ikelog_ctx;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -326,7 +326,9 @@ outputs:
             #types: [file, tree_connect, negotiate, dcerpc, create,
             #  session_setup, ioctl, rename, set_file_path_info, generic]
         - tftp
-        - ike
+        - ike:
+            # Log attributes as object (future Suricata 9.0 behavior)
+            #object-attributes: false
         - dcerpc
         - krb5
         - bittorrent-dht


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/7829

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2669

As this solutiont to this problem in 8.0 is a little more feature than in 9,
its worth reviewing the fixes in parallel.

By default, we suffix duplicate attribute names with an index. User can opt-in
to 9.0 style attribute as object logging.
