### PR TITLE
ci: build test DPDK 23.11+ and stop testing < 21.11 v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2541,7 +2541,7 @@ jobs:
     needs: [ prepare-deps, prepare-cbindgen ]
     strategy:
       matrix:
-        dpdk_version: [ 22.11.10, 21.11.9 ]
+        dpdk_version: [ 24.11.3, 23.11.5, 22.11.10, 21.11.9 ]
     steps:
 
       # Cache Rust stuff.


### PR DESCRIPTION
Follow-up of #13956 

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6382

Describe changes:
v2
- rebased

v1
- new DPDK versions added to the matrix
- old versions removed