### PR TITLE
detect: anchor all PARSE_REGEX to reject leading/trailing content

### DIFF
--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -33,9 +33,9 @@ typedef struct DetectBase64Decode_ {
     uint8_t relative;
 } DetectBase64Decode;
 
-static const char decode_pattern[] = "\\s*(bytes\\s+(\\d+),?)?"
+static const char decode_pattern[] = "^\\s*(bytes\\s+(\\d+),?)?"
     "\\s*(offset\\s+(\\d+),?)?"
-    "\\s*(\\w+)?";
+    "\\s*(\\w+)?$";
 
 static DetectParseRegex decode_pcre;
 

--- a/src/detect-datarep.c
+++ b/src/detect-datarep.c
@@ -42,7 +42,7 @@
 #include "util-misc.h"
 #include "util-path.h"
 
-#define PARSE_REGEX         "([a-z]+)(?:,\\s*([\\-_A-z0-9\\s\\.]+)){1,4}"
+#define PARSE_REGEX         "^([a-z]+)(?:,\\s*([\\-_A-z0-9\\s\\.]+)){1,4}$"
 static DetectParseRegex parse_regex;
 
 int DetectDatarepMatch (ThreadVars *, DetectEngineThreadCtx *, Packet *,

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -44,7 +44,7 @@
 #include "detect-engine-event.h"
 #include "util-unittest.h"
 
-#define PARSE_REGEX "\\S[0-9A-z_]+[.][A-z0-9_+.]+$"
+#define PARSE_REGEX "^\\S[0-9A-z_]+[.][A-z0-9_+.]+$"
 
 static DetectParseRegex parse_regex;
 

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -39,7 +39,7 @@
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 
-#define PARSE_REGEX "^(\\s*only\\s*)|\\s*([0-9]+)\\s*,\\s*([0-9]+)\\s*$"
+#define PARSE_REGEX "^(\\s*only\\s*$)|\\s*([0-9]+)\\s*,\\s*([0-9]+)\\s*$"
 
 static DetectParseRegex parse_regex;
 

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -53,7 +53,7 @@
 #include "util-debug.h"
 #include "util-conf.h"
 
-#define PARSE_REGEX         "^([a-z]+)(?:,\\s*(.*))?"
+#define PARSE_REGEX         "^([a-z]+)(?:,\\s*(.*))?$"
 static DetectParseRegex parse_regex;
 
 #define MAX_TOKENS 100

--- a/src/detect-mark.c
+++ b/src/detect-mark.c
@@ -38,7 +38,7 @@
 #include "util-byte.h"
 #include "util-debug.h"
 
-#define PARSE_REGEX "([0x]*[0-9a-f]+)/([0x]*[0-9a-f]+)"
+#define PARSE_REGEX "^([0x]*[0-9a-f]+)/([0x]*[0-9a-f]+)$"
 
 static DetectParseRegex parse_regex;
 

--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -46,7 +46,7 @@
 /* Breakout key and scheme (optional) and domain/path (mandatory) */
 #define PARSE_REGEX                                                                                \
     "^\\s*([A-Za-z0-9]+)\\s*,\"?\\s*\"?\\s*([a-zA-Z]+:\\/\\/)?([a-zA-Z0-9\\-_\\.\\/"               \
-    "\\?\\=]+)\"?\\s*\"?"
+    "\\?\\=]+)\"?\\s*\"?$"
 
 static DetectParseRegex parse_regex;
 

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -67,7 +67,7 @@
 #define PARSE_REGEX                                                                                \
     "^\\s*" PARSE_REGEX_NAME "\\s+" PARSE_REGEX_VALUE "\\s*,\\s*" PARSE_REGEX_NAME                 \
     "\\s+" PARSE_REGEX_VALUE "\\s*,\\s*" PARSE_REGEX_NAME "\\s+" PARSE_REGEX_VALUE                 \
-    "\\s*,\\s*" PARSE_REGEX_NAME "\\s+" PARSE_REGEX_VALUE "\\s*"
+    "\\s*,\\s*" PARSE_REGEX_NAME "\\s+" PARSE_REGEX_VALUE "\\s*$"
 
 static DetectParseRegex parse_regex;
 


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues/8338

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

## Description
When a rule option is missing its terminating semicolon, the detect parser passes everything up to the next unescaped semicolon as the option value, which includes the next option. If a keyword's PARSE_REGEX can match without being fully anchored, it will silently accept the malformed value, causing the next rule option to be lost. This can cause rules to load without error but silently lose critical rule options, altering the rule's meaning.

Add ^ and/or $ anchors to all PARSE_REGEX patterns that were missing them (where the regex doesn't already end with .* or .+ which consume all input anyway):

 - detect-threshold: add $
 - detect-datarep: add ^ and $
 - detect-engine-event: add ^
 - detect-flowbits: add $
 - detect-mark: add ^ and $
 - detect-reference: add $
 - detect-fast-pattern: add $ to the 'only' alternative
 - detect-base64-decode: add ^ and $

## Caveats
- I'm not 100% on the fast-pattern changes, as i'm not a big regex whizz!
- Apart from with "threshold", i'm not 100% sure that these are all bugs (as there may be some additional cchecks after running regex code that i'm not aware of).

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
