### PR TITLE
doc: update Rust installation instructions v1

### DIFF
--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -126,13 +126,10 @@ Rust support
   In case of insufficient version you can install Rust directly
   from the Rust project itself::
 
-    1) Install Rust https://www.rust-lang.org/en-US/install.html
+    1) Install Rust https://rust-lang.org/tools/install/
     2) Install cbindgen - if the cbindgen is not found in the repository
        or the cbindgen version is lower than required, it can be
        alternatively installed as: cargo install --force cbindgen
-    3) Make sure the cargo path is within your PATH environment
-       echo 'export PATH="~/.cargo/bin:${PATH}"' >> ~/.bashrc
-       export PATH="~/.cargo/bin:${PATH}"
 
 Auto-Setup
 ^^^^^^^^^^


### PR DESCRIPTION
The Rust website has changed the location of the installer. Additionally, their installer now includes automatic append to .bashrc to source the correct path to Rust binaries.

Ticket: https://redmine.openinfosecfoundation.org/issues/8344

Describe changes:
- link update

I also thought of leaving 3) "just in case", but opted for a shorter version.