### PR TITLE
Add --with-ebpf-includes parameter

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -498,7 +498,11 @@
                     AC_SUBST(LLC)
                   ],
                   [AC_MSG_ERROR([clang needed to build ebpf files])])
-            AC_MSG_CHECKING([libbpf has bpf/bpf_helpers.h])
+            AC_ARG_WITH(ebpf_includes,
+                    [  --with-ebpf-includes=DIR  include directory for building eBPF programs],
+                    [AC_SUBST([ebpf_includes],["$withval"])],
+                    [AC_SUBST([ebpf_includes],["/usr/include/${build_alias}"])])
+	    AC_MSG_CHECKING([libbpf has bpf/bpf_helpers.h])
             AC_COMPILE_IFELSE(
                 [AC_LANG_PROGRAM(
                     [

--- a/ebpf/Makefile.am
+++ b/ebpf/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST= include bypass_filter.c filter.c lb.c vlan_filter.c xdp_filter.c \
 if BUILD_EBPF
 
 # Maintaining a local copy of UAPI linux/bpf.h
-BPF_CFLAGS = -Iinclude
+BPF_CFLAGS = -Iinclude -I$(ebpf_includes)
 
 BPF_TARGETS  = lb.bpf
 BPF_TARGETS += filter.bpf
@@ -19,7 +19,6 @@ all: $(BPF_TARGETS)
 $(BPF_TARGETS): %.bpf: %.c
 #      From C-code to LLVM-IR format suffix .ll (clang -S -emit-llvm)
 	${CLANG} -Wall $(BPF_CFLAGS) -O2 -g \
-		-I/usr/include/$(build_cpu)-$(build_os)/ \
 		-D__KERNEL__ -D__ASM_SYSREG_H \
 		-target bpf -S -emit-llvm $< -o ${@:.bpf=.ll}
 #      From LLVM-IR to BPF-bytecode in ELF-obj file


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/3097#note-10

Describe changes:

Add a switch `--with-ebpf-includes` to the configure script that lets the user specify the location in which eBPF-specific headers can be found.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
