### PR TITLE
github-ci: fix codecov - v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -909,6 +909,11 @@ jobs:
           fail_ci_if_error: false
           files: coverage.lcov
           flags: suricata-verify
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: coverage-suricata-verify
+          path: coverage.lcov
 
   # Fedora build using Clang.
   fedora-43-clang:
@@ -1613,6 +1618,11 @@ jobs:
           fail_ci_if_error: false
           files: coverage.lcov
           flags: unittests
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: coverage-unittests
+          path: coverage.lcov
 
   ubuntu-22-04-cov-pcapunix:
     name: Ubuntu 22.04 (unix socket mode coverage)
@@ -1721,6 +1731,11 @@ jobs:
           fail_ci_if_error: false
           files: coverage.lcov
           flags: pcap
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: coverage-pcap
+          path: coverage.lcov
 
   ubuntu-22-04-cov-afpdpdk:
     name: Ubuntu 22.04 (afpacket and dpdk coverage)
@@ -1864,6 +1879,11 @@ jobs:
           fail_ci_if_error: false
           files: coverage.lcov
           flags: livemode
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: coverage-livemode
+          path: coverage.lcov
 
   ubuntu-24-04-pcap-unix:
     name: Ubuntu 24.04 (pcap unix socket ASAN)
@@ -2092,6 +2112,11 @@ jobs:
           files: coverage.lcov
           flags: netns
           verbose: true
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: coverage-netns
+          path: coverage.lcov
 
   ubuntu-24-04-asan-afpdpdk:
     name: Ubuntu 24.04 (afpacket and dpdk live tests with ASAN)
@@ -2303,6 +2328,11 @@ jobs:
           fail_ci_if_error: false
           files: coverage.lcov
           flags: fuzzcorpus
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: coverage-fuzzcorpus
+          path: coverage.lcov
 
   ubuntu-20-04-ndebug:
     name: Ubuntu 20.04 (-DNDEBUG)

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -902,11 +902,12 @@ jobs:
       - name: Running suricata-verify
         run: python3 ./suricata-verify/run.py -q --debug-failed --aggressive-cleanup
       - run: llvm-profdata merge -o default.profdata $(find suricata-verify/tests/ -name '*.profraw')
-      - run: llvm-cov show ./src/suricata -instr-profile=default.profdata --show-instantiations --ignore-filename-regex="^/root/.*" > coverage.txt
+      - run: llvm-cov export ./src/suricata -instr-profile=default.profdata -format=lcov --ignore-filename-regex="^/root/.*" > coverage.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           fail_ci_if_error: false
+          files: coverage.lcov
           flags: suricata-verify
 
   # Fedora build using Clang.
@@ -1591,7 +1592,7 @@ jobs:
           LLVM_PROFILE_FILE: "/tmp/dumpconfig.profraw"
       - run: llvm-profdata-19 merge -o dumpconfig.profdata /tmp/dumpconfig.profraw
       - run: llvm-profdata-19 merge -o combined.profdata $(find /tmp/ -name '*.profraw')
-      - run: llvm-cov-19 show ./src/suricata -instr-profile=combined.profdata --show-instantiations --ignore-filename-regex="^/root/.*" > coverage.txt
+      - run: llvm-cov-19 export ./src/suricata -instr-profile=combined.profdata -format=lcov --ignore-filename-regex="^/root/.*" > coverage.lcov
       - run: |
           cd rust
           cargo test --no-run
@@ -1605,11 +1606,12 @@ jobs:
           LLVM_PROFILE_FILE: "/tmp/ct.profraw"
           CARGO_INCREMENTAL: 0
       - run: llvm-profdata-19 merge -o ct.profdata /tmp/ct.profraw
-      - run: llvm-cov-19 show $(find rust/target/debug/deps/ -type f -regex 'rust/target/debug/deps/suricata\-[a-z0-9]+$') -instr-profile=ct.profdata --show-instantiations --ignore-filename-regex="^/root/.*" >> coverage.txt
+      - run: llvm-cov-19 export $(find rust/target/debug/deps/ -type f -regex 'rust/target/debug/deps/suricata\-[a-z0-9]+$') -instr-profile=ct.profdata -format=lcov --ignore-filename-regex="^/root/.*" >> coverage.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           fail_ci_if_error: false
+          files: coverage.lcov
           flags: unittests
 
   ubuntu-22-04-cov-pcapunix:
@@ -1712,11 +1714,12 @@ jobs:
         env:
           LLVM_PROFILE_FILE: "/tmp/unix.profraw"
       - run: llvm-profdata-15 merge -o default.profdata $(find /tmp/ -name '*.profraw')
