### PR TITLE
dpdk: segmented mbufs + net_pcap PCAP EOF V7

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -1682,6 +1682,8 @@ static int DeviceConfigure(DPDKIfaceConfig *iconf)
         SCReturnInt(retval);
     }
 
+    iconf->is_pcap_iface = strcmp(dev_info.driver_name, "net_pcap") == 0;
+
     if (iconf->nb_rx_queues > dev_info.max_rx_queues) {
         SCLogError("%s: configured RX queues %u is higher than device maximum (%" PRIu16 ")",
                 iconf->iface, iconf->nb_rx_queues, dev_info.max_rx_queues);
@@ -1839,6 +1841,9 @@ static void *ParseDpdkConfigAndConfigureDevice(const char *iface)
     }
     SC_ATOMIC_RESET(iconf->workers_sync->worker_checked_in);
     iconf->workers_sync->worker_cnt = iconf->threads;
+    if (iconf->is_pcap_iface) {
+        DPDKPcapWorkersSync(iconf->threads);
+    }
 
     // initialize LiveDev DPDK values
     LiveDevice *ldev_instance = LiveGetDevice(iface);

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -459,23 +459,18 @@ static inline Packet *PacketInitFromMbuf(DPDKThreadVars *ptv, struct rte_mbuf *m
     return p;
 }
 
-static inline void DPDKSegmentedMbufWarning(struct rte_mbuf *mbuf)
+static inline void DPDKSegmentedMbufWarning(void)
 {
     static thread_local bool segmented_mbufs_warned = false;
-    if (!segmented_mbufs_warned && !rte_pktmbuf_is_contiguous(mbuf)) {
-        char warn_s[] = "Segmented mbufs detected! Redmine Ticket #6012 "
-                        "Check your configuration or report the issue";
+    if (unlikely(!segmented_mbufs_warned)) {
         enum rte_proc_type_t eal_t = rte_eal_process_type();
         if (eal_t == RTE_PROC_SECONDARY) {
-            SCLogWarning("%s. To avoid segmented mbufs, "
-                         "try to increase mbuf size in your primary application",
-                    warn_s);
-        } else if (eal_t == RTE_PROC_PRIMARY) {
-            SCLogWarning("%s. To avoid segmented mbufs, "
-                         "try to increase MTU in your suricata.yaml",
-                    warn_s);
+            SCLogWarning("Segmented mbufs detected! Suricata handles them but for better "
+                         "performance, try to increase mbuf size in your primary application");
+        } else {
+            SCLogWarning("Segmented mbufs detected! Suricata handles them but for better "
+                         "performance, try to increase MTU in your suricata.yaml");
         }
-
         segmented_mbufs_warned = true;
     }
 }
@@ -524,6 +519,60 @@ cleanup:
         SCFree(xstats);
     if (xstats_names != NULL)
         SCFree(xstats_names);
+}
+
+static inline void DPDKSegmentedMbufTooLargeWarning(uint32_t pkt_len)
+{
+    static thread_local bool size_warned = false;
+    if (unlikely(!size_warned)) {
+        SCLogWarning("Segmented mbuf larger than max payload size (%u > %d), packet will be "
+                     "truncated",
+                pkt_len, MAX_PAYLOAD_SIZE);
+        size_warned = true;
+    }
+}
+
+/**
+ * \brief Handle segmented (chained) mbufs by linearizing them
+ *
+ * For segmented mbufs, attempts to linearize the data into a contiguous buffer.
+ * First tries rte_pktmbuf_linearize() which copies all segment data into the
+ * first segment. If that fails (not enough tailroom), copies data into the
+ * packet's internal buffer.
+ *
+ * \param p Pointer to the Packet structure
+ * \param mbuf Pointer to the DPDK mbuf
+ * \return 0 on success, -1 on failure
+ */
+static inline int DPDKSegmentedMbufHandle(Packet *p, struct rte_mbuf *mbuf)
+{
+    if (rte_pktmbuf_linearize(mbuf) == 0) {
+        PacketSetData(p, rte_pktmbuf_mtod(mbuf, uint8_t *), rte_pktmbuf_pkt_len(mbuf));
+        return 0;
+    }
+
+    /* Linearization failed (not enough tailroom), copy to packet buffer */
+    uint32_t pkt_len = rte_pktmbuf_pkt_len(mbuf);
+    uint32_t copy_len = pkt_len;
+    if (unlikely(pkt_len > MAX_PAYLOAD_SIZE)) {
+        DPDKSegmentedMbufTooLargeWarning(pkt_len);
+        copy_len = MAX_PAYLOAD_SIZE;
+    }
+
+    uint32_t offset = 0;
+    for (struct rte_mbuf *seg = mbuf; seg != NULL && offset < copy_len; seg = seg->next) {
+        uint32_t seg_len = rte_pktmbuf_data_len(seg);
+        uint32_t to_copy = (offset + seg_len > copy_len) ? (copy_len - offset) : seg_len;
+        if (PacketCopyDataOffset(p, offset, rte_pktmbuf_mtod(seg, uint8_t *), to_copy) != 0) {
+            SCLogWarning("Failed to copy segmented mbuf data at offset %u", offset);
+            return -1;
+        }
+        offset += to_copy;
+    }
+
+    SET_PKT_LEN(p, copy_len);
+
+    return 0;
 }
 
 static void HandleShutdown(DPDKThreadVars *ptv)
