### PR TITLE
Add payload-only-classtypes filtering to suricata conf to filter payl…

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -127,6 +127,7 @@ Metadata::
 
         - alert:
             #payload: yes             # enable dumping payload in Base64
+            #payload-only-classtypes: [] # dump payload only for specified classtypes (empty = all)
             #payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             #payload-printable: yes   # enable dumping payload in printable (lossy) format
             #payload-length: yes      # enable dumping payload length, including the gaps

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -84,6 +84,7 @@ outputs:
       types:
         - alert:
             # payload: yes             # enable dumping payload in Base64
+            # payload-only-classtypes: [] # dump payload only for specified classtypes (empty = all)
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # payload-length: yes      # enable dumping payload length, including the gaps

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -197,6 +197,7 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (real_ct && update_ct) {
         s->class_id = ct->classtype_id;
         s->class_msg = ct->classtype_desc;
+        s->classtype = ct->classtype;
     }
     return 0;
 }

--- a/src/detect.h
+++ b/src/detect.h
@@ -737,6 +737,8 @@ typedef struct Signature_ {
 
     /** classification message */
     char *class_msg;
+    /** classtype */
+    char *classtype;
     /** Reference */
     DetectReference *references;
     /** Metadata */

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -63,6 +63,7 @@
 #include "util-print.h"
 #include "util-optimize.h"
 #include "util-buffer.h"
+#include "util-hash-string.h"
 #include "util-reference-config.h"
 #include "util-validate.h"
 
@@ -103,6 +104,7 @@ typedef struct AlertJsonOutputCtx_ {
     HttpXFFCfg *xff_cfg;
     HttpXFFCfg *parent_xff_cfg;
     OutputJsonCtx *eve_ctx;
+    HashTable *payload_classtype_filter;
 } AlertJsonOutputCtx;
 
 typedef struct JsonAlertLogThread_ {
@@ -642,6 +644,31 @@ static bool AlertJsonStreamData(const AlertJsonOutputCtx *json_output_ctx, JsonA
     return false;
 }
 
+/**
+ * \brief Check if alert's classtype matches the payload extraction filter if filtering is
+ * configured
+ * \param filter HashTable of classtype names to check (can be NULL)
+ * \param pa PacketAlert containing the signature
+ * \return true if payload should be extracted, false otherwise
+ */
+static bool ShouldDumpPayloadInAlert(const HashTable *filter, const PacketAlert *pa)
+{
+    // No filter configured = always extract based on payload flags (default behavior)
+    if (filter == NULL) {
+        return true;
+    }
+
+    // No classtype in alert, yet filtering is configured -> no extraction
+    if (pa->s == NULL || pa->s->classtype == NULL) {
+        return false;
+    }
+
+    // Check if classtype in alert matches any in the filter hash table
+    const char *alert_classtype = pa->s->classtype;
+    size_t len = strlen(alert_classtype);
+    return HashTableLookup(filter, alert_classtype, (uint16_t)len) != NULL;
+}
+
 static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 {
     AlertJsonOutputCtx *json_output_ctx = aft->json_output_ctx;
@@ -747,9 +774,13 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             }
         }
 
+        bool should_dump_payload =
+                ShouldDumpPayloadInAlert(json_output_ctx->payload_classtype_filter, pa);
+
         /* payload */
-        if (json_output_ctx->flags &
-                (LOG_JSON_PAYLOAD | LOG_JSON_PAYLOAD_BASE64 | LOG_JSON_PAYLOAD_LENGTH)) {
+        if (should_dump_payload &&
+                json_output_ctx->flags &
+                        (LOG_JSON_PAYLOAD | LOG_JSON_PAYLOAD_BASE64 | LOG_JSON_PAYLOAD_LENGTH)) {
             int stream = (p->proto == IPPROTO_TCP) ?
                          (pa->flags & (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_STREAM_MATCH) ?
                          1 : 0) : 0;
@@ -944,9 +975,77 @@ static void JsonAlertLogDeInitCtxSub(OutputCtx *output_ctx)
         if (xff_cfg != NULL) {
             SCFree(xff_cfg);
         }
+        if (json_output_ctx->payload_classtype_filter != NULL) {
+            HashTableFree(json_output_ctx->payload_classtype_filter);
+        }
         SCFree(json_output_ctx);
     }
     SCFree(output_ctx);
+}
+
+/**
+ * \brief Parse payload-only-classtypes filter from YAML
+ * \param conf Configuration node
+ * \return HashTable* on success, NULL if not configured or empty
+ */
+static HashTable *JsonAlertParsePayloadClasstypeFilter(SCConfNode *conf)
+{
+    if (conf == NULL) {
+        return NULL;
+    }
+
+    SCConfNode *payload_extraction_node = SCConfNodeLookupChild(conf, "payload-only-classtypes");
+    if (payload_extraction_node == NULL) {
+        return NULL;
+    }
+
+    if (!SCConfNodeIsSequence(payload_extraction_node)) {
+        SCLogError("payload-only-classtypes must be a list of classtype names");
+        return NULL;
+    }
+
+    SCConfNode *item;
+    uint32_t count = 0;
+    TAILQ_FOREACH (item, &payload_extraction_node->head, next) {
+        if (item->val != NULL && strlen(item->val) > 0) {
+            count++;
+        }
+    }
+
+    if (count == 0) {
+        SCLogDebug("payload_extraction is empty - treating as not configured");
+        return NULL;
+    }
+
+    HashTable *ht = HashTableInit(256, StringHashFunc, StringHashCompareFunc, StringHashFreeFunc);
+    if (ht == NULL) {
+        return NULL;
+    }
+
+    uint32_t idx = 0;
+    TAILQ_FOREACH (item, &payload_extraction_node->head, next) {
+        if (item->val == NULL || strlen(item->val) == 0) {
+            continue;
+        }
+
+        char *classtype = SCStrdup(item->val);
+        if (classtype == NULL) {
+            HashTableFree(ht);
+            return NULL;
+        }
+
+        if (HashTableAdd(ht, classtype, (uint16_t)strlen(classtype)) < 0) {
+            SCLogDebug("HashTable Add failed for classtype filtering");
+            SCFree(classtype);
+            HashTableFree(ht);
+            return NULL;
+        }
+        idx++;
+    }
+
+    SCLogInfo("payload_extraction filter enabled for %u classtype(s)", idx);
+
+    return ht;
 }
 
 static void SetFlag(const SCConfNode *conf, const char *name, uint16_t flag, uint16_t *out_flags)
@@ -998,6 +1097,8 @@ static void JsonAlertLogSetupMetadata(AlertJsonOutputCtx *json_output_ctx, SCCon
         SetFlag(conf, "websocket-payload", LOG_JSON_WEBSOCKET_PAYLOAD_BASE64, &flags);
         SetFlag(conf, "verdict", LOG_JSON_VERDICT, &flags);
         SetFlag(conf, "payload-length", LOG_JSON_PAYLOAD_LENGTH, &flags);
+
+        json_output_ctx->payload_classtype_filter = JsonAlertParsePayloadClasstypeFilter(conf);
 
         /* Check for obsolete flags and warn that they have no effect. */
         static const char *deprecated_flags[] = { "http", "tls", "ssh", "smtp", "dnp3", "app-layer",

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -181,6 +181,9 @@ outputs:
       types:
         - alert:
             # payload: yes             # enable dumping payload in Base64
+            # allows filtering payload extraction in EVE alerts based on the rule's classtype.
+            # If filtering enabled (list not empty, rules without any classtype will have payload filtered)
+            # payload-only-classtypes: ["list", "of", "classtypes"]
             # payload-buffer-size: 4 KiB  # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # payload-length: yes      # enable dumping payload length, including the gaps


### PR DESCRIPTION
…oad dump by classtype if needed

Use case is in an environment where we do not control the rules written but we do control the suricata configuration, and we want to prevent some payload extracted logged tothe clients for security reasons.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8245

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3023
SU_REPO=
SU_BRANCH=

Old version was here:

https://github.com/OISF/suricata/pull/14968