### PR TITLE
detect/vlan: move vlan.id keyword to generic integer

### DIFF
--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -43,7 +43,7 @@ pub enum DetectUintMode {
     DetectUintModeNegBitmask,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct DetectUintData<T> {
     pub arg1: T,

--- a/rust/src/detect/vlan.rs
+++ b/rust/src/detect/vlan.rs
@@ -15,18 +15,23 @@
  * 02110-1301, USA.
  */
 
-use super::uint::{detect_parse_uint, DetectUintData};
-use std::ffi::CStr;
-use std::str::FromStr;
+use super::uint::{
+    detect_parse_array_uint, detect_uint_match_at_index, DetectUintArrayData, DetectUintData,
+    DetectUintIndex,
+};
+use std::ffi::{c_int, c_void, CStr};
 
 pub const DETECT_VLAN_ID_ANY: i8 = i8::MIN;
 pub const DETECT_VLAN_ID_ALL: i8 = i8::MAX;
-pub static VLAN_MAX_LAYERS: i8 = 3;
+pub const DETECT_VLAN_ID_ALL1: i8 = i8::MAX - 1;
+pub const DETECT_VLAN_ID_OR_ABSENT: i8 = i8::MAX - 2;
+pub const DETECT_VLAN_ID_ERROR: i8 = i8::MAX - 3;
+pub static VLAN_MAX_LAYERS: i32 = 3;
 
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 /// This data structure is also used in detect-vlan.c
-pub struct DetectVlanIdData {
+pub struct DetectVlanIdDataPrefilter {
     /// Vlan id
     pub du16: DetectUintData<u16>,
     /// Layer can be DETECT_VLAN_ID_ANY to match with any vlan layer
@@ -36,38 +41,41 @@ pub struct DetectVlanIdData {
     pub layer: i8,
 }
 
-pub fn detect_parse_vlan_id(s: &str) -> Option<DetectVlanIdData> {
-    let parts: Vec<&str> = s.split(',').collect();
-    let du16 = detect_parse_uint(parts[0]).ok()?.1;
-    if parts.len() > 2 {
-        return None;
-    }
-    if du16.arg1 > 0xFFF || du16.arg2 > 0xFFF {
-        // vlan id is encoded on 12 bits
-        return None;
-    }
-    let layer = if parts.len() == 2 {
-        if parts[1] == "all" {
-            DETECT_VLAN_ID_ALL
-        } else if parts[1] == "any" {
-            DETECT_VLAN_ID_ANY
-        } else {
-            let u8_layer = i8::from_str(parts[1]).ok()?;
-            if !(-VLAN_MAX_LAYERS..=VLAN_MAX_LAYERS - 1).contains(&u8_layer) {
-                return None;
-            }
-            u8_layer
+pub fn detect_parse_vlan_id(s: &str) -> Option<DetectUintArrayData<u16>> {
+    let r = detect_parse_array_uint(s);
+    if let Some(a) = &r {
+        if a.du.arg1 > 0xFFF || a.du.arg2 > 0xFFF {
+            // vlan id is encoded on 12 bits
+            SCLogError!("vlan id should be less than 4096");
+            return None;
         }
-    } else {
-        DETECT_VLAN_ID_ANY
-    };
-    return Some(DetectVlanIdData { du16, layer });
+        match a.index {
+            DetectUintIndex::All => {
+                // keep previous behavior that vlan.id: all matched only if there was vlan
+                return Some(DetectUintArrayData {
+                    du: a.du.clone(),
+                    index: DetectUintIndex::All1,
+                    start: a.start,
+                    end: a.end,
+                });
+            }
+            DetectUintIndex::Index((_, i)) => {
+                if !(-VLAN_MAX_LAYERS..=VLAN_MAX_LAYERS - 1).contains(&i) {
+                    SCLogError!(
+                        "vlan id index should belong in range {:?}",
+                        (-VLAN_MAX_LAYERS..=VLAN_MAX_LAYERS - 1)
+                    );
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+    return r;
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCDetectVlanIdParse(
-    ustr: *const std::os::raw::c_char,
-) -> *mut DetectVlanIdData {
+pub unsafe extern "C" fn SCDetectVlanIdParse(ustr: *const std::os::raw::c_char) -> *mut c_void {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
     if let Ok(s) = ft_name.to_str() {
         if let Some(ctx) = detect_parse_vlan_id(s) {
@@ -79,9 +87,75 @@ pub unsafe extern "C" fn SCDetectVlanIdParse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCDetectVlanIdFree(ctx: &mut DetectVlanIdData) {
+pub unsafe extern "C" fn SCDetectVlanIdFree(ctx: &mut DetectUintArrayData<u16>) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectVlanIdMatch(
+    vlan_idx: u16, vlan_id: *const u16, ctx: *const c_void,
+) -> c_int {
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u16>);
+    let vlans = std::slice::from_raw_parts(vlan_id, vlan_idx as usize);
+    return detect_uint_match_at_index::<u16, u16>(vlans, ctx, |vi| Some(*vi), true);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectVlanIdPrefilterMatch(
+    vlan_idx: u16, vlan_id: *const u16, ctx: &DetectVlanIdDataPrefilter,
+) -> c_int {
+    let index = match ctx.layer {
+        DETECT_VLAN_ID_ANY => DetectUintIndex::Any,
+        DETECT_VLAN_ID_ALL => DetectUintIndex::All,
+        DETECT_VLAN_ID_ALL1 => DetectUintIndex::All1,
+        DETECT_VLAN_ID_OR_ABSENT => DetectUintIndex::OrAbsent,
+        i => DetectUintIndex::Index((false, i.into())),
+    };
+
+    let ctx = DetectUintArrayData {
+        du: ctx.du16.clone(),
+        index,
+        start: 0,
+        end: 0,
+    };
+    let vlans = std::slice::from_raw_parts(vlan_id, vlan_idx as usize);
+    return detect_uint_match_at_index::<u16, u16>(vlans, &ctx, |vi| Some(*vi), true);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectVlanIdPrefilter(
+    ctx: &DetectUintArrayData<u16>,
+) -> DetectVlanIdDataPrefilter {
+    let layer = match ctx.index {
+        DetectUintIndex::Any => DETECT_VLAN_ID_ANY,
+        DetectUintIndex::All => DETECT_VLAN_ID_ALL,
+        DetectUintIndex::All1 => DETECT_VLAN_ID_ALL1,
+        DetectUintIndex::OrAbsent => DETECT_VLAN_ID_OR_ABSENT,
+        DetectUintIndex::Index((_, i)) => i as i8,
+        DetectUintIndex::NumberMatches(_) => DETECT_VLAN_ID_ERROR,
+    };
+    DetectVlanIdDataPrefilter {
+        du16: ctx.du.clone(),
+        layer,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectVlanIdPrefilterable(ctx: *const c_void) -> bool {
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u16>);
+    if ctx.start != 0 || ctx.end != 0 {
+        return false;
+    }
+    match ctx.index {
+        DetectUintIndex::Any => true,
+        DetectUintIndex::All => true,
+        DetectUintIndex::All1 => true,
+        DetectUintIndex::OrAbsent => true,
+        // do not prefilter for precise index with "or out of bounds"
+        DetectUintIndex::Index((oob, _)) => !oob,
+        DetectUintIndex::NumberMatches(_) => false,
+    }
 }
 
 #[cfg(test)]
@@ -93,101 +167,119 @@ mod test {
     fn test_detect_parse_vlan_id() {
         assert_eq!(
             detect_parse_vlan_id("300").unwrap(),
-            DetectVlanIdData {
-                du16: DetectUintData {
+            DetectUintArrayData {
+                du: DetectUintData {
                     arg1: 300,
                     arg2: 0,
                     mode: DetectUintMode::DetectUintModeEqual,
                 },
-                layer: DETECT_VLAN_ID_ANY
+                index: DetectUintIndex::Any,
+                start: 0,
+                end: 0,
             }
         );
         assert_eq!(
             detect_parse_vlan_id("300,any").unwrap(),
-            DetectVlanIdData {
-                du16: DetectUintData {
+            DetectUintArrayData {
+                du: DetectUintData {
                     arg1: 300,
                     arg2: 0,
                     mode: DetectUintMode::DetectUintModeEqual,
                 },
-                layer: DETECT_VLAN_ID_ANY
+                index: DetectUintIndex::Any,
+                start: 0,
+                end: 0,
             }
         );
         assert_eq!(
             detect_parse_vlan_id("300,all").unwrap(),
-            DetectVlanIdData {
-                du16: DetectUintData {
+            DetectUintArrayData {
+                du: DetectUintData {
                     arg1: 300,
                     arg2: 0,
                     mode: DetectUintMode::DetectUintModeEqual,
                 },
-                layer: DETECT_VLAN_ID_ALL
+                index: DetectUintIndex::All1,
+                start: 0,
+                end: 0,
             }
         );
         assert_eq!(
             detect_parse_vlan_id("200,1").unwrap(),
-            DetectVlanIdData {
-                du16: DetectUintData {
+            DetectUintArrayData {
+                du: DetectUintData {
                     arg1: 200,
                     arg2: 0,
                     mode: DetectUintMode::DetectUintModeEqual,
                 },
-                layer: 1
+                index: DetectUintIndex::Index((false, 1)),
+                start: 0,
+                end: 0,
             }
         );
         assert_eq!(
             detect_parse_vlan_id("200,-1").unwrap(),
-            DetectVlanIdData {
-                du16: DetectUintData {
+            DetectUintArrayData {
+                du: DetectUintData {
                     arg1: 200,
                     arg2: 0,
                     mode: DetectUintMode::DetectUintModeEqual,
                 },
-                layer: -1
+                index: DetectUintIndex::Index((false, -1)),
+                start: 0,
+                end: 0,
             }
         );
         assert_eq!(
             detect_parse_vlan_id("!200,2").unwrap(),
-            DetectVlanIdData {
-                du16: DetectUintData {
+            DetectUintArrayData {
+                du: DetectUintData {
                     arg1: 200,
                     arg2: 0,
                     mode: DetectUintMode::DetectUintModeNe,
                 },
-                layer: 2
+                index: DetectUintIndex::Index((false, 2)),
+                start: 0,
+                end: 0,
             }
         );
         assert_eq!(
             detect_parse_vlan_id(">200,2").unwrap(),
-            DetectVlanIdData {
-                du16: DetectUintData {
+            DetectUintArrayData {
+                du: DetectUintData {
                     arg1: 200,
                     arg2: 0,
                     mode: DetectUintMode::DetectUintModeGt,
                 },
-                layer: 2
+                index: DetectUintIndex::Index((false, 2)),
+                start: 0,
+                end: 0,
             }
         );
         assert_eq!(
             detect_parse_vlan_id("200-300,0").unwrap(),
-            DetectVlanIdData {
-                du16: DetectUintData {
+            DetectUintArrayData {
+                du: DetectUintData {
                     arg1: 200,
                     arg2: 300,
                     mode: DetectUintMode::DetectUintModeRange,
                 },
-                layer: 0
+                index: DetectUintIndex::Index((false, 0)),
+                start: 0,
+                end: 0,
             }
         );
         assert_eq!(
             detect_parse_vlan_id("0xC8,2").unwrap(),
-            DetectVlanIdData {
-                du16: DetectUintData {
+            DetectUintArrayData {
+                du: DetectUintData {
                     arg1: 200,
                     arg2: 0,
                     mode: DetectUintMode::DetectUintModeEqual,
                 },
-                layer: 2
+                index: DetectUintIndex::Index((false, 2)),
+                start: 0,
+                end: 0,
             }
         );
         assert!(detect_parse_vlan_id("200abc").is_none());

--- a/rust/src/nfs/detect.rs
+++ b/rust/src/nfs/detect.rs
@@ -68,7 +68,6 @@ unsafe extern "C" fn nfs_procedure_parse(
 ) -> *mut DetectUintData<u32> {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
     if let Ok(s) = ft_name.to_str() {
-        // TODO big composite type
         if let Some(ctx) = nfs_procedure_parse_aux(s) {
             let boxed = Box::new(ctx);
             return Box::into_raw(boxed) as *mut _;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7929

Describe changes:
- detect/vlan: move vlan.id code to generic integer

https://github.com/OISF/suricata/pull/13908 with some review fixes

DRAFT: @victorjulien 

How do you expect `http2.priority: >0, all` to behave when we have a http2 transaction without any priorities ?

- `http2.priority: >0, all0` will match
- `http2.priority: >0, all1` will not match as it matches only if there is one priority

`vlan.id` has already all behaving like all1 in 8 and main
Current behavior for all with other integers in main is all0

Should we have `all` implicitly mean `all1` ?