### PR TITLE
transform/subslice: Add subslice transform 

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1536,7 +1536,7 @@ the default behavior).
 Each supported protocol has a dedicated subsection under ``protocols``.
 
 Asn1_max_frames
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 Asn1 (`Abstract Syntax One
 <http://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One>`_) is a
@@ -2011,7 +2011,7 @@ default is 1 MB.
         max-msg-length: 1mb
 
 SMTP
-~~~~~~
+~~~~
 
 SMTP parsers can extract files from attachments.
 It is also possible to extract raw conversations as files with the
@@ -3078,6 +3078,32 @@ to display the diagnostic message if a signal unexpectedly terminates Suricata -
         # message with the offending stacktrace if enabled.
         #stacktrace-on-signal: on
 
+
+subslice
+~~~~~~~~
+
+The subslice transform works on an input buffer and accepts two options to specify
+the ``offset`` and ``nbytes`` value to specify the subslice of the input buffer to
+produce. If the ``offset`` and ``nbytes`` value *exceeds* the input buffer length,
+the transform has two options. Option 1 is to produce an empty buffer since the subslice
+options can't apply. The second option is to truncate the input buffer and apply
+the subslice as though ``offset`` and ``nbytes`` *matched the buffer length*.This behavior
+is controlled by a configuration variable ``subslice.truncate``. The default value is ``yes``
+to truncate the input buffer. If set to ``no``, when the values exceed the buffer
+length, ``bsize:0`` would match.
+
+::
+
+    # Indicate subslice transform behavior if the buffer is smaller
+    # than offset + nbytes.
+    # The subslice transform accepts 2 parameters -- offset and nbytes.
+    # When nbytes + offset exceeds the buffer, the transform can
+    # - Do nothing
+    # - Truncate the subslice by adjusting nbytes so nbytes + offset = input buffer len
+    # The default is to truncate (on). Set to off to not truncate and produce an
+    # empty buffer (bsize:0 will match).
+    subslice:
+      truncate: on
 
 .. _deprecation policy: https://suricata.io/about/deprecation-policy/
 

--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -386,3 +386,67 @@ the buffer.
        local sub = string.sub(input, offset + 1, offset + bytes)
        return string.upper(sub), bytes
    end
+
+subslice
+--------
+
+This transform creates a slice of the input buffer.
+
+The subslice transform requires parameters:
+
+  * `offset` Specifies the starting offset at which to create the
+    subslice. When negative, expresses how far from the end of the
+    input buffer to begin. [REQUIRED]
+  * `nbytes` Specifies the size of the subslice. When negative,
+    specifies that the subslice will end that many bytes from
+    the end of the input buffer. [OPTIONAL]
+
+Specify the subslice desired -- `nbytes` is optional:
+
+Format::
+
+     subslice: offset <,nbytes>;
+
+When `nbytes` is not specified, the size of the subslice will be the size
+of the input buffer minus the `offset` value. The value of ``offset`` must
+
+The following examples use an input buffer of ``This is Suricata``.
+
+Examples
+
+The subslice will be a copy of the input buffer but omit the input buffer's first byte.
+The subslice is ``his is Suricata``::
+
+    subslice: 1;
+
+This example creates the subslice ``This is Suric``::
+
+    subslice: 0, 13;
+
+This example starts at offset ``10`` and ends at 5 bytes from the end
+of the buffer which creates a subslice from offset ``10`` to offset ``12``.
+The length of the input buffer is ``17`` bytes; ``5`` bytes from the end
+is ``12``::
+
+    subslice: 10, -5;
+
+This example will create a subslice from the last 3 bytes of the input
+buffer and create ``ata``::
+
+    subslice: -3;
+
+When the buffer has less bytes than ``offset + nbytes``, the transform
+will either trim the resulting buffer as though ``offset + nbytes == buffer_length``
+or produce an empty buffer on which `bsize:0` would match. The behavior
+s controlled by the ``subslice.truncate`` configuration variable.
+
+This example receives an input buffer with the value ``curl/7.64.1`` and
+produces ``curl/7.64.1``::
+
+    subslice: 0,30;
+
+With truncation off, i.e.,, ``subslice.truncate=no``, the buffer produced
+by the transform with the same input buffer would be the empty
+string: ``""`` and ``bsize:0`` would match::
+
+    subslice: 0,30;

