### PR TITLE
draft: update msrv to 1.85 (for ci/qa check)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2429,10 +2429,10 @@ jobs:
           parallel-finished: true
           fail-on-error: false
 
-  ubuntu-20-04-ndebug:
-    name: Ubuntu 20.04 (-DNDEBUG)
+  ubuntu-24-04-ndebug:
+    name: Ubuntu 24.04 (-DNDEBUG)
     runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    container: ubuntu:24.04
     needs: [prepare-deps, prepare-cbindgen]
     steps:
       - name: Cache ~/.cargo
@@ -2473,7 +2473,6 @@ jobs:
                 libjansson-dev \
                 libevent-dev \
                 libevent-pthreads-2.1-7 \
-                libpython2.7 \
                 libpcre2-dev \
                 make \
                 parallel \

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1368,7 +1368,7 @@ jobs:
                 autoconf \
                 automake \
                 build-essential \
-                cargo \
+                cargo-1.89 \
                 cbindgen \
                 clang-14 \
                 coccinelle \
@@ -1400,7 +1400,6 @@ jobs:
                 parallel \
                 python-is-python3 \
                 python3-yaml \
-                rustc \
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
@@ -1414,6 +1413,10 @@ jobs:
       - run: tar xf prep/suricata-verify.tar.gz
       - run: ./autogen.sh
       - run: ./configure --enable-unittests --enable-coccinelle
+        env:
+          RUSTC: rustc-1.89
+          CARGO: cargo-1.89
+          RUSTDOC: rustdoc-1.89
       - run: make -j ${{ env.CPUS }}
       - run: CONCURRENCY_LEVEL=${{ env.CPUS }} make check
       - run: python3 ./suricata-verify/run.py -q --debug-failed
@@ -1959,7 +1962,7 @@ jobs:
                 autoconf \
                 automake \
                 llvm-18-dev \
-                cargo \
+                cargo-1.89 \
                 cbindgen \
                 clang-18 \
                 git \
@@ -2016,6 +2019,9 @@ jobs:
           CFLAGS: "-g -fsanitize=address -fno-omit-frame-pointer"
           ac_cv_func_malloc_0_nonnull: "yes"
           ac_cv_func_realloc_0_nonnull: "yes"
+          RUSTC: rustc-1.89
+          CARGO: cargo-1.89
+          RUSTDOC: rustdoc-1.89
       - run: make -j ${{ env.CPUS }}
         env:
           CC: "clang-18"
@@ -2201,7 +2207,7 @@ jobs:
                 autoconf \
                 automake \
                 llvm-18-dev \
-                cargo \
+                cargo-1.89 \
                 cbindgen \
                 clang-18 \
                 git \
@@ -2231,7 +2237,6 @@ jobs:
                 make \
                 parallel \
                 python3-yaml \
-                rustc \
                 software-properties-common \
                 sudo \
                 zlib1g \
@@ -2257,6 +2262,9 @@ jobs:
           CFLAGS: "-g -fsanitize=address -fno-omit-frame-pointer"
           ac_cv_func_malloc_0_nonnull: "yes"
           ac_cv_func_realloc_0_nonnull: "yes"
+          RUSTC: rustc-1.89
+          CARGO: cargo-1.89
+          RUSTDOC: rustdoc-1.89
       - run: make -j ${{ env.CPUS }}
         env:
           CC: "clang-18"
@@ -2443,7 +2451,7 @@ jobs:
                 build-essential \
                 autoconf \
                 automake \
-                cargo \
+                cargo-1.89 \
                 git \
                 hwloc \
                 libhwloc-dev \
@@ -2470,7 +2478,6 @@ jobs:
                 make \
                 parallel \
                 python3-yaml \
-                rustc \
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev \
@@ -2486,6 +2493,10 @@ jobs:
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
       - run: CFLAGS="$DEFAULT_CFLAGS -DNDEBUG" ./configure --enable-warnings --enable-unittests
+        env:
+          RUSTC: rustc-1.89
+          CARGO: cargo-1.89
+          RUSTDOC: rustdoc-1.89
       - run: make -j ${{ env.CPUS }}
       - run: make check
       - run: make dist
@@ -2598,7 +2609,7 @@ jobs:
                 build-essential \
                 autoconf \
                 automake \
-                cargo \
+                cargo-1.89 \
                 git \
                 hwloc \
                 libhwloc-dev \
@@ -2623,7 +2634,6 @@ jobs:
                 make \
                 parallel \
                 python3-yaml \
-                rustc \
                 software-properties-common \
                 sudo \
                 zlib1g \
@@ -2648,6 +2658,9 @@ jobs:
           LDFLAGS: "-fsanitize=address" 
           ac_cv_func_malloc_0_nonnull: "yes"
           ac_cv_func_realloc_0_nonnull: "yes"
