### PR TITLE
 configure/qa-simulation: explicitly declare default - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -539,7 +539,7 @@
 
   # enable qa-simulation mode -- disabled by default
     AC_ARG_ENABLE(qa-simulation,
-           AS_HELP_STRING([--enable-qa-simulation], [Enable qa-simulation mode]))
+           AS_HELP_STRING([--enable-qa-simulation], [Enable qa-simulation mode]), [enable_qa_simulation=$enableval],[enable_qa_simulation=no])
     AS_IF([test "x$enable_qa_simulation" = "xyes"], [
         AC_DEFINE([QA_SIMULATION],[1],[Enable qa-simulation mode])
     ])


### PR DESCRIPTION
This is needed to generate the `--build-info` report.

Related to
Ticket #7885

(cherry picked from commit 41834f0a05d24253e332f28db30d3710d78d7c93)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
related to https://redmine.openinfosecfoundation.org/issues/7885

Describe changes:
- explicitly add the `no` for when `qa-simulation` is disabled, otherwise this won't show in the `build-info` report