### PR TITLE
dpdk: supress a warning of the bond function v1

### DIFF
--- a/src/util-dpdk-bonding.c
+++ b/src/util-dpdk-bonding.c
@@ -52,7 +52,18 @@ uint16_t BondingMemberDevicesGet(
 {
 #ifdef HAVE_DPDK_BOND
 #if RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0)
+
+#if RTE_VERSION < RTE_VERSION_NUM(24, 11, 0, 0) // DPDK 23.11 - 24.07
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif /* RTE_VERSION < RTE_VERSION_NUM(24, 11, 0, 0) */
+
     int32_t len = rte_eth_bond_members_get(bond_pid, bonded_devs, bonded_devs_length);
+
+#if RTE_VERSION < RTE_VERSION_NUM(24, 11, 0, 0)
+#pragma GCC diagnostic pop
+#endif /* RTE_VERSION < RTE_VERSION_NUM(24, 11, 0, 0) */
+
 #else
     int32_t len = rte_eth_bond_slaves_get(bond_pid, bonded_devs, bonded_devs_length);
 #endif /* RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0) */


### PR DESCRIPTION
DPDK Bonding API has been changed in DPDK version 23.11 where the old *slave* API was marked as deprecated and the new *member* API was marked as experimental.
Both API variants emit a warning, so there is no way to avoid the warning. The deprecated version is removed from the follow up versions, while the experimental version will become stable in the next DPDK releases. This is based on a policy in DPDK where an API change needs to be merged in main for 1 stable release before removing the experimental flag.

In DPDK 24.11, this has been fixed, and warning suppression is not added.

Ticket: 7009
https://redmine.openinfosecfoundation.org/issues/7009

This is a mandatory PR in order for the PR extending the build tests in the GitHub CI to pass.
Branch out from #13644 