### PR TITLE
  Add more descriptions to decoder stats counters - v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6356,10 +6356,12 @@
                                     "additionalProperties": false,
                                     "properties": {
                                         "header_too_small": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of packets with header too small for E-tag"
                                         },
                                         "unknown_type": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of E-tag packets with unknown type"
                                         }
                                     }
                                 },
@@ -6542,52 +6544,68 @@
                                     "additionalProperties": false,
                                     "properties": {
                                         "frag_ignored": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 fragments ignored due to resource allocation errors"
                                         },
                                         "frag_overlap": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 fragments with overlapping data"
                                         },
                                         "frag_pkt_too_large": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 fragments ignored due to being too large"
                                         },
                                         "hlen_too_small": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets flagged invalid due to header smaller than minimum size"
                                         },
                                         "icmpv6": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets flagged invalid due to having an ICMPV6 header"
                                         },
                                         "iplen_smaller_than_hlen": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets flagged invalid due to length being smaller than IP header size"
                                         },
                                         "opt_duplicate": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets with duplicated IP options"
                                         },
                                         "opt_eol_required": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets with 'end of list' option not present, but required, in IP options"
                                         },
                                         "opt_invalid": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets with invalid IP options"
                                         },
                                         "opt_invalid_len": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets flagged invalid due to IP options with invalid length"
                                         },
                                         "opt_malformed": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets flagged invalid due to malformed IP options"
                                         },
                                         "opt_pad_required": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets with padding bytes required in IP options"
                                         },
                                         "opt_unknown": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets flagged invalid due to unknown IP option"
                                         },
                                         "pkt_too_small": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets flagged invalid due to size smaller than minimum header size"
                                         },
                                         "trunc_pkt": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets flagged invalid due to truncated packet"
                                         },
                                         "wrong_ip_version": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4 packets flagged invalid due to having wrong IP version in IP options"
                                         }
                                     }
                                 },
@@ -6596,97 +6614,128 @@
                                     "additionalProperties": false,
                                     "properties": {
                                         "data_after_none_header": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with data after the 'none' header"
                                         },
                                         "dstopts_only_padding": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with all DST options as only padding"
                                         },
                                         "dstopts_unknown_opt": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with unknown DST option"
                                         },
                                         "exthdr_ah_res_not_null": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with AH header reserved fields not null"
                                         },
                                         "exthdr_dupl_ah": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with duplicated 'authentication' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_dh": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with duplicated 'destination' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_eh": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with duplicated 'ESP' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_fh": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with duplicated 'fragment' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_hh": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with duplicated 'hop-by-hop' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_rh": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with duplicated'routing' header in IPv6 extension headers"
                                         },
                                         "exthdr_invalid_optlen": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets flagged invalid due to invalid option length in a hop or dst extended header"
                                         },
                                         "exthdr_useless_fh": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with useless 'fragment header' in the extended headers"
                                         },
                                         "fh_non_zero_reserved_field": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with 'fragment header' with non-zero reserved field"
                                         },
                                         "frag_ignored": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 fragments ignored due to resource allocation errors"
                                         },
                                         "frag_invalid_length": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 fragments with invalid length"
                                         },
                                         "frag_overlap": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 fragments with overlapping data"
                                         },
                                         "frag_pkt_too_large": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 fragments ignored due to being too large"
                                         },
                                         "hopopts_only_padding": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with all HOP options as only padding"
                                         },
                                         "hopopts_unknown_opt": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with unknown HOP option"
                                         },
                                         "icmpv4": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with ICMPv4 header"
                                         },
                                         "ipv4_in_ipv6_too_small": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description":"Number of IPv4-in-IPv6 packets flagged invalid due to being too small"
                                         },
                                         "ipv4_in_ipv6_wrong_version": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv4-in-IPv6 packets with wrong IP version"
                                         },
                                         "ipv6_in_ipv6_too_small": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6-in-IPv6 packets flagged invalid due to being too small"
                                         },
                                         "ipv6_in_ipv6_wrong_version": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6-in-IPv6 packets with wrong IP version"
                                         },
                                         "pkt_too_small": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets flagged invalid due to size smaller than minimum header size"
                                         },
                                         "rh_type_0": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with extended header 'routing' with type 0"
                                         },
                                         "trunc_exthdr": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets flagged invalid due to truncated extension header"
                                         },
                                         "trunc_pkt": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets flagged invalid due to truncated packet"
                                         },
                                         "unknown_next_header": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with unknown next header"
                                         },
                                         "wrong_ip_version": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets flagged invalid due to wrong IP version"
                                         },
                                         "zero_len_padn": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of IPv6 packets with PadN option without data (length zero)"
                                         }
                                     }
                                 },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6206,13 +6206,16 @@
                     "additionalProperties": false,
                     "properties": {
                         "kernel_drops": {
-                            "type": "integer"
+                            "type": "integer",
+                            "description": "Number of packets dropped by the kernel"
                         },
                         "kernel_ifdrops": {
-                            "type": "integer"
+                            "type": "integer",
+                            "description": "Number of packets dropped by the interface"
                         },
                         "kernel_packets": {
-                            "type": "integer"
+                            "type": "integer",
+                            "description": "Number of packets received from the kernel"
                         }
                     }
                 },
@@ -6357,11 +6360,11 @@
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer",
-                                            "description": "Number of packets with header too small for E-tag"
+                                            "description": "Number of packets with header too small for ETAG"
                                         },
                                         "unknown_type": {
                                             "type": "integer",
-                                            "description": "Number of E-tag packets with unknown type"
+                                            "description": "Number of ETAG packets with unknown type"
                                         }
                                     }
                                 },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6329,15 +6329,15 @@
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer",
-                                            "description": "Number of packets with header too small for ERPSAN"
+                                            "description": "Number of packets with header too small for ERSPAN"
                                         },
                                         "too_many_vlan_layers": {
                                             "type": "integer",
-                                            "description": "Number of packets with too many VLAN layers for ERPSAN"
+                                            "description": "Number of packets with too many VLAN layers for ERSPAN"
                                         },
                                         "unsupported_version": {
                                             "type": "integer",
-                                            "description": "Number of packets with unsupported version for ERPSAN"
+                                            "description": "Number of packets with unsupported version for ERSPAN"
                                         }
                                     }
                                 },

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -218,7 +218,6 @@ static int IPV4OptValidateCIPSO(Packet *p, const IPV4Opt *o)
 
         /* Tag header must fit within option length */
         if (unlikely(len < 2)) {
-            //printf("CIPSO tag header too large %" PRIu16 " < 2\n", len);
             ENGINE_SET_INVALID_EVENT(p, IPV4_OPT_MALFORMED);
             return -1;
         }
@@ -229,7 +228,6 @@ static int IPV4OptValidateCIPSO(Packet *p, const IPV4Opt *o)
 
         /* Tag length must fit within the option length */
         if (unlikely(tlen > len)) {
-            //printf("CIPSO tag len too large %" PRIu8 " > %" PRIu16 "\n", tlen, len);
             ENGINE_SET_INVALID_EVENT(p, IPV4_OPT_MALFORMED);
             return -1;
         }
@@ -242,7 +240,6 @@ static int IPV4OptValidateCIPSO(Packet *p, const IPV4Opt *o)
             case 7:
                 /* Tag is at least 4 and at most the remainder of option len */
                 if (unlikely((tlen < 4) || (tlen > len))) {
-                    //printf("CIPSO tag %" PRIu8 " bad tlen=%" PRIu8 " len=%" PRIu8 "\n", ttype, tlen, len);
                     ENGINE_SET_INVALID_EVENT(p, IPV4_OPT_MALFORMED);
                     return -1;
                 }
@@ -251,7 +248,6 @@ static int IPV4OptValidateCIPSO(Packet *p, const IPV4Opt *o)
                  * type 7, which has no such field.
                  */
                 if (unlikely((ttype != 7) && (*tag != 0))) {
-                    //printf("CIPSO tag %" PRIu8 " ao=%" PRIu8 "\n", ttype, tlen);
                     ENGINE_SET_INVALID_EVENT(p, IPV4_OPT_MALFORMED);
                     return -1;
                 }
@@ -267,7 +263,6 @@ static int IPV4OptValidateCIPSO(Packet *p, const IPV4Opt *o)
                 ENGINE_SET_INVALID_EVENT(p,IPV4_OPT_MALFORMED);
                 return -1;
             default:
-                //printf("CIPSO tag %" PRIu8 " unknown tag\n", ttype);
                 ENGINE_SET_INVALID_EVENT(p, IPV4_OPT_MALFORMED);
                 /** \todo May not want to return error here on unknown tag type (at least not for 3|4) */
                 return -1;


### PR DESCRIPTION
Previous PR: #13932 

Describe changes:
v2:
- update descriptions for `ipv4|ipv6.frag_ignored`
- update description for `ipv4.opt_eol_required`
- update description for `kernel_drops`
- decode/ipv4: remove commented-out debug-like printf statements

v1: 
Add descriptions for:
- stats.capture
- stats.decoder.event.ipv4
- stats.decoder.event.ipv6
- stats.decoder.event.etag
- fix typo in stats descriptions for decoder.event.erspan

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7793
https://redmine.openinfosecfoundation.org/issues/6434
