### PR TITLE
redis: Add authentication support

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -76,6 +76,8 @@ Output types::
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
+      #  username: null ## ACL username; if null (default), no username is used
+      #  password: null ## AUTH password; if null (default), authentication is disabled
       #  async: true ## if redis replies are read asynchronously
       #  mode: list ## possible values: list|lpush (default), rpush, channel|publish, xadd|stream
       #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -21,6 +21,8 @@ outputs:
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
+      #  username: null ## ACL username; if null (default), no username is used
+      #  password: null ## AUTH password; if null (default), authentication is disabled
       #  async: true ## if redis replies are read asynchronously
       #  mode: list ## possible values: list|lpush (default), rpush, channel|publish, xadd|stream
       #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -96,7 +96,7 @@ static SCLogRedisContext *SCLogRedisContextAsyncAlloc(void)
     ctx->sync = NULL;
     ctx->async   = NULL;
     ctx->ev_base = NULL;
-    ctx->connected = 0;
+    ctx->state = REDIS_STATE_DISCONNECTED;
     ctx->batch_count = 0;
     ctx->last_push = 0;
     ctx->tried = 0;
@@ -116,13 +116,67 @@ static void SCRedisAsyncCommandCallback(redisAsyncContext *ac, void *r, void *pr
     SCLogRedisContext *ctx = log_ctx->redis;
 
     if (reply == NULL) {
-        if (ctx->connected > 0)
+        if (ctx->state != REDIS_STATE_DISCONNECTED)
             SCLogInfo("Missing reply from redis, disconnected.");
-        ctx->connected = 0;
+        ctx->state = REDIS_STATE_DISCONNECTED;
     } else {
-        ctx->connected = 1;
         event_base_loopbreak(ctx->ev_base);
     }
+}
+
+/** \brief SCRedisAsyncAuthCallback() Callback when AUTH reply from redis happens.
+ *  \param ac redis async context
+ *  \param r redis reply
+ *  \param privdata opaque data with pointer to LogFileCtx
+ */
+static void SCRedisAsyncAuthCallback(redisAsyncContext *ac, void *r, void *privdata)
+{
+    redisReply *reply = r;
+    LogFileCtx *log_ctx = privdata;
+    SCLogRedisContext *ctx = log_ctx->redis;
+
+    if (reply == NULL) {
+        if (ctx->tried == 0) {
+            SCLogWarning("Failed to connect to Redis... (will keep trying)");
+        }
+        ctx->state = REDIS_STATE_DISCONNECTED;
+        ctx->tried = time(NULL);
+    } else {
+        if (reply->type != REDIS_REPLY_ERROR) {
+            SCLogInfo("Redis authenticated successfully.");
+            ctx->state = REDIS_STATE_AUTHENTICATED;
+            ctx->tried = 0;
+        } else {
+            if (ctx->tried == 0) {
+                SCLogWarning("Redis AUTH failed: %s (will keep trying)", reply->str);
+            }
+            ctx->state = REDIS_STATE_CONNECTED;
+            ctx->tried = time(NULL);
+        }
+    }
+    event_base_loopbreak(ctx->ev_base);
+}
+
+/** \brief SCLogAsyncRedisSendAuth() - Authenticates with redis
+ *  \param log_ctx Log file context allocated by caller
+ */
+static void SCLogAsyncRedisSendAuth(LogFileCtx *log_ctx)
+{
+    SCLogRedisContext *ctx = log_ctx->redis;
+
+    /* only try to reauth once per second */
+    if (ctx->tried >= time(NULL)) {
+        return;
+    }
+
+    if (log_ctx->redis_setup.username != NULL) {
+        redisAsyncCommand(ctx->async, SCRedisAsyncAuthCallback, log_ctx, "AUTH %s %s",
+                log_ctx->redis_setup.username, log_ctx->redis_setup.password);
+    } else {
+        redisAsyncCommand(ctx->async, SCRedisAsyncAuthCallback, log_ctx, "AUTH %s",
+                log_ctx->redis_setup.password);
+    }
+    event_base_dispatch(ctx->ev_base);
 }
 
 /** \brief SCRedisAsyncEchoCommandCallback() Callback for an ECHO command reply
@@ -136,24 +190,35 @@ static void SCRedisAsyncEchoCommandCallback(redisAsyncContext *ac, void *r, void
     redisReply *reply = r;
     SCLogRedisContext * ctx = privdata;
 
-    if (reply) {
-       if (ctx->connected == 0) {
-          SCLogNotice("Connected to Redis.");
-          ctx->connected = 1;
-          ctx->tried = 0;
-       }
+    if (reply == NULL) {
+        if (ctx->tried == 0) {
+            SCLogWarning("Failed to connect to Redis... (will keep trying)");
+        }
+        ctx->state = REDIS_STATE_DISCONNECTED;
+        ctx->tried = time(NULL);
     } else {
-       ctx->connected = 0;
-       if (ctx->tried == 0) {
-           SCLogWarning("Failed to connect to Redis... (will keep trying)");
-       }
-       ctx->tried = time(NULL);
+        if (reply->type != REDIS_REPLY_ERROR) {
+            SCLogNotice("Connected to Redis.");
+            ctx->state = REDIS_STATE_CONNECTED;
+            ctx->tried = 0;
+        } else {
+            if (strncmp(reply->str, "NOAUTH", 6) == 0) {
+                if (ctx->tried == 0) {
+                    SCLogWarning("Redis authentication required, but not configured.");
+                }
+            } else {
+                if (ctx->tried == 0) {
+                    SCLogWarning("Redis ECHO command failed: %s", reply->str);
+                }
+            }
+            ctx->state = REDIS_STATE_DISCONNECTED;
+            ctx->tried = time(NULL);
+        }
     }
     event_base_loopbreak(ctx->ev_base);
 }
 
-/** \brief SCRedisAsyncEchoCommandCallback() Callback for an QUIT command reply
- *         Emits and awaits response for an async ECHO command.
+/** \brief SCLogAsyncRedisSendEcho() - Emits and awaits response for an async ECHO command.
  *         It's used for check if redis is alive.
  *  \param ctx redis context
  */