@@ -597,9 +646,19 @@ static TmEcode ReceiveDPDKLoop(ThreadVars *tv, void *data, void *slot)
                 rte_pktmbuf_free(ptv->received_mbufs[i]);
                 continue;
             }
-            DPDKSegmentedMbufWarning(ptv->received_mbufs[i]);
-            PacketSetData(p, rte_pktmbuf_mtod(p->dpdk_v.mbuf, uint8_t *),
-                    rte_pktmbuf_pkt_len(p->dpdk_v.mbuf));
+
+            if (likely(rte_pktmbuf_is_contiguous(p->dpdk_v.mbuf))) {
+                PacketSetData(p, rte_pktmbuf_mtod(p->dpdk_v.mbuf, uint8_t *),
+                        rte_pktmbuf_pkt_len(p->dpdk_v.mbuf));
+            } else {
+                /* Slow path: segmented mbuf, needs linearization or copy */
+                DPDKSegmentedMbufWarning();
+                if (DPDKSegmentedMbufHandle(p, p->dpdk_v.mbuf) != 0) {
+                    TmqhOutputPacketpool(ptv->tv, p);
+                    continue;
+                }
+            }
+
             if (TmThreadsSlotProcessPkt(ptv->tv, ptv->slot, p) != TM_ECODE_OK) {
                 TmqhOutputPacketpool(ptv->tv, p);
                 DPDKFreeMbufArray(ptv->received_mbufs, nb_rx - i - 1, i + 1);

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -103,6 +103,12 @@ TmEcode NoDPDKSupportExit(ThreadVars *tv, const void *initdata, void **data)
 #define STANDARD_SLEEP_TIME_US       100U
 #define MAX_EPOLL_TIMEOUT_MS         500U
 static rte_spinlock_t intr_lock[RTE_MAX_ETHPORTS];
+static SC_ATOMIC_DECL_AND_INIT(uint16_t, pcap_workers_left);
+
+void DPDKPcapWorkersSync(uint16_t workers)
+{
+    SC_ATOMIC_ADD(pcap_workers_left, workers);
+}
 
 /**
  * \brief Structure to hold thread specific variables.
@@ -115,6 +121,7 @@ typedef struct DPDKThreadVars_ {
     LiveDevice *livedev;
     ChecksumValidationMode checksum_mode;
     bool intr_enabled;
+    bool is_pcap_iface;
     /* references to packet and drop counters */
     StatsCounterId capture_dpdk_packets;
     StatsCounterId capture_dpdk_rx_errs;
@@ -612,6 +619,91 @@ static void PeriodicDPDKDumpCounters(DPDKThreadVars *ptv)
     }
 }
 
