### PR TITLE
Revert "rust/debug: use functions from ffi crate where possible"

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1582,7 +1582,6 @@ dependencies = [
  "sha2",
  "snmp-parser",
  "suricata-derive",
- "suricata-ffi",
  "suricata-htp",
  "suricata-lua-sys",
  "suricata-sys",

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -87,7 +87,6 @@ time = "=0.3.41"
 
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 suricata-sys = { path = "./sys", version = "@PACKAGE_VERSION@" }
-suricata-ffi = { path = "./ffi", version = "@PACKAGE_VERSION@" }
 
 suricata-lua-sys = { version = "5.4.8002" }
 


### PR DESCRIPTION
This reverts commit f9514774610f4226ff8e3a22896ae19c2c47047a.

Linking the "suricata" crate with "suricata-ffi" appears to break the
Codecov.io support for no obvious reason. Revert this commit until it
can be figured out.

This commit just reduced duplicated code by having the Suricata crate
re-use code from the -ffi crate that was moved there for exposure to
library and plugin users. Will need investigation as to why using it
breaks Codecov.