--- a/rust/src/detect/transforms/mod.rs
+++ b/rust/src/detect/transforms/mod.rs
@@ -27,3 +27,4 @@ pub mod http_headers;
 pub mod strip_whitespace;
 pub mod urldecode;
 pub mod xor;
+pub mod subslice;

--- a/rust/src/detect/transforms/subslice.rs
+++ b/rust/src/detect/transforms/subslice.rs
@@ -1,0 +1,458 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use suricata_sys::sys::{
+    DetectEngineCtx, DetectEngineThreadCtx, InspectionBuffer, SCDetectHelperTransformRegister,
+    SCDetectSignatureAddTransform, SCInspectionBufferCheckAndExpand, SCInspectionBufferTruncate,
+    SCTransformTableElmt, Signature,
+};
+
+use std::os::raw::{c_int, c_void};
+use crate::conf::conf_get_bool;
+
+use std::ffi::CStr;
+
+static mut G_TRANSFORM_SUBSLICE_ID: c_int = 0;
+static mut G_BOOL_TRUNCATE: bool = true;
+
+#[derive(Debug, PartialEq)]
+#[repr(C)]
+struct DetectTransformSubsliceData {
+    pub offset: isize,
+    pub nbytes: Option<isize>,
+}
+
+impl Default for DetectTransformSubsliceData {
+    fn default() -> Self {
+        DetectTransformSubsliceData {
+            offset: 0,
+            nbytes: None,
+        }
+    }
+}
+
+fn subslice_do_parse(i: &str) -> Option<DetectTransformSubsliceData> {
+    let parts: Vec<_> = i.trim().split(',').map(str::trim).collect();
+
+    match parts.as_slice() {
+        [offset] => {
+            let offset = offset.parse::<isize>().ok()?;
+            if offset == 0 {
+                return None;
+            }
+            Some(DetectTransformSubsliceData { offset, nbytes: None })
+        }
+        [offset, nbytes] => {
+            let offset = offset.parse::<isize>().ok()?;
+            let nbytes = nbytes.parse::<isize>().ok()?;
+            if nbytes == 0 {
+                return None;
+            }
+            Some(DetectTransformSubsliceData {
+                offset,
+                nbytes: Some(nbytes),
+            })
+        }
+        _ => None,
+    }
+}
+
+unsafe fn subslice_parse(raw: *const std::os::raw::c_char) -> *mut c_void {
+    let raw: &CStr = CStr::from_ptr(raw);
+    if let Ok(s) = raw.to_str() {
+        if let Some(ctx) = subslice_do_parse(s) {
+            let boxed = Box::new(ctx);
+            return Box::into_raw(boxed) as *mut _;
+        }
+    }
+    return std::ptr::null_mut();
+}
+
+unsafe extern "C" fn subslice_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    std::mem::drop(Box::from_raw(ctx as *mut DetectTransformSubsliceData));
+}
+
+unsafe extern "C" fn subslice_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, opt_str: *const std::os::raw::c_char,
+) -> c_int {
+    if opt_str.is_null() {
+        return -1;
+    }
+
+    let ctx = subslice_parse(opt_str);
+    if ctx.is_null() {
+        return -1;
+    }
+
+    let r = SCDetectSignatureAddTransform(s, G_TRANSFORM_SUBSLICE_ID, ctx);
+    if r != 0 {
+        subslice_free(de, ctx);
+    }
+
+    return r;
+}
+
+fn check_truncate() -> bool {
+    unsafe {
+        return G_BOOL_TRUNCATE;
+    }
+}
+
+fn subslice_apply<'a>(data: &'a [u8], ctx: &DetectTransformSubsliceData) -> Option<&'a [u8]> {
+    let len = data.len() as isize;
+
+    // Reject impossible offsets
+    if ctx.offset.abs() > len {
+        return None;
+    }
+
+    // Compute start index
+    let start = if ctx.offset >= 0 {
+        ctx.offset
+    } else {
+        len + ctx.offset // start is < 0
+    };
+
+    // Compute end index
+    let end = match ctx.nbytes {
+        None => len,
+        Some(0) => return None,
+        Some(e) if e < 0 => {
+            let end = len + e;
+            if end < 0 { return None; }
+            end
+        }
+        Some(e) if e > len && !check_truncate() => return None,
+        Some(e) => e + start,
+    };
+
+    // Normalize if indices reversed
+    let (start, end) = if end < start { (end, start) } else { (start, end) };
+
+    // Safety: both start and end are within range
+    let (start, mut end) = (start as usize, end as usize);
+    if start >= data.len() || end > data.len() && !check_truncate() {
+        return None;
+    }
+
+    if end > data.len() {
+        end = data.len();
+    }
+
+    Some(&data[start..end])
+}
+
+fn subslice_transform_do(
+    input: &[u8], output: &mut [u8], ctx: &DetectTransformSubsliceData,
+) -> u32 {
+    let Some(slice) = subslice_apply(input, ctx) else {
+        return 0;
+    };
+
+    // copy result into output
+    let len = slice.len();
+    output[..len].copy_from_slice(slice);
+
+    len as u32
+}
+
+unsafe extern "C" fn subslice_transform(
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *mut c_void,
+) {
+    let input = (*buffer).inspect;
+    let input_len = (*buffer).inspect_len;
+    if input.is_null() || input_len == 0 {
+        return;
+    }
+
+    let output = SCInspectionBufferCheckAndExpand(buffer, input_len);
+    if output.is_null() {
+        return;
+    }
+    let output = std::slice::from_raw_parts_mut(output, input_len as usize);
+    let ctx = cast_pointer!(ctx, DetectTransformSubsliceData);
+    let input = build_slice!(input, input_len as usize);
+    let out_length = subslice_transform_do(input, output, ctx);
+    SCInspectionBufferTruncate(buffer, out_length);
+}
+
+unsafe extern "C" fn subslice_id(data: *mut *const u8, length: *mut u32, ctx: *mut c_void) {
+    if data.is_null() || length.is_null() || ctx.is_null() {
+        return;
+    }
+
+    // This works because the structure is flat
+    // Once variables are really implemented, we should investigate if the structure should own
+    // its serialization or just borrow it to a caller
+    *data = ctx as *const u8;
+    *length = std::mem::size_of::<DetectTransformSubsliceData>() as u32;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn DetectTransformSubsliceRegister() {
+    let kw = SCTransformTableElmt {
+        name: b"subslice\0".as_ptr() as *const libc::c_char,
+        desc: b"create a subslice from the current buffer\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/transforms.html#subslice\0".as_ptr() as *const libc::c_char,
+        Setup: Some(subslice_setup),
+        flags: 0,
+        Transform: Some(subslice_transform),
+        Free: Some(subslice_free),
+        TransformValidate: None,
+        TransformId: Some(subslice_id),
+    };
+    unsafe {
+        G_TRANSFORM_SUBSLICE_ID = SCDetectHelperTransformRegister(&kw);
+        if G_TRANSFORM_SUBSLICE_ID < 0 {
+            SCLogWarning!("Failed registering transform subslice");
+        }
+    }
+
+    G_BOOL_TRUNCATE = conf_get_bool("subslice.truncate");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static TEST_STRING: &[u8] = b"this is suricata";
+
+    #[test]
+    fn test_subslice_parse_invalid() {
+        assert!(subslice_do_parse("f, y").is_none());
+        assert!(subslice_do_parse("0:-10").is_none());
+        assert!(subslice_do_parse("1 1").is_none());
+        assert!(subslice_do_parse("0").is_none());
+        assert!(subslice_do_parse("1,0").is_none());
+        assert!(subslice_do_parse("").is_none());
+    }
+
+    #[test]
+    fn test_subslice_parse_valid() {
+        assert!(subslice_do_parse("0, 9").is_some());
+        assert!(subslice_do_parse("       0      ,     9       ").is_some());
+        assert!(subslice_do_parse("0,9").is_some());
+        assert!(subslice_do_parse("1, 1").is_some());
+        assert!(subslice_do_parse("1").is_some());
+        assert!(subslice_do_parse("-1").is_some());
+        assert!(subslice_do_parse("0, -3").is_some());
+        assert!(subslice_do_parse("-10, -2").is_some());
+    }
+
+    #[test]
+    fn test_subslice_transform_offset() {
+        let expected_output = b"his is suricata";
+        let expected_output_len = expected_output.len();
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+
+        let mut out = vec![0u8; expected_output_len];
+        let ctx = subslice_do_parse("1").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        assert_eq!(cnt, expected_output_len as u32);
+        assert_eq!(&out[..cnt as usize], expected_output);
+    }
+
+    #[test]
+    fn test_subslice_transform_nbytes() {
+        let expected_output = b"this is s";
+        let expected_output_len = expected_output.len();
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+        let mut out = vec![0u8; expected_output_len];
+
+        let ctx = subslice_do_parse("00,9").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        assert_eq!(cnt, expected_output_len as u32);
+        assert_eq!(&out[..cnt as usize], expected_output);
+    }
+
+    #[test]
+    fn test_subslice_transform_nbytes_2() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"OISF provides architecture and infrastructure to open source security software communities and to projects like Suricata, the world-class threat-detection engine. As the need for robust and relevant security technologies grows, OISF serves to protect and maintain the authenticity of open source space. We welcome participation from diverse groups to generate networks and build active communities. We strengthen our communal space by offering user and developer training sessions around the world. OISF hosts SuriCon, the dynamic annual OISF/Suricata User Conference which gives our entire community a unique opportunity to collaborate together.
+
+OISF is funded by donations from world-class security organizations committed to our mission. A list of these organizations is available on our Consortium Members page.");
+        let mut out = vec![0u8; 24];
+        if let Some(ctx) = subslice_do_parse("15, 24") {
+            subslice_transform_do(&buf, &mut out, &ctx);
+        }
+        assert_eq!(&out[..24], b"rchitecture and infrastr");
+    }
+
+    #[test]
+    fn test_subslice_transform_nbytes_3() {
+        let expected_output = b"s is suricata";
+        let expected_output_len = expected_output.len();
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+        let mut out = vec![0u8; expected_output_len];
+
+        let ctx = subslice_do_parse("3").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        assert_eq!(cnt, expected_output_len as u32);
+        assert_eq!(&out[..cnt as usize], expected_output);
+    }
+
+    #[test]
+    fn test_subslice_transform_offset_nbytes() {
+        let expected_output = b"his is suric";
+        let expected_output_len = expected_output.len();
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+        let mut out = vec![0u8; expected_output_len];
+
+        let ctx = subslice_do_parse("1,12").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        assert_eq!(cnt, expected_output_len as u32);
+        assert_eq!(&out[..cnt as usize], expected_output);
+    }
+
+    #[test]
+    fn test_subslice_transform_offset_neg_nbytes() {
+        let expected_output = b" is suric";
+        let expected_output_len = expected_output.len();
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+        let mut out = vec![0u8; expected_output_len];
+
+        let ctx = subslice_do_parse("13,-12").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        assert_eq!(cnt, expected_output_len as u32);
+        assert_eq!(&out[..cnt as usize], expected_output);
+    }
+
+    // offset + nbytes > data_len() [NO TRUNCATE]
+    #[test]
+    fn test_subslice_transform_offset_and_nbytes_exceeds_len_00() {
+        let expected_output = b"";
+        let expected_output_len = expected_output.len();
+
+        unsafe {
+            G_BOOL_TRUNCATE = false;
+        }
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+        let mut out = vec![0u8; expected_output_len];
+
+        let ctx = subslice_do_parse("2, 30").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        assert_eq!(cnt, expected_output_len as u32);
+        assert_eq!(&out[..cnt as usize], expected_output);
+    }
+
+    // offset + nbytes > data_len() [TRUNCATE]
+    #[test]
+    fn test_subslice_transform_offset_and_nbytes_exceeds_len_01() {
+        let expected_output = b"is is suricata";
+        let expected_output_len = expected_output.len();
+
+        unsafe {
+            G_BOOL_TRUNCATE = true;
+        }
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+        let mut out = vec![0u8; expected_output_len];
+
+        let ctx = subslice_do_parse("2, 30").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        // Reset for other tests
+        unsafe {
+            G_BOOL_TRUNCATE = false;
+        }
+
+        assert_eq!(cnt, expected_output_len as u32);
+        assert_eq!(&out[..cnt as usize], expected_output);
+    }
+
+    // Positive offset with nbytes out of range
+    #[test]
+    fn test_subslice_transform_offset_neg_nbytes_2() {
+        let expected_output = b"his is suric";
+        let expected_output_len = expected_output.len();
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+        let mut out = vec![0u8; expected_output_len];
+
+        let ctx = subslice_do_parse("13,-15").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        assert_eq!(cnt, expected_output_len as u32);
+        assert_eq!(&out[..cnt as usize], expected_output);
+    }
+
+    // Positive offset with nbytes out of range
+    #[test]
+    fn test_subslice_transform_offset_neg_nbytes_3() {
+        let expected_output = b"r";
+        let expected_output_len = expected_output.len();
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+        let mut out = vec![0u8; expected_output_len];
+
+        let ctx = subslice_do_parse("10,-5").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        assert_eq!(cnt, expected_output_len as u32);
+        assert_eq!(&out[..cnt as usize], expected_output);
+    }
+
+    #[test]
+    fn test_subslice_transform_offset_neg_offset() {
+        let expected_output = b"ata";
+        let expected_output_len = expected_output.len();
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+        let mut out = vec![0u8; expected_output_len];
+
+        let ctx = subslice_do_parse("-3").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        assert_eq!(cnt, expected_output_len as u32);
+        assert_eq!(&out[..cnt as usize], expected_output);
+    }
+
+    // abs(offset) exceeds length
+    #[test]
+    fn test_subslice_transform_offset_neg_offset_2() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(TEST_STRING);
+        let mut out = vec![0u8; 3];
+
+        let ctx = subslice_do_parse("-17").unwrap();
+        let cnt = subslice_transform_do(&buf, &mut out, &ctx);
+
+        assert_eq!(cnt, 0);
+    }
+}

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -781,6 +781,7 @@ void SigTableSetup(void)
     DetectTransformFromBase64DecodeRegister();
     SCDetectTransformDomainRegister();
     DetectTransformLuaxformRegister();
