### PR TITLE
Test leaks/v1

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -26,6 +26,7 @@
  */
 
 #include "suricata-common.h"
+
 #include "app-layer-ftp.h"
 #include "app-layer.h"
 #include "app-layer-parser.h"
@@ -1411,6 +1412,7 @@ void FTPParserCleanup(void)
 
 /* UNITTESTS */
 #ifdef UNITTESTS
+#include "flow-util.h"
 #include "stream-tcp.h"
 
 /** \test Send a get request in one chunk. */
@@ -1439,6 +1441,7 @@ static int FTPParserTest01(void)
     FAIL_IF_NULL(ftp_state);
     FAIL_IF(ftp_state->command != FTP_COMMAND_PORT);
 
+    FLOW_DESTROY(&f);
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
     PASS;
@@ -1486,6 +1489,7 @@ static int FTPParserTest11(void)
 
     FAIL_IF(ftp_state->command != FTP_COMMAND_RETR);
 
+    FLOW_DESTROY(&f);
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
     PASS;
@@ -1533,6 +1537,7 @@ static int FTPParserTest12(void)
 
     FAIL_IF(ftp_state->command != FTP_COMMAND_STOR);
 
+    FLOW_DESTROY(&f);
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
     PASS;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -5626,6 +5626,7 @@ libhtp:\n\
     SCConfDeInit();
     SCConfRestoreContextBackup();
     HtpConfigRestoreBackup();
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2784,7 +2784,9 @@ static int HTPParserTest01b(void)
     const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
-    FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
+    char *v = bstr_util_strdup_to_c(htp_header_value(h));
+    FAIL_IF(strcmp(v, "Victor/1.0"));
+    SCFree(v);
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_POST);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_0);
 
@@ -2839,7 +2841,9 @@ static int HTPParserTest01c(void)
     const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
-    FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
+    char *v = bstr_util_strdup_to_c(htp_header_value(h));
+    FAIL_IF(strcmp(v, "Victor/1.0"));
+    SCFree(v);
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_POST);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_0);
 
@@ -2895,7 +2899,9 @@ static int HTPParserTest01a(void)
     const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
-    FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
+    char *v = bstr_util_strdup_to_c(htp_header_value(h));
+    FAIL_IF(strcmp(v, "Victor/1.0"));
+    SCFree(v);
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_POST);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_0);
 

--- a/src/detect-engine-proto.c
+++ b/src/detect-engine-proto.c
@@ -149,6 +149,7 @@ int DetectProtoContainsProto(const DetectProto *dp, int proto)
 #include "detect-engine.h"
 #include "detect-parse.h"
 #include "detect-engine-mpm.h"
