### PR TITLE
github-ci: prep for msrv update - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2819,8 +2819,9 @@ jobs:
 
   ubuntu-22-04-minimal-recommended-build:
     name: Ubuntu 22.04 (Minimal/Recommended Build)
-    needs: [prepare-deps, prepare-cbindgen]
+    needs: [ubuntu-22-04-dist]
     runs-on: ubuntu-22.04
+    container: ubuntu:22.04
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
@@ -2832,23 +2833,15 @@ jobs:
       - name: Determine number of CPUs
         run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
-      - name: Install git dependencies
-        run: |
-          sudo apt update
-          sudo apt -y install \
-            git \
-            libtool
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - run: git config --global --add safe.directory /__w/suricata/suricata
-      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+      - name: Download suricata.tar.gz
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
         with:
-          name: prep
-          path: prep
-      - run: tar xf prep/suricata-update.tar.gz
-      - run: tar xf prep/suricata-verify.tar.gz
-      - run: ./autogen.sh
-      
+          name: dist
+      - run: tar xvf suricata-*.tar.gz --strip-components=1
+
+      # Install packages required by the install script.
+      - run: apt update -y && apt install -y sudo
+
       - name: Install minimal dependencies
         run: ./scripts/docs-ubuntu-debian-minimal-build.sh
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1300,7 +1300,7 @@ jobs:
     name: AlmaLinux 9 (Minimal/Recommended Build)
     runs-on: ubuntu-latest
     container: almalinux:9
-    needs: [prepare-deps, prepare-cbindgen]
+    needs: [ubuntu-22-04-dist]
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
@@ -1312,36 +1312,24 @@ jobs:
       - name: Determine number of CPUs
         run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
-      - name: Install git dependencies
-        run: |
-          dnf -y install \
-            sudo \
-            git \
-            libtool \
-            which
+      - name: Download suricata.tar.gz
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+        with:
+          name: dist
+      - run: tar xf suricata-*.tar.gz --strip-components=1
 
-      - name: Install Almalinux 9 extra repositories
-        run : |
+      - name: Update packages and install sudo
+        run: dnf -y update && dnf install -y sudo
+
+      - name: Install AlmaLinux 9 extra repositories
+        run: |
           dnf -y update
-          dnf -y install dnf-plugins-core epel-release
+          dnf -y install dnf-plugins-core epel-release sudo
           dnf config-manager --set-enabled crb
 
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: ./.github/actions/install-cbindgen
-      - run: git config --global --add safe.directory /__w/suricata/suricata
-      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
-      
       - name: Install minimal dependencies
         run: ./scripts/docs-almalinux9-minimal-build.sh
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - run: git config --global --add safe.directory /__w/suricata/suricata
-      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
-        with:
-          name: prep
-          path: prep
-      - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
       - run: make -j ${{ env.CPUS }}
       - run: ./src/suricata --build-info # check if we can run Suricata

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -49,13 +49,15 @@ if RUST_CROSS_COMPILE
 RUST_TARGET = --target $(host_triplet)
 endif
 
+CARGO_ENV =	RUSTC="$(RUSTC)" RUSTDOC="$(RUSTDOC)"
+
 if HAVE_CYGPATH
-CARGO_ENV =	@rustup_home@ \
+CARGO_ENV +=	@rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(e_rustdir)/target" \
 		SURICATA_LUA_SYS_HEADER_DST="$(e_rustdir)/gen"
 else
-CARGO_ENV =	@rustup_home@ \
+CARGO_ENV +=	@rustup_home@ \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
 		SURICATA_LUA_SYS_HEADER_DST="$(abs_top_builddir)/rust/gen"
@@ -126,7 +128,7 @@ endif
 
 check:
 	cd $(abs_top_srcdir)/rust && \
-		$(CARGO_ENV) RUSTDOC=$(RUSTDOC) \
+		$(CARGO_ENV) \
 		$(CARGO) test --all $(RELEASE) --features "$(RUST_FEATURES)"
 	$(MAKE) check-bindgen-bindings
 
@@ -135,7 +137,8 @@ vendor:
 
 update-bindings:
 if HAVE_BINDGEN
-	CARGO=$(CARGO) $(CBINDGEN) --quiet --config cbindgen.toml src/jsonbuilder.rs -o gen/jsonbuilder.h
+	$(CARGO_ENV) CARGO=$(CARGO) $(CBINDGEN) --quiet --config cbindgen.toml \
+		src/jsonbuilder.rs -o gen/jsonbuilder.h
 	$(BINDGEN) \
 		-o sys/src/sys.rs.tmp \
 		--rust-target 1.68 \
@@ -168,7 +171,7 @@ endif
 if HAVE_CBINDGEN
 gen/rust-bindings.h: $(RUST_SURICATA_LIB) cbindgen.toml
 	cd $(abs_top_srcdir)/rust && \