+    DetectTransformSubsliceRegister();
 
     DetectFileHandlerRegister();
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1264,6 +1264,17 @@ app-layer:
     mdns:
       enabled: yes
 
+# Indicate subslice transform behavior if the buffer is smaller
+# than offset + nbytes.
+# The subslice transform accepts 2 parameters -- offset and nbytes.
+# When nbytes + offset exceeds the buffer, the transform can
+# - Do nothing
+# - Truncate the subslice by adjusting nbytes so nbytes + offset = input buffer len
+# The default is to truncate (on). Set to off to not truncate and produce an
+# empty buffer (bsize:0 will match).
+subslice:
+  truncate: on
+
 # Limit for the maximum number of asn1 frames to decode (default 256)
 asn1-max-frames: 256
 


### PR DESCRIPTION
Continuation of #14372  

The subslice transform creates a slice of the input buffer.

Specify the subslice desired -- nbytes is optional:
        subslice: offset <,nbytes>

offset: Specifies the starting offset for the new subslice. When negative, it expresses how far from the end of the input buffer to begin.

nbytes: Specifies the size of the subslice. When negative, specifies the byte count preceding the offset to include.

When nbytes is not specified, the size of the subslice will be the size of the input buffer - offset.

Examples:
        subslice: 1;     - The subslice will be a copy of the input
            buffer but omit the input buffer's first byte
            "This is Suricata" -> "his is Suricata"
        subslice: 0, 13; - The slice is created from the first 13 bytes
            of the input buffer
            "This is Suricata" -> "This is Suric"
        subslice: 10, -5; - This is the same as subslice[5, 5]
            "This is Suricata" -> "is Su"
        subslice: -3; - The subslice will be the last 3 bytes of the
            input buffer.
            "This is Suricata" -> "ata"


Link to ticket: https://redmine.openinfosecfoundation.org/issues/7672

Describe changes:
- Add subslice transform and unit tests
- Document subslice transform, with examples

Updates:
- Removed support for bracketed values, e.g., `[3], `[3, 8]`
- Changed function `DetectTransformSubsliceData` to be attributed with `repr(C)`
- Modified handling of negative `nbyte` values to mean "bytes from the end" .
- `start=0` is an error unless `nbytes` is specified
- `end=0` is always an error.
- Corrected clippy issues.
- Added configuration variable `subslice.truncate` to control behavior when `offset + nbytes > length`

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2749
SU_REPO=
SU_BRANCH=