+          RUSTC: rustc-1.89
+          CARGO: cargo-1.89
+          RUSTDOC: rustdoc-1.89
       - run: make -j ${{ env.CPUS }}
       - run: make check
       - name: Extracting suricata-verify
@@ -2683,7 +2696,7 @@ jobs:
                 build-essential \
                 autoconf \
                 automake \
-                cargo \
+                cargo-1.89 \
                 git \
                 hwloc \
                 libhwloc-dev \
@@ -2703,7 +2716,6 @@ jobs:
                 libjansson-dev \
                 libpython2.7 \
                 make \
-                rustc \
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
@@ -2717,6 +2729,10 @@ jobs:
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
       - run: AFL_HARDEN=1 ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes CFLAGS="-fsanitize=address -fno-omit-frame-pointer" CXXFLAGS=$CFLAGS CC=afl-clang-fast CXX=afl-clang-fast++ LDFLAGS="-fsanitize=address" ./configure --enable-warnings --enable-fuzztargets --disable-shared
+        env:
+          RUSTC: rustc-1.89
+          CARGO: cargo-1.89
+          RUSTDOC: rustdoc-1.89
       - run: AFL_HARDEN=1 make -j ${{ env.CPUS }}
 
   ubuntu-22-04-netmap-build:
@@ -2884,7 +2900,7 @@ jobs:
                 build-essential \
                 autoconf \
                 automake \
-                cargo \
+                cargo-1.89 \
                 git \
                 hwloc \
                 libhwloc-dev \
@@ -2909,7 +2925,6 @@ jobs:
                 make \
                 parallel \
                 python3-yaml \
-                rustc \
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev \
@@ -2950,6 +2965,10 @@ jobs:
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-dpdk --enable-hwloc
+        env:
+          RUSTC: rustc-1.89
+          CARGO: cargo-1.89
+          RUSTDOC: rustdoc-1.89
       - run: make -j ${{ env.CPUS }}
       - run: make check
       # IDS config
@@ -3165,7 +3184,7 @@ jobs:
               autoconf \
               automake \
               build-essential \
-              cargo \
+              cargo-1.89 \
               cmake \
               curl \
               git \
@@ -3193,7 +3212,6 @@ jobs:
               pkg-config \
               python3 \
               python3-yaml \
-              rustc \
               sphinx-doc \
               sphinx-common \
               texlive-latex-base \
@@ -3202,6 +3220,7 @@ jobs:
               texlive-latex-extra \
               zlib1g \
               zlib1g-dev
+      - run: echo "/usr/lib/rust-1.89/bin" >> $GITHUB_PATH
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - run: git config --global --add safe.directory /__w/suricata/suricata
       - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1443,7 +1443,7 @@ jobs:
                 autoconf \
                 automake \
                 build-essential \
-                cargo-1.82 \
+                cargo-1.85 \
                 cbindgen \
                 clang-14 \
                 dpdk-dev \
@@ -1487,7 +1487,7 @@ jobs:
       - run: tar xf prep/suricata-update.tar.gz
       - run: tar xf prep/suricata-verify.tar.gz
       - run: ./autogen.sh
-      - run: CARGO=cargo-1.82 RUSTC=rustc-1.82 RUSTDOC=rustdoc-1.82 ./configure --enable-unittests
+      - run: CARGO=cargo-1.85 RUSTC=rustc-1.85 RUSTDOC=rustdoc-1.85 ./configure --enable-unittests
       - run: make -j ${{ env.CPUS }}
       - run: make check
       - run: python3 ./suricata-verify/run.py -q --debug-failed

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -17,7 +17,7 @@ jobs:
   check-commits:
     name: Commit Check
     runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    container: ubuntu:24.04
     steps:
       - name: Caching ~/.cargo
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb
@@ -32,7 +32,7 @@ jobs:
                 build-essential \
                 autoconf \
                 automake \
-                cargo \
+                cargo-1.89 \
                 curl \
                 git \
                 jq \
@@ -52,17 +52,16 @@ jobs:
                 libjansson-dev \
                 libevent-dev \
                 libevent-pthreads-2.1-7 \
-                libpython2.7 \
                 libssl-dev \
                 make \
                 parallel \
                 pkg-config \
                 python3-yaml \
