### PR TITLE
detect: split tcp mask flag

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1142,11 +1142,14 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     if (s->mask & SIG_MASK_REQUIRE_FLOW) {
         SCJbAppendString(ctx.js, "flow");
     }
-    if (s->mask & SIG_MASK_REQUIRE_FLAGS_INITDEINIT) {
-        SCJbAppendString(ctx.js, "tcp_flags_init_deinit");
+    if (s->mask & SIG_MASK_REQUIRE_FLAGS_DEINIT) {
+        SCJbAppendString(ctx.js, "tcp_flags_deinit");
     }
     if (s->mask & SIG_MASK_REQUIRE_FLAGS_UNUSUAL) {
         SCJbAppendString(ctx.js, "tcp_flags_unusual");
+    }
+    if (s->mask & SIG_MASK_REQUIRE_FLAGS_SYN) {
+        SCJbAppendString(ctx.js, "tcp_flags_syn");
     }
     if (s->mask & SIG_MASK_REQUIRE_ENGINE_EVENT) {
         SCJbAppendString(ctx.js, "engine_event");

--- a/src/detect.h
+++ b/src/detect.h
@@ -310,11 +310,11 @@ typedef struct DetectPort_ {
 /** \note: additions should be added to the rule analyzer as well */
 #define SIG_MASK_REQUIRE_PAYLOAD            BIT_U8(0)
 #define SIG_MASK_REQUIRE_FLOW               BIT_U8(1)
-#define SIG_MASK_REQUIRE_FLAGS_INITDEINIT   BIT_U8(2)    /* SYN, FIN, RST */
+#define SIG_MASK_REQUIRE_FLAGS_DEINIT       BIT_U8(2)    /* FIN, RST */
 #define SIG_MASK_REQUIRE_FLAGS_UNUSUAL      BIT_U8(3)    /* URG, ECN, CWR */
 #define SIG_MASK_REQUIRE_NO_PAYLOAD         BIT_U8(4)
 #define SIG_MASK_REQUIRE_REAL_PKT           BIT_U8(5)
-// vacancy 1x
+#define SIG_MASK_REQUIRE_FLAGS_SYN          BIT_U8(6) /* SYN, can be with ECN/CWR */
 #define SIG_MASK_REQUIRE_ENGINE_EVENT       BIT_U8(7)
 
 #define FILE_SIG_NEED_FILE          0x01


### PR DESCRIPTION
Previous mask flag SIG_MASK_REQUIRE_FLAGS_INITDEINIT could be used to filter out rules that required SYN/FIN/RST.

This commit splits the flag into a separate one for SYNs, as there are quite a few rules that use SYN flag detection and evaluating these for RST/FIN packets is inefficient.

The SYN flag does take possible ECN/CWR flags into account, getting set for just SYN, for SYN|ECN, SYN|CWR and SYN|ECN/CWR.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2852