### PR TITLE
8.0.x: rust: fix clippy issues - v1

### DIFF
--- a/rust/src/ftp/response.rs
+++ b/rust/src/ftp/response.rs
@@ -104,10 +104,7 @@ pub unsafe extern "C" fn SCFTPFreeResponseLine(response: *mut FTPResponseLine) {
     }
 
     if !response.response.is_null() {
-        let _ = Box::from_raw(std::slice::from_raw_parts_mut(
-            response.response,
-            response.length,
-        ));
+        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(response.response, response.length));
     }
 }
 

--- a/rust/src/modbus/detect.rs
+++ b/rust/src/modbus/detect.rs
@@ -16,7 +16,6 @@
  */
 
 use super::modbus::ModbusTransaction;
-use crate::debug_validate_bug_on;
 use lazy_static::lazy_static;
 use regex::Regex;
 use sawp_modbus::{AccessType, CodeCategory, Data, Flags, FunctionCode, Message};


### PR DESCRIPTION
- rust: fix clippy warning for implicit cast
- rust: fix clippy warning for unused import

Includes cherry-pick from https://github.com/OISF/suricata/pull/14475.
