### PR TITLE
codecov fixup/v4

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,6 +2,7 @@ codecov:
   require_ci_to_pass: false
   notify:
     after_n_builds: 6
+  disable_default_path_fixes: true
 
 coverage:
   precision: 2

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,6 +4,9 @@ codecov:
     after_n_builds: 6
   disable_default_path_fixes: true
 
+fixes:
+  - "/__w/suricata/suricata/::"
+
 coverage:
   precision: 2
   round: down

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -908,6 +908,8 @@ jobs:
         with:
           fail_ci_if_error: false
           flags: suricata-verify
+          files: ./coverage.txt
+          disable_search: true
 
   # Fedora build using Clang.
   fedora-43-clang:
@@ -1611,6 +1613,8 @@ jobs:
         with:
           fail_ci_if_error: false
           flags: unittests
+          files: ./coverage.txt
+          disable_search: true
 
   ubuntu-22-04-cov-pcapunix:
     name: Ubuntu 22.04 (unix socket mode coverage)
@@ -1718,6 +1722,8 @@ jobs:
         with:
           fail_ci_if_error: false
           flags: pcap
+          files: ./coverage.txt
+          disable_search: true
 
   ubuntu-22-04-cov-afpdpdk:
     name: Ubuntu 22.04 (afpacket and dpdk coverage)
@@ -1860,6 +1866,8 @@ jobs:
         with:
           fail_ci_if_error: false
           flags: livemode
+          files: ./coverage.txt
+          disable_search: true
 
   ubuntu-24-04-pcap-unix:
     name: Ubuntu 24.04 (pcap unix socket ASAN)
@@ -2086,6 +2094,8 @@ jobs:
         with:
           fail_ci_if_error: false
           flags: netns
+          files: ./coverage.txt
+          disable_search: true
           verbose: true
 
   ubuntu-24-04-asan-afpdpdk:
@@ -2297,6 +2307,8 @@ jobs:
         with:
           fail_ci_if_error: false
           flags: fuzzcorpus
+          files: ./coverage.txt
+          disable_search: true
 
   ubuntu-20-04-ndebug:
     name: Ubuntu 20.04 (-DNDEBUG)


### PR DESCRIPTION
- **codecov: disable built-in path fixing**
  

- **codecov: add explicit fix mappings**
  Recommended by GPT-5.3-codex after an analysis of the issue.
  

- **github-ci: limit codecov upload inputs**
  Set codecov-action to upload only ./coverage.txt and disable
  auto-search in all coverage jobs.
  
  This avoids picking unrelated .txt/.lst files from the workspace.
  