### PR TITLE
decode/ipv6: actually set ipv6 pkt too small event - v1

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -13,7 +13,7 @@ alert pkthdr any any -> any any (msg:"SURICATA IPv4 option end of list required"
 alert pkthdr any any -> any any (msg:"SURICATA IPv4 duplicated IP option"; decode-event:ipv4.opt_duplicate; classtype:protocol-command-decode; sid:2200009; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA IPv4 unknown IP option"; decode-event:ipv4.opt_unknown; classtype:protocol-command-decode; sid:2200010; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA IPv4 wrong IP version"; decode-event:ipv4.wrong_ip_version; classtype:protocol-command-decode; sid:2200011; rev:2;)
-alert pkthdr any any -> any any (msg:"SURICATA IPv6 packet too small"; decode-event:ipv6.pkt_too_small; classtype:protocol-command-decode; sid:2200012; rev:2;)
+#alert pkthdr any any -> any any (msg:"SURICATA IPv6 packet too small"; decode-event:ipv6.pkt_too_small; classtype:protocol-command-decode; sid:2200012; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA IPv6 truncated packet"; decode-event:ipv6.trunc_pkt; classtype:protocol-command-decode; sid:2200013; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA IPv6 truncated extension header"; decode-event:ipv6.trunc_exthdr; classtype:protocol-command-decode; sid:2200014; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA IPv6 duplicated Fragment extension header"; decode-event:ipv6.exthdr_dupl_fh; classtype:protocol-command-decode; sid:2200015; rev:2;)


### PR DESCRIPTION
The event exists, but it was never set.
Disabled the existing rule, to avoid flooding.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7963

Describe changes:
- actually set event when ipv6 pkt is too small -- following pattern in similar IPv4 decoding function
- add unit test to test this (I'm wasn't sure how to create a valid sv test for this. I tried manually editing a valid IPv6 packet in a pcap to be shorter than the IPv6 header length (40), but that lead to Suricata marking it as truncated) 
- disable the rule for said event

