### PR TITLE
decode/ipv6: flag invalid pkt w/ wrong ip ver event - v1

### DIFF
--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -317,8 +317,7 @@ static void DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, 
                         /* a zero padN len would be weird */
                         if (ip6_optlen == 0)
                             ENGINE_SET_EVENT(p, IPV6_EXTHDR_ZERO_LEN_PADN);
-                    }
-                    else if (*ptr == IPV6OPT_RA) /* RA */
+                    } else if (*ptr == IPV6OPT_RA) /* RA */
                     {
                         ra->ip6ra_type = *(ptr);
                         ra->ip6ra_len  = ip6_optlen;
@@ -331,8 +330,7 @@ static void DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, 
                         memcpy(&ra->ip6ra_value, (ptr + 2), sizeof(ra->ip6ra_value));
                         ra->ip6ra_value = SCNtohs(ra->ip6ra_value);
                         other_cnt++;
-                    }
-                    else if (*ptr == IPV6OPT_JUMBO) /* Jumbo */
+                    } else if (*ptr == IPV6OPT_JUMBO) /* Jumbo */
                     {
                         jumbo->ip6j_type = *(ptr);
                         jumbo->ip6j_len  = ip6_optlen;
@@ -344,8 +342,7 @@ static void DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, 
 
                         memcpy(&jumbo->ip6j_payload_len, (ptr+2), sizeof(jumbo->ip6j_payload_len));
                         jumbo->ip6j_payload_len = SCNtohl(jumbo->ip6j_payload_len);
-                    }
-                    else if (*ptr == IPV6OPT_HAO) /* HAO */
+                    } else if (*ptr == IPV6OPT_HAO) /* HAO */
                     {
                         hao->ip6hao_type = *(ptr);
                         hao->ip6hao_len  = ip6_optlen;
@@ -355,7 +352,7 @@ static void DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, 
                             break;
                         }
 
-                        memcpy(&hao->ip6hao_hoa, (ptr+2), sizeof(hao->ip6hao_hoa));
+                        memcpy(&hao->ip6hao_hoa, (ptr + 2), sizeof(hao->ip6hao_hoa));
                         other_cnt++;
                     } else {
                         if (nh == IPPROTO_HOPOPTS)

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2024 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -58,7 +58,7 @@ static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, c
         }
         FlowSetupPacket(p);
     } else {
-        ENGINE_SET_EVENT(p, IPV4_IN_IPV6_WRONG_IP_VER);
+        ENGINE_SET_INVALID_EVENT(p, IPV4_IN_IPV6_WRONG_IP_VER);
     }
 }
 
@@ -83,7 +83,7 @@ static int DecodeIP6inIP6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         }
         FlowSetupPacket(p);
     } else {
-        ENGINE_SET_EVENT(p, IPV6_IN_IPV6_WRONG_IP_VER);
+        ENGINE_SET_INVALID_EVENT(p, IPV6_IN_IPV6_WRONG_IP_VER);
     }
     return TM_ECODE_OK;
 }

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -312,7 +312,6 @@ static void DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, 
 
                     if (*ptr == IPV6OPT_PADN) /* PadN */
                     {
-                        //printf("PadN option\n");
                         padn_cnt++;
 
                         /* a zero padN len would be weird */
@@ -331,8 +330,6 @@ static void DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, 
 
                         memcpy(&ra->ip6ra_value, (ptr + 2), sizeof(ra->ip6ra_value));
                         ra->ip6ra_value = SCNtohs(ra->ip6ra_value);
-                        //printf("RA option: type %" PRIu32 " len %" PRIu32 " value %" PRIu32 "\n",
-                        //    ra->ip6ra_type, ra->ip6ra_len, ra->ip6ra_value);
                         other_cnt++;
                     }
                     else if (*ptr == IPV6OPT_JUMBO) /* Jumbo */
@@ -347,8 +344,6 @@ static void DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, 
 
                         memcpy(&jumbo->ip6j_payload_len, (ptr+2), sizeof(jumbo->ip6j_payload_len));
                         jumbo->ip6j_payload_len = SCNtohl(jumbo->ip6j_payload_len);
-                        //printf("Jumbo option: type %" PRIu32 " len %" PRIu32 " payload len %" PRIu32 "\n",
-                        //    jumbo->ip6j_type, jumbo->ip6j_len, jumbo->ip6j_payload_len);
                     }
                     else if (*ptr == IPV6OPT_HAO) /* HAO */
                     {
@@ -361,12 +356,6 @@ static void DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, 
                         }
 
                         memcpy(&hao->ip6hao_hoa, (ptr+2), sizeof(hao->ip6hao_hoa));
-                        //printf("HAO option: type %" PRIu32 " len %" PRIu32 " ",
-                        //    hao->ip6hao_type, hao->ip6hao_len);
-                        //char addr_buf[46];
-                        //PrintInet(AF_INET6, (char *)&(hao->ip6hao_hoa),
-                        //    addr_buf,sizeof(addr_buf));
-                        //printf("home addr %s\n", addr_buf);
                         other_cnt++;
                     } else {
                         if (nh == IPPROTO_HOPOPTS)


### PR DESCRIPTION

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7964

Describe changes:
- following what's done for decoding ipv4 (`decode-ipv4.c`), when decoding ipv4|ipv6-in-ipv6 packets, flag packet invalid when inner packet has wrong ip version
- clean up commented-out debug-like printf statements
- apply clang formatting changes

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2670