### PR TITLE
dpdk: add initial unittests for DPDK codebase v9

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -881,6 +881,7 @@ jobs:
                 ccache \
                 clang \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -906,6 +907,7 @@ jobs:
                 lz4-devel \
                 make \
                 parallel \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python \
@@ -925,7 +927,7 @@ jobs:
       - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow" ./configure --disable-shared
       - run: make check
       - run: make distclean
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         env:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"
@@ -981,6 +983,7 @@ jobs:
                 cbindgen \
                 ccache \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -1003,6 +1006,7 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -1019,7 +1023,7 @@ jobs:
           path: prep
       - run: tar xf prep/suricata-update.tar.gz
       - run: ./autogen.sh
-      - run: ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         env:
           CFLAGS: "${{ env.DEFAULT_CFLAGS }} -Wshadow -fsanitize=address -fno-omit-frame-pointer -flto=auto -O2"
           LDFLAGS: "-fsanitize=address"
@@ -1071,6 +1075,7 @@ jobs:
                 ccache \
                 clang \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -1093,6 +1098,7 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -1119,7 +1125,7 @@ jobs:
       - run: >-
           sudo -u suricata -s env PATH="/home/suricata/.cargo/bin:$PATH" ./configure --enable-warnings
           --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis
-          --enable-nfqueue --disable-ja3 --disable-ja4
+          --enable-nfqueue --enable-dpdk --disable-ja3 --disable-ja4
         working-directory: /home/suricata/suricata
         env:
           ac_cv_func_realloc_0_nonnull: "yes"
@@ -1440,6 +1446,7 @@ jobs:
                 automake \
                 clang-19 \
                 curl \
+                dpdk-dev \
                 git \
                 hwloc \
                 libhwloc-dev \
@@ -1484,7 +1491,7 @@ jobs:
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.85.1 -y
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
-      - run: ./configure --enable-warnings --disable-shared --enable-unittests
+      - run: ./configure --enable-warnings --disable-shared --enable-unittests --enable-dpdk
         env:
           CC: "clang-19"
           CXX: "clang++-19"
@@ -3009,6 +3016,7 @@ jobs:
                 autoconf \
                 build-essential \
                 ccache \
+                dpdk-dev \
                 curl \
                 git \
                 hwloc \
@@ -3022,6 +3030,7 @@ jobs:
                 libcap-ng-dev \
                 libcap-ng0 \
                 libmagic-dev \
+                libnuma-dev \
                 libjansson-dev \
                 libgeoip-dev \
                 libhiredis-dev \
@@ -3049,7 +3058,7 @@ jobs:
       - run: tar xf prep/suricata-update.tar.gz
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-fuzztargets
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-fuzztargets --enable-ebpf-build --enable-dpdk
       - run: make -j ${{ env.CPUS }}
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -35,6 +35,7 @@
 #include "runmode-dpdk.h"
 #include "decode.h"
 #include "source-dpdk.h"
+#include "util-affinity.h"
 #include "util-runmodes.h"
 #include "util-byte.h"
 #include "util-cpu.h"

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -468,7 +468,7 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
         SCReturnInt(-EINVAL);
     }
 
-    if (iconf->threads <= 0) {
+    if (iconf->threads == 0) {
         SCLogError("%s: positive number of threads required", iconf->iface);
         SCReturnInt(-ERANGE);
     }

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -52,6 +52,7 @@
 #include "util-conf.h"
 #include "suricata.h"
 #include "util-affinity.h"
+#include "conf-yaml-loader.h"
 
 #ifdef HAVE_DPDK
 
@@ -2007,6 +2008,369 @@ int RunModeIdsDpdkWorkers(void)
 #endif /* HAVE_DPDK */
     SCReturnInt(0);
 }
