### PR TITLE
output: Display ethertype properly

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -761,7 +761,7 @@ static int CreateJSONEther(
         if (PacketIsEthernet(p)) {
             const EthernetHdr *ethh = PacketGetEthernet(p);
             SCJbOpenObject(js, "ether");
-            SCJbSetUint(js, "ether_type", ethh->eth_type);
+            SCJbSetUint(js, "ether_type", SCNtohs(ethh->eth_type));
             const uint8_t *src;
             const uint8_t *dst;
             switch (dir) {


### PR DESCRIPTION
This displays the ethertype in host format, not network format, so that the value is accurate.

Without this change, an unknown ethertype value such as 0xfbb7 is displayed in decimal as: 47099 (0xb7fb). The correct value should be 64439 (0xfbb7)

Issue: 7855

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7855

Describe changes:
- Display ethertype in host, not network, order.


### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2673
SU_REPO=
SU_BRANCH=
