### PR TITLE
userguide: add references to rules/README to docs - v1

### DIFF
--- a/doc/userguide/rule-management/adding-your-own-rules.rst
+++ b/doc/userguide/rule-management/adding-your-own-rules.rst
@@ -14,6 +14,9 @@ your console/terminal window:
 
 Write your rule, see :doc:`../rules/intro` and save it.
 
+.. tip:: To ensure that there are no duplicated SIDs, check rule SID ranges read
+   more about `sid` at :ref:`suricata-rules-sids`.
+
 Update the Suricata configuration file so your rule is included. Use
 one of the following examples:
 

--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -37,6 +37,8 @@ signature is emphasized below:
 .. note:: The following characters must be escaped inside the msg:
 	      ``;`` ``\`` ``"``
 
+.. _suricata-rules-sids:
+
 sid (signature ID)
 ------------------
 
@@ -57,8 +59,8 @@ Example of sid in a signature:
    provided as the last keyword (or second-to-last if there is a ``rev``)
    of the signature.
 
-   There are reserved ranges of sids, the reservations are recorded
-   at https://sidallocation.org/ .
+   **There are reserved ranges of sids, the reservations are recorded
+   at https://sidallocation.org/ .**
 
 .. Note::
 
@@ -68,6 +70,16 @@ Example of sid in a signature:
    As Suricata-update currently considers the rule's ``sid`` only (cf. `Bug#5447
    <https://redmine.openinfosecfoundation.org/issues/5447>`_), it is advisable
    to opt for a completely unique ``sid`` altogether.
+
+Suricata Engine Events Rules SID range
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Suricata provides signatures for engine events, bundled in the `rules`
+folder, in the `suricata` directory/repository.
+The full signature ID range for such rules is: 2200000 - 2299999.
+
+These sid ranges can be seen in the `rules README file
+<https://github.com/OISF/suricata/blob/main/rules/README.md>`_).
 
 rev (revision)
 --------------


### PR DESCRIPTION
To make it easier to find/ more visible.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none

Describe changes:
- add a small section mentioning the suricata events rules sid range, and pointing to the README that has the ranges and SIDs
- also link to the SID meta keyword section from the `writing your own rules` section