+
 /**
  * \brief this function is used to initialize the detection engine context and
  *        setup the signature with passed values.
@@ -158,32 +159,31 @@ static int DetectProtoInitTest(DetectEngineCtx **de_ctx, Signature **sig,
 {
     char fullstr[1024];
     int result = 0;
+    static uint32_t test_sid = 1;
 
-    *de_ctx = NULL;
     *sig = NULL;
 
-    if (snprintf(fullstr, 1024, "alert %s any any -> any any (msg:\"DetectProto"
-            " test\"; sid:1;)", str) >= 1024)
-    {
+    if (snprintf(fullstr, 1024,
+                "alert %s any any -> any any (msg:\"DetectProto"
+                " test\"; sid:%u;)",
+                str, test_sid++) >= 1024) {
         goto end;
     }
 
-    *de_ctx = DetectEngineCtxInit();
     if (*de_ctx == NULL) {
-        goto end;
+        *de_ctx = DetectEngineCtxInit();
+        if (*de_ctx == NULL) {
+            goto end;
+        }
+
+        (*de_ctx)->flags |= DE_QUIET;
     }
 
-    (*de_ctx)->flags |= DE_QUIET;
-
-    (*de_ctx)->sig_list = SigInit(*de_ctx, fullstr);
-    if ((*de_ctx)->sig_list == NULL) {
+    Signature *s = DetectEngineAppendSig(*de_ctx, fullstr);
+    if (s == NULL) {
         goto end;
     }
-
-    *sig = (*de_ctx)->sig_list;
-
-    if (DetectProtoParse(dp, str) < 0)
-        goto end;
+    *sig = s;
 
     result = 1;
 

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -518,12 +518,13 @@ static int DeStateSigTest01(void)
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     FAIL_IF(PacketAlertCheck(p, 1));
 
+    UTHFreePacket(p);
+    FLOW_DESTROY(&f);
     AppLayerParserThreadCtxFree(alp_tctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
-    UTHFreePacket(p);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -633,12 +634,13 @@ static int DeStateSigTest02(void)
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     FAIL_IF(!(PacketAlertCheck(p, 2)));
 
+    UTHFreePacket(p);
+    FLOW_DESTROY(&f);
     AppLayerParserThreadCtxFree(alp_tctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
-    UTHFreePacket(p);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -717,12 +719,14 @@ static int DeStateSigTest03(void)
 
     FAIL_IF(!(file->flags & FILE_STORE));
 
-    AppLayerParserThreadCtxFree(alp_tctx);
+    UTHFreePacket(p);
     UTHFreeFlow(f);
 
+    AppLayerParserThreadCtxFree(alp_tctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -796,11 +800,13 @@ static int DeStateSigTest04(void)
 
     FAIL_IF(file->flags & FILE_STORE);
 
-    AppLayerParserThreadCtxFree(alp_tctx);
+    UTHFreePacket(p);
     UTHFreeFlow(f);
+    AppLayerParserThreadCtxFree(alp_tctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -878,11 +884,13 @@ static int DeStateSigTest05(void)
     FAIL_IF_NOT(http_state->state_data.file_flags & FLOWFILE_NO_STORE_TS);
     FAIL_IF(file->flags & FILE_NOSTORE);
 
-    AppLayerParserThreadCtxFree(alp_tctx);
+    UTHFreePacket(p);
     UTHFreeFlow(f);
+    AppLayerParserThreadCtxFree(alp_tctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -959,11 +967,13 @@ static int DeStateSigTest06(void)
     FAIL_IF_NOT(tx_ud->tx_data.file_flags & FLOWFILE_NO_STORE_TS);
     FAIL_IF(file->flags & FILE_NOSTORE);
 
-    AppLayerParserThreadCtxFree(alp_tctx);
+    UTHFreePacket(p);
     UTHFreeFlow(f);
+    AppLayerParserThreadCtxFree(alp_tctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -1044,11 +1054,13 @@ static int DeStateSigTest07(void)
     FAIL_IF_NULL(file);
     FAIL_IF(file->flags & FILE_STORE);
 
-    AppLayerParserThreadCtxFree(alp_tctx);
+    UTHFreePacket(p);
     UTHFreeFlow(f);
+    AppLayerParserThreadCtxFree(alp_tctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -1172,11 +1184,13 @@ static int DeStateSigTest08(void)
     FAIL_IF_NULL(file);
     FAIL_IF_NOT(file->flags & FILE_STORE);
 
-    AppLayerParserThreadCtxFree(alp_tctx);
+    UTHFreePacket(p);
     UTHFreeFlow(f);
+    AppLayerParserThreadCtxFree(alp_tctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -1298,11 +1312,13 @@ static int DeStateSigTest09(void)
     FAIL_IF_NULL(file);
     FAIL_IF_NOT(file->flags & FILE_STORE);
 
-    AppLayerParserThreadCtxFree(alp_tctx);
+    UTHFreePacket(p);
     UTHFreeFlow(f);
+    AppLayerParserThreadCtxFree(alp_tctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -1424,11 +1440,13 @@ static int DeStateSigTest10(void)
     FAIL_IF_NULL(file);
     FAIL_IF_NOT(file->flags & FILE_STORE);
 
-    AppLayerParserThreadCtxFree(alp_tctx);
+    UTHFreePacket(p);
     UTHFreeFlow(f);
+    AppLayerParserThreadCtxFree(alp_tctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -1624,12 +1624,12 @@ static int FlowBitsTestSig06(void)
     }
     FAIL_IF_NOT(result);
 
-    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
-    DetectEngineCtxFree(de_ctx);
-
+    PacketFree(p);
     FLOW_DESTROY(&f);
 
-    SCFree(p);
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -1699,12 +1699,11 @@ static int FlowBitsTestSig07(void)
     }
     FAIL_IF(result);
 
+    PacketFree(p);
+    FLOW_DESTROY(&f);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-
-    FLOW_DESTROY(&f);
-
-    SCFree(p);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 
@@ -1775,12 +1774,11 @@ static int FlowBitsTestSig08(void)
     }
     FAIL_IF(result);
 
+    PacketFree(p);
+    FLOW_DESTROY(&f);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-
-    FLOW_DESTROY(&f);
-
-    SCFree(p);
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 

--- a/src/flow-storage.c
+++ b/src/flow-storage.c
@@ -88,6 +88,7 @@ static int FlowStorageTest01(void)
 {
     Flow *f = NULL;
 
+    StorageCleanup();
     StorageInit();
 
     FlowStorageId id1 = FlowStorageRegister("test", 8, StorageTestAlloc, StorageTestFree);
@@ -169,6 +170,7 @@ static int FlowStorageTest02(void)
 {
     Flow *f = NULL;
 
+    StorageCleanup();
     StorageInit();
 
     FlowStorageId id1 = FlowStorageRegister("test", sizeof(void *), NULL, StorageTestFree);
@@ -220,6 +222,7 @@ static int FlowStorageTest03(void)
 {
     Flow *f = NULL;
 
+    StorageCleanup();
     StorageInit();
 
     FlowStorageId id1 = FlowStorageRegister("test1", sizeof(void *), NULL, StorageTestFree);

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -256,6 +256,11 @@ void RunUnittests(int list_unittests, const char *regex_arg)
 
     TagInitCtx();
 
+    /* test and initialize the unit testing subsystem */
+    if (regex_arg == NULL) {
+        regex_arg = ".*";
+        UtRunSelftest(regex_arg); /* inits and cleans up again */
+    }
     UtInitialize();
 
     RegisterAllModules();