-		CARGO=$(CARGO) $(CBINDGEN) --config $(abs_top_srcdir)/rust/cbindgen.toml \
+		$(CARGO_ENV) CARGO=$(CARGO) $(CBINDGEN) --config $(abs_top_srcdir)/rust/cbindgen.toml \
 		--quiet --verify --output $(abs_top_builddir)/rust/gen/rust-bindings.h || true
 else
 gen/rust-bindings.h:
@@ -177,18 +180,18 @@ endif
 if HAVE_CBINDGEN
 gen/htp/htp_rs.h: $(RUST_SURICATA_LIB) htp/cbindgen.toml
 	cd $(abs_top_srcdir)/rust/htp && \
-		CARGO=$(CARGO) $(CBINDGEN) --config $(abs_top_srcdir)/rust/htp/cbindgen.toml \
+		$(CARGO_ENV) CARGO=$(CARGO) $(CBINDGEN) --config $(abs_top_srcdir)/rust/htp/cbindgen.toml \
 		--quiet --verify --output $(abs_top_builddir)/rust/gen/htp/htp_rs.h || true
 else
 gen/htp/htp_rs.h:
 endif
 
 doc:
-	CARGO_HOME=$(CARGO_HOME) RUSTDOC=$(RUSTDOC) $(CARGO) doc --all-features --no-deps
+	$(CARGO_ENV) $(CARGO) doc --all-features --no-deps
 
 if HAVE_CBINDGEN
 dist/rust-bindings.h:
-	CARGO=$(CARGO) $(CBINDGEN) --config $(abs_top_srcdir)/rust/cbindgen.toml \
+	$(CARGO_ENV) CARGO=$(CARGO) $(CBINDGEN) --config $(abs_top_srcdir)/rust/cbindgen.toml \
 		--quiet --output $(abs_top_builddir)/rust/dist/rust-bindings.h
 else
 dist/rust-bindings.h:
@@ -197,7 +200,7 @@ endif
 if HAVE_CBINDGEN
 dist/htp/htp_rs.h:
 	cd $(abs_top_srcdir)/rust/htp && \
-	CARGO=$(CARGO) $(CBINDGEN) --config cbindgen.toml \
+	$(CARGO_ENV) CARGO=$(CARGO) $(CBINDGEN) --config cbindgen.toml \
 		--quiet --output $(abs_top_builddir)/rust/dist/htp/htp_rs.h
 else
 dist/htp/htp_rs.h:
@@ -206,5 +209,5 @@ endif
 Cargo.toml: Cargo.toml.in
 
 update-lock: Cargo.toml
-	$(CARGO) update
+	$(CARGO_ENV) $(CARGO) update
 	mv Cargo.lock Cargo.lock.in

--- a/scripts/docs-almalinux9-minimal-build.sh
+++ b/scripts/docs-almalinux9-minimal-build.sh
@@ -3,7 +3,7 @@
 # Serves for RPM-based docs and is verified by Github Actions
 
 # install-guide-documentation tag start: Minimal RPM-based dependencies
-sudo dnf install -y rustc cargo cbindgen
-sudo dnf install -y gcc gcc-c++ jansson-devel libpcap-devel \
+sudo dnf install -y dnf-plugins-core epel-release
+sudo dnf install -y cargo gcc jansson-devel libpcap-devel \
     libyaml-devel make pcre2-devel zlib-devel
 # install-guide-documentation tag end: Minimal RPM-based dependencies

--- a/scripts/docs-ubuntu-debian-minimal-build.sh
+++ b/scripts/docs-ubuntu-debian-minimal-build.sh
@@ -4,6 +4,6 @@
 
 # install-guide-documentation tag start: Minimal dependencies
 sudo apt -y install autoconf automake build-essential cargo \
-    cbindgen libjansson-dev libpcap-dev libpcre2-dev libtool \
+    libjansson-dev libpcap-dev libpcre2-dev libtool \
     libyaml-dev make pkg-config rustc zlib1g-dev
 # install-guide-documentation tag end: Minimal dependencies


### PR DESCRIPTION
- **github-ci: update debian/ubuntu minimal build to use dist**
- **github-ci: update almalinux minimal build to use dist archive**

The above 2 are more of a cleanup to better represent what we are trying to
document. They need to be split when we do update the MSRV so I thought it
would be easier to reason about and review the change sooner than later.

- **rust/Makefile: add RUSTC and RUSTDOC to CARGO_ENV**

Ubuntu packages Rust 1.89 (and other versions) such that they can used like:

    PATH=/usr/lib/rust-1.89/bin:$PATH ./configure

However, our ./configure doesn't remember the paths to rustc and rustdoc, it
does to cargo however. This updates the Makefile's to remember the location, so
the PATH can be provided just on the ./configure line and not everywhere. Given
we did it, in purpose for "cargo", I think it was just an oversight the others
didn't get it as well.