+static inline TmEcode ReceiveDPDKPkts(DPDKThreadVars *ptv, uint16_t nb_rx)
+{
+    ptv->pkts += (uint64_t)nb_rx;
+    for (uint16_t i = 0; i < nb_rx; i++) {
+        Packet *p = PacketInitFromMbuf(ptv, ptv->received_mbufs[i]);
+        if (p == NULL) {
+            rte_pktmbuf_free(ptv->received_mbufs[i]);
+            continue;
+        }
+
+        if (likely(rte_pktmbuf_is_contiguous(p->dpdk_v.mbuf))) {
+            PacketSetData(p, rte_pktmbuf_mtod(p->dpdk_v.mbuf, uint8_t *),
+                    rte_pktmbuf_pkt_len(p->dpdk_v.mbuf));
+        } else {
+            DPDKSegmentedMbufWarning();
+            if (DPDKSegmentedMbufHandle(p, p->dpdk_v.mbuf) != 0) {
+                TmqhOutputPacketpool(ptv->tv, p);
+                continue;
+            }
+        }
+
+        if (TmThreadsSlotProcessPkt(ptv->tv, ptv->slot, p) != TM_ECODE_OK) {
+            TmqhOutputPacketpool(ptv->tv, p);
+            DPDKFreeMbufArray(ptv->received_mbufs, nb_rx - i - 1, i + 1);
+            return TM_ECODE_FAILED;
+        }
+    }
+    return TM_ECODE_OK;
+}
+
+static TmEcode ReceiveDPDKLoopLive(ThreadVars *tv, DPDKThreadVars *ptv, uint16_t burst_size)
+{
+    while (true) {
+        if (unlikely(suricata_ctl_flags != 0)) {
+            HandleShutdown(ptv);
+            break;
+        }
+
+        uint16_t nb_rx =
+                rte_eth_rx_burst(ptv->port_id, ptv->queue_id, ptv->received_mbufs, burst_size);
+        if (RXPacketCountHeuristic(tv, ptv, nb_rx)) {
+            continue;
+        }
+
+        if (ReceiveDPDKPkts(ptv, nb_rx) != TM_ECODE_OK) {
+            SCReturnInt(EXIT_FAILURE);
+        }
+
+        PeriodicDPDKDumpCounters(ptv);
+        StatsSyncCountersIfSignalled(&tv->stats);
+    }
+
+    SCReturnInt(TM_ECODE_OK);
+}
+
+static TmEcode ReceiveDPDKLoopPcap(ThreadVars *tv, DPDKThreadVars *ptv, uint16_t burst_size)
+{
+    while (true) {
+        if (unlikely(suricata_ctl_flags != 0)) {
+            HandleShutdown(ptv);
+            break;
+        }
+
+        uint16_t nb_rx =
+                rte_eth_rx_burst(ptv->port_id, ptv->queue_id, ptv->received_mbufs, burst_size);
+        if (nb_rx == 0) {
+            SCLogNotice("%s: PCAP end of file", ptv->livedev->dev);
+            if (SC_ATOMIC_SUB(pcap_workers_left, 1) == 1) {
+                EngineStop();
+            }
+            HandleShutdown(ptv);
+            break;
+        }
+
+        if (ReceiveDPDKPkts(ptv, nb_rx) != TM_ECODE_OK) {
+            SCReturnInt(EXIT_FAILURE);
+        }
+
+        PeriodicDPDKDumpCounters(ptv);
+        StatsSyncCountersIfSignalled(&tv->stats);
+    }
+
+    SCReturnInt(TM_ECODE_DONE);
+}
+
 /**
  *  \brief Main DPDK reading Loop function
  */
@@ -627,50 +719,10 @@ static TmEcode ReceiveDPDKLoop(ThreadVars *tv, void *data, void *slot)
     if (ret != TM_ECODE_OK) {
         SCReturnInt(ret);
     }