@@ -263,11 +268,6 @@ void RunUnittests(int list_unittests, const char *regex_arg)
     HostBitInitCtx();
 
     StorageFinalize();
-    /* test and initialize the unit testing subsystem */
-    if (regex_arg == NULL){
-        regex_arg = ".*";
-        UtRunSelftest(regex_arg); /* inits and cleans up again */
-    }
 
     AppLayerHtpEnableRequestBodyCallback();
     AppLayerHtpNeedFileInspection();

--- a/src/tests/detect-http-client-body.c
+++ b/src/tests/detect-http-client-body.c
@@ -189,9 +189,12 @@ static int RunTest (struct TestSteps *steps, const char *sig, const char *yaml)
     FLOW_DESTROY(&f);
 
     if (yaml) {
+        HTPFreeConfig();
+        SCConfDeInit();
         HtpConfigRestoreBackup();
         SCConfRestoreContextBackup();
     }
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 

--- a/src/tests/detect-http-cookie.c
+++ b/src/tests/detect-http-cookie.c
@@ -136,6 +136,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -228,6 +229,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -320,6 +322,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -412,6 +415,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -504,6 +508,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -596,6 +601,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -688,6 +694,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -780,6 +787,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -872,6 +880,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -965,6 +974,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1058,6 +1068,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1151,6 +1162,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1244,6 +1256,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1337,6 +1350,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1430,6 +1444,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1523,6 +1538,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1616,6 +1632,7 @@ end:
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p, 1);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1765,9 +1782,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
-
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1856,8 +1874,10 @@ end:
     if (de_ctx != NULL) {
         DetectEngineCtxFree(de_ctx);
     }
-    StreamTcpFreeConfig(true);
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1946,8 +1966,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -2037,8 +2059,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -2128,8 +2152,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -2219,8 +2245,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -2309,8 +2337,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -2319,9 +2349,6 @@ end:
  */
 static int DetectHttpCookieSigTest08(void)
 {
-    int result = 0;
-    Flow f;
-
     uint8_t httpbuf_request[] =
         "GET / HTTP/1.1\r\n"
         "User-Agent: Mozilla/1.0\r\n"
@@ -2334,9 +2361,8 @@ static int DetectHttpCookieSigTest08(void)
         "\r\n";
     uint32_t httpbuf_response_len = sizeof(httpbuf_response) - 1; /* minus the \0 */
 
+    Flow f;
     TcpSession ssn;
-    Packet *p1 = NULL, *p2 = NULL;
-    Signature *s = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
     HtpState *http_state = NULL;
@@ -2352,13 +2378,13 @@ static int DetectHttpCookieSigTest08(void)
     f.flags |= FLOW_IPV4;
     f.alproto = ALPROTO_HTTP1;
 
-    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    Packet *p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
 
-    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    Packet *p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
     p2->flow = &f;
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
@@ -2367,18 +2393,14 @@ static int DetectHttpCookieSigTest08(void)
     StreamTcpInitConfig(true);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
-
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                                   "(flow:to_client; content:\"response_user_agent\"; "
-                                   "http_cookie; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    }
+    Signature *s =
+            DetectEngineAppendSig(de_ctx, "alert http any any -> any any "
+                                          "(flow:to_client; content:\"response_user_agent\"; "
+                                          "http_cookie; sid:1;)");
+    FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -2386,55 +2408,34 @@ static int DetectHttpCookieSigTest08(void)
     /* request */
     int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP1, STREAM_TOSERVER, httpbuf_request,
             httpbuf_request_len);
