### PR TITLE
stream/tcp: add `tcp.async_stream` stats counter - v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -8266,6 +8266,10 @@
                         "active_sessions": {
                             "type": "integer"
                         },
+                        "async_stream": {
+                            "type": "integer",
+                            "description": "Number of times the engine inspected an asynchronous TCP stream (if stream.async-oneside enabled)"
+                        },
                         "insert_data_normal_fail": {
                             "type": "integer"
                         },

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1243,6 +1243,7 @@ static int StreamTcpPacketStateNone(
         if (stream_config.async_oneside) {
             SCLogDebug("ssn %p: =~ ASYNC", ssn);
             ssn->flags |= STREAMTCP_FLAG_ASYNC;
+            StatsCounterIncr(&tv->stats, stt->counter_tcp_async_stream);
         }
 
         /** window scaling for midstream pickups, we can't do much other
@@ -1343,6 +1344,7 @@ static int StreamTcpPacketStateNone(
         if (stream_config.async_oneside) {
             SCLogDebug("ssn %p: =~ ASYNC", ssn);
             ssn->flags |= STREAMTCP_FLAG_ASYNC;
+            StatsCounterIncr(&tv->stats, stt->counter_tcp_async_stream);
         }
 
         /* sequence number & window */
@@ -1512,6 +1514,7 @@ static int StreamTcpPacketStateNone(
         if (stream_config.async_oneside) {
             SCLogDebug("ssn %p: =~ ASYNC", ssn);
             ssn->flags |= STREAMTCP_FLAG_ASYNC;
+            StatsCounterIncr(&tv->stats, stt->counter_tcp_async_stream);
         }
 
         /** window scaling for midstream pickups, we can't do much other
@@ -2400,6 +2403,8 @@ static int StreamTcpPacketStateSynSent(
            same host, which sent the SYN, this suggests the ASYNC streams.*/
         if (!stream_config.async_oneside)
             return 0;
+
+        StatsCounterIncr(&tv->stats, stt->counter_tcp_async_stream);
 
         /* we are in ASYNC (one side) mode now. */
 
@@ -5703,6 +5708,8 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         {
             SCLogDebug("ssn %p: removing ASYNC flag as we have packets on both sides", ssn);
             ssn->flags &= ~STREAMTCP_FLAG_ASYNC;
+            /* since the stream isn't really async, let's decrease the counter */
+            StatsCounterDecr(&tv->stats, stt->counter_tcp_async_stream);
         }
     }
 
@@ -6185,6 +6192,7 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     stt->counter_tcp_wrong_thread = StatsRegisterCounter("tcp.pkt_on_wrong_thread", &tv->stats);
     stt->counter_tcp_ack_unseen_data = StatsRegisterCounter("tcp.ack_unseen_data", &tv->stats);
+    stt->counter_tcp_async_stream = StatsRegisterCounter("tcp.async_stream", &tv->stats);
 
     /* init reassembly ctx */
     stt->ra_ctx = StreamTcpReassembleInitThreadCtx(tv);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -112,6 +112,8 @@ typedef struct StreamTcpThread_ {
     StatsCounterId counter_tcp_wrong_thread;
     /** ack for unseen data */
     StatsCounterId counter_tcp_ack_unseen_data;
+    /** async sessions */
+    StatsCounterId counter_tcp_async_stream;
 
     /** tcp reassembly thread data */
     TcpReassemblyThreadCtx *ra_ctx;


### PR DESCRIPTION
The counter is incremented when the engine detects an asynchronous TCP stream and stream.async-oneside: true.

Same as with midstream pickups, we want more visibility into when the engine is applying this setting.

Task #8339
Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Previous PR: https://github.com/OISF/suricata/pull/14967

Describe changes:
- remove commit that removed logic for setting the `ASYNC` flag in a valid packet (we first want to make sure there's "harm" in flagging, and that this isn't something that would impact negatively the engine (since the engine removes the flag in a further step, if it interprets if the stream isn't async)
- decrease the `async.oneside` counter when the engine sees traffic from the other direction
- rebase

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2955
