### PR TITLE
pfring: fix typo in StringParseUint16 - v1

### DIFF
--- a/plugins/pfring/Makefile.am
+++ b/plugins/pfring/Makefile.am
@@ -8,5 +8,20 @@ noinst_HEADERS = \
 	runmode-pfring.h \
 	source-pfring.h
 
+# default CFLAGS
+AM_CFLAGS = ${OPTIMIZATION_CFLAGS} ${GCC_CFLAGS} ${CLANG_CFLAGS}            \
+    ${SECCFLAGS} ${PCAP_CFLAGS} ${EXTRA_CFLAGS}                                                         \
+    -Wall -Wno-unused-parameter -Wmissing-prototypes -Wmissing-declarations \
+    -Wstrict-prototypes -Wwrite-strings -Wbad-function-cast                 \
+    -Wformat-security -Wno-format-nonliteral -Wmissing-format-attribute     \
+    -funsigned-char
+
+# different flags for different cases
+if DEBUG
+AM_CFLAGS += -ggdb -O0
+endif
+
+AM_LDFLAGS = ${SECLDFLAGS}
+
 install-exec-hook:
 	cd $(DESTDIR)$(pkglibdir) && $(RM) $(pkglib_LTLIBRARIES)

--- a/plugins/pfring/plugin.c
+++ b/plugins/pfring/plugin.c
@@ -23,7 +23,7 @@
 #include "runmode-pfring.h"
 #include "util-device.h"
 
-void InitCapturePlugin(const char *args, int plugin_slot, int receive_slot, int decode_slot)
+static void InitCapturePlugin(const char *args, int plugin_slot, int receive_slot, int decode_slot)
 {
     LiveBuildDeviceList("plugin");
     RunModeIdsPfringRegister(plugin_slot);
@@ -31,7 +31,7 @@ void InitCapturePlugin(const char *args, int plugin_slot, int receive_slot, int 
     TmModuleDecodePfringRegister(decode_slot);
 }
 
-void SCPluginInit(void)
+static void SCPluginInit(void)
 {
     SCCapturePlugin *plugin = SCCalloc(1, sizeof(SCCapturePlugin));
     if (plugin == NULL) {
@@ -53,7 +53,7 @@ const SCPlugin PluginRegistration = {
     .Init = SCPluginInit,
 };
 
-const SCPlugin *SCPluginRegister()
+const SCPlugin *SCPluginRegister(void)
 {
     return &PluginRegistration;
 }

--- a/plugins/pfring/runmode-pfring.c
+++ b/plugins/pfring/runmode-pfring.c
@@ -115,7 +115,7 @@ static void *OldParsePfringConfig(const char *iface)
         pfconf->threads = 1;
     } else {
         if (threadsstr != NULL) {
-            if (StringParseUnt16(&pfconf->threads, 10, 0, threadsstr) < 0) {
+            if (StringParseUint16(&pfconf->threads, 10, 0, threadsstr) < 0) {
                 SCLogWarning("Invalid value for "
                              "pfring.threads: '%s'. Resetting to 1.",
                         threadsstr);


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8271

Plus some minor fixes to prevent this from passing CI again.