+
+#if defined(HAVE_DPDK) && defined(UNITTESTS)
+
+/**
+ * \brief Verify that the CPU requirement is met
+ * \retval 0 if the requirement is met, 2 if the test is skipped, negative number otherwise
+ */
+static int UnitTestsUtilAffinityVerifyCPURequirement(void)
+{
+    ThreadsAffinityType *wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", NULL);
+    if (wtaf == NULL) {
+        SCLogError("Specify worker-cpu-set list in the threading section");
+        SCReturnInt(-EINVAL);
+    }
+    ThreadsAffinityType *mtaf = GetAffinityTypeForNameAndIface("management-cpu-set", NULL);
+    if (mtaf == NULL) {
+        SCLogError("Specify management-cpu-set list in the threading section");
+        SCReturnInt(-EINVAL);
+    }
+    UtilAffinityCpusExclude(wtaf, mtaf);
+    uint32_t sched_cpus = UtilAffinityGetAffinedCPUNum(wtaf) + UtilAffinityGetAffinedCPUNum(mtaf);
+
+    if (UtilCpuGetNumProcessorsOnline() < sched_cpus) {
+        char err_msg[256];
+        snprintf(err_msg, sizeof(err_msg),
+                "not enough cpus in the system, the test requires at least %d cores", sched_cpus);
+        SKIP(err_msg);
+    }
+    return 0;
+}
+
+static void DPDKRunmodeSetThreadsInit(const char *input, size_t input_len)
+{
+    SCConfCreateContextBackup();
+    SCConfInit();
+    ResetAffinityForTest();
+    AutoRemainingThreadsReset();
+    int ret = SCConfYamlLoadString(input, input_len);
+    if (ret != 0) {
+        FatalError("Unable to load configuration");
+    }
+    RunModeInitializeThreadSettings();
+    LiveBuildDeviceListCustom("unittest-ifaces", "iface");
+    LiveDeviceFinalize();
+    AutoRemainingThreadsInit();
+}
+
+#define SKIP_INCOMPATIBLE_ENVIRONMENT                                                              \
+    do {                                                                                           \
+        int ret = UnitTestsUtilAffinityVerifyCPURequirement();                                     \
+        FAIL_IF(ret < 0);                                                                          \
+        if (ret != 0)                                                                              \
+            return ret;                                                                            \
+    } while (0)
+
+static void DPDKRunmodeSetThreadsDeinit(void)
+{
+    LiveDeviceListClean();
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+}
+
+/**
+ * \brief Management CPU set excludes all available CPUs from the Worker CPU set
+ */
+static int DPDKRunmodeSetThreads01(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ \"0-1\" ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"0-1\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "1");
+    FAIL_IF_NOT(r == -EINVAL);
+
+    DPDKRunmodeSetThreadsDeinit();
+
+    PASS;
+}
+
+/**
+ * \brief Management/Worker CPU set exclusion leaves 2 CPUs available
+ */
+static int DPDKRunmodeSetThreads02(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0,1 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"0-3\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "auto");
+    FAIL_IF_NOT(iconf.threads == 2);
+    FAIL_IF_NOT(r == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Management/Worker CPU set exclusion leaves 2 CPUs available
+ */
+static int DPDKRunmodeSetThreads03(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-2\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "auto");
+    FAIL_IF_NOT(iconf.threads == 2);
+    FAIL_IF_NOT(r == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Auto assignment of 1 CPU per interface
+ */
+static int DPDKRunmodeSetThreads04(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev1\n\
+    - iface: test_dev2\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-2\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf1 = { 0 };
+    int r1 = ConfigSetThreads(&iconf1, "auto");
+    DPDKIfaceConfig iconf2 = { 0 };
+    int r2 = ConfigSetThreads(&iconf2, "auto");
+    FAIL_IF_NOT(iconf1.threads == 1);
+    FAIL_IF_NOT(r1 == 0);
+    FAIL_IF_NOT(iconf2.threads == 1);
+    FAIL_IF_NOT(r2 == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Auto assignment test with 2 CPUs available for the first interface
+ */
+static int DPDKRunmodeSetThreads05(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev1\n\
+    - iface: test_dev2\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-3\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf1 = { 0 }; // test_dev1
+    int r1 = ConfigSetThreads(&iconf1, "auto");
+    DPDKIfaceConfig iconf2 = { 0 }; // test_dev2
+    int r2 = ConfigSetThreads(&iconf2, "auto");
+    FAIL_IF_NOT(iconf1.threads == 2);
+    FAIL_IF_NOT(r1 == 0);
+    FAIL_IF_NOT(iconf2.threads == 1);
+    FAIL_IF_NOT(r2 == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Sanity test for the ConfigSetThreads function
+ */
+static int DPDKRunmodeSetThreads06(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-2\" ]\n\
+";
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "-2");
+    FAIL_IF_NOT(r == -EINVAL);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "0");
+    FAIL_IF_NOT(r == -ERANGE);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "abc");
+    FAIL_IF_NOT(r == -EINVAL);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "99999999999999");
+    FAIL_IF(r == 0);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "1");
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.threads == 1);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "2");
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.threads == 2);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize01(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    const char *entry_str;
+
+    entry_str = NULL;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    entry_str = "";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    entry_str = "-1";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    entry_str = "999999999999999999";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize02(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "auto");
+    iconf.mempool_size = 1023;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF(iconf.mempool_cache_size >= RTE_MEMPOOL_CACHE_MAX_SIZE);
+    FAIL_IF(iconf.mempool_cache_size >= iconf.mempool_size / 1.5);
+    FAIL_IF_NOT(iconf.mempool_size % iconf.mempool_cache_size == 0);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize03(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "%d", 1);
+    iconf.mempool_size = 1023;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.mempool_cache_size == 1);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize04(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "%d", RTE_MEMPOOL_CACHE_MAX_SIZE + 1);
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -ERANGE);
+
+    PASS;
+}
+
+/**
+ * \brief This function registers unit tests for AlertFastLog API.
+ */
+void DPDKRunmodeRegisterTests(void)
+{
+
+    UtRegisterTest("DPDKRunmodeSetThreads01", DPDKRunmodeSetThreads01);
+    UtRegisterTest("DPDKRunmodeSetThreads02", DPDKRunmodeSetThreads02);
+    UtRegisterTest("DPDKRunmodeSetThreads03", DPDKRunmodeSetThreads03);
+    UtRegisterTest("DPDKRunmodeSetThreads04", DPDKRunmodeSetThreads04);
+    UtRegisterTest("DPDKRunmodeSetThreads05", DPDKRunmodeSetThreads05);
+    UtRegisterTest("DPDKRunmodeSetThreads06", DPDKRunmodeSetThreads06);
+
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize01", DPDKRunmodeSetMempoolCacheSize01);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize02", DPDKRunmodeSetMempoolCacheSize02);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize03", DPDKRunmodeSetMempoolCacheSize03);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize04", DPDKRunmodeSetMempoolCacheSize04);
+}
+#endif /* UNITTESTS and HAVE_DPDK */
 
 /**
  * @}

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -46,4 +46,6 @@ int RunModeIdsDpdkWorkers(void);
 void RunModeDpdkRegister(void);
 const char *RunModeDpdkGetDefaultMode(void);
 
+void DPDKRunmodeRegisterTests(void);
+
 #endif /* SURICATA_RUNMODE_DPDK_H */

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -127,6 +127,8 @@
 #include "source-windivert.h"
 #endif
 
