### PR TITLE
detect/mqtt: reason_code keyword is now a multi-integer

### DIFF
--- a/doc/userguide/rules/mqtt-keywords.rst
+++ b/doc/userguide/rules/mqtt-keywords.rst
@@ -98,6 +98,8 @@ Match on the numeric value of the reason code that is used in MQTT 5.0 for some 
 
 mqtt.reason_code uses an :ref:`unsigned 8-bits integer <rules-integer-keywords>`.
 
+mqtt.reason_code is also a :ref:`multi-integer <multi-integers>`.
+
 Examples::
 
   # match on attempts to unsubscribe from a non-subscribed topic


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7929

Describe changes:
- detect/mqtt: reason_code keyword is now a multi-integer

Draft to get feedback :
The current `detect_uint_match_at_index` uses a `Vec`
Here for mqtt.reason_code, we do not have a `Vec` ready, because we have a Vector of Vector of u8...
So, proposal is to build a `Vec<u8>` and keep old code if detect index is any

Other keywords have the same pattern :
- enip.cip_attribute (array of arrays)
- enip.cip_class (array of arrays)
- enip.cip_status (array of arrays)
- enip.cip_instance (array of arrays)
- enip.cip_extendedstatus (array of arrays)