-      - run: llvm-cov-15 show ./src/suricata -instr-profile=default.profdata --show-instantiations --ignore-filename-regex="^/root/.*" > coverage.txt
+      - run: llvm-cov-15 export ./src/suricata -instr-profile=default.profdata -format=lcov --ignore-filename-regex="^/root/.*" > coverage.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           fail_ci_if_error: false
+          files: coverage.lcov
           flags: pcap
 
   ubuntu-22-04-cov-afpdpdk:
@@ -1854,11 +1857,12 @@ jobs:
         env:
           LLVM_PROFILE_FILE: "/tmp/mt-autofp.profraw"
       - run: llvm-profdata-15 merge -o default.profdata $(find /tmp/ -name '*.profraw')
-      - run: llvm-cov-15 show ./src/suricata -instr-profile=default.profdata --show-instantiations --ignore-filename-regex="^/root/.*" > coverage.txt
+      - run: llvm-cov-15 export ./src/suricata -instr-profile=default.profdata -format=lcov --ignore-filename-regex="^/root/.*" > coverage.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           fail_ci_if_error: false
+          files: coverage.lcov
           flags: livemode
 
   ubuntu-24-04-pcap-unix:
@@ -2080,11 +2084,12 @@ jobs:
       - run: llvm-profdata-19 merge -o nfq-ips-workers.profdata /tmp/nfq-ips-workers.profraw
 
       - run: llvm-profdata-19 merge -o combined.profdata afp-ips.profdata nfq-ips.profdata afp-ips-autofp.profdata nfq-ips-workers.profdata afp-ips-bond1.profdata afp-ips-bond2.profdata
-      - run: llvm-cov-19 show ./src/suricata -instr-profile=combined.profdata --show-instantiations --ignore-filename-regex="^/root/.*" > coverage.txt
+      - run: llvm-cov-19 export ./src/suricata -instr-profile=combined.profdata -format=lcov --ignore-filename-regex="^/root/.*" > coverage.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           fail_ci_if_error: false
+          files: coverage.lcov
           flags: netns
           verbose: true
 
@@ -2291,11 +2296,12 @@ jobs:
           SURICATA_LUA_SYS_CFLAGS: "-fsanitize=address"
       - run: ./qa/run-ossfuzz-corpus.sh
       - run: llvm-profdata-15 merge -o default.profdata $(find /tmp/ -name '*.profraw')
-      - run: llvm-cov-15 show ./src/suricata -instr-profile=default.profdata --show-instantiations --ignore-filename-regex="^/root/.*" > coverage.txt
+      - run: llvm-cov-15 export ./src/suricata -instr-profile=default.profdata -format=lcov --ignore-filename-regex="^/root/.*" > coverage.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           fail_ci_if_error: false
+          files: coverage.lcov
           flags: fuzzcorpus
 
   ubuntu-20-04-ndebug:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2104,11 +2104,11 @@ jobs:
       - run: llvm-profdata-19 merge -o nfq-ips-workers.profdata /tmp/nfq-ips-workers.profraw
 
       - run: llvm-profdata-19 merge -o combined.profdata afp-ips.profdata nfq-ips.profdata afp-ips-autofp.profdata nfq-ips-workers.profdata afp-ips-bond1.profdata afp-ips-bond2.profdata
-      - run: llvm-cov-19 export ./src/suricata -instr-profile=combined.profdata -format=lcov --ignore-filename-regex="^/root/.*" > coverage.lcov
+      - run: llvm-cov-19 export ./src/suricata -instr-profile=combined.profdata -format=lcov --ignore-filename-regex="^/github/home/.cargo/.*" > coverage.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           files: coverage.lcov
           flags: netns
           verbose: true

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1586,8 +1586,8 @@ jobs:
       - run: llvm-profdata-19 merge -o lah.profdata /tmp/lah.profraw
       - run: ./src/suricata --list-rule-protos -l /tmp
         env:
-          LLVM_PROFILE_FILE: "/tmp/lah.profraw"
-      - run: llvm-profdata-19 merge -o lah.profdata /tmp/lah.profraw
+          LLVM_PROFILE_FILE: "/tmp/lrp.profraw"
+      - run: llvm-profdata-19 merge -o lrp.profdata /tmp/lrp.profraw
       - run: ./src/suricata --dump-features -c suricata.yaml -l /tmp
         env:
           LLVM_PROFILE_FILE: "/tmp/dumpfeatures.profraw"


### PR DESCRIPTION
- **github-ci: upload lcov reports to codecov**
  Seems to fix our issues with codecov.io.
  

- **github-ci: upload coverage lcov as artifacts**
  

- **github-ci: for codecov netns check, account for cargo build dir**
  It's not in /root/ like with container based builds.
  

- **github-ci: fix cov-ut profile file collision**
  