### PR TITLE
8.0.x: clean-up minimum recommended builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2514,8 +2514,9 @@ jobs:
 
   ubuntu-22-04-minimal-recommended-build:
     name: Ubuntu 22.04 (Minimal/Recommended Build)
-    needs: [prepare-deps, prepare-cbindgen]
+    needs: [ubuntu-22-04-dist]
     runs-on: ubuntu-22.04
+    container: ubuntu:22.04
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
@@ -2527,23 +2528,15 @@ jobs:
       - name: Determine number of CPUs
         run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
-      - name: Install git dependencies
-        run: |
-          sudo apt update
-          sudo apt -y install \
-            git \
-            libtool
-
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - run: git config --global --add safe.directory /__w/suricata/suricata
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+      - name: Download suricata.tar.gz
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
         with:
-          name: prep
-          path: prep
-      - run: tar xf prep/suricata-update.tar.gz
-      - run: tar xf prep/suricata-verify.tar.gz
-      - run: ./autogen.sh
-      
+          name: dist
+      - run: tar xvf suricata-*.tar.gz --strip-components=1
+
+      # Install packages required by the install script.
+      - run: apt update -y && apt install -y sudo
+
       - name: Install minimal dependencies
         run: ./scripts/docs-ubuntu-debian-minimal-build.sh
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1229,7 +1229,7 @@ jobs:
     name: AlmaLinux 9 (Minimal/Recommended Build)
     runs-on: ubuntu-latest
     container: almalinux:9
-    needs: [prepare-deps, prepare-cbindgen]
+    needs: [ubuntu-22-04-dist]
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
@@ -1241,36 +1241,22 @@ jobs:
       - name: Determine number of CPUs
         run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
-      - name: Install git dependencies
-        run: |
-          dnf -y install \
-            sudo \
-            git \
-            libtool \
-            which
+      - name: Download suricata.tar.gz
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+        with:
+          name: dist
+      - run: tar xf suricata-*.tar.gz --strip-components=1
 
-      - name: Install Almalinux 9 extra repositories
-        run : |
-          dnf -y update
-          dnf -y install dnf-plugins-core epel-release
+      # Some packages are not in the script, but documented as they differ
+      # based on variant/version of RHEL.
+      - name: Install prerequisites not covered by script
+        run: |
+          dnf -y install sudo dnf-plugins-core epel-release
           dnf config-manager --set-enabled crb
 
-
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - uses: ./.github/actions/install-cbindgen
-      - run: git config --global --add safe.directory /__w/suricata/suricata
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
-      
       - name: Install minimal dependencies
         run: ./scripts/docs-almalinux9-minimal-build.sh
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - run: git config --global --add safe.directory /__w/suricata/suricata
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
-        with:
-          name: prep
-          path: prep
-      - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
       - run: make -j ${{ env.CPUS }}
       - run: ./src/suricata --build-info # check if we can run Suricata

--- a/scripts/docs-almalinux9-minimal-build.sh
+++ b/scripts/docs-almalinux9-minimal-build.sh
@@ -3,7 +3,6 @@
 # Serves for RPM-based docs and is verified by Github Actions
 
 # install-guide-documentation tag start: Minimal RPM-based dependencies
-sudo dnf install -y rustc cargo cbindgen
-sudo dnf install -y gcc gcc-c++ jansson-devel libpcap-devel \
+sudo dnf install -y cargo gcc jansson-devel libpcap-devel \
     libyaml-devel make pcre2-devel zlib-devel
 # install-guide-documentation tag end: Minimal RPM-based dependencies

--- a/scripts/docs-ubuntu-debian-minimal-build.sh
+++ b/scripts/docs-ubuntu-debian-minimal-build.sh
@@ -4,6 +4,6 @@
 
 # install-guide-documentation tag start: Minimal dependencies
 sudo apt -y install autoconf automake build-essential cargo \
-    cbindgen libjansson-dev libpcap-dev libpcre2-dev libtool \
+    libjansson-dev libpcap-dev libpcre2-dev libtool \
     libyaml-dev make pkg-config rustc zlib1g-dev
 # install-guide-documentation tag end: Minimal dependencies


### PR DESCRIPTION
Partial backport of https://github.com/OISF/suricata/pull/15037.

As these jobs test the build instructions from https://docs.suricata.io/en/suricata-8.0.4/install.html#dependencies-and-compilation, which are not git based builds, I think the jobs testing the scripts should not be git based builds either. As such, I think its suitable to backport so their actual intention is tested.