### PR TITLE
dpdk: fix the CPU exclude logic v1

### DIFF
--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -1088,12 +1088,15 @@ uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType 
  */
 void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf)
 {
-    cpu_set_t tmpset;
     SCMutexLock(&mod_taf->taf_mutex);
     SCMutexLock(&static_taf->taf_mutex);
-    CPU_XOR(&tmpset, &mod_taf->cpu_set, &static_taf->cpu_set);
+    int max_cpus = UtilCpuGetNumProcessorsOnline();
+    for (int cpu = 0; cpu < max_cpus; cpu++) {
+        if (CPU_ISSET(cpu, &mod_taf->cpu_set) && CPU_ISSET(cpu, &static_taf->cpu_set)) {
+            CPU_CLR(cpu, &mod_taf->cpu_set);
+        }
+    }
     SCMutexUnlock(&static_taf->taf_mutex);
-    mod_taf->cpu_set = tmpset;
     SCMutexUnlock(&mod_taf->taf_mutex);
 }
 #endif /* HAVE_DPDK */


### PR DESCRIPTION
The exclude function incorrectly performs a XOR operation. While it works when the worker cores occupy all cores, it is not the correct operation. For example, when a core is affined to only management and not worker threads, the XOR operation affines it to the worker set. (1 XOR 0 -> 1, where in fact the desired outcome is 0)

Ticket: 7975
https://redmine.openinfosecfoundation.org/issues/7975

Describe changes:
- exclude function update

This is a mandatory fix in order for the DPDK unit tests  to pass (it will be a follow-up of #13644 )
This is actually a branch out from #13644 to make the PR more digestible.