### PR TITLE
Solaris porting changes.

### DIFF
--- a/src/source-pcap-file-directory-helper.c
+++ b/src/source-pcap-file-directory-helper.c
@@ -304,7 +304,7 @@ TmEcode PcapDirectoryPopulateBuffer(PcapFileDirectoryVars *pv,
     PendingFile *file_to_add = NULL;
 
     while ((dir = readdir(pv->directory)) != NULL) {
-#ifndef OS_WIN32
+#if defined(DT_REG)
         if (dir->d_type != DT_REG) {
             continue;
         }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -3089,6 +3089,8 @@ int InitGlobal(void)
 
 void SuricataPreInit(const char *progname)
 {
+    UtilCpuEnableSparcMisalignEmulation();
+
     SCInstanceInit(&suricata, progname);
 
     if (InitGlobal() != 0) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -3225,7 +3225,7 @@ void SuricataPostInit(void)
 #endif
 
     if (limit_nproc) {
-#if defined(HAVE_SYS_RESOURCE_H)
+#if defined(HAVE_SYS_RESOURCE_H) && defined(RLIMIT_NPROC)
 #ifdef linux
         if (geteuid() == 0) {
             SCLogWarning("setrlimit has no effect when running as root.");

--- a/src/threads.h
+++ b/src/threads.h
@@ -244,7 +244,7 @@ enum {
     unsigned long _scgetthread_tid = (unsigned long)tpid; \
     _scgetthread_tid; \
 })
-#elif defined(sun)
+#elif defined(__sun)
 #include <thread.h>
 #define SCGetThreadIdLong(...) ({ \
     thread_t tmpthid = thr_self(); \
@@ -302,9 +302,7 @@ extern thread_local char t_thread_name[THREAD_NAME_LEN + 1];
             SCLogDebug("Error setting thread name \"%s\": %s", tname, strerror(errno));            \
     })
 #else
-#define SCSetThreadName(n) ({ \
-    strlcpy(t_thread_name, n, sizeof(t_thread_name)); \
-}
+#define SCSetThreadName(n) ({ strlcpy(t_thread_name, n, sizeof(t_thread_name)); })
 #endif
 
 

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -701,7 +701,7 @@ void TmSlotSetFuncAppend(ThreadVars *tv, TmModule *tm, const void *data)
     }
 }
 
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
 static int SetCPUAffinitySet(cpu_set_t *cs)
 {
 #if defined OS_FREEBSD
@@ -735,7 +735,7 @@ static int SetCPUAffinitySet(cpu_set_t *cs)
  */
 static int SetCPUAffinity(uint16_t cpuid)
 {
-#if defined __OpenBSD__ || defined sun
+#if defined __OpenBSD__ || defined __sun
     return 0;
 #else
     int cpu = (int)cpuid;
@@ -871,7 +871,7 @@ TmEcode TmThreadSetupOptions(ThreadVars *tv)
         SetCPUAffinity(tv->cpu_affinity);
     }
 
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
     if (tv->thread_setup_flags & THREAD_SET_PRIORITY)
         TmThreadSetPrio(tv);
     if (tv->thread_setup_flags & THREAD_SET_AFFTYPE) {

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -65,7 +65,7 @@ ThreadsAffinityType thread_affinity[MAX_CPU_SET] = {
 
 int thread_affinity_init_done = 0;
 
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
 #ifdef HAVE_HWLOC
 static hwloc_topology_t topology = NULL;
 #endif /* HAVE_HWLOC */
@@ -206,7 +206,7 @@ ThreadsAffinityType *GetOrAllocAffinityTypeForIfaceOfName(
     return parent_affinity;
 }
 
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
 static void AffinitySetupInit(void)
 {
     int i, j;
@@ -587,7 +587,7 @@ static bool AffinityConfigIsLegacy(void)
  */
 void AffinitySetupLoadFromConfig(void)
 {
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
     if (thread_affinity_init_done == 0) {
         AffinitySetupInit();
         AffinityConfigIsLegacy();
@@ -643,7 +643,7 @@ void AffinitySetupLoadFromConfig(void)
 #endif /* OS_WIN32 and __OpenBSD__ */
 }
 
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
 #ifdef HAVE_HWLOC
 static int HwLocDeviceNumaGet(hwloc_topology_t topo, hwloc_obj_t obj)
 {
@@ -1006,7 +1006,7 @@ static bool AutopinEnabled(void)
 uint16_t AffinityGetNextCPU(ThreadVars *tv, ThreadsAffinityType *taf)
 {
     uint16_t ncpu = 0;
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
     int iface_numa = -1;
     if (AutopinEnabled()) {
 #ifdef HAVE_HWLOC
@@ -1043,7 +1043,7 @@ uint16_t AffinityGetNextCPU(ThreadVars *tv, ThreadsAffinityType *taf)
 uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf)
 {
     uint16_t ncpu = 0;
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
     SCMutexLock(&taf->taf_mutex);
     for (int i = UtilCpuGetNumProcessorsOnline(); i >= 0; i--)
         if (CPU_ISSET(i, &taf->cpu_set)) {

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -75,7 +75,7 @@ typedef struct ThreadsAffinityType_ {
     struct ThreadsAffinityType_ *parent; // e.g. worker-cpu-set for interfaces
     SCMutex taf_mutex;
 
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
     cpu_set_t cpu_set;
     cpu_set_t lowprio_cpu;
     cpu_set_t medprio_cpu;

--- a/src/util-byte.h
+++ b/src/util-byte.h
@@ -45,7 +45,12 @@
 #define SCByteSwap16(x) OSSwapInt16(x)
 #define SCByteSwap32(x) OSSwapInt32(x)
 #define SCByteSwap64(x) OSSwapInt64(x)
-#elif defined(__WIN32) || defined(_WIN32) || defined(sun)
+#elif defined(__sun)
+#include <sys/byteorder.h>
+#define SCByteSwap16(x) BSWAP_16(x)
+#define SCByteSwap32(x) BSWAP_32(x)
+#define SCByteSwap64(x) BSWAP_64(x)
+#elif defined(__WIN32) || defined(_WIN32)
 /* Quick & dirty solution, nothing seems to exist for this in Win32 API */
 #define SCByteSwap16(x)                         \
 	((((x) & 0xff00) >> 8)                      \

--- a/src/util-cpu.c
+++ b/src/util-cpu.c
@@ -204,3 +204,16 @@ uint64_t UtilCpuGetTicks(void)
 #endif
     return val;
 }
+
+/**
+ * \brief Handle memory access miss align on SPARC processors
+ */
+void UtilCpuEnableSparcMisalignEmulation(void)
+{
+/* 'ta 6' tells the kernel to synthesize any unaligned accesses this process
+ * makes, instead of just signalling an error and terminating the process.
+ */
+#ifdef __sparc
+    __asm("ta 6");
+#endif /* __sparc */
+}

--- a/src/util-cpu.h
+++ b/src/util-cpu.h
@@ -33,4 +33,6 @@ void UtilCpuPrintSummary(void);
 
 uint64_t UtilCpuGetTicks(void);
 
+void UtilCpuEnableSparcMisalignEmulation(void);
+
 #endif /* SURICATA_UTIL_CPU_H */

--- a/src/util-path.c
+++ b/src/util-path.c
@@ -196,7 +196,7 @@ bool SCPathExists(const char *path)
  */
 bool SCIsRegularDirectory(const struct dirent *const dir_entry)
 {
-#ifndef OS_WIN32
+#if !defined(OS_WIN32) && !defined(__sun)
     if ((dir_entry->d_type == DT_DIR) &&
         (strcmp(dir_entry->d_name, ".") != 0) &&
         (strcmp(dir_entry->d_name, "..") != 0)) {
@@ -214,7 +214,7 @@ bool SCIsRegularDirectory(const struct dirent *const dir_entry)
  */
 bool SCIsRegularFile(const struct dirent *const dir_entry)
 {
-#ifndef OS_WIN32
+#if defined(DT_REG)
     return dir_entry->d_type == DT_REG;
 #endif
     return false;

--- a/src/util-syslog.c
+++ b/src/util-syslog.c
@@ -28,12 +28,15 @@
 #include "util-syslog.h"
 
 /* holds the string-enum mapping for the syslog facility in SCLogOPIfaceCtx */
+// clang-format off
 SCEnumCharMap sc_syslog_facility_map[] = {
     { "auth",           LOG_AUTH },
     { "authpriv",       LOG_AUTHPRIV },
     { "cron",           LOG_CRON },
     { "daemon",         LOG_DAEMON },
+#if defined(LOG_FTP)
     { "ftp",            LOG_FTP },
+#endif
     { "kern",           LOG_KERN },
     { "lpr",            LOG_LPR },
     { "mail",           LOG_MAIL },
@@ -52,6 +55,7 @@ SCEnumCharMap sc_syslog_facility_map[] = {
     { "local7",         LOG_LOCAL7 },
     { NULL,             -1         }
 };
+// clang-format on
 
 /** \brief returns the syslog facility enum map */
 SCEnumCharMap *SCSyslogGetFacilityMap(void)

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -462,7 +462,7 @@ time_t SCMkTimeUtc (struct tm *tp)
     result += tp->tm_min;
     result *= 60;
     result += tp->tm_sec;
-#ifndef OS_WIN32
+#if !defined(OS_WIN32) && !defined(__sun)
     if (tp->tm_gmtoff)
         result -= tp->tm_gmtoff;
 #endif
@@ -497,7 +497,7 @@ int SCStringPatternToTime (char *string, const char **patterns, int num_patterns
         tp->tm_hour = tp->tm_min = tp->tm_sec = 0;
         tp->tm_year = tp->tm_mon = tp->tm_mday = tp->tm_wday = INT_MIN;
         tp->tm_isdst = -1;
-#ifndef OS_WIN32
+#if !defined(OS_WIN32) && !defined(__sun)
         tp->tm_gmtoff = 0;
         tp->tm_zone = NULL;
 #endif


### PR DESCRIPTION
Ticket: 7005

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7005

Describe changes:
- src/source-pcap-file-directory-helper.c, src/util-path.c: Solaris doesn't define d_type dirent member and DT_REG type.

- src/suricata.c: Fix alignment problems on SPARC. Based on similar fixes found at:
https://lists.debian.org/debian-sparc/2012/01/msg00012.html
and:
https://www.winehq.org/pipermail/wine-patches/2011-February/098547.html.
- src/suricata.c: Only Linux and the BSDs support the RLIMIT_NPROC resource limit.
- src/util-syslog.c: Solaris syslog.h doesn't define LOG_FTP.
- src/util-time.c: Solaris tm doesn't define tm_gmtoff member.
- sun macro replacement with __sun. sun is not defined when C++ standard is used.