-    while (true) {
-        if (unlikely(suricata_ctl_flags != 0)) {
-            HandleShutdown(ptv);
-            break;
-        }
 
-        uint16_t nb_rx =
-                rte_eth_rx_burst(ptv->port_id, ptv->queue_id, ptv->received_mbufs, burst_size);
-        if (RXPacketCountHeuristic(tv, ptv, nb_rx)) {
-            continue;
-        }
-
-        ptv->pkts += (uint64_t)nb_rx;
-        for (uint16_t i = 0; i < nb_rx; i++) {
-            Packet *p = PacketInitFromMbuf(ptv, ptv->received_mbufs[i]);
-            if (p == NULL) {
-                rte_pktmbuf_free(ptv->received_mbufs[i]);
-                continue;
-            }
-
-            if (likely(rte_pktmbuf_is_contiguous(p->dpdk_v.mbuf))) {
-                PacketSetData(p, rte_pktmbuf_mtod(p->dpdk_v.mbuf, uint8_t *),
-                        rte_pktmbuf_pkt_len(p->dpdk_v.mbuf));
-            } else {
-                /* Slow path: segmented mbuf, needs linearization or copy */
-                DPDKSegmentedMbufWarning();
-                if (DPDKSegmentedMbufHandle(p, p->dpdk_v.mbuf) != 0) {
-                    TmqhOutputPacketpool(ptv->tv, p);
-                    continue;
-                }
-            }
-
-            if (TmThreadsSlotProcessPkt(ptv->tv, ptv->slot, p) != TM_ECODE_OK) {
-                TmqhOutputPacketpool(ptv->tv, p);
-                DPDKFreeMbufArray(ptv->received_mbufs, nb_rx - i - 1, i + 1);
-                SCReturnInt(EXIT_FAILURE);
-            }
-        }
-
-        PeriodicDPDKDumpCounters(ptv);
-        StatsSyncCountersIfSignalled(&tv->stats);
-    }
-
-    SCReturnInt(TM_ECODE_OK);
+    if (ptv->is_pcap_iface)
+        return ReceiveDPDKLoopPcap(tv, ptv, burst_size);
+    return ReceiveDPDKLoopLive(tv, ptv, burst_size);
 }
 
 /**
@@ -716,6 +768,7 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
 
     ptv->threads = dpdk_config->threads;
     ptv->intr_enabled = (dpdk_config->flags & DPDK_IRQ_MODE) ? true : false;
+    ptv->is_pcap_iface = dpdk_config->is_pcap_iface;
     ptv->port_id = dpdk_config->port_id;
     ptv->out_port_id = dpdk_config->out_port_id;
     ptv->port_socket_id = dpdk_config->socket_id;

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -81,6 +81,7 @@ typedef struct DPDKIfaceConfig_ {
     SC_ATOMIC_DECLARE(uint16_t, queue_id);
     SC_ATOMIC_DECLARE(uint16_t, inconsistent_numa_cnt);
     DPDKWorkerSync *workers_sync;
+    bool is_pcap_iface;
     void (*DerefFunc)(void *);
 
     struct rte_flow *flow[100];
@@ -101,5 +102,6 @@ typedef struct DPDKPacketVars_ {
 
 void TmModuleReceiveDPDKRegister(void);
 void TmModuleDecodeDPDKRegister(void);
+void DPDKPcapWorkersSync(uint16_t workers);
 
 #endif /* SURICATA_SOURCE_DPDK_H */


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in doc/userguide/) to reflect the changes made
- [ ] I have updated the JSON schema (in etc/schema.json) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6012, https://redmine.openinfosecfoundation.org/issues/8225

Describe changes:

**Commit 1: dpdk: add support for segmented mbufs (Ticket #6012)**

When running as a secondary DPDK process, Suricata may receive
segmented (chained) mbufs from the primary application. Previously,
these packets would trigger a warning and potentially be processed
incorrectly since only the first segment was accessible.

Now Suricata handles segmented mbufs by:
1. Attempting to linearize in-place with rte_pktmbuf_linearize()
2. If linearization fails (insufficient tailroom), copying all segments into the packet's internal buffer

A one-time warning is still logged advising users to increase
mbuf size (secondary) or MTU (primary) for better performance.

**Commit 2: dpdk: stop engine after net_pcap PCAP end of file (Ticket #8225)**

When using DPDK's net_pcap PMD to read PCAP files, Suricata
previously stayed stuck in the RX loop after the file was fully
consumed because no EOF signal exists — only zero packets returned
by rte_eth_rx_burst.

Detect the net_pcap driver during device configuration and track
active pcap workers with a global atomic counter. When a worker
receives zero packets it decrements the counter; the last worker
to finish calls EngineStop to initiate graceful shutdown.

A separate receive loop (ReceiveDPDKLoopPcap) is used for net_pcap
interfaces to keep the zero-RX EOF check off the live capture fast
path. The common packet burst processing is extracted into the inline
helper ReceiveDPDKPkts shared by both loops.

### Provide values to any of the below to override the defaults.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2962
SU_REPO=
SU_BRANCH=

Supersedes #14988 and #14817.

changes since #14988 (V5):
- combine segmented mbufs and pcap EOF into a single PR
- rebase to latest main

changes since V6:
- rebase to latest main