+#include "runmode-dpdk.h"
+
 #endif /* UNITTESTS */
 
 void TmqhSetup (void);
@@ -222,6 +224,9 @@ static void RegisterUnittests(void)
     UtilCIDRTests();
     OutputJsonStatsRegisterTests();
     CoredumpConfigRegisterTests();
+#ifdef HAVE_DPDK
+    DPDKRunmodeRegisterTests();
+#endif
 }
 #endif
 

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -1106,7 +1106,7 @@ void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *
  * \brief Helper function to reset affinity state for unit tests
  * This properly clears CPU sets without destroying initialized mutexes
  */
-static void ResetAffinityForTest(void)
+void ResetAffinityForTest(void)
 {
     thread_affinity_init_done = 0;
     for (int i = 0; i < MAX_CPU_SET; i++) {

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -111,6 +111,7 @@ uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf);
 uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2);
 void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf);
 #endif /* HAVE_DPDK */
+void ResetAffinityForTest(void);
 
 int BuildCpusetWithCallback(
         const char *name, SCConfNode *node, void (*Callback)(int i, void *data), void *data);

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -360,6 +360,8 @@ int LiveDeviceListClean(void)
         SCFree(pd);
     }
 
+    // set the list to NULL
+    TAILQ_INIT(&live_devices);
     SCReturnInt(TM_ECODE_OK);
 }
 
@@ -471,6 +473,9 @@ void LiveDeviceFinalize(void)
         }
         SCFree(ld);
     }
+
+    // set the list to NULL
+    TAILQ_INIT(&pre_live_devices);
 }
 
 static void LiveDevExtensionFree(void *x)

--- a/src/util-unittest.c
+++ b/src/util-unittest.c
@@ -188,7 +188,7 @@ void UtListTests(const char *regex_arg)
 uint32_t UtRunTests(const char *regex_arg)
 {
     UtTest *ut;
-    uint32_t good = 0, bad = 0, matchcnt = 0;
+    uint32_t good = 0, skip = 0, bad = 0, matchcnt = 0;
     int ret = 0, rcomp = 0;
 
     StreamTcpInitMemuse();
@@ -225,22 +225,28 @@ uint32_t UtRunTests(const char *regex_arg)
                     ret = 0;
                 }
 
-                printf("%s\n", ret ? "pass" : "FAILED");
-
                 if (!ret) {
                     if (unittests_fatal == 1) {
                         fprintf(stderr, "ERROR: unittest failed.\n");
                         exit(EXIT_FAILURE);
                     }
                     bad++;
+                    printf("FAILED\n");
+                } else if (ret == 2) {
+                    skip++;
+                    printf("skip\n");
                 } else {
                     good++;
+                    printf("pass\n");
                 }
             }
         }
         if(matchcnt > 0){
             printf("==== TEST RESULTS ====\n");
             printf("PASSED: %" PRIu32 "\n", good);
+            if (skip > 0) {
+                printf("SKIPPED: %" PRIu32 "\n", skip);
+            }
             printf("FAILED: %" PRIu32 "\n", bad);
             printf("======================\n");
         } else {

--- a/src/util-unittest.h
+++ b/src/util-unittest.h
@@ -106,6 +106,18 @@ extern int unittests_fatal;
         return 1; \
     } while (0)
 
+/**
+ * \brief Skip the test.
+ *
+ * Used to skip the tests that cannot be run in the current environment.
+ * The aim is to keep this at 0.
+ */
+#define SKIP(reason)                                                                               \
+    do {                                                                                           \
+        SCLogInfo("Test skipped: %s", reason);                                                     \
+        return 2;                                                                                  \
+    } while (0)
+
 #endif
 
 #endif /* SURICATA_UTIL_UNITTEST_H */


### PR DESCRIPTION
Main follow-up of #13644 

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6927

The PR is adding unit tests tailored to verify CPU threading logic and the automatic calculation of mempool cache of the interface.

Describe changes:
- new unit tests
- skip directive for unit tests for incompatible environments

First, #13954 needs to be merged in order for the unit tests to pass.