-    if (r != 0) {
-        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(r != 0);
 
     http_state = f.alstate;
-    if (http_state == NULL) {
-        printf("no http state: ");
-        goto end;
-    }
+    FAIL_IF_NULL(http_state);
 
     /* do detect */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
-    if (PacketAlertCheck(p1, 1)) {
-        goto end;
-    }
+    FAIL_IF(PacketAlertCheck(p1, 1));
 
     /* response */
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP1, STREAM_TOCLIENT, httpbuf_response,
             httpbuf_response_len);
-    if (r != 0) {
-        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(r != 0);
 
     /* do detect */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
-    if (!PacketAlertCheck(p2, 1)) {
-        goto end;
-    }
+    FAIL_IF(!PacketAlertCheck(p2, 1));
 
-    result = 1;
-
-end:
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
-    if (det_ctx != NULL) {
-        DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
-    }
-    if (de_ctx != NULL) {
-        DetectEngineCtxFree(de_ctx);
-    }
-
-    StreamTcpFreeConfig(true);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
-    return result;
+    FLOW_DESTROY(&f);
+
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
+    PASS;
 }
 
 /**
@@ -2561,9 +2562,11 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 

--- a/src/tests/detect-http-server-body.c
+++ b/src/tests/detect-http-server-body.c
@@ -151,10 +151,13 @@ static int RunTest(struct TestSteps *steps, const char *sig, const char *yaml)
     FLOW_DESTROY(&f);
 
     if (yaml) {
+        HTPFreeConfig();
+        SCConfDeInit();
         HtpConfigRestoreBackup();
         SCConfRestoreContextBackup();
         EngineModeSetIDS();
     }
+    StatsThreadCleanup(&th_v);
     PASS;
 }
 

--- a/src/tests/detect-http-stat-code.c
+++ b/src/tests/detect-http-stat-code.c
@@ -154,10 +154,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -260,9 +261,10 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -390,10 +392,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -510,10 +513,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -630,10 +634,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -750,10 +755,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -870,10 +876,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -990,10 +997,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1111,10 +1119,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1232,10 +1241,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1353,10 +1363,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1474,10 +1485,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1595,10 +1607,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1716,10 +1729,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1837,10 +1851,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1936,9 +1951,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
-
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -2047,9 +2063,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
-
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -2159,9 +2176,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
-
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -2271,9 +2289,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
-
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 

--- a/src/tests/detect-http-stat-msg.c
+++ b/src/tests/detect-http-stat-msg.c
@@ -154,10 +154,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -260,9 +261,10 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -390,10 +392,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -510,10 +513,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -630,10 +634,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -750,10 +755,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -870,10 +876,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -990,10 +997,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1111,10 +1119,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1232,10 +1241,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1353,10 +1363,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1474,10 +1485,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1595,10 +1607,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1716,10 +1729,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1837,10 +1851,11 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
 
-    StreamTcpFreeConfig(true);
-    FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -1949,9 +1964,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
-
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -2049,9 +2065,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
-
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 
@@ -2161,9 +2178,10 @@ end:
         DetectEngineCtxFree(de_ctx);
     }
 
-    StreamTcpFreeConfig(true);
-
     UTHFreePackets(&p, 1);
+    FLOW_DESTROY(&f);
+    StreamTcpFreeConfig(true);
+    StatsThreadCleanup(&th_v);
     return result;
 }
 

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -1187,6 +1187,7 @@ static int ThreadingAffinityTest01(void)
     FAIL_IF_NOT(CPU_ISSET(3, &worker_taf->cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set));
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1216,6 +1217,7 @@ static int ThreadingAffinityTest02(void)
     FAIL_IF_NOT(CPU_ISSET(2, &worker_taf->cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == 2);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1246,6 +1248,7 @@ static int ThreadingAffinityTest03(void)
     FAIL_IF_NOT(CPU_ISSET(3, &worker_taf->cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == 4);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1278,6 +1281,7 @@ static int ThreadingAffinityTest04(void)
     FAIL_IF(CPU_ISSET(4, &worker_taf->cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == 3);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1304,6 +1308,7 @@ static int ThreadingAffinityTest05(void)
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == UtilCpuGetNumProcessorsOnline());
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1339,6 +1344,7 @@ static int ThreadingAffinityTest06(void)
     FAIL_IF_NOT(CPU_ISSET(3, &worker_taf->hiprio_cpu));
     FAIL_IF_NOT(worker_taf->prio == PRIO_MEDIUM);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1366,6 +1372,7 @@ static int ThreadingAffinityTest07(void)
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->mode_flag == EXCLUSIVE_AFFINITY);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1393,6 +1400,7 @@ static int ThreadingAffinityTest08(void)
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_threads == 4);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1430,6 +1438,7 @@ static int ThreadingAffinityTest09(void)
     FAIL_IF_NOT(CPU_COUNT(&iface_taf->cpu_set) == 2);
     FAIL_IF_NOT(iface_taf->mode_flag == EXCLUSIVE_AFFINITY);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1480,6 +1489,7 @@ static int ThreadingAffinityTest10(void)
 
     FAIL_IF_NOT(eth0_found && eth1_found);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1519,6 +1529,7 @@ static int ThreadingAffinityTest11(void)
     FAIL_IF_NOT(CPU_ISSET(3, &iface_taf->hiprio_cpu));
     FAIL_IF_NOT(iface_taf->prio == PRIO_HIGH);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1572,6 +1583,7 @@ static int ThreadingAffinityTest12(void)
     FAIL_IF_NOT(iface_taf->prio == PRIO_HIGH);
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[WORKER_CPU_SET].cpu_set) == 2);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1598,6 +1610,7 @@ static int ThreadingAffinityTest13(void)
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == 0);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1622,6 +1635,7 @@ static int ThreadingAffinityTest14(void)
     FAIL_IF_NOT(
             CPU_COUNT(&thread_affinity[WORKER_CPU_SET].cpu_set) == UtilCpuGetNumProcessorsOnline());
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1648,6 +1662,7 @@ static int ThreadingAffinityTest15(void)
 
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[MANAGEMENT_CPU_SET].cpu_set) == 0);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1673,6 +1688,7 @@ static int ThreadingAffinityTest16(void)
     SCConfYamlLoadString(config, strlen(config));
     AffinitySetupLoadFromConfig();
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1697,6 +1713,7 @@ static int ThreadingAffinityTest17(void)
     SCConfYamlLoadString(config, strlen(config));
     AffinitySetupLoadFromConfig();
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1721,6 +1738,7 @@ static int ThreadingAffinityTest18(void)
     SCConfYamlLoadString(config, strlen(config));
     AffinitySetupLoadFromConfig();
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1745,6 +1763,7 @@ static int ThreadingAffinityTest19(void)
     SCConfYamlLoadString(config, strlen(config));
     AffinitySetupLoadFromConfig();
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1769,6 +1788,7 @@ static int ThreadingAffinityTest20(void)
     SCConfYamlLoadString(config, strlen(config));
     AffinitySetupLoadFromConfig();
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1793,6 +1813,7 @@ static int ThreadingAffinityTest21(void)
     SCConfYamlLoadString(config, strlen(config));
     AffinitySetupLoadFromConfig();
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1829,6 +1850,7 @@ static int ThreadingAffinityTest22(void)
     FAIL_IF_NOT(CPU_ISSET(1, &iface_taf->cpu_set));
     FAIL_IF_NOT(iface_taf->nb_children == 0);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1866,6 +1888,7 @@ static int ThreadingAffinityTest23(void)
     result = GetAffinityTypeForNameAndIface("worker-cpu-set", "");
     FAIL_IF_NOT(result == NULL); // Returns NULL as no child with an empty name exists
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1897,6 +1920,7 @@ static int ThreadingAffinityTest24(void)
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 0);
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }
@@ -1983,6 +2007,7 @@ static int ThreadingAffinityTest27(void)
     FAIL_IF(CPU_COUNT(&mgmt_taf->cpu_set) != 1 ||
             CPU_COUNT(&worker_taf->cpu_set) != UtilCpuGetNumProcessorsOnline());
 
+    SCConfDeInit();
     SCConfRestoreContextBackup();
     PASS;
 }

--- a/src/util-flow-rate.c
+++ b/src/util-flow-rate.c
@@ -268,6 +268,9 @@ static int FlowRateTest01(void)
     FAIL_IF(frs->dir[0].last_ts.secs != p3->ts.secs);
     FAIL_IF(frs->dir[0].buf[0] != 139);
 
+    UTHFreePacket(p1);
+    UTHFreePacket(p2);
+    UTHFreePacket(p3);
     FlowRateStoreFree(frs);
     PASS;
 }
@@ -315,6 +318,10 @@ static int FlowRateTest02(void)
     FAIL_IF(frs->dir[0].last_ts.secs != p4->ts.secs);
     FAIL_IF(frs->dir[0].buf[3] != 46);
 
+    UTHFreePacket(p1);
+    UTHFreePacket(p2);
+    UTHFreePacket(p3);
+    UTHFreePacket(p4);
     FlowRateStoreFree(frs);
     PASS;
 }
@@ -384,6 +391,12 @@ static int FlowRateTest03(void)
     FAIL_IF(frs->dir[0].start_ts.secs != p5->ts.secs);
     FAIL_IF(frs->dir[0].buf[1] != 47);
 
+    UTHFreePacket(p1);
+    UTHFreePacket(p2);
+    UTHFreePacket(p3);
+    UTHFreePacket(p4);
+    UTHFreePacket(p5);
+    UTHFreePacket(p6);
     FlowRateStoreFree(frs);
     PASS;
 }
@@ -417,6 +430,8 @@ static int FlowRateTest04(void)
     FAIL_IF(frs->dir[0].buf[0] != 44);
     FAIL_IF(frs->dir[0].start_ts.secs != p2->ts.secs);
 
+    UTHFreePacket(p1);
+    UTHFreePacket(p2);
     FlowRateStoreFree(frs);
     PASS;
 }
@@ -478,6 +493,11 @@ static int FlowRateTest05(void)
     FAIL_IF(frs->dir[0].start_ts.secs != p5->ts.secs);
     FAIL_IF(frs->dir[0].buf[0] != 43);
 
+    UTHFreePacket(p1);
+    UTHFreePacket(p2);
+    UTHFreePacket(p3);
+    UTHFreePacket(p4);
+    UTHFreePacket(p5);
     FlowRateStoreFree(frs);
     PASS;
 }
@@ -550,6 +570,12 @@ static int FlowRateTest06(void)
     FAIL_IF(frs->dir[0].buf[2] != 0);
     FAIL_IF(frs->dir[0].buf[3] != 48);
 
+    UTHFreePacket(p1);
+    UTHFreePacket(p2);
+    UTHFreePacket(p3);
+    UTHFreePacket(p4);
+    UTHFreePacket(p5);
+    UTHFreePacket(p6);
     FlowRateStoreFree(frs);
     PASS;
 }
@@ -623,6 +649,12 @@ static int FlowRateTest07(void)
     FAIL_IF(frs->dir[0].buf[2] != 0);
     FAIL_IF(frs->dir[0].buf[3] != 48);
 
+    UTHFreePacket(p1);
+    UTHFreePacket(p2);
+    UTHFreePacket(p3);
+    UTHFreePacket(p4);
+    UTHFreePacket(p5);
+    UTHFreePacket(p6);
     FlowRateStoreFree(frs);
     PASS;
 }

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -493,6 +493,7 @@ Flow *UTHBuildFlow(int family, const char *src, const char *dst, Port sp, Port d
 void UTHFreeFlow(Flow *flow)
 {
     if (flow != NULL) {
+        FLOW_DESTROY(flow);
         SCFree(flow);//FlowFree(flow);
     }
 }

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -802,6 +802,7 @@ int UTHPacketMatchSigMpm(Packet *p, char *sig, uint16_t mpm_type)
 end:
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
+    StatsThreadCleanup(&th_v);
     SCConfSet("mpm-algo", "auto");
     SCReturnInt(result);
 }


### PR DESCRIPTION
Unittest cleanups:
- fix many memleaks in test PASS-paths
- for a bunch of tests convert to FAIL/PASS api
- fix mem leak for `--list-unittests`