@@ -181,7 +246,7 @@ static void SCRedisAsyncQuitCommandCallback(redisAsyncContext *ac, void *r, void
  */
 static void SCLogAsyncRedisSendQuit(SCLogRedisContext * ctx)
 {
-    if (ctx->connected) {
+    if (ctx->state != REDIS_STATE_DISCONNECTED) {
         redisAsyncCommand(ctx->async, SCRedisAsyncQuitCommandCallback, ctx, "QUIT");
         SCLogInfo("QUIT Command sent to redis. Connection will terminate!");
     }
@@ -191,7 +256,7 @@ static void SCLogAsyncRedisSendQuit(SCLogRedisContext * ctx)
     ctx->async = NULL;
     event_base_free(ctx->ev_base);
     ctx->ev_base = NULL;
-    ctx->connected = 0;
+    ctx->state = REDIS_STATE_DISCONNECTED;
 }
 
 /** \brief SCConfLogReopenAsyncRedis() Open or re-opens connection to redis for logging.
@@ -247,6 +312,16 @@ static int SCConfLogReopenAsyncRedis(LogFileCtx *log_ctx)
     return 0;
 }
 
+/** \brief SCLogAsyncRedisIsReady() Determines whether is ready to send data.
+ *  \param file_ctx Log file context allocated by caller
+ */
+static inline bool SCLogAsyncRedisIsReady(LogFileCtx *file_ctx)
+{
+    SCLogRedisContext *ctx = file_ctx->redis;
+
+    return file_ctx->redis_setup.password ? ctx->state == REDIS_STATE_AUTHENTICATED
+                                          : ctx->state == REDIS_STATE_CONNECTED;
+}
 
 /** \brief SCLogRedisWriteAsync() writes string to redis output in async mode
  *  \param file_ctx Log file context allocated by caller
@@ -256,17 +331,25 @@ static int SCLogRedisWriteAsync(LogFileCtx *file_ctx, const char *string, size_t
 {
     SCLogRedisContext *ctx = file_ctx->redis;
 
-    if (! ctx->connected) {
-        if (SCConfLogReopenAsyncRedis(file_ctx) == -1) {
-            return -1;
+    if (!SCLogAsyncRedisIsReady(file_ctx)) {
+        if (ctx->state == REDIS_STATE_DISCONNECTED) {
+            if (SCConfLogReopenAsyncRedis(file_ctx) == -1) {
+                return -1;
+            }
         }
         if (ctx->tried == 0) {
-           SCLogNotice("Trying to connect to Redis");
+            SCLogNotice("Trying to connect to Redis");
         }
-        SCLogAsyncRedisSendEcho(ctx);
+        if (file_ctx->redis_setup.password == NULL) {
+            // Just verify the connection is alive with ECHO
+            SCLogAsyncRedisSendEcho(ctx);
+        } else {
+            // Send AUTH to authenticate and verify the connection is alive
+            SCLogAsyncRedisSendAuth(file_ctx);
+        }
     }
 
-    if (!ctx->connected) {
+    if (!SCLogAsyncRedisIsReady(file_ctx)) {
         return -1;
     }
 
@@ -322,6 +405,29 @@ static int SCConfLogReopenSyncRedis(LogFileCtx *log_ctx)
         return -1;
     }
     SCLogInfo("Connected to redis server [%s].", log_ctx->redis_setup.server);
+
+    if (log_ctx->redis_setup.password != NULL) {
+        redisReply *reply;
+        if (log_ctx->redis_setup.username != NULL) {
+            reply = redisCommand(ctx->sync, "AUTH %s %s", log_ctx->redis_setup.username,
+                    log_ctx->redis_setup.password);
+        } else {
+            reply = redisCommand(ctx->sync, "AUTH %s", log_ctx->redis_setup.password);
+        }
+
+        if (reply == NULL || reply->type == REDIS_REPLY_ERROR) {
+            SCLogError("Redis AUTH failed: %s", reply ? reply->str : ctx->sync->errstr);
+            if (reply) {
+                freeReplyObject(reply);
+            }
+            redisFree(ctx->sync);
+            ctx->sync = NULL;
+            ctx->tried = time(NULL);
+            return -1;
+        }
+        freeReplyObject(reply);
+        SCLogInfo("Redis authenticated successfully.");
+    }
 
     log_ctx->redis = ctx;
     log_ctx->Close = SCLogFileCloseRedis;
@@ -473,6 +579,8 @@ int SCConfLogOpenRedis(SCConfNode *redis_node, void *lf_ctx)
     if (redis_node) {
         log_ctx->redis_setup.server = SCConfNodeLookupChildValue(redis_node, "server");
         log_ctx->redis_setup.key = SCConfNodeLookupChildValue(redis_node, "key");
+        log_ctx->redis_setup.username = SCConfNodeLookupChildValue(redis_node, "username");
+        log_ctx->redis_setup.password = SCConfNodeLookupChildValue(redis_node, "password");
 
         redis_port = SCConfNodeLookupChildValue(redis_node, "port");
         redis_mode = SCConfNodeLookupChildValue(redis_node, "mode");
@@ -489,6 +597,10 @@ int SCConfLogOpenRedis(SCConfNode *redis_node, void *lf_ctx)
         redis_mode = "list";
     if (!log_ctx->redis_setup.key) {
         log_ctx->redis_setup.key = redis_default_key;
+    }
+    if (log_ctx->redis_setup.username && !log_ctx->redis_setup.password) {
+        SCLogWarning("Redis username configured without password; ignoring username.");
+        log_ctx->redis_setup.username = NULL;
     }
 
 #ifndef HAVE_LIBEVENT
@@ -585,7 +697,7 @@ void SCLogFileCloseRedis(LogFileCtx *log_ctx)
     if (log_ctx->redis_setup.is_async) {
 #if HAVE_LIBEVENT == 1
         if (ctx->async) {
-            if (ctx->connected > 0) {
+            if (ctx->state != REDIS_STATE_DISCONNECTED) {
                 SCLogAsyncRedisSendQuit(ctx);
             }
             if (ctx->ev_base != NULL) {

--- a/src/util-log-redis.h
+++ b/src/util-log-redis.h
@@ -41,6 +41,8 @@ typedef struct RedisSetup_ {
     const char *format;
     const char *command;
     const char *key;
+    const char *username;
+    const char *password;
     const char *server;
     uint16_t  port;
     int is_async;
@@ -48,12 +50,28 @@ typedef struct RedisSetup_ {
     char *stream_format;
 } RedisSetup;
 
+#if HAVE_LIBEVENT
+enum RedisConnState {
+    /** The context is not connected to the Redis server. */
+    REDIS_STATE_DISCONNECTED,
+
+    /** A connection to the Redis server has been established.
+     *  If authentication is not required, this is the final state where data can be safely sent.
+     *  If authentication is required, the client must proceed to authenticate before sending data.
+     */
+    REDIS_STATE_CONNECTED,
+
+    /** The connection is fully authenticated, and ready to send data. */
+    REDIS_STATE_AUTHENTICATED,
+};
+#endif /* HAVE_LIBEVENT */
+
 typedef struct SCLogRedisContext_ {
     redisContext *sync;
 #if HAVE_LIBEVENT
     redisAsyncContext *async;
     struct event_base *ev_base;
-    int connected;
+    enum RedisConnState state;
 #endif /* HAVE_LIBEVENT */
     time_t tried;
     int  batch_count;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -116,6 +116,8 @@ outputs:
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
+      #  username: null ## ACL username; if null (default), no username is used
+      #  password: null ## AUTH password; if null (default), authentication is disabled
       #  async: true ## if redis replies are read asynchronously
       #  mode: list ## possible values: list|lpush (default), rpush, channel|publish, xadd|stream
       #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush


### PR DESCRIPTION
Replaces: https://github.com/OISF/suricata/pull/13898

Changes since v2:
-  Made authentication failure retry interval consistent with connection failure.

Changes since v1:
- Reworked async mode to use a state machine for connection and authentication. 
- Authentication is now retried on failure.
- Handled `reply == NULL` in the authentication callback. 
- Added a guard: if a Redis username is set without a password, ignore the username and log a warning.
## Manual testing  
I manually tested the changes in both sync and async modes across different scenarios. All expected results matched actual results.

| Case | Scenario                  | Result                                  |
| :--- | :------------------------ | :-------------------------------------- |
| 1    | No auth                   | Success, logs written                   |
| 2    | Wrong password            | Connection failed, error logged         |
| 3    | Correct password          | Success, logs written                   |
| 4    | Missing password          | Connection failed, error logged         |
| 5    | ACL (valid)               | Success, logs written                   |
| 6    | ACL (wrong password)      | Connection failed, error logged         |
| 7    | ACL (no username provided)| Connection failed, error logged         |
| 8    | Re-authentication         | Connection recovered, logs written after re-auth      |

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7062

Describe changes:
- Add authentication support to the Redis logging output.
- Authentication configuration defaults to `null` for backward compatibility.
