### PR TITLE
engine/mt: Ensure master lock held for reload 

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3153,6 +3153,9 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
     uint32_t max_tenant_id = 0;
     DetectEngineCtx *list = master->list;
 
+    DEBUG_VALIDATE_BUG_ON(!SCMutexIsLocked(&master->lock));
+
+    /* coverity[missing_lock] */
     if (master->tenant_selector == TENANT_SELECTOR_UNKNOWN) {
         SCLogError("no tenant selector set: "
                    "set using multi-detect.selector");

--- a/src/threads-debug.h
+++ b/src/threads-debug.h
@@ -116,6 +116,7 @@
 #define SCMutexInit(mut, mutattrs) SCMutexInit_dbg(mut, mutattrs)
 #define SCMutexLock(mut) SCMutexLock_dbg(mut)
 #define SCMutexTrylock(mut) SCMutexTrylock_dbg(mut)
+#define SCMutexIsLocked(mut)       (SCMutexTrylock(mut) == EBUSY)
 #define SCMutexUnlock(mut) SCMutexUnlock_dbg(mut)
 #define SCMutexDestroy pthread_mutex_destroy
 #define SCMUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER

--- a/src/threads-profile.h
+++ b/src/threads-profile.h
@@ -90,6 +90,7 @@ extern thread_local uint64_t mutex_lock_cnt;
 #define SCMutexInit(mut, mutattr ) pthread_mutex_init(mut, mutattr)
 #define SCMutexLock(mut) SCMutexLock_profile(mut)
 #define SCMutexTrylock(mut) pthread_mutex_trylock(mut)
+#define SCMutexIsLocked(mut)       (SCMutexTrylock(mut) == EBUSY)
 #define SCMutexUnlock(mut) pthread_mutex_unlock(mut)
 #define SCMutexDestroy pthread_mutex_destroy
 #define SCMUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER

--- a/src/threads.c
+++ b/src/threads.c
@@ -43,6 +43,7 @@ static int ThreadMacrosTest01Mutex(void)
     r |= SCMutexInit(&mut, NULL);
     r |= SCMutexLock(&mut);
     r |= (SCMutexTrylock(&mut) == EBUSY)? 0 : 1;
+    r |= SCMutexIsLocked(&mut) ? 0 : 1;
     r |= SCMutexUnlock(&mut);
     r |= SCMutexDestroy(&mut);
 

--- a/src/threads.h
+++ b/src/threads.h
@@ -118,6 +118,7 @@ enum {
 #define SCMutexInit(mut, mutattr ) pthread_mutex_init(mut, mutattr)
 #define SCMutexLock(mut) pthread_mutex_lock(mut)
 #define SCMutexTrylock(mut) pthread_mutex_trylock(mut)
+#define SCMutexIsLocked(mut)           (SCMutexTrylock(mut) == EBUSY)
 #define SCMutexUnlock(mut) pthread_mutex_unlock(mut)
 #define SCMutexDestroy pthread_mutex_destroy
 #define SCMUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER


### PR DESCRIPTION
Continuation of #13739 

Issue: 7819

DetectEngineReload must hold the `master->lock`; recent changes changed the locking usages to avoid deadlock when registering/handling tenants. These changes added the presumption that the master lock is held at a higher level. Coverity highlighted that the lock is not held consistently.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7819

Describe changes:
- The recent fix for MT related deadlocks placed a new requirement that DetectEngineReload must be called w/the master->lock held.

Update
- Add `SCMutexIsLocked`
- Use `SCMutexIsLocked` under DBV to assert `master->lock` held
- Suppress coverity missing lock report
- Extend unit test to use `SCMutexIsLocked`

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
