### PR TITLE
rust/ffi: rename debug module to ndebug

### DIFF
--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-pub mod debug;
+pub mod ndebug;
 pub mod eve;
 pub mod jsonbuilder;
 pub mod plugin;

--- a/rust/ffi/src/ndebug.rs
+++ b/rust/ffi/src/ndebug.rs
@@ -118,8 +118,8 @@ macro_rules! function {
 macro_rules! do_log {
     ($level:expr, $($arg:tt)*) => {
         #[allow(unused_unsafe)]
-        if unsafe { $crate::debug::LEVEL as i32 } >= $level as i32 {
-            $crate::debug::sclog($level, file!(), line!(), $crate::function!(),
+        if unsafe { $crate::ndebug::LEVEL as i32 } >= $level as i32 {
+            $crate::ndebug::sclog($level, file!(), line!(), $crate::function!(),
                   &(format!($($arg)*)));
         }
     }
@@ -188,6 +188,6 @@ macro_rules! SCLogDebug {
 #[macro_export]
 macro_rules! SCFatalErrorOnInit {
     ($($arg:tt)*) => {
-        $crate::debug::fatalerror(&format!($($arg)*));
+        $crate::ndebug::fatalerror(&format!($($arg)*));
     }
 }

--- a/rust/ffi/src/plugin.rs
+++ b/rust/ffi/src/plugin.rs
@@ -22,7 +22,7 @@ use suricata_sys::sys::{SCLogGetLogLevel, SCPlugin, SC_API_VERSION, SC_PACKAGE_V
 
 pub fn init() {
     unsafe {
-        crate::debug::set_log_level(SCLogGetLogLevel());
+        crate::ndebug::set_log_level(SCLogGetLogLevel());
     }
 }
 

--- a/rust/src/debug.rs
+++ b/rust/src/debug.rs
@@ -58,7 +58,7 @@ pub fn sc_log_message(
     level: SCLogLevel, filename: &str, line: std::os::raw::c_uint, function: &str, module: &str,
     message: &str,
 ) -> SCError {
-    suricata_ffi::debug::log_message(level, filename, line, function, module, message)
+    suricata_ffi::ndebug::log_message(level, filename, line, function, module, message)
 }
 
 #[cfg(test)]
@@ -170,7 +170,7 @@ macro_rules! SCLogDebug {
 #[macro_export]
 macro_rules!SCFatalErrorOnInit {
     ($($arg:tt)*) => {
-        suricata_ffi::debug::fatalerror(&format!($($arg)*));
+        suricata_ffi::ndebug::fatalerror(&format!($($arg)*));
     }
 }
 


### PR DESCRIPTION
## Summary
- rename rust/ffi/src/debug.rs to rust/ffi/src/ndebug.rs
- update the FFI module export and plugin initialization to use ndebug
- update Rust-side calls into suricata-ffi to the new module path

## Testing
- cd rust && CC=/usr/bin/gcc CXX=/usr/bin/g++ cargo build -p suricata-ffi -p suricata