### PR TITLE
rust/conf: Accept xiB unit suffixes

### DIFF
--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -185,8 +185,11 @@ fn get_memunit(unit: &str) -> u64 {
     match unit {
         "b" => BYTE,
         "kb" => KILOBYTE,
+        "kib" => KILOBYTE,
         "mb" => MEGABYTE,
+        "mib" => MEGABYTE,
         "gb" => GIGABYTE,
+        "gib" => GIGABYTE,
         _ => 0,
     }
 }
@@ -200,13 +203,15 @@ fn get_memunit(unit: &str) -> u64 {
 /// # Arguments
 ///
 /// * `arg` - A string slice that holds the value parsed from the config
+///
+/// Note that kb/mb/gb and kib/mib/gib are equivalent
 pub fn get_memval(arg: &str) -> Result<u64, &'static str> {
     let arg = arg.trim();
     let val: f64;
     let mut unit: &str;
     let mut parser = tuple((
         preceded(multispace0, double),
-        preceded(multispace0, verify(not_line_ending, |c: &str| c.len() < 3)),
+        preceded(multispace0, verify(not_line_ending, |c: &str| c.len() < 4)),
     ));
     let r: IResult<&str, (f64, &str)> = parser(arg);
     if let Ok(r) = r {
@@ -242,13 +247,22 @@ mod tests {
         let s = "10Kb";
         assert_eq!(Ok(res * KILOBYTE), get_memval(s));
 
+        let s = "10Kib";
+        assert_eq!(Ok(res * KILOBYTE), get_memval(s));
+
         let s = "10KB";
         assert_eq!(Ok(res * KILOBYTE), get_memval(s));
 
         let s = "10mb";
         assert_eq!(Ok(res * MEGABYTE), get_memval(s));
 
+        let s = "10mib";
+        assert_eq!(Ok(res * MEGABYTE), get_memval(s));
+
         let s = "10gb";
+        assert_eq!(Ok(res * GIGABYTE), get_memval(s));
+
+        let s = "10gib";
         assert_eq!(Ok(res * GIGABYTE), get_memval(s));
     }
 


### PR DESCRIPTION
Update the memval to recognize
- kb and kib
- mb and mib
- gb and gib as equivalent.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7903

Describe changes:
- Recognize "kib", "mib", and "gib" (case ignore) as equivalents for "kb", "mb", and "gb"
- Extended unit test to validate equivalency

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