-                rustc \
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: echo "/usr/lib/rust-1.89/bin" >> $GITHUB_PATH
       - name: Installing sccache
         run: |
           (cd /tmp && curl -OL https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,7 +78,7 @@ jobs:
               autoconf \
               automake \
               build-essential \
-              cargo \
+              cargo-1.89 \
               cmake \
               curl \
               git \
@@ -104,7 +104,6 @@ jobs:
               pkg-config \
               python3 \
               python3-yaml \
-              rustc \
               sphinx-doc \
               sphinx-common \
               texlive-latex-base \
@@ -129,6 +128,8 @@ jobs:
           cp prep/cbindgen $HOME/.cargo/bin
           chmod 755 $HOME/.cargo/bin/cbindgen
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Add Rust 1.89 to path
+        run: echo "/usr/lib/rust-1.89/bin" >> $GITHUB_PATH
       - run: tar xf prep/suricata-update.tar.gz
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -48,7 +48,7 @@ jobs:
                 build-essential \
                 autoconf \
                 automake \
-                cargo \
+                cargo-1.89 \
                 cbindgen \
                 clang-format-14 \
                 git \
@@ -132,6 +132,10 @@ jobs:
         shell: bash {0}
       - run: ./autogen.sh
       - run: ./configure --enable-warnings --enable-unittests
+        env:
+          RUSTC: rustc-1.89
+          CARGO: cargo-1.89
+          RUSTDOC: rustdoc-1.89
       - name: Check formatting
         run: |
           ./scripts/clang-format.sh check-branch --diffstat --show-commits  >> check_formatting_log.txt 2>&1

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v6.0.2
     - uses: cachix/install-nix-action@v31
       with:
-        nix_path: nixpkgs=channel:nixos-24.11
+        nix_path: nixpkgs=channel:nixos-25.11
     - run: nix-shell --run ./scripts/bundle.sh
     - run: nix-shell --run ./autogen.sh
     - run: nix-shell --run "./configure CC=clang"

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -36,7 +36,7 @@ jobs:
                 build-essential \
                 autoconf \
                 automake \
-                cargo \
+                cargo-1.85 \
                 cbindgen \
                 clang-20 \
                 clang-tools-20 \
@@ -65,7 +65,6 @@ jobs:
                 llvm-20-dev \
                 make \
                 python3-yaml \
-                rustc \
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
@@ -76,6 +75,9 @@ jobs:
       - run: scan-build-20 ./configure --enable-warnings --enable-dpdk --enable-nfqueue --enable-nflog
         env:
           CC: clang-20
+          RUSTC: rustc-1.85
+          CARGO: cargo-1.85
+          RUSTDOC: rustdoc-1.85
       # disable security.insecureAPI.DeprecatedOrUnsafeBufferHandling explicitly as
       # this will require significant effort to address.
       - run: |

--- a/configure.ac
+++ b/configure.ac
@@ -2097,7 +2097,7 @@ fi
     cargo_version_output=$($CARGO --version)
     cargo_version=$(echo "$cargo_version_output" | sed 's/^.*[[^0-9]]\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\).*$/\1/')
 
-    MIN_RUSTC_VERSION="1.75.0" # MSRV
+    MIN_RUSTC_VERSION="1.85.0" # MSRV
     AC_MSG_CHECKING(for Rust version $MIN_RUSTC_VERSION or newer)
     AS_VERSION_COMPARE([$rustc_version], [$MIN_RUSTC_VERSION],
         [

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -4,7 +4,7 @@ version = "@PACKAGE_VERSION@"
 license = "GPL-2.0-only"
 description = "Suricata Rust components"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.85.0"
 
 [workspace]
 members = [

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -49,6 +49,13 @@
 // just due to FFI.
 #![allow(clippy::missing_safety_doc)]
 
+// Disable the clippy warning for not using modern C string
+// literals. Ubuntu 24.04 still ships cbindgen 0.26.0 that doesn't
+// support these, so migrating to modern C string literals would
+// require Ubuntu 24.04 users wishing to build from git to install
+// cbindgen with cargo.
+#![allow(clippy::manual_c_str_literals)]
+
 // Allow unknown lints, our MSRV doesn't know them all, for
 // example static_mut_refs.
 #![allow(unknown_lints)]


### PR DESCRIPTION
- **rust: set minimum rust version to 1.85**
  1.85 was chosen for now as it supports edition 2024. However, we have
  not set our edition to 2024 yet.
  

- **github-ci: update rust vars job to rust 1.85**
  

- **github-ci/nix: update to nixos-25.11**
  To pick up a newer version of Rust.
  

- **github-ci/formatting: update to rust 1.89**
  

- **github-ci/scan-build: update to rust 1.85**
  

- **github-ci/builds: update ubuntu builds to use rust 1.89**
  

- **rust: disable clippy warning for manual c str literals**
  Disable the clippy warning for not using modern C string
  literals. Ubuntu 24.04 still ships cbindgen 0.26.0 that doesn't
  support these, so migrating to modern C string literals would require
  Ubuntu 24.04 users wishing to build from git to install cbindgen with
  cargo.
  

- **github-ci: update -DNDEBUG build to Ubuntu 24.04**
  Ubuntu 20.04 is EOL and does not contain Rust 1.85 or newer.
  