### PR TITLE
detect/files: support protocols only over udp (backport8)

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -206,13 +206,9 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 {
     SCEnter();
 
-    if (!DetectProtoContainsProto(&s->proto, IPPROTO_TCP)) {
-        SCLogError("The 'file_data' keyword cannot be used with non-TCP protocols");
-        return -1;
-    }
-
-    if (s->alproto != ALPROTO_UNKNOWN && !AppLayerParserSupportsFiles(IPPROTO_TCP, s->alproto)) {
-        SCLogError("The 'file_data' keyword cannot be used with TCP protocol %s",
+    if (s->alproto != ALPROTO_UNKNOWN && !AppLayerParserSupportsFiles(IPPROTO_TCP, s->alproto) &&
+            !AppLayerParserSupportsFiles(IPPROTO_UDP, s->alproto)) {
+        SCLogError("The 'file_data' keyword cannot be used with protocol %s",
                 AppLayerGetProtoName(s->alproto));
         return -1;
     }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2764,7 +2764,8 @@ static int SigValidateFileHandling(const Signature *s)
         SCReturnInt(1);
     }
 
-    if (s->alproto != ALPROTO_UNKNOWN && !AppLayerParserSupportsFiles(IPPROTO_TCP, s->alproto)) {
+    if (s->alproto != ALPROTO_UNKNOWN && !AppLayerParserSupportsFiles(IPPROTO_TCP, s->alproto) &&
+            !AppLayerParserSupportsFiles(IPPROTO_UDP, s->alproto)) {
         SCLogError("protocol %s doesn't "
                    "support file matching",
                 AppProtoToString(s->alproto));
@@ -2776,7 +2777,8 @@ static int SigValidateFileHandling(const Signature *s)
             if (s->init_data->alprotos[i] == ALPROTO_UNKNOWN) {
                 break;
             }
-            if (AppLayerParserSupportsFiles(IPPROTO_TCP, s->init_data->alprotos[i])) {
+            if (AppLayerParserSupportsFiles(IPPROTO_TCP, s->init_data->alprotos[i]) ||
+                    AppLayerParserSupportsFiles(IPPROTO_UDP, s->init_data->alprotos[i])) {
                 found = true;
                 break;
             }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7974

Describe changes:
- backport of #13964 clean cherry-pick

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2683
