### PR TITLE
output: Display ethertype properly

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -43,6 +43,10 @@ Logging Changes
   duplicate attribute types. See :ref:`IKE logging changes
   <9.0-ike-logging-changes>`
 
+- Ethertype values (``ether.ether_type``) are now logged matching the network order value.
+  E.g., previously, ``ether_type`` values were logged in host order;  an ethertype value of ``0xfbb7``
+  (network order) was logged as `47099`` (``0xb7fb``). This ethertype value will be logged as ``64439``.
+
 Upgrading to 8.0.1
 ------------------
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -761,7 +761,7 @@ static int CreateJSONEther(
         if (PacketIsEthernet(p)) {
             const EthernetHdr *ethh = PacketGetEthernet(p);
             SCJbOpenObject(js, "ether");
-            SCJbSetUint(js, "ether_type", ethh->eth_type);
+            SCJbSetUint(js, "ether_type", SCNtohs(ethh->eth_type));
             const uint8_t *src;
             const uint8_t *dst;
             switch (dir) {


### PR DESCRIPTION
Continuation of #13982  

This displays the ethertype in host format *as a decimal string*, not network format,  matches the packet value.

Without this change, an ethertype value such as 0xfbb7 is displayed in decimal as: 47099 (0xb7fb). The correct value should be 64439 (0xfbb7).

Issue: 7855

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7855

Describe changes:
- Display ethertype in host, not network, order.
- Clarify commit comments -- change applies to all displayed ethertypes
- Added upgrade note.
- ~~Changed output format from decimal integer to hexadecimal string.~~

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2673
SU_REPO=
SU_BRANCH=
