### PR TITLE
stats: improve wait loops

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -417,7 +417,15 @@ static void *StatsMgmtThread(void *arg)
         /* wait for the set time, or until we are woken up by
          * the shutdown procedure */
         SCCtrlMutexLock(tv_local->ctrl_mutex);
-        SCCtrlCondTimedwait(tv_local->ctrl_cond, tv_local->ctrl_mutex, &cond_time);
+        while (1) {
+            if (TmThreadsCheckFlag(tv_local, THV_KILL)) {
+                break;
+            }
+            int rc = SCCtrlCondTimedwait(tv_local->ctrl_cond, tv_local->ctrl_mutex, &cond_time);
+            if (rc == ETIMEDOUT || rc < 0) {
+                break;
+            }
+        }
         SCCtrlMutexUnlock(tv_local->ctrl_mutex);
 
         SCMutexLock(&stats_table_mutex);
@@ -494,7 +502,15 @@ static void *StatsWakeupThread(void *arg)
         /* wait for the set time, or until we are woken up by
          * the shutdown procedure */
         SCCtrlMutexLock(tv_local->ctrl_mutex);
-        SCCtrlCondTimedwait(tv_local->ctrl_cond, tv_local->ctrl_mutex, &cond_time);
+        while (1) {
+            if (TmThreadsCheckFlag(tv_local, THV_KILL)) {
+                break;
+            }
+            int rc = SCCtrlCondTimedwait(tv_local->ctrl_cond, tv_local->ctrl_mutex, &cond_time);
+            if (rc == ETIMEDOUT || rc < 0) {
+                break;
+            }
+        }
         SCCtrlMutexUnlock(tv_local->ctrl_mutex);
 
         SCMutexLock(&tv_root_lock);


### PR DESCRIPTION
Check bail condition before entering conditional wait.

CID 1554236: (#1 of 1): Indefinite wait (BAD_CHECK_OF_WAIT_COND)
dead_wait: A wait is performed without ensuring that the condition is not already satisfied while holding lock ThreadVars_.ctrl_mutex. This can cause unnecessary waiting if the notification happens before the lock is acquired.

CID 1554238: (#1 of 1): Indefinite wait (BAD_CHECK_OF_WAIT_COND)
dead_wait: A wait is performed without ensuring that the condition is not already satisfied while holding lock ThreadVars_.ctrl_mutex. This can cause unnecessary waiting if the notification happens before the lock is acquired.
