### PR TITLE
[draft] threads: remove global packet pools

### DIFF
--- a/examples/lib/custom/main.c
+++ b/examples/lib/custom/main.c
@@ -96,7 +96,7 @@ static void *SimpleWorker(void *arg)
             goto done;
         }
 
-        Packet *p = PacketGetFromQueueOrAlloc();
+        Packet *p = PacketGetFromQueueOrAlloc(tv);
         if (unlikely(p == NULL)) {
             /* Memory allocation error. */
             goto done;

--- a/examples/plugins/ci-capture/source.c
+++ b/examples/plugins/ci-capture/source.c
@@ -65,8 +65,8 @@ static TmEcode ReceiveLoop(ThreadVars *tv, void *data, void *slot)
     /* Notify we are running and processing packets. */
     TmThreadsSetFlag(tv, THV_RUNNING);
 
-    PacketPoolWait();
-    Packet *p = PacketGetFromQueueOrAlloc();
+    PacketPoolWait(tv);
+    Packet *p = PacketGetFromQueueOrAlloc(tv);
     if (unlikely(p == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/plugins/napatech/source-napatech.c
+++ b/plugins/napatech/source-napatech.c
@@ -847,7 +847,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
     while (!(suricata_ctl_flags & SURICATA_STOP)) {
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        PacketPoolWait();
+        PacketPoolWait(tv);
 
         /* Napatech returns packets 1 at a time */
         status = NT_NetRxGet(ntv->rx_stream, &packet_buffer, 1000);
@@ -863,7 +863,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
             break;
         }
 
-        Packet *p = PacketGetFromQueueOrAlloc();
+        Packet *p = PacketGetFromQueueOrAlloc(tv);
         if (unlikely(p == NULL)) {
             NT_NetRxRelease(ntv->rx_stream, packet_buffer);
             SCReturnInt(TM_ECODE_FAILED);

--- a/plugins/pfring/source-pfring.c
+++ b/plugins/pfring/source-pfring.c
@@ -330,9 +330,9 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
 
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        PacketPoolWait();
+        PacketPoolWait(tv);
 
-        p = PacketGetFromQueueOrAlloc();
+        p = PacketGetFromQueueOrAlloc(tv);
         if (p == NULL) {
             SCReturnInt(TM_ECODE_FAILED);
         }

--- a/src/decode-geneve.c
+++ b/src/decode-geneve.c
@@ -43,6 +43,7 @@
 #include "pkt-var.h"
 #include "util-profiling.h"
 #include "host.h"
+#include "tmqh-packetpool.h"
 
 #define VALID_GENEVE_VERSIONS                                                                      \
     {                                                                                              \
@@ -301,6 +302,7 @@ static int DecodeGeneveTest01(void)
 
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
@@ -315,6 +317,7 @@ static int DecodeGeneveTest01(void)
     FlowShutdown();
     PacketFree(p);
     PacketFree(tp);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -343,6 +346,7 @@ static int DecodeGeneveTest02(void)
 
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
@@ -357,6 +361,7 @@ static int DecodeGeneveTest02(void)
     FlowShutdown();
     PacketFree(p);
     PacketFree(tp);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -390,6 +395,7 @@ static int DecodeGeneveTest03(void)
 
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
@@ -404,6 +410,7 @@ static int DecodeGeneveTest03(void)
     FlowShutdown();
     PacketFree(p);
     PacketFree(tp);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -434,6 +441,7 @@ static int DecodeGeneveTest04(void)
 
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
@@ -444,6 +452,7 @@ static int DecodeGeneveTest04(void)
     DecodeGeneveConfigPorts(GENEVE_DEFAULT_PORT_S); /* Reset Geneve port list for future calls */
     FlowShutdown();
     PacketFree(p);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -474,6 +483,7 @@ static int DecodeGeneveTest05(void)
 
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
@@ -483,6 +493,7 @@ static int DecodeGeneveTest05(void)
 
     FlowShutdown();
     PacketFree(p);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 #endif /* UNITTESTS */

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -37,6 +37,7 @@
 #include "defrag.h"
 #include "flow.h"
 #include "util-print.h"
+#include "tmqh-packetpool.h"
 
 /* Generic validation
  *
@@ -1293,6 +1294,7 @@ static int DecodeIPV4DefragTest01(void)
 
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     FlowInitConfig(FLOW_QUIET);
     DefragInit();
@@ -1327,6 +1329,7 @@ static int DecodeIPV4DefragTest01(void)
     PacketRecycle(p);
     FlowShutdown();
     PacketFree(p);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -1389,6 +1392,7 @@ static int DecodeIPV4DefragTest02(void)
 
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     FlowInitConfig(FLOW_QUIET);
     DefragInit();
@@ -1424,6 +1428,7 @@ static int DecodeIPV4DefragTest02(void)
     PacketRecycle(p);
     FlowShutdown();
     PacketFree(p);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -1480,6 +1485,7 @@ static int DecodeIPV4DefragTest03(void)
     DecodeThreadVars dtv;
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     FlowInitConfig(FLOW_QUIET);
     DefragInit();
@@ -1524,6 +1530,7 @@ static int DecodeIPV4DefragTest03(void)
     PacketRecycle(p);
     FlowShutdown();
     PacketFree(p);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -37,6 +37,7 @@
 #include "flow-hash.h"
 #include "util-print.h"
 #include "util-validate.h"
+#include "tmqh-packetpool.h"
 
 /**
  * \brief Function to decode IPv4 in IPv6 packets
@@ -768,6 +769,7 @@ static int DecodeIPV6FragTest01 (void)
 
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     PacketCopyData(p1, raw_frag1, sizeof(raw_frag1));
     PacketCopyData(p2, raw_frag2, sizeof(raw_frag2));
@@ -805,6 +807,7 @@ end:
     }
     DefragDestroy();
     FlowShutdown();
+    PacketPoolDestroy(&tv);
     return result;
 }
 

--- a/src/decode-vxlan.c
+++ b/src/decode-vxlan.c
@@ -39,6 +39,7 @@
 #include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
+#include "tmqh-packetpool.h"
 
 #define VXLAN_HEADER_LEN sizeof(VXLANHeader)
 
@@ -249,6 +250,7 @@ static int DecodeVXLANtest01 (void)
     DecodeThreadVars dtv;
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     DecodeVXLANConfigPorts(VXLAN_DEFAULT_PORT_S);
     FlowInitConfig(FLOW_QUIET);
@@ -264,6 +266,7 @@ static int DecodeVXLANtest01 (void)
     FlowShutdown();
     PacketFree(p);
     PacketFreeOrRelease(tp);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -288,6 +291,7 @@ static int DecodeVXLANtest02 (void)
     DecodeThreadVars dtv;
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     DecodeVXLANConfigPorts("1");
     FlowInitConfig(FLOW_QUIET);
@@ -299,6 +303,7 @@ static int DecodeVXLANtest02 (void)
     DecodeVXLANConfigPorts(VXLAN_DEFAULT_PORT_S); /* reset */
     FlowShutdown();
     PacketFree(p);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -342,6 +347,7 @@ decoder:\n\
     DecodeThreadVars dtv;
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     DecodeVXLANConfig();
     DecodeVXLANConfigPorts(VXLAN_DEFAULT_PORT_S);
@@ -360,6 +366,7 @@ decoder:\n\
     PacketFreeOrRelease(tp);
     SCConfDeInit();
     SCConfRestoreContextBackup();
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -399,6 +406,7 @@ decoder:\n\
     DecodeThreadVars dtv;
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     DecodeVXLANConfig();
     DecodeVXLANConfigPorts(VXLAN_DEFAULT_PORT_S);
@@ -417,6 +425,7 @@ decoder:\n\
     PacketFreeOrRelease(tp);
     SCConfDeInit();
     SCConfRestoreContextBackup();
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -457,6 +466,7 @@ decoder:\n\
     DecodeThreadVars dtv;
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     DecodeVXLANConfig();
     DecodeVXLANConfigPorts(VXLAN_DEFAULT_PORT_S);
@@ -471,6 +481,7 @@ decoder:\n\
     PacketFree(p);
     SCConfDeInit();
     SCConfRestoreContextBackup();
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -511,6 +522,7 @@ decoder:\n\
     DecodeThreadVars dtv;
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     DecodeVXLANConfig();
     DecodeVXLANConfigPorts(VXLAN_DEFAULT_PORT_S);
@@ -529,6 +541,7 @@ decoder:\n\
     PacketFreeOrRelease(tp);
     SCConfDeInit();
     SCConfRestoreContextBackup();
+    PacketPoolDestroy(&tv);
     PASS;
 }
 
@@ -551,6 +564,7 @@ static int DecodeVXLANtest07(void)
     DecodeThreadVars dtv;
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
+    PacketPoolInit(&tv);
 
     DecodeVXLANConfigPorts(VXLAN_DEFAULT_PORT_S);
     FlowInitConfig(FLOW_QUIET);
@@ -565,6 +579,7 @@ static int DecodeVXLANtest07(void)
 
     FlowShutdown();
     PacketFree(p);
+    PacketPoolDestroy(&tv);
     PASS;
 }
 #endif /* UNITTESTS */

--- a/src/decode.c
+++ b/src/decode.c
@@ -290,10 +290,10 @@ void PacketFreeOrRelease(Packet *p)
  *
  *  \retval p packet, NULL on error
  */
-Packet *PacketGetFromQueueOrAlloc(void)
+Packet *PacketGetFromQueueOrAlloc(ThreadVars *tv)
 {
     /* try the pool first */
-    Packet *p = PacketPoolGetPacket();
+    Packet *p = PacketPoolGetPacket(tv);
 
     if (p == NULL) {
         /* non fatal, we're just not processing a packet then */
@@ -403,7 +403,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     }
 
     /* get us a packet */
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PacketGetFromQueueOrAlloc(tv);
     if (unlikely(p == NULL)) {
         SCReturnPtr(NULL, "Packet");
     }
@@ -470,12 +470,13 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
  *
  *  \retval p the pseudo packet or NULL if out of memory
  */
-Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, uint8_t proto)
+Packet *PacketDefragPktSetup(
+        ThreadVars *tv, Packet *parent, const uint8_t *pkt, uint32_t len, uint8_t proto)
 {
     SCEnter();
 
     /* get us a packet */
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PacketGetFromQueueOrAlloc(tv);
     if (unlikely(p == NULL)) {
         SCReturnPtr(NULL, "Packet");
     }

--- a/src/decode.h
+++ b/src/decode.h
@@ -1115,10 +1115,11 @@ enum DecodeTunnelProto {
 
 Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *parent,
                              const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto);
-Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, uint8_t proto);
+Packet *PacketDefragPktSetup(
+        ThreadVars *tv, Packet *parent, const uint8_t *pkt, uint32_t len, uint8_t proto);
 void PacketDefragPktSetupParent(Packet *parent);
 void DecodeRegisterPerfCounters(DecodeThreadVars *, ThreadVars *);
-Packet *PacketGetFromQueueOrAlloc(void);
+Packet *PacketGetFromQueueOrAlloc(ThreadVars *tv);
 Packet *PacketGetFromAlloc(void);
 void PacketDecodeFinalize(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p);
 void PacketUpdateEngineEventCounters(ThreadVars *tv,

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -263,7 +263,7 @@ Defrag4Reassemble(ThreadVars *tv, DefragTracker *tracker, Packet *p)
 
     /* Allocate a Packet for the reassembled packet.  On failure we
      * SCFree all the resources held by this tracker. */
-    rp = PacketDefragPktSetup(p, NULL, 0, IPV4_GET_RAW_IPPROTO(oip4h));
+    rp = PacketDefragPktSetup(tv, p, NULL, 0, IPV4_GET_RAW_IPPROTO(oip4h));
     if (rp == NULL) {
         goto error_remove_tracker;
     }
@@ -424,7 +424,7 @@ Defrag6Reassemble(ThreadVars *tv, DefragTracker *tracker, Packet *p)
     /* Allocate a Packet for the reassembled packet.  On failure we
      * SCFree all the resources held by this tracker. */
     rp = PacketDefragPktSetup(
-            p, (const uint8_t *)oip6h, IPV6_GET_RAW_PLEN(oip6h) + sizeof(IPV6Hdr), 0);
+            tv, p, (const uint8_t *)oip6h, IPV6_GET_RAW_PLEN(oip6h) + sizeof(IPV6Hdr), 0);
     if (rp == NULL) {
         goto error_remove_tracker;
     }
@@ -1415,6 +1415,7 @@ static int DefragInOrderSimpleTest(void)
     int id = 12;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     p1 = BuildIpv4TestPacket(IPPROTO_ICMP, id, 0, 1, 'A', 8);
     FAIL_IF_NULL(p1);
@@ -1452,6 +1453,7 @@ static int DefragInOrderSimpleTest(void)
     PacketFree(p3);
     PacketFree(reassembled);
 
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -1466,6 +1468,7 @@ static int DefragReverseSimpleTest(void)
     int id = 12;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     p1 = BuildIpv4TestPacket(IPPROTO_ICMP, id, 0, 1, 'A', 8);
     FAIL_IF_NULL(p1);
@@ -1502,6 +1505,7 @@ static int DefragReverseSimpleTest(void)
     PacketFree(p3);
     PacketFree(reassembled);
 
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -1517,6 +1521,7 @@ static int DefragInOrderSimpleIpv6Test(void)
     int id = 12;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     p1 = BuildIpv6TestPacket(IPPROTO_ICMPV6, id, 0, 1, 'A', 8);
     FAIL_IF_NULL(p1);
@@ -1553,6 +1558,7 @@ static int DefragInOrderSimpleIpv6Test(void)
     PacketFree(p3);
     PacketFree(reassembled);
 
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -1565,6 +1571,7 @@ static int DefragReverseSimpleIpv6Test(void)
     int id = 12;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     dc = DefragContextNew();
     FAIL_IF_NULL(dc);
@@ -1602,6 +1609,7 @@ static int DefragReverseSimpleIpv6Test(void)
     PacketFree(p3);
     PacketFree(reassembled);
 
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -1611,6 +1619,7 @@ static int DefragDoSturgesNovakTest(int policy, uint8_t *expected, size_t expect
     int i;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     /*
      * Build the packets.
@@ -1720,6 +1729,7 @@ static int DefragDoSturgesNovakTest(int policy, uint8_t *expected, size_t expect
     for (i = 0; i < 17; i++) {
         PacketFree(packets[i]);
     }
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -1729,6 +1739,7 @@ static int DefragDoSturgesNovakIpv6Test(int policy, uint8_t *expected, size_t ex
     int i;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     /*
      * Build the packets.
@@ -1830,6 +1841,7 @@ static int DefragDoSturgesNovakIpv6Test(int policy, uint8_t *expected, size_t ex
     for (i = 0; i < 17; i++) {
         PacketFree(packets[i]);
     }
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2283,6 +2295,7 @@ static int DefragTimeoutTest(void)
     FAIL_IF_NOT(SCConfSet("defrag.trackers", "16"));
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     /* Load in 16 packets. */
     for (i = 0; i < 16; i++) {
@@ -2311,6 +2324,7 @@ static int DefragTimeoutTest(void)
     SCMutexUnlock(&tracker->lock);
     PacketFree(p);
 
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2328,6 +2342,7 @@ static int DefragNoDataIpv4Test(void)
     int id = 12;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     dc = DefragContextNew();
     FAIL_IF_NULL(dc);
@@ -2346,6 +2361,7 @@ static int DefragNoDataIpv4Test(void)
     DefragContextDestroy(dc);
     PacketFree(p);
 
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2356,6 +2372,7 @@ static int DefragTooLargeIpv4Test(void)
     Packet *p = NULL;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     dc = DefragContextNew();
     FAIL_IF_NULL(dc);
@@ -2378,6 +2395,7 @@ static int DefragTooLargeIpv4Test(void)
     DefragContextDestroy(dc);
     PacketFree(p);
 
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2392,6 +2410,7 @@ static int DefragVlanTest(void)
     Packet *p1 = NULL, *p2 = NULL, *r = NULL;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     p1 = BuildIpv4TestPacket(IPPROTO_ICMP, 1, 0, 1, 'A', 8);
     FAIL_IF_NULL(p1);
@@ -2424,6 +2443,7 @@ static int DefragVlanQinQTest(void)
     Packet *p1 = NULL, *p2 = NULL, *r = NULL;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     p1 = BuildIpv4TestPacket(IPPROTO_ICMP, 1, 0, 1, 'A', 8);
     FAIL_IF_NULL(p1);
@@ -2458,6 +2478,7 @@ static int DefragVlanQinQinQTest(void)
     Packet *r = NULL;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     Packet *p1 = BuildIpv4TestPacket(IPPROTO_ICMP, 1, 0, 1, 'A', 8);
     FAIL_IF_NULL(p1);
@@ -2492,6 +2513,7 @@ static int DefragTrackerReuseTest(void)
     DefragTracker *tracker1 = NULL, *tracker2 = NULL;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     /* Build a packet, its not a fragment but shouldn't matter for
      * this test. */
@@ -2525,6 +2547,7 @@ static int DefragTrackerReuseTest(void)
     FAIL_IF(tracker2->remove);
 
     PacketFree(p1);
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2544,6 +2567,7 @@ static int DefragMfIpv4Test(void)
     Packet *p = NULL;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     Packet *p1 = BuildIpv4TestPacket(IPPROTO_ICMP, ip_id, 2, 1, 'C', 8);
     Packet *p2 = BuildIpv4TestPacket(IPPROTO_ICMP, ip_id, 0, 1, 'A', 8);
@@ -2572,6 +2596,7 @@ static int DefragMfIpv4Test(void)
     PacketFree(p2);
     PacketFree(p3);
     PacketFree(p);
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2591,6 +2616,7 @@ static int DefragMfIpv6Test(void)
     Packet *p = NULL;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     Packet *p1 = BuildIpv6TestPacket(IPPROTO_ICMPV6, ip_id, 2, 1, 'C', 8);
     Packet *p2 = BuildIpv6TestPacket(IPPROTO_ICMPV6, ip_id, 0, 1, 'A', 8);
@@ -2619,6 +2645,7 @@ static int DefragMfIpv6Test(void)
     PacketFree(p2);
     PacketFree(p3);
     PacketFree(p);
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2633,6 +2660,7 @@ static int DefragTestBadProto(void)
     int id = 12;
 
     DefragInit();
+    PacketPoolInit(&test_tv);
 
     p1 = BuildIpv4TestPacket(IPPROTO_ICMP, id, 0, 1, 'A', 8);
     FAIL_IF_NULL(p1);
@@ -2649,6 +2677,7 @@ static int DefragTestBadProto(void)
     PacketFree(p2);
     PacketFree(p3);
 
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2675,6 +2704,7 @@ static int DefragTestJeremyLinux(void)
                          "DDDDDD";
 
     DefragInit();
+    PacketPoolInit(&test_tv);
     default_policy = DEFRAG_POLICY_LINUX;
 
     int id = 1;
@@ -2705,6 +2735,7 @@ static int DefragTestJeremyLinux(void)
     }
     PacketFree(r);
 
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2722,6 +2753,7 @@ static int DefragTestJeremyLinux(void)
 static int DefragBsdFragmentAfterNoMfIpv4Test(void)
 {
     DefragInit();
+    PacketPoolInit(&test_tv);
     default_policy = DEFRAG_POLICY_BSD;
     Packet *packets[4];
 
@@ -2764,6 +2796,7 @@ static int DefragBsdFragmentAfterNoMfIpv4Test(void)
         PacketFree(packets[i]);
     }
     PacketFree(r);
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2771,6 +2804,7 @@ static int DefragBsdFragmentAfterNoMfIpv4Test(void)
 static int DefragBsdFragmentAfterNoMfIpv6Test(void)
 {
     DefragInit();
+    PacketPoolInit(&test_tv);
     default_policy = DEFRAG_POLICY_BSD;
     Packet *packets[4];
 
@@ -2813,6 +2847,7 @@ static int DefragBsdFragmentAfterNoMfIpv6Test(void)
         PacketFree(packets[i]);
     }
     PacketFree(r);
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2820,6 +2855,7 @@ static int DefragBsdFragmentAfterNoMfIpv6Test(void)
 static int DefragBsdSubsequentOverlapsStartOfOriginalIpv4Test_2(void)
 {
     DefragInit();
+    PacketPoolInit(&test_tv);
     default_policy = DEFRAG_POLICY_BSD;
     Packet *packets[4];
 
@@ -2870,6 +2906,7 @@ static int DefragBsdSubsequentOverlapsStartOfOriginalIpv4Test_2(void)
         PacketFree(packets[i]);
     }
     PacketFree(r);
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2877,6 +2914,7 @@ static int DefragBsdSubsequentOverlapsStartOfOriginalIpv4Test_2(void)
 static int DefragBsdSubsequentOverlapsStartOfOriginalIpv6Test_2(void)
 {
     DefragInit();
+    PacketPoolInit(&test_tv);
     default_policy = DEFRAG_POLICY_BSD;
     Packet *packets[4];
 
@@ -2926,6 +2964,7 @@ static int DefragBsdSubsequentOverlapsStartOfOriginalIpv6Test_2(void)
         PacketFree(packets[i]);
     }
     PacketFree(r);
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2945,6 +2984,7 @@ static int DefragBsdSubsequentOverlapsStartOfOriginalIpv6Test_2(void)
 static int DefragBsdSubsequentOverlapsStartOfOriginalIpv4Test(void)
 {
     DefragInit();
+    PacketPoolInit(&test_tv);
     default_policy = DEFRAG_POLICY_BSD;
     Packet *packets[2];
 
@@ -2978,6 +3018,7 @@ static int DefragBsdSubsequentOverlapsStartOfOriginalIpv4Test(void)
         PacketFree(packets[i]);
     }
     PacketFree(r);
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -2985,6 +3026,7 @@ static int DefragBsdSubsequentOverlapsStartOfOriginalIpv4Test(void)
 static int DefragBsdSubsequentOverlapsStartOfOriginalIpv6Test(void)
 {
     DefragInit();
+    PacketPoolInit(&test_tv);
     default_policy = DEFRAG_POLICY_BSD;
     Packet *packets[2];
 
@@ -3018,6 +3060,7 @@ static int DefragBsdSubsequentOverlapsStartOfOriginalIpv6Test(void)
         PacketFree(packets[i]);
     }
     PacketFree(r);
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -3036,6 +3079,7 @@ static int DefragBsdSubsequentOverlapsStartOfOriginalIpv6Test(void)
 static int DefragBsdMissingFragmentIpv4Test(void)
 {
     DefragInit();
+    PacketPoolInit(&test_tv);
     default_policy = DEFRAG_POLICY_BSD;
     Packet *packets[5];
 
@@ -3077,6 +3121,7 @@ static int DefragBsdMissingFragmentIpv4Test(void)
     for (int i = 0; i < 5; i++) {
         PacketFree(packets[i]);
     }
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }
@@ -3084,6 +3129,7 @@ static int DefragBsdMissingFragmentIpv4Test(void)
 static int DefragBsdMissingFragmentIpv6Test(void)
 {
     DefragInit();
+    PacketPoolInit(&test_tv);
     default_policy = DEFRAG_POLICY_BSD;
     Packet *packets[5];
 
@@ -3124,6 +3170,7 @@ static int DefragBsdMissingFragmentIpv6Test(void)
     for (int i = 0; i < 5; i++) {
         PacketFree(packets[i]);
     }
+    PacketPoolDestroy(&test_tv);
     DefragDestroy();
     PASS;
 }

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -750,14 +750,14 @@ static TmEcode FlowManagerThreadInit(ThreadVars *t, const void *initdata, void *
     ftd->counter_defrag_timeout = StatsRegisterCounter("defrag.mgr.tracker_timeout", t);
     ftd->counter_defrag_memuse = StatsRegisterCounter("defrag.memuse", t);
 
-    PacketPoolInit();
+    PacketPoolInit(t);
     return TM_ECODE_OK;
 }
 
 static TmEcode FlowManagerThreadDeinit(ThreadVars *t, void *data)
 {
     StreamTcpThreadCacheCleanup();
-    PacketPoolDestroy();
+    PacketPoolDestroy(t);
     SCFree(data);
     return TM_ECODE_OK;
 }

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -261,10 +261,10 @@ error:
     return NULL;
 }
 
-Packet *FlowPseudoPacketGet(int direction, Flow *f, const TcpSession *ssn)
+Packet *FlowPseudoPacketGet(ThreadVars *tv, int direction, Flow *f, const TcpSession *ssn)
 {
-    PacketPoolWait();
-    Packet *p = PacketPoolGetPacket();
+    PacketPoolWait(tv);
+    Packet *p = PacketPoolGetPacket(tv);
     if (p == NULL) {
         return NULL;
     }

--- a/src/flow-timeout.h
+++ b/src/flow-timeout.h
@@ -29,6 +29,6 @@
 void FlowSendToLocalThread(Flow *f);
 bool FlowNeedsReassembly(Flow *f);
 void FlowWorkToDoCleanup(void);
-Packet *FlowPseudoPacketGet(int direction, Flow *f, const TcpSession *ssn);
+Packet *FlowPseudoPacketGet(ThreadVars *tv, int direction, Flow *f, const TcpSession *ssn);
 
 #endif /* SURICATA_FLOW_TIMEOUT_H */

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -122,7 +122,7 @@ static int FlowFinish(ThreadVars *tv, Flow *f, FlowWorkerThreadData *fw, void *d
 
     /* insert a pseudo packet in the toserver direction */
     if (client == STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION) {
-        Packet *p = FlowPseudoPacketGet(0, f, ssn);
+        Packet *p = FlowPseudoPacketGet(tv, 0, f, ssn);
         if (p != NULL) {
             PKT_SET_SRC(p, PKT_SRC_FFR);
             if (server == STREAM_HAS_UNPROCESSED_SEGMENTS_NONE) {
@@ -136,7 +136,7 @@ static int FlowFinish(ThreadVars *tv, Flow *f, FlowWorkerThreadData *fw, void *d
 
     /* handle toclient */
     if (server == STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION) {
-        Packet *p = FlowPseudoPacketGet(1, f, ssn);
+        Packet *p = FlowPseudoPacketGet(tv, 1, f, ssn);
         if (p != NULL) {
             PKT_SET_SRC(p, PKT_SRC_FFR);
             p->flowflags |= FLOW_PKT_LAST_PSEUDO;

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -277,13 +277,20 @@ void RunUnittests(int list_unittests, const char *regex_arg)
     if (list_unittests) {
         UtListTests(regex_arg);
     } else {
+        /* Create a minimal ThreadVars for unit test packet pool */
+        ThreadVars unittest_tv;
+        memset(&unittest_tv, 0, sizeof(unittest_tv));
+        strlcpy(unittest_tv.name, "unittest", sizeof(unittest_tv.name));
+        unittest_tv.t = pthread_self();
+        unittest_tv.id = 1;
+
         /* global packet pool */
         extern uint32_t max_pending_packets;
         max_pending_packets = 128;
-        PacketPoolInit();
+        PacketPoolInit(&unittest_tv);
 
         uint32_t failed = UtRunTests(regex_arg);
-        PacketPoolDestroy();
+        PacketPoolDestroy(&unittest_tv);
         UtCleanup();
 #ifdef BUILD_HYPERSCAN
         MpmHSGlobalCleanup();

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -926,7 +926,7 @@ static int AFPReadFromRing(AFPThreadVars *ptv)
         if (unlikely(AFPShouldIgnoreFrame(ptv, sll)))
             goto next_frame;
 
-        Packet *p = PacketGetFromQueueOrAlloc();
+        Packet *p = PacketGetFromQueueOrAlloc(ptv->tv);
         if (p == NULL) {
             return AFPSuriFailure(ptv, h);
         }
@@ -956,7 +956,7 @@ static inline void AFPFlushBlock(struct tpacket_block_desc *pbd)
 
 static inline int AFPParsePacketV3(AFPThreadVars *ptv, struct tpacket_block_desc *pbd, struct tpacket3_hdr *ppd)
 {
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PacketGetFromQueueOrAlloc(ptv->tv);
     if (p == NULL) {
         SCReturnInt(AFP_SURI_FAILURE);
     }
@@ -1387,7 +1387,7 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
 
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        PacketPoolWait();
+        PacketPoolWait(tv);
 
         StatsIncr(ptv->tv, ptv->capture_afp_poll);
 

--- a/src/source-af-xdp.c
+++ b/src/source-af-xdp.c
@@ -708,7 +708,7 @@ static TmEcode ReceiveAFXDPLoop(ThreadVars *tv, void *data, void *slot)
     // packets)
     TmThreadsSetFlag(tv, THV_RUNNING);
 
-    PacketPoolWait();
+    PacketPoolWait(tv);
     while (1) {
         /* Start by checking the state of our interface */
         if (unlikely(ptv->afxdp_state == AFXDP_STATE_DOWN)) {
@@ -777,7 +777,7 @@ static TmEcode ReceiveAFXDPLoop(ThreadVars *tv, void *data, void *slot)
         gettimeofday(&ts, NULL);
         ptv->pkts += rcvd;
         for (uint32_t i = 0; i < rcvd; i++) {
-            p = PacketGetFromQueueOrAlloc();
+            p = PacketGetFromQueueOrAlloc(ptv->tv);
             if (unlikely(p == NULL)) {
                 StatsIncr(ptv->tv, ptv->capture_afxdp_acquire_pkt_failed);
                 continue;

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -353,7 +353,7 @@ static TmEcode ReceiveDPDKLoopInit(ThreadVars *tv, DPDKThreadVars *ptv)
     // Indicate that the thread is actually running its application level
     // code (i.e., it can poll packets)
     TmThreadsSetFlag(tv, THV_RUNNING);
-    PacketPoolWait();
+    PacketPoolWait(tv);
 
     rte_eth_stats_reset(ptv->port_id);
     rte_eth_xstats_reset(ptv->port_id);
@@ -416,7 +416,7 @@ static inline bool RXPacketCountHeuristic(ThreadVars *tv, DPDKThreadVars *ptv, u
  */
 static inline Packet *PacketInitFromMbuf(DPDKThreadVars *ptv, struct rte_mbuf *mbuf)
 {
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PacketGetFromQueueOrAlloc(ptv->tv);
     if (unlikely(p == NULL)) {
         return NULL;
     }

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -396,7 +396,7 @@ ProcessErfDagRecords(ErfDagThreadVars *ewtn, uint8_t *top, uint32_t *pkts_read)
 
         /* Make sure we have at least one packet in the packet pool,
          * to prevent us from alloc'ing packets at line rate. */
-        PacketPoolWait();
+        PacketPoolWait(tv);
 
         prec = (char *)ewtn->btm;
         dr = (dag_record_t*)prec;
@@ -486,7 +486,7 @@ ProcessErfDagRecord(ErfDagThreadVars *ewtn, char *prec)
     /* skip over extension headers */
     pload = (erf_payload_t *)(prec + dag_record_size + (8 * hdr_num));
 
-    p = PacketGetFromQueueOrAlloc();
+    p = PacketGetFromQueueOrAlloc(ewtn->tv);
     if (p == NULL) {
         SCLogError("Failed to allocate a Packet on stream: %d, DAG: %s", ewtn->dagstream,
                 ewtn->dagname);

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -127,9 +127,9 @@ TmEcode ReceiveErfFileLoop(ThreadVars *tv, void *data, void *slot)
 
         /* Make sure we have at least one packet in the packet pool,
          * to prevent us from alloc'ing packets at line rate. */
-        PacketPoolWait();
+        PacketPoolWait(tv);
 
-        p = PacketGetFromQueueOrAlloc();
+        p = PacketGetFromQueueOrAlloc(tv);
         if (unlikely(p == NULL)) {
             SCLogError("Failed to allocate a packet.");
             EngineStop();

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -281,9 +281,9 @@ TmEcode ReceiveIPFWLoop(ThreadVars *tv, void *data, void *slot)
 
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        PacketPoolWait();
+        PacketPoolWait(tv);
 
-        p = PacketGetFromQueueOrAlloc();
+        p = PacketGetFromQueueOrAlloc(tv);
         if (p == NULL) {
             SCReturnInt(TM_ECODE_FAILED);
         }

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -674,7 +674,7 @@ static void NetmapProcessPacket(NetmapThreadVars *ntv, const struct nm_pkthdr *p
         }
     }
 
-    Packet *p = PacketPoolGetPacket();
+    Packet *p = PacketPoolGetPacket(ntv->tv);
     if (unlikely(p == NULL)) {
         return;
     }
@@ -812,7 +812,7 @@ static TmEcode ReceiveNetmapLoop(ThreadVars *tv, void *data, void *slot)
 
         /* make sure we have at least one packet in the packet pool,
          * to prevent us from alloc'ing packets at line rate */
-        PacketPoolWait();
+        PacketPoolWait(tv);
 
         int r = poll(&fds, 1, POLL_TIMEOUT);
         if (r < 0) {

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -151,7 +151,7 @@ static int NFLOGCallback(struct nflog_g_handle *gh, struct nfgenmsg *msg,
     int ret;
 
     /* grab a packet*/
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PacketGetFromQueueOrAlloc(ntv->tv);
     if (p == NULL)
         return -1;
 

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -551,7 +551,7 @@ static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
     int ret;
 
     /* grab a packet */
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PacketGetFromQueueOrAlloc(tv);
     if (p == NULL) {
         return -1;
     }

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -69,7 +69,7 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     }
 #endif
     PcapFileFileVars *ptv = (PcapFileFileVars *)user;
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PacketGetFromQueueOrAlloc(ptv->shared->tv);
 
     if (unlikely(p == NULL)) {
         SCReturn;
@@ -147,7 +147,7 @@ TmEcode PcapFileDispatch(PcapFileFileVars *ptv)
 
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        PacketPoolWait();
+        PacketPoolWait(ptv->shared->tv);
 
         /* Right now we just support reading packets one at a time. */
         int r = pcap_dispatch(ptv->pcap_handle, packet_q_len,

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -328,7 +328,7 @@ static void PcapCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     SCEnter();
 
     PcapThreadVars *ptv = (PcapThreadVars *)user;
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PacketGetFromQueueOrAlloc(ptv->tv);
 
     if (unlikely(p == NULL)) {
         SCReturn;
@@ -409,7 +409,7 @@ static TmEcode ReceivePcapLoop(ThreadVars *tv, void *data, void *slot)
 
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */
-        PacketPoolWait();
+        PacketPoolWait(tv);
 
         int r = pcap_dispatch(ptv->pcap_handle, packet_q_len,
                           (pcap_handler)PcapCallbackLoop, (u_char *)ptv);

--- a/src/source-windivert.c
+++ b/src/source-windivert.c
@@ -437,10 +437,10 @@ static TmEcode WinDivertRecvHelper(ThreadVars *tv, WinDivertThreadVars *wd_tv)
     /* make sure we have at least one packet in the packet pool, to prevent us
      * from alloc'ing packets at line rate
      */
-    PacketPoolWait();
+    PacketPoolWait(tv);
 
     /* obtain a packet buffer */
-    Packet *p = PacketGetFromQueueOrAlloc();
+    Packet *p = PacketGetFromQueueOrAlloc(tv);
     if (unlikely(p == NULL)) {
         SCLogDebug(
                 "PacketGetFromQueueOrAlloc() - failed to obtain Packet buffer");

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6855,7 +6855,7 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
         SCReturn;
     }
 
-    Packet *np = PacketPoolGetPacket();
+    Packet *np = PacketPoolGetPacket(tv);
     if (np == NULL) {
         SCReturn;
     }

--- a/src/tests/fuzz/fuzz_decodepcapfile.c
+++ b/src/tests/fuzz/fuzz_decodepcapfile.c
@@ -80,7 +80,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
         extern uint32_t max_pending_packets;
         max_pending_packets = 128;
-        PacketPoolInit();
+        PacketPoolInit(tv);
         SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
 
         initialized = 1;

--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -99,7 +99,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
         extern uint32_t max_pending_packets;
         max_pending_packets = 128;
-        PacketPoolInit();
+        PacketPoolInit(&tv);
         if (DetectEngineReload(&surifuzz) < 0) {
             return 0;
         }

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -92,7 +92,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
         extern uint32_t max_pending_packets;
         max_pending_packets = 128;
-        PacketPoolInit();
+        PacketPoolInit(&tv);
         SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
         initialized = 1;
     }

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -117,7 +117,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
         extern uint32_t max_pending_packets;
         max_pending_packets = 128;
-        PacketPoolInit();
+        PacketPoolInit(&tv);
         SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
         initialized = 1;
     }

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -31,6 +31,7 @@
 #include "util-storage.h"
 
 struct TmSlot_;
+struct PktPool_;
 
 /** Thread flags set and read by threads to control the threads */
 // bit 0 vacant
@@ -138,6 +139,9 @@ typedef struct ThreadVars_ {
 
     /** Interface-specific thread affinity */
     char *iface_name;
+
+    /** Packet pool for this thread */
+    struct PktPool_ *pkt_pool;
 
     Storage storage[];
 } ThreadVars;

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -221,7 +221,7 @@ static inline void TmThreadsCaptureInjectPacket(ThreadVars *tv, Packet *p)
 {
     TmThreadsUnsetFlag(tv, THV_CAPTURE_INJECT_PKT);
     if (p == NULL)
-        p = PacketGetFromQueueOrAlloc();
+        p = PacketGetFromQueueOrAlloc(tv);
     if (p != NULL) {
         p->flags |= PKT_PSEUDO_STREAM_END;
         PKT_SET_SRC(p, PKT_SRC_CAPTURE_TIMEOUT);

--- a/src/tmqh-packetpool.h
+++ b/src/tmqh-packetpool.h
@@ -41,6 +41,11 @@ typedef struct PktPoolLockedStack_{
 } __attribute__((aligned(CLS))) PktPoolLockedStack;
 
 typedef struct PktPool_ {
+    /* Back-reference to the ThreadVars that owns this pool.
+     * Used for multi-instance support and debugging.
+     * Set once at pool creation, never modified. */
+    ThreadVars *tv;
+
     /* link listed of free packets local to this thread.
      * No mutex is needed.
      */
@@ -76,11 +81,11 @@ Packet *TmqhInputPacketpool(ThreadVars *);
 void TmqhOutputPacketpool(ThreadVars *, Packet *);
 void TmqhReleasePacketsToPacketPool(PacketQueue *);
 void TmqhPacketpoolRegister(void);
-Packet *PacketPoolGetPacket(void);
-void PacketPoolWait(void);
+Packet *PacketPoolGetPacket(ThreadVars *);
+void PacketPoolWait(ThreadVars *);
 void PacketPoolReturnPacket(Packet *p);
-void PacketPoolInit(void);
-void PacketPoolDestroy(void);
+void PacketPoolInit(ThreadVars *);
+void PacketPoolDestroy(ThreadVars *);
 void PacketPoolPostRunmodes(void);
 
 #endif /* SURICATA_TMQH_PACKETPOOL_H */

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -47,6 +47,7 @@
 #include "util-error.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "tmqh-packetpool.h"
 
 #if defined(UNITTESTS) || defined(FUZZ)
 Flow *TestHelperBuildFlow(int family, const char *src, const char *dst, Port sp, Port dp)
@@ -388,8 +389,10 @@ Packet *UTHBuildPacketFromEth(uint8_t *raw_eth, uint16_t pktsize)
         return NULL;
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
+    PacketPoolInit(&th_v);
 
     DecodeEthernet(&th_v, &dtv, p, raw_eth, pktsize);
+    PacketPoolDestroy(&th_v);
     return p;
 }
 
@@ -697,6 +700,7 @@ int UTHMatchPacketsWithResults(DetectEngineCtx *de_ctx, Packet **p, int num_pack
     DetectEngineThreadCtx *det_ctx = NULL;
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
+    PacketPoolInit(&th_v);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -711,6 +715,7 @@ int UTHMatchPacketsWithResults(DetectEngineCtx *de_ctx, Packet **p, int num_pack
 cleanup:
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     StatsThreadCleanup(&th_v);
+    PacketPoolDestroy(&th_v);
     return result;
 }
 
@@ -736,6 +741,7 @@ int UTHMatchPackets(DetectEngineCtx *de_ctx, Packet **p, int num_packets)
     DetectEngineThreadCtx *det_ctx = NULL;
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
+    PacketPoolInit(&th_v);
     SCSigRegisterSignatureOrderingFuncs(de_ctx);
     SCSigOrderSignatures(de_ctx);
     SCSigSignatureOrderingModuleCleanup(de_ctx);
@@ -751,6 +757,7 @@ int UTHMatchPackets(DetectEngineCtx *de_ctx, Packet **p, int num_packets)
      */
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     StatsThreadCleanup(&th_v);
+    PacketPoolDestroy(&th_v);
     return result;
 }
 
@@ -776,6 +783,7 @@ int UTHPacketMatchSigMpm(Packet *p, char *sig, uint16_t mpm_type)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
+    PacketPoolInit(&th_v);
 
     if (mpm_type == MPM_AC) {
         SCConfSet("mpm-algo", "ac");
@@ -814,6 +822,7 @@ end:
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     StatsThreadCleanup(&th_v);
+    PacketPoolDestroy(&th_v);
     SCConfSet("mpm-algo", "auto");
     SCReturnInt(result);
 }
@@ -838,6 +847,7 @@ int UTHPacketMatchSig(Packet *p, const char *sig)
 
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&th_v, 0, sizeof(th_v));
+    PacketPoolInit(&th_v);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL) {
@@ -868,6 +878,7 @@ end:
     if (de_ctx != NULL)
         DetectEngineCtxFree(de_ctx);
     StatsThreadCleanup(&th_v);
+    PacketPoolDestroy(&th_v);
     return result;
 }
 
@@ -877,6 +888,7 @@ uint32_t UTHBuildPacketOfFlows(uint32_t start, uint32_t end, uint8_t dir)
     memset(&fls, 0, sizeof(fls));
     ThreadVars tv;
     memset(&tv, 0, sizeof(tv));
+    PacketPoolInit(&tv);
 
     uint32_t i = start;
     uint8_t payload[] = "Payload";
@@ -906,6 +918,7 @@ uint32_t UTHBuildPacketOfFlows(uint32_t start, uint32_t end, uint8_t dir)
         FlowFree(f);
     }
 
+    PacketPoolDestroy(&tv);
     return i;
 }
 


### PR DESCRIPTION
Non-urgent, just been sitting on this, and a QA run would be nice.

Replace global thread-local packet pools with packet pools owned by thread vars.

The idea is to remove global data such that a library user can have multiple instances of the Suricata engine that don't share any data. As library users can provide their own threads, and may utilize different threading infrastructure such as thread pools, we should do our best not to leak resources from one instance into another.

The downside is that we might lose some optimizations that thread-local storage can provide, such as a faster path to returning a packet to another thread's pool.

This is part of the overall idea that multiple instances of the Suricata engine should be able to co-exist in one process space without cross-contamination. This generally means getting rid of all global state.  The packet pool was relatively easy to attack, with the drawback of losing an optimization. It's also a performance-critical module as well, so it's a good one to look at.

Other thoughts:
- We could just force library users into our threading model. But that seems short-sighted, given the move to work-stealing thread pools by most modern programming frameworks
- I think it's autofp that only really made use of this batching that we lost here
- Would pluggable packet pools make sense as a goal?

TODO:
- If it is agreed that removing these thread-local globals is best for the long-term design, create a tracking ticket and sub-tasks.
