### PR TITLE
Draft: detect/windows-pe: windows portable executable keyword and metadata

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -697,6 +697,12 @@ Fields:
 * "num_imports": Number of imported DLLs
 * "num_exports": Number of exported functions
 * "has_wx_section": Boolean, true if any section has both WRITE and EXECUTE permissions
+* "signed": Boolean, true if the PE has a non-empty Certificate Table (Authenticode-signed; not cryptographically verified)
+* "cert_subject": [optional] Subject of the embedded signing certificate
+* "cert_issuer": [optional] Issuer of the embedded signing certificate
+* "cert_serial": [optional] Serial number of the signing certificate (colon-separated hex)
+* "cert_thumbprint": [optional] SHA-1 thumbprint of the signing certificate (uppercase hex)
+* "file_version": [optional] FileVersion from the VERSIONINFO resource (``major.minor.build.revision``)
 * "export_name": [optional] Internal DLL name from the export directory
 * "imports": [optional] Array of imported DLL names (lowercase)
 * "sections_detail": [optional] Array of per-section objects, each containing:
@@ -742,6 +748,7 @@ Example ``fileinfo`` event with ``executable`` metadata::
         "num_imports": 3,
         "num_exports": 0,
         "has_wx_section": false,
+        "signed": false,
         "imports": ["kernel32.dll", "user32.dll", "ws2_32.dll"],
         "sections_detail": [
           {"name": ".text", "virtual_size": 8192, "virtual_address": 4096,

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -664,6 +664,106 @@ range `start` and `end` value are replicated in the ``fileinfo`` fields::
         fileinfo.start: 500
         fileinfo.end: 1000
 
+.. _eve-format-executable:
+
+Executable metadata
+^^^^^^^^^^^^^^^^^^^
+
+When a file is identified as a Windows PE executable, an ``executable`` object
+is added as a sibling to the ``fileinfo`` object in the event. This metadata is
+produced automatically for any file beginning with the ``MZ`` DOS header and
+containing a valid PE signature.
+
+Fields:
+
+* "type": Executable format identifier (always ``"windows_pe"``)
+* "arch": Machine type as a lowercase hex string (e.g., ``"0x014c"``, ``"0x8664"``)
+* "arch_name": Human-readable architecture (``"x86"``, ``"x86-64"``, ``"ARM"``, ``"ARM64"``, or ``"unknown"``)
+* "sections": Number of sections in the PE file
+* "subsystem": Human-readable subsystem name (``"WINDOWS_GUI"``, ``"WINDOWS_CUI"``, ``"NATIVE"``, etc.)
+* "subsystem_id": Numeric subsystem value
+* "characteristics": Raw COFF characteristics value
+* "characteristics_names": [optional] Array of decoded characteristic flags (``"EXECUTABLE_IMAGE"``, ``"DLL"``, ``"LARGE_ADDRESS_AWARE"``, ``"32BIT_MACHINE"``)
+* "dll_characteristics": Raw DLL characteristics value
+* "security_features": [optional] Array of decoded security feature names (``"HIGH_ENTROPY_VA"``, ``"DYNAMIC_BASE"``, ``"NX_COMPAT"``, ``"NO_SEH"``, ``"GUARD_CF"``)
+* "entry_point": AddressOfEntryPoint RVA
+* "size_of_image": Total mapped image size in bytes
+* "pe_offset": Offset of the PE signature within the file
+* "pe_type": PE format type (``"PE32"`` for 32-bit, ``"PE32+"`` for 64-bit)
+* "magic": Optional header magic value (267 for PE32, 523 for PE32+)
+* "timestamp": COFF TimeDateStamp (Unix epoch seconds)
+* "checksum": Optional header checksum (0 when not set)
+* "size_of_headers": Combined size of headers
+* "num_imports": Number of imported DLLs
+* "num_exports": Number of exported functions
+* "has_wx_section": Boolean, true if any section has both WRITE and EXECUTE permissions
+* "export_name": [optional] Internal DLL name from the export directory
+* "imports": [optional] Array of imported DLL names (lowercase)
+* "sections_detail": [optional] Array of per-section objects, each containing:
+
+  * "name": Section name (e.g., ``.text``, ``.data``)
+  * "virtual_size": Size when loaded into memory
+  * "virtual_address": RVA of the section
+  * "raw_data_size": Size on disk
+  * "characteristics": Raw section characteristics flags
+  * "wx": Boolean, true if the section is both writable and executable
+
+Example ``fileinfo`` event with ``executable`` metadata::
+
+    {
+      "event_type": "fileinfo",
+      "fileinfo": {
+        "filename": "sample.exe",
+        "size": 45056,
+        "state": "CLOSED",
+        "stored": false,
+        "gaps": false,
+        "tx_id": 0
+      },
+      "executable": {
+        "type": "windows_pe",
+        "arch": "0x014c",
+        "arch_name": "x86",
+        "sections": 3,
+        "subsystem": "WINDOWS_CUI",
+        "subsystem_id": 3,
+        "characteristics": 258,
+        "characteristics_names": ["EXECUTABLE_IMAGE", "32BIT_MACHINE"],
+        "dll_characteristics": 352,
+        "security_features": ["HIGH_ENTROPY_VA", "DYNAMIC_BASE", "NX_COMPAT"],
+        "entry_point": 4096,
+        "size_of_image": 45056,
+        "pe_offset": 64,
+        "pe_type": "PE32",
+        "magic": 267,
+        "timestamp": 1709856000,
+        "checksum": 0,
+        "size_of_headers": 512,
+        "num_imports": 3,
+        "num_exports": 0,
+        "has_wx_section": false,
+        "imports": ["kernel32.dll", "user32.dll", "ws2_32.dll"],
+        "sections_detail": [
+          {"name": ".text", "virtual_size": 8192, "virtual_address": 4096,
+           "raw_data_size": 8192, "characteristics": 1610612768, "wx": false},
+          {"name": ".rdata", "virtual_size": 4096, "virtual_address": 12288,
+           "raw_data_size": 4096, "characteristics": 1073741888, "wx": false},
+          {"name": ".data", "virtual_size": 4096, "virtual_address": 16384,
+           "raw_data_size": 4096, "characteristics": 3221225536, "wx": false}
+        ]
+      }
+    }
+
+.. note::
+
+   The ``imports``, ``sections_detail``, and ``export_name`` fields require
+   access to the raw file data at logging time. When the streaming buffer has
+   been pruned before logging, only the cached scalar metadata fields are
+   included.
+
+See also :ref:`windows_pe keyword <File Rule Keywords>` for detection rule
+syntax and options.
+
 .. _eve-format-http:
 
 Event type: HTTP

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -703,6 +703,7 @@ Fields:
 * "cert_serial": [optional] Serial number of the signing certificate (colon-separated hex)
 * "cert_thumbprint": [optional] SHA-1 thumbprint of the signing certificate (uppercase hex)
 * "file_version": [optional] FileVersion from the VERSIONINFO resource (``major.minor.build.revision``)
+* "version_info": [optional] Object of VERSIONINFO StringFileInfo key/value strings (e.g. ``CompanyName``, ``ProductName``, ``OriginalFilename``)
 * "export_name": [optional] Internal DLL name from the export directory
 * "imports": [optional] Array of imported DLL names (lowercase)
 * "sections_detail": [optional] Array of per-section objects, each containing:

--- a/doc/userguide/rules/file-keywords.rst
+++ b/doc/userguide/rules/file-keywords.rst
@@ -320,9 +320,46 @@ A valid Windows PE file consists of:
 * ``section_name``: Match if any section has the given name (case-insensitive, e.g., ``.text``, ``.UPX0``)
 * ``export_name``: Match the internal DLL name from the export directory (case-insensitive)
 * ``section_wx``: Flag - match if any section has both WRITE and EXECUTE permissions (no value needed)
+* ``signature``: Flag - match if the PE is Authenticode-signed (has a non-empty Certificate Table). Presence only; the signature is not cryptographically verified (no value needed)
+* ``cert_thumbprint``: Match the SHA-1 thumbprint of an embedded signing certificate - exact match, separator-insensitive (e.g. ``29D492AD...`` or ``29:D4:92:AD:...``)
+* ``cert_serial``: Match the serial number of an embedded signing certificate - exact match, separator-insensitive
+* ``cert_subject``: Match the subject of an embedded signing certificate - case-insensitive substring
+* ``cert_issuer``: Match the issuer of an embedded signing certificate - case-insensitive substring
+* ``file_version``: Match the FileVersion from the VERSIONINFO resource - dotted ``major.minor.build.revision`` with comparison operators and ranges (e.g. ``>6.1.0.0``, ``6.0.0.0-11.0.0.0``). Only matches files that carry a version resource
 * DLL names can be specified directly to match imported DLLs from the PE Import Directory Table - case-insensitive exact match, AND logic. Multiple DLLs can be comma-separated: ``ws2_32.dll, wininet.dll``
 
 All numeric options support comparison operators: ``<``, ``>``, and range notation (e.g., ``1000<>5000``).
+
+.. note::
+
+   The ``cert_*`` filters match the identity of a certificate *carried* by the
+   file; they do not verify the signature, so a matched thumbprint or serial only
+   tells you which certificate the file claims. This is the mechanism for tracking
+   files signed with a known-revoked or stolen code-signing certificate. The
+   Certificate Table and the ``.rsrc`` resource both typically sit near the end of
+   a PE, so ``cert_*`` and ``file_version`` only match once the file has been
+   fully reassembled from offset 0; the bare ``signature`` flag reads the header
+   only and works on a partial capture.
+
+.. note::
+
+   ``cert_*`` and ``file_version`` inspect data near the end of the file, so the
+   whole file must be buffered from its start when inspection runs. The defaults
+   truncate larger files before that data is reached, so these options silently
+   fail to match files above a few tens of KB unless the following are raised to
+   at least the largest PE you want to inspect (each adds memory per concurrent
+   file, so size them to your environment):
+
+   * ``app-layer.protocols.http.libhtp.default-config.response-body-limit``
+     (default 100 KiB) -- caps how much of the HTTP body is reassembled.
+   * ``app-layer.protocols.http.libhtp.default-config.response-body-minimal-inspect-size``
+     (default 40 KiB) -- defers inspection until this many bytes are buffered, so
+     the file is inspected in one pass from offset 0 instead of a sliding window.
+   * ``stream.reassembly.depth`` -- caps TCP stream reassembly.
+
+   For example, to inspect PEs up to 8 MB, set each of the three to ``8mb``. The
+   ``signature`` presence flag needs none of this. (SMTP file transfers have the
+   analogous ``content-inspect-min-size``/``content-inspect-window`` settings.)
 
 The keyword is typically used in conjunction with ``file.data`` and content matches to
 detect PE file characteristics.
@@ -489,6 +526,38 @@ Detect PE with a specific export DLL name (case-insensitive)::
       file.data; content:"MZ"; startswith; \
       windows_pe: export_name mydll.dll; \
       sid:18; rev:1;)
+
+Detect any Authenticode-signed PE (presence only)::
+
+  alert http any any -> any any (msg:"Signed PE download"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: signature; \
+      sid:19; rev:1;)
+
+Track a file signed with a known-bad certificate (by thumbprint)::
+
+  alert http any any -> any any (msg:"PE signed with revoked cert"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: cert_thumbprint 29D492AD11646EB10B9F0BC7CB816D4318C7F4D6; \
+      sid:20; rev:1;)
+
+Match a PE signed by a specific vendor (subject substring)::
+
+  alert http any any -> any any (msg:"PE signed by Acme"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: cert_subject "Acme Corp"; \
+      sid:21; rev:1;)
+
+Detect a PE whose FileVersion is below a patched build::
+
+  alert http any any -> any any (msg:"Outdated PE version"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: file_version <6.1.7601.17514; \
+      sid:22; rev:1;)
 
 **Threat Hunting Examples**
 

--- a/doc/userguide/rules/file-keywords.rst
+++ b/doc/userguide/rules/file-keywords.rst
@@ -10,7 +10,7 @@ properties. They depend on properly configured
 file.data
 ---------
 
-The ``file.data`` sticky buffer matches on contents of files that are 
+The ``file.data`` sticky buffer matches on contents of files that are
 seen in flows that Suricata evaluates. The various payload keywords can
 be used (e.g. ``startswith``, ``nocase`` and ``bsize``) with ``file.data``.
 
@@ -277,3 +277,367 @@ checked. This is because Suricata can know a file is bigger than a
 value (it has seen some of it already), but it can't know if the final
 size would have been within a range, an exact value or smaller than a
 value.
+
+windows_pe
+----------
+
+The ``windows_pe`` keyword is used for detecting Windows Portable Executable (PE) files
+in network traffic. PE files are the standard executable format for Windows operating
+systems and include .exe, .dll, .sys and other executable file types.
+
+**Structure of Windows PE Files**
+
+A valid Windows PE file consists of:
+
+1. **DOS Header**: Beginning with the "MZ" signature (0x4D 0x5A)
+2. **DOS Stub**: Legacy DOS program
+3. **PE Header**: Beginning with the "PE\\0\\0" signature (0x50 0x45 0x00 0x00)
+4. **COFF Header**: Contains machine type, number of sections, and other metadata
+5. **Optional Header**: Contains additional metadata about the executable
+6. **Section Headers**: Describe the sections (.text, .data, .rsrc, etc.)
+7. **Sections**: The actual code and data
+
+**Syntax**::
+
+  windows_pe;
+  windows_pe: [arch <arch>][, size <uint32>][, sections <uint16>]...;
+
+**Options**:
+
+* ``arch``: CPU architecture filter - ``x86``, ``x86_64``, ``arm``, ``arm64`` (optional, matches any if omitted)
+* ``size``: Match SizeOfImage field (total mapped bytes) - uint32 with comparison operators
+* ``sections``: Match NumberOfSections field (section count) - uint16 with comparison operators
+* ``entry_point``: Match AddressOfEntryPoint RVA - uint32 with comparison operators
+* ``subsystem``: Match PE subsystem type - uint16 value (2=GUI, 3=Console, 1=Native, etc.)
+* ``characteristics``: Match COFF characteristics field - uint16 numeric comparison (e.g., exact match ``0x2002``; this is NOT a bitmask test)
+* ``dll_characteristics``: Match DLL characteristics field - uint16 numeric comparison (e.g., ``0x0040``; NOT a bitmask test)
+* ``pe_type``: Match PE type - ``pe32`` (32-bit) or ``pe32+``/``pe64`` (64-bit)
+* ``timestamp``: Match COFF TimeDateStamp field (Unix epoch seconds) - uint32 with comparison operators
+* ``checksum``: Match optional header Checksum field - uint32 with comparison operators
+* ``size_of_headers``: Match SizeOfHeaders field (combined header size) - uint32 with comparison operators
+* ``num_imports``: Match number of imported DLLs - uint16 with comparison operators
+* ``num_exports``: Match number of exported functions - uint32 with comparison operators
+* ``section_name``: Match if any section has the given name (case-insensitive, e.g., ``.text``, ``.UPX0``)
+* ``export_name``: Match the internal DLL name from the export directory (case-insensitive)
+* ``section_wx``: Flag - match if any section has both WRITE and EXECUTE permissions (no value needed)
+* DLL names can be specified directly to match imported DLLs from the PE Import Directory Table - case-insensitive exact match, AND logic. Multiple DLLs can be comma-separated: ``ws2_32.dll, wininet.dll``
+
+All numeric options support comparison operators: ``<``, ``>``, and range notation (e.g., ``1000<>5000``).
+
+The keyword is typically used in conjunction with ``file.data`` and content matches to
+detect PE file characteristics.
+
+**Unified Keyword Syntax**
+
+The ``windows_pe`` keyword consolidates all PE metadata filtering into a single comma-separated option list.
+With no options, use the keyword alone (``windows_pe;``). With options, use ``key value`` pairs separated by commas::
+
+  windows_pe: arch x86_64, size >1000000, sections <8;
+
+To match a PE that imports a specific DLL::
+
+  windows_pe: ws2_32.dll;
+
+To match a PE that imports multiple DLLs (AND — all must be present)::
+
+  windows_pe: ws2_32.dll, wininet.dll;
+
+This unified approach consolidates all PE metadata filtering into a single keyword with multiple options.
+
+**Examples**
+
+Detect any Windows PE file download::
+
+  alert http any any -> any any (msg:"Windows PE file detected"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe; \
+      sid:1; rev:1;)
+
+Detect x86_64 PE files::
+
+  alert http any any -> any any (msg:"x86_64 PE detected"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: arch x86_64; \
+      sid:2; rev:1;)
+
+Detect PE file with specific size constraints::
+
+  alert http any any -> any any (msg:"Medium-sized PE"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: size 100000<>500000; \
+      sid:3; rev:1;)
+
+Detect PE files with few sections (possibly packed)::
+
+  alert http any any -> any any (msg:"Packed PE detected"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: sections <4; \
+      sid:4; rev:1;)
+
+Detect PE files with low entry point::
+
+  alert http any any -> any any (msg:"Low entry point PE"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: entry_point <4096; \
+      sid:5; rev:1;)
+
+Detect PE files with subsystem::
+
+  alert http any any -> any any (msg:"Console PE"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: subsystem 3; \
+      sid:6; rev:1;)
+
+Detect PE DLL files by characteristics (exact numeric match)::
+
+  alert http any any -> any any (msg:"PE DLL download"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: characteristics 0x2002; \
+      sid:7; rev:1;)
+
+Detect PE files without ASLR::
+
+  alert http any any -> any any (msg:"PE without ASLR"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: dll_characteristics <0x0040; \
+      sid:8; rev:1;)
+
+Detect PE files that import WS2_32.dll (Winsock networking)::
+
+  alert http any any -> any any (msg:"PE imports Winsock"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: ws2_32.dll; \
+      sid:10; rev:1;)
+
+Detect PE files that import WININET.dll (HTTP/FTP client)::
+
+  alert http any any -> any any (msg:"PE imports WinINet"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: wininet.dll; \
+      sid:11; rev:1;)
+
+Combined metadata example (all constraints in one keyword)::
+
+  alert http any any -> any any (msg:"Packed x64 PE"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: arch x86_64, size >100000, sections <4, entry_point <4096; \
+      sid:9; rev:1;)
+
+Detect 64-bit PE files only::
+
+  alert http any any -> any any (msg:"64-bit PE detected"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: pe_type pe32+; \
+      sid:12; rev:1;)
+
+Detect PE with zero checksum (not integrity-verified)::
+
+  alert http any any -> any any (msg:"PE with zero checksum"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: checksum 0; \
+      sid:13; rev:1;)
+
+Detect PE with writable+executable section (code injection indicator)::
+
+  alert http any any -> any any (msg:"PE with W+X section"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: section_wx; \
+      sid:14; rev:1;)
+
+Detect PE with many imports (potentially complex or suspicious)::
+
+  alert http any any -> any any (msg:"PE with many imports"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: num_imports >20; \
+      sid:15; rev:1;)
+
+Detect PE with a specific section name (packer indicator)::
+
+  alert http any any -> any any (msg:"PE with UPX section"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: section_name .UPX0; \
+      sid:16; rev:1;)
+
+Detect PE with exports (likely a DLL)::
+
+  alert http any any -> any any (msg:"PE with exports"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: num_exports >0; \
+      sid:17; rev:1;)
+
+Detect PE with a specific export DLL name (case-insensitive)::
+
+  alert http any any -> any any (msg:"PE exports as mydll.dll"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: export_name mydll.dll; \
+      sid:18; rev:1;)
+
+**Threat Hunting Examples**
+
+Detect unsigned or tampered drivers::
+
+  alert http any any -> any any (msg:"Unsigned driver detected"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: arch x86_64, characteristics 0x0002, subsystem 1; \
+      sid:100; rev:1;)
+
+Detect potentially malicious x86 utilities (no DEP/NX support)::
+
+  alert http any any -> any any (msg:"Suspicious x86 binary without DEP/NX"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: arch x86, dll_characteristics <0x0100; \
+      sid:101; rev:1;)
+
+Detect large DLLs (possible backdoor or trojan library)::
+
+  alert http any any -> any any (msg:"Abnormally large DLL download"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: characteristics 0x2000, size >50000000; \
+      sid:102; rev:1;)
+
+Detect uncommon ARM/ARM64 executables in HTTP traffic::
+
+  alert http any any -> any any (msg:"ARM executable in HTTP traffic"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: arch arm64; \
+      sid:103; rev:1;)
+
+Detect file with suspicious low entry point (code injection indicator)::
+
+  alert http any any -> any any (msg:"PE with suspicious low entry point"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: entry_point <512; \
+      sid:104; rev:1;)
+
+Detect all x86_64 PE files with ASLR disabled::
+
+  alert http any any -> any any (msg:"x86_64 PE without ASLR/DYNAMIC_BASE"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: arch x86_64, dll_characteristics <0x0040; \
+      sid:105; rev:1;)
+
+Detect PE with writable+executable section and networking imports (likely malware)::
+
+  alert http any any -> any any (msg:"W+X PE with Winsock"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: section_wx, ws2_32.dll; \
+      sid:106; rev:1;)
+
+Detect PE files with old timestamps (potentially backdated or anomalous)::
+
+  alert http any any -> any any (msg:"PE with old timestamp"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: timestamp <1000000000; \
+      sid:107; rev:1;)
+
+Detect packed PE with UPX section name::
+
+  alert http any any -> any any (msg:"UPX-packed PE"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: section_name .UPX0; \
+      sid:108; rev:1;)
+
+**Validation Requirements**
+
+For a file to be considered a valid PE file, it must satisfy:
+
+* **DOS Header Magic**: First 2 bytes must be "MZ" (0x4D 0x5A)
+* **Minimum Size**: At least 64 bytes for the DOS header
+* **PE Offset**: Valid offset at bytes 60-63 (little-endian) pointing to the PE signature
+* **PE Signature**: "PE\\0\\0" (0x50 0x45 0x00 0x00) at the PE offset location
+* **Reasonable Bounds**: PE offset must be within the file size and not exceed 0x10000
+
+**Understanding PE Metadata in Logs**
+
+When a PE file is detected, the following metadata fields are logged to eve.json for analysis:
+
+* ``type`` - Executable format type identifier (always ``"windows_pe"`` for this keyword)
+* ``arch`` - The machine type/CPU architecture as a hex string (e.g., ``"0x014c"`` for x86)
+* ``arch_name`` - Human-readable architecture name (e.g., ``"x86"``, ``"x86-64"``, ``"ARM"``, ``"ARM64"``, or ``"unknown"``)
+* ``subsystem`` - Human-readable application subsystem name (e.g., ``"WINDOWS_GUI"``, ``"WINDOWS_CUI"``, ``"NATIVE"``)
+* ``subsystem_id`` - Numeric subsystem value
+* ``sections`` - Number of sections in the file
+* ``characteristics`` and ``characteristics_names`` - COFF flags (EXECUTABLE_IMAGE, DLL, etc.)
+* ``dll_characteristics`` - Raw DLL characteristics value
+* ``security_features`` - Array of human-readable security feature names decoded from dll_characteristics (HIGH_ENTROPY_VA, DYNAMIC_BASE, NX_COMPAT, NO_SEH, GUARD_CF)
+* ``entry_point`` - AddressOfEntryPoint RVA
+* ``size_of_image`` - Total mapped size
+* ``pe_offset`` - Location of PE signature in file (typically 0x40; unusual values may indicate malformed or tampered files)
+* ``pe_type`` - PE type: ``"PE32"`` (32-bit) or ``"PE32+"`` (64-bit)
+* ``magic`` - Optional header magic value (267=PE32, 523=PE32+)
+* ``timestamp`` - TimeDateStamp from the COFF header (Unix epoch seconds)
+* ``checksum`` - Checksum from the optional header (0 when not set)
+* ``size_of_headers`` - Combined size of DOS stub, PE header, and section headers
+* ``num_imports`` - Number of imported DLLs
+* ``num_exports`` - Number of exported functions
+* ``has_wx_section`` - Boolean: true if any section has both WRITE and EXECUTE permissions
+* ``export_name`` - Internal DLL name from the export directory table (when present)
+* ``imports`` - Array of imported DLL names (lowercase)
+* ``sections_detail`` - Array of per-section details (name, virtual_size, virtual_address, raw_data_size, characteristics, wx flag)
+
+**Note on ``pe_offset`` for Threat Hunting**: While logged, ``pe_offset`` has limited matching utility. Values outside the normal range (0x40-0x1000) are rare and primarily useful in forensic analysis of polyglot files or suspected packing. It is not recommended as a matching criterion in detection rules.
+
+**Use Cases**
+
+* **Malware Detection**: Identify potential malware executables in HTTP/SMTP/FTP traffic
+* **Policy Enforcement**: Block executable downloads in corporate environments
+* **Threat Hunting**: Track PE file transfers for forensic analysis
+* **File Classification**: Categorize and log Windows executable traffic
+* **Incident Response**: Detect lateral movement via executable transfers
+
+**Performance Considerations**
+
+* Use ``windows_pe`` with ``file.data`` buffer for optimal performance
+* Combine with ``content:"MZ"; startswith;`` to leverage the MPM (multi-pattern
+  matcher) for efficient pre-filtering before PE validation
+* Consider using ``filesize`` to avoid processing very large files
+* Works best with proper file extraction configuration
+
+**Supported Protocols**
+
+The ``windows_pe`` keyword can be used with any protocol that supports file extraction:
+
+* HTTP/HTTPS
+* SMTP
+* FTP
+* SMB
+* NFS
+
+---
+
+**Related Keywords**
+
+* ``file.data`` - The buffer containing file data to inspect
+* ``file.name`` - Match on the filename
+* ``file.magic`` - Match on libmagic file type information
+* ``filesize`` - Match on file size
+* ``filestore`` - Store matched files to disk
+* ``fileext`` - Match on file extension
+* ``entropy`` - Analyze entropy of buffered data (can be used with executable metadata)

--- a/doc/userguide/rules/file-keywords.rst
+++ b/doc/userguide/rules/file-keywords.rst
@@ -326,6 +326,7 @@ A valid Windows PE file consists of:
 * ``cert_subject``: Match the subject of an embedded signing certificate - case-insensitive substring
 * ``cert_issuer``: Match the issuer of an embedded signing certificate - case-insensitive substring
 * ``file_version``: Match the FileVersion from the VERSIONINFO resource - dotted ``major.minor.build.revision`` with comparison operators and ranges (e.g. ``>6.1.0.0``, ``6.0.0.0-11.0.0.0``). Only matches files that carry a version resource
+* ``version_info``: Match a VERSIONINFO StringFileInfo string (``CompanyName``, ``ProductName``, ``OriginalFilename``, ``FileVersion``, etc.). Each entry is matched as ``Key: Value``, so the value can match a key, a value, or both. The value is a case-insensitive substring, or a regex when written ``/pattern/flags`` (flags ``i``/``s``/``m``/``x``)
 * DLL names can be specified directly to match imported DLLs from the PE Import Directory Table - case-insensitive exact match, AND logic. Multiple DLLs can be comma-separated: ``ws2_32.dll, wininet.dll``
 
 All numeric options support comparison operators: ``<``, ``>``, and range notation (e.g., ``1000<>5000``).
@@ -337,13 +338,23 @@ All numeric options support comparison operators: ``<``, ``>``, and range notati
    tells you which certificate the file claims. This is the mechanism for tracking
    files signed with a known-revoked or stolen code-signing certificate. The
    Certificate Table and the ``.rsrc`` resource both typically sit near the end of
-   a PE, so ``cert_*`` and ``file_version`` only match once the file has been
-   fully reassembled from offset 0; the bare ``signature`` flag reads the header
-   only and works on a partial capture.
+   a PE, so ``cert_*``, ``file_version`` and ``version_info`` only match once the
+   file has been fully reassembled from offset 0; the bare ``signature`` flag reads
+   the header only and works on a partial capture.
 
 .. note::
 
-   ``cert_*`` and ``file_version`` inspect data near the end of the file, so the
+   A ``version_info`` filter matches if *any* StringFileInfo entry matches.
+   Multiple ``version_info`` options are ANDed (each must match some entry, possibly
+   a different one), while a single regex with alternation gives OR
+   (``version_info: "/(CompanyA|CompanyB)/i"``). A regex is matched per entry, so it
+   cannot require two different fields at once (the ``regex`` crate has no
+   lookaround/backreferences); use two ``version_info`` options for that. For full
+   PCRE, use the ``pcre`` keyword on ``file.data``.
+
+.. note::
+
+   ``cert_*``, ``file_version`` and ``version_info`` inspect data near the end of the file, so the
    whole file must be buffered from its start when inspection runs. The defaults
    truncate larger files before that data is reached, so these options silently
    fail to match files above a few tens of KB unless the following are raised to
@@ -558,6 +569,22 @@ Detect a PE whose FileVersion is below a patched build::
       file.data; content:"MZ"; startswith; \
       windows_pe: file_version <6.1.7601.17514; \
       sid:22; rev:1;)
+
+Detect a PE claiming a specific vendor in its version info::
+
+  alert http any any -> any any (msg:"PE version info vendor"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: version_info "CompanyName: Acme Software"; \
+      sid:23; rev:1;)
+
+Detect a screensaver original filename via regex (masquerading)::
+
+  alert http any any -> any any (msg:"PE OriginalFilename .scr"; \
+      flow:established,to_client; \
+      file.data; content:"MZ"; startswith; \
+      windows_pe: version_info "/OriginalFilename: .*\\.scr$/i"; \
+      sid:24; rev:1;)
 
 **Threat Hunting Examples**
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -19,7 +19,8 @@
                 "context": {
                     "type": "object",
                     "additionalProperties": true,
-                    "description": "Extra context data created by keywords such as dataset with JSON"
+                    "description":
+                            "Extra context data created by keywords such as dataset with JSON"
                 },
                 "engine": {
                     "type": "string",
@@ -191,14 +192,16 @@
         },
         "app_proto_expected": {
             "type": "string",
-            "description": "In case of a protocol change to a specific protocol, and this specific protocol was not recognised, this field will have the value of the expected protocol",
+            "description":
+                    "In case of a protocol change to a specific protocol, and this specific protocol was not recognised, this field will have the value of the expected protocol",
             "suricata": {
                 "$comment": "TODO implement keyword app-layer-protocol option"
             }
         },
         "app_proto_orig": {
             "type": "string",
-            "description": "Original application layer protocol of the flow after a protocol change",
+            "description":
+                    "Original application layer protocol of the flow after a protocol change",
             "suricata": {
                 "keywords": [
                     "app-layer-protocol"
@@ -1879,6 +1882,233 @@
         "event_type": {
             "type": "string"
         },
+        "executable": {
+            "type": "object",
+            "description": "[optional] Metadata from Windows Portable Executable (PE) files",
+            "additionalProperties": false,
+            "properties": {
+                "arch": {
+                    "type": "string",
+                    "description":
+                            "Machine type/architecture as hex string (e.g., \"0x14c\" for x86, \"0x8664\" for x86_64, \"0x1c0\" for ARM, \"0xaa64\" for ARM64)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "arch_name": {
+                    "type": "string",
+                    "description":
+                            "Human-readable architecture name derived from machine type (e.g., x86, x86-64, ARM, ARM64, or unknown)"
+                },
+                "characteristics": {
+                    "type": "integer",
+                    "description":
+                            "COFF characteristics flags (e.g., 0x0002 for EXECUTABLE_IMAGE, 0x2000 for DLL)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "characteristics_names": {
+                    "type": "array",
+                    "description":
+                            "Human-readable COFF characteristics (EXECUTABLE_IMAGE, DLL, LARGE_ADDRESS_AWARE, 32BIT_MACHINE)",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "checksum": {
+                    "type": "integer",
+                    "description": "Checksum from the optional header",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "dll_characteristics": {
+                    "type": "integer",
+                    "description":
+                            "DLL characteristics flags / security features (e.g., 0x0040 for ASLR, 0x0100 for DEP)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "entry_point": {
+                    "type": "integer",
+                    "description": "AddressOfEntryPoint RVA (Relative Virtual Address)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "export_name": {
+                    "type": "string",
+                    "description": "Internal DLL name from the export directory table",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "has_wx_section": {
+                    "type": "boolean",
+                    "description":
+                            "True if any section has both WRITE and EXECUTE permissions (suspicious)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "imports": {
+                    "type": "array",
+                    "description":
+                            "List of DLL names imported by the PE file (from the Import Directory Table)",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "magic": {
+                    "type": "integer",
+                    "description": "Optional header magic value (0x10b=PE32, 0x20b=PE32+)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "num_exports": {
+                    "type": "integer",
+                    "description": "Number of exported functions",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "num_imports": {
+                    "type": "integer",
+                    "description": "Number of imported DLLs",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "pe_offset": {
+                    "type": "integer",
+                    "description": "Offset to the PE signature in the file"
+                },
+                "pe_type": {
+                    "type": "string",
+                    "description": "PE type: PE32 (32-bit) or PE32+ (64-bit)"
+                },
+                "sections": {
+                    "type": "integer",
+                    "description": "Number of sections in the PE file",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "sections_detail": {
+                    "type": "array",
+                    "description": "Detailed per-section information",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "characteristics": {
+                                "type": "integer",
+                                "description": "Section characteristics flags"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Section name (up to 8 characters)"
+                            },
+                            "raw_data_size": {
+                                "type": "integer",
+                                "description": "Size of raw data on disk"
+                            },
+                            "virtual_address": {
+                                "type": "integer",
+                                "description": "Virtual address (RVA) of the section"
+                            },
+                            "virtual_size": {
+                                "type": "integer",
+                                "description": "Virtual size of the section"
+                            },
+                            "wx": {
+                                "type": "boolean",
+                                "description":
+                                        "True if section has both WRITE and EXECUTE permissions"
+                            }
+                        }
+                    }
+                },
+                "security_features": {
+                    "type": "array",
+                    "description":
+                            "Human-readable security features (HIGH_ENTROPY_VA, DYNAMIC_BASE, NX_COMPAT, NO_SEH, GUARD_CF)",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size_of_headers": {
+                    "type": "integer",
+                    "description":
+                            "Combined size of DOS stub, PE header, and section headers rounded to FileAlignment",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "size_of_image": {
+                    "type": "integer",
+                    "description": "SizeOfImage field (total mapped size of the PE)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "subsystem": {
+                    "type": "string",
+                    "description": "PE subsystem (e.g., WINDOWS_GUI, WINDOWS_CUI, NATIVE)"
+                },
+                "subsystem_id": {
+                    "type": "integer",
+                    "description": "Numeric subsystem ID (2=GUI, 3=Console, 1=Native, etc.)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "timestamp": {
+                    "type": "integer",
+                    "description": "TimeDateStamp from COFF header (Unix epoch seconds)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Executable format type identifier (e.g., \"windows_pe\")"
+                }
+            }
+        },
         "fileinfo": {
             "type": "object",
             "additionalProperties": false,
@@ -1946,7 +2176,8 @@
                 },
                 "storing": {
                     "type": "boolean",
-                    "description": "Indicates whether the file is in the process of being stored; true when not yet stored"
+                    "description":
+                            "Indicates whether the file is in the process of being stored; true when not yet stored"
                 },
                 "tx_id": {
                     "type": "integer",
@@ -1963,6 +2194,117 @@
                 "properties": {
                     "end": {
                         "type": "integer"
+                    },
+                    "executable": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "arch": {
+                                "type": "string"
+                            },
+                            "arch_name": {
+                                "type": "string"
+                            },
+                            "characteristics": {
+                                "type": "integer"
+                            },
+                            "characteristics_names": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "checksum": {
+                                "type": "integer"
+                            },
+                            "dll_characteristics": {
+                                "type": "integer"
+                            },
+                            "entry_point": {
+                                "type": "integer"
+                            },
+                            "export_name": {
+                                "type": "string"
+                            },
+                            "has_wx_section": {
+                                "type": "boolean"
+                            },
+                            "imports": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "magic": {
+                                "type": "integer"
+                            },
+                            "num_exports": {
+                                "type": "integer"
+                            },
+                            "num_imports": {
+                                "type": "integer"
+                            },
+                            "pe_offset": {
+                                "type": "integer"
+                            },
+                            "pe_type": {
+                                "type": "string"
+                            },
+                            "sections": {
+                                "type": "integer"
+                            },
+                            "sections_detail": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "characteristics": {
+                                            "type": "integer"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "raw_data_size": {
+                                            "type": "integer"
+                                        },
+                                        "virtual_address": {
+                                            "type": "integer"
+                                        },
+                                        "virtual_size": {
+                                            "type": "integer"
+                                        },
+                                        "wx": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            },
+                            "security_features": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "size_of_headers": {
+                                "type": "integer"
+                            },
+                            "size_of_image": {
+                                "type": "integer"
+                            },
+                            "subsystem": {
+                                "type": "string"
+                            },
+                            "subsystem_id": {
+                                "type": "integer"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "file_id": {
                         "type": "integer"
@@ -2338,7 +2680,8 @@
                     "description": "The domain name of the server, the Host header",
                     "suricata": {
                         "keywords": [
-                            "http.host", "http.host.raw"
+                            "http.host",
+                            "http.host.raw"
                         ]
                     }
                 },
@@ -2429,7 +2772,8 @@
                 },
                 "http_content_type": {
                     "type": "string",
-                    "description": "The media type of the resource or data, the Content-Type header",
+                    "description":
+                            "The media type of the resource or data, the Content-Type header",
                     "suricata": {
                         "keywords": [
                             "http.content_type"
@@ -2451,7 +2795,8 @@
                 },
                 "http_refer": {
                     "type": "string",
-                    "description": "An absolute or partial address of the web page that makes the request, the Referer header",
+                    "description":
+                            "An absolute or partial address of the web page that makes the request, the Referer header",
                     "suricata": {
                         "keywords": [
                             "http.referer"
@@ -2486,7 +2831,8 @@
                 },
                 "http_user_agent": {
                     "type": "string",
-                    "description": "A characteristic string that lets servers and network peers identify the application, operating system, vendor, and/or version of the requesting user agent, the User-Agent header",
+                    "description":
+                            "A characteristic string that lets servers and network peers identify the application, operating system, vendor, and/or version of the requesting user agent, the User-Agent header",
                     "suricata": {
                         "keywords": [
                             "http.user_agent"
@@ -2586,7 +2932,9 @@
                     "description": "The HTTP request URI",
                     "suricata": {
                         "keywords": [
-                            "http.uri", "http.uri.raw", "urilen"
+                            "http.uri",
+                            "http.uri.raw",
+                            "urilen"
                         ]
                     }
                 },
@@ -2596,7 +2944,8 @@
                 },
                 "xff": {
                     "type": "string",
-                    "description": "A de-facto standard header for identifying the originating IP address of a client connecting to a web server through a proxy server, the X-Forwarded-For header request header"
+                    "description":
+                            "A de-facto standard header for identifying the originating IP address of a client connecting to a web server through a proxy server, the X-Forwarded-For header request header"
                 }
             }
         },
@@ -2661,7 +3010,10 @@
                                 ]
                             },
                             "raw": {
-                                "type": ["string", "number"]
+                                "type": [
+                                    "string",
+                                    "number"
+                                ]
                             },
                             "value": {
                                 "type": "string"
@@ -2730,7 +3082,10 @@
                                                 ]
                                             },
                                             "raw": {
-                                                "type": ["string", "number"]
+                                                "type": [
+                                                    "string",
+                                                    "number"
+                                                ]
                                             },
                                             "value": {
                                                 "type": "string"
@@ -2901,7 +3256,8 @@
                 },
                 "weak_encryption": {
                     "type": "boolean",
-                    "description": "Whether the encryption used in AS-REP or TGS-REP is a weak cipher",
+                    "description":
+                            "Whether the encryption used in AS-REP or TGS-REP is a weak cipher",
                     "suricata": {
                         "$comment": "TODO add keyword (rather option for encryption keyword)"
                     }
@@ -3803,7 +4159,8 @@
                             "rrname_truncated": {
                                 "description": "Name was truncated by Suricata due to length",
                                 "type": "boolean",
-                                "$comment": "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
+                                "$comment":
+                                        "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
                             },
                             "txt": {
                                 "type": "array",
@@ -3847,7 +4204,8 @@
                             "rrname_truncated": {
                                 "description": "Name was truncated by Suricata due to length",
                                 "type": "boolean",
-                                "$comment": "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
+                                "$comment":
+                                        "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
                             },
                             "txt": {
                                 "type": "array",
@@ -3881,7 +4239,8 @@
                             "rrname_truncated": {
                                 "description": "Name was truncated by Suricata due to length",
                                 "type": "boolean",
-                                "$comment": "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
+                                "$comment":
+                                        "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
                             }
                         }
                     }
@@ -3951,10 +4310,11 @@
                             "rrname_truncated": {
                                 "description": "Name was truncated by Suricata due to length",
                                 "type": "boolean",
-                                "$comment": "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
+                                "$comment":
+                                        "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
                             },
                             "rrtype": {
-                                "type": "string", 
+                                "type": "string",
                                 "description": "Type of resource being requested"
                             }
                         }
@@ -4799,7 +5159,8 @@
             "properties": {
                 "age": {
                     "type": "integer",
-                    "description": "Duration of the flow (measured from timestamp of last packet and first packet)",
+                    "description":
+                            "Duration of the flow (measured from timestamp of last packet and first packet)",
                     "suricata": {
                         "keywords": [
                             "flow.age"
@@ -4846,7 +5207,8 @@
                 },
                 "tx_cnt": {
                     "type": "integer",
-                    "description": "Number of transactions seen in the flow (only present if flow has an application layer)"
+                    "description":
+                            "Number of transactions seen in the flow (only present if flow has an application layer)"
                 }
             }
         },
@@ -5029,11 +5391,13 @@
                             "properties": {
                                 "data_size": {
                                     "type": "integer",
-                                    "description": "Accumulated data size of all CopyData messages sent"
+                                    "description":
+                                            "Accumulated data size of all CopyData messages sent"
                                 },
                                 "msg_count": {
                                     "type": "integer",
-                                    "description": "How many CopyData messages were sent (does not necessarily match number of rows from the query)"
+                                    "description":
+                                            "How many CopyData messages were sent (does not necessarily match number of rows from the query)"
                                 }
                             }
                         },
@@ -5134,7 +5498,8 @@
                             "properties": {
                                 "data_size": {
                                     "type": "integer",
-                                    "description": "Accumulated data size of all CopyData messages sent"
+                                    "description":
+                                            "Accumulated data size of all CopyData messages sent"
                                 },
                                 "row_count": {
                                     "type": "integer",
@@ -5149,7 +5514,8 @@
                             "properties": {
                                 "columns": {
                                     "type": "integer",
-                                    "description": "Number of columns that will be copied in the CopyData message"
+                                    "description":
+                                            "Number of columns that will be copied in the CopyData message"
                                 }
                             }
                         },
@@ -5160,7 +5526,8 @@
                             "properties": {
                                 "columns": {
                                     "type": "integer",
-                                    "description": "Number of columns that will be copied in the CopyData message"
+                                    "description":
+                                            "Number of columns that will be copied in the CopyData message"
                                 }
                             }
                         },
@@ -6273,7 +6640,8 @@
             "properties": {
                 "app_layer": {
                     "type": "object",
-                    "description": "Module with observational and performance-related statistics from application layer protocol parsers and flows",
+                    "description":
+                            "Module with observational and performance-related statistics from application layer protocol parsers and flows",
                     "additionalProperties": false,
                     "properties": {
                         "error": {
@@ -6835,7 +7203,7 @@
                 },
                 "capture": {
                     "type": "object",
-                    "description":"Observational statistics for packet capture module",
+                    "description": "Observational statistics for packet capture module",
                     "additionalProperties": false,
                     "properties": {
                         "afpacket": {
@@ -6868,7 +7236,8 @@
                         },
                         "errors": {
                             "type": "integer",
-                            "description": "Number of Suricata errors reported while reading capture module"
+                            "description":
+                                    "Number of Suricata errors reported while reading capture module"
                         },
                         "kernel_drops": {
                             "type": "integer",
@@ -6943,7 +7312,8 @@
                                     "properties": {
                                         "invalid_hardware_size": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with invalid hardware size (valid size is 6)"
+                                            "description":
+                                                    "Number of ARP packets with invalid hardware size (valid size is 6)"
                                         },
                                         "invalid_pkt": {
                                             "type": "integer",
@@ -6951,23 +7321,28 @@
                                         },
                                         "invalid_protocol_size": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with invalid protocol size (valid size is 4)"
+                                            "description":
+                                                    "Number of ARP packets with invalid protocol size (valid size is 4)"
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with header length too small"
+                                            "description":
+                                                    "Number of ARP packets with header length too small"
                                         },
                                         "unsupported_hardware": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with unsupported hardware"
+                                            "description":
+                                                    "Number of ARP packets with unsupported hardware"
                                         },
                                         "unsupported_opcode": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with unsupported Operation Codes"
+                                            "description":
+                                                    "Number of ARP packets with unsupported Operation Codes"
                                         },
                                         "unsupported_protocol": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with unsupported protocol"
+                                            "description":
+                                                    "Number of ARP packets with unsupported protocol"
                                         }
                                     }
                                 },
@@ -6997,15 +7372,18 @@
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer",
-                                            "description": "Number of packets with header too small for ERSPAN"
+                                            "description":
+                                                    "Number of packets with header too small for ERSPAN"
                                         },
                                         "too_many_vlan_layers": {
                                             "type": "integer",
-                                            "description": "Number of packets with too many VLAN layers for ERSPAN"
+                                            "description":
+                                                    "Number of packets with too many VLAN layers for ERSPAN"
                                         },
                                         "unsupported_version": {
                                             "type": "integer",
-                                            "description": "Number of packets with unsupported version for ERSPAN"
+                                            "description":
+                                                    "Number of packets with unsupported version for ERSPAN"
                                         }
                                     }
                                 },
@@ -7025,11 +7403,13 @@
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer",
-                                            "description": "Number of packets with header too small for ETAG"
+                                            "description":
+                                                    "Number of packets with header too small for ETAG"
                                         },
                                         "unknown_type": {
                                             "type": "integer",
-                                            "description": "Number of ETAG packets with unknown type"
+                                            "description":
+                                                    "Number of ETAG packets with unknown type"
                                         }
                                     }
                                 },
@@ -7039,11 +7419,13 @@
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "Number of packets too small for Ethernet"
+                                            "description":
+                                                    "Number of packets too small for Ethernet"
                                         },
                                         "unknown_ethertype": {
                                             "type": "integer",
-                                            "description": "Number of packets with Unkonwn Ethertype for Ethernet"
+                                            "description":
+                                                    "Number of packets with Unkonwn Ethertype for Ethernet"
                                         }
                                     }
                                 },
@@ -7053,7 +7435,8 @@
                                     "properties": {
                                         "unknown_payload_type": {
                                             "type": "integer",
-                                            "description": "Number of packets with unknown payload type for Geneve"
+                                            "description":
+                                                    "Number of packets with unknown payload type for Geneve"
                                         }
                                     }
                                 },
@@ -7067,59 +7450,73 @@
                                         },
                                         "version0_flags": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 0 flags set for GRE"
+                                            "description":
+                                                    "Number of packets with version 0 flags set for GRE"
                                         },
                                         "version0_hdr_too_big": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 0 and header too big for GRE"
+                                            "description":
+                                                    "Number of packets with version 0 and header too big for GRE"
                                         },
                                         "version0_malformed_sre_hdr": {
                                             "type": "integer",
-                                            "description": "Number of packets of with version 0 and malformed SRE header for GRE"
+                                            "description":
+                                                    "Number of packets of with version 0 and malformed SRE header for GRE"
                                         },
                                         "version0_recur": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 0 and flag recursion control set for GRE"
+                                            "description":
+                                                    "Number of packets with version 0 and flag recursion control set for GRE"
                                         },
                                         "version1_chksum": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and checksum flag set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and checksum flag set for GRE"
                                         },
                                         "version1_flags": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 flags set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 flags set for GRE"
                                         },
                                         "version1_hdr_too_big": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and header too big for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and header too big for GRE"
                                         },
                                         "version1_malformed_sre_hdr": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and malformed SRE header for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and malformed SRE header for GRE"
                                         },
                                         "version1_no_key": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and no key flag set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and no key flag set for GRE"
                                         },
                                         "version1_recur": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and flag recursion control set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and flag recursion control set for GRE"
                                         },
                                         "version1_route": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and flag route set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and flag route set for GRE"
                                         },
                                         "version1_ssr": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and flag SSR set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and flag SSR set for GRE"
                                         },
                                         "version1_wrong_protocol": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and wrong protocol set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and wrong protocol set for GRE"
                                         },
                                         "wrong_version": {
                                             "type": "integer",
-                                            "description": "Number of packets with wrong version set for GRE"
+                                            "description":
+                                                    "Number of packets with wrong version set for GRE"
                                         }
                                     }
                                 },
@@ -7133,7 +7530,8 @@
                                         },
                                         "ipv4_unknown_ver": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv4 packets with unknown version"
+                                            "description":
+                                                    "Number of ICMPv4 packets with unknown version"
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
@@ -7141,11 +7539,13 @@
                                         },
                                         "unknown_code": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv4 packets with unknown code"
+                                            "description":
+                                                    "Number of ICMPv4 packets with unknown code"
                                         },
                                         "unknown_type": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv4 packets with unknown type"
+                                            "description":
+                                                    "Number of ICMPv4 packets with unknown type"
                                         }
                                     }
                                 },
@@ -7155,7 +7555,8 @@
                                     "properties": {
                                         "experimentation_type": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with private experimentation type"
+                                            "description":
+                                                    "Number of ICMPv6 packets with private experimentation type"
                                         },
                                         "ipv6_trunc_pkt": {
                                             "type": "integer",
@@ -7163,11 +7564,13 @@
                                         },
                                         "ipv6_unknown_version": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with unknown version"
+                                            "description":
+                                                    "Number of ICMPv6 packets with unknown version"
                                         },
                                         "mld_message_with_invalid_hl": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with MLD messages and invalid HL (not 1)"
+                                            "description":
+                                                    "Number of ICMPv6 packets with MLD messages and invalid HL (not 1)"
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
@@ -7175,15 +7578,18 @@
                                         },
                                         "unassigned_type": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with unassigned type"
+                                            "description":
+                                                    "Number of ICMPv6 packets with unassigned type"
                                         },
                                         "unknown_code": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with unknown code"
+                                            "description":
+                                                    "Number of ICMPv6 packets with unknown code"
                                         },
                                         "unknown_type": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with unknown type"
+                                            "description":
+                                                    "Number of ICMPv6 packets with unknown type"
                                         }
                                     }
                                 },
@@ -7193,7 +7599,8 @@
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer",
-                                            "description": "Number of IEEE802.1ah packets with header too small"
+                                            "description":
+                                                    "Number of IEEE802.1ah packets with header too small"
                                         }
                                     }
                                 },
@@ -7207,11 +7614,13 @@
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "IGMP packets too small to fit a IGMP header"
+                                            "description":
+                                                    "IGMP packets too small to fit a IGMP header"
                                         },
                                         "v3_pkt_too_small": {
                                             "type": "integer",
-                                            "description": "IGMPv3 packets too small to fit a IGMP header"
+                                            "description":
+                                                    "IGMPv3 packets too small to fit a IGMP header"
                                         }
                                     }
                                 },
@@ -7221,7 +7630,8 @@
                                     "properties": {
                                         "invalid_ip_version": {
                                             "type": "integer",
-                                            "description": "Number of RAW packets with invalid IP version"
+                                            "description":
+                                                    "Number of RAW packets with invalid IP version"
                                         }
                                     }
                                 },
@@ -7231,71 +7641,88 @@
                                     "properties": {
                                         "frag_ignored": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 fragments ignored due to resource allocation errors"
+                                            "description":
+                                                    "Number of IPv6 fragments ignored due to resource allocation errors"
                                         },
                                         "frag_overlap": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 fragments with overlapping data"
+                                            "description":
+                                                    "Number of IPv4 fragments with overlapping data"
                                         },
                                         "frag_pkt_too_large": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 fragments ignored due to being too large"
+                                            "description":
+                                                    "Number of IPv4 fragments ignored due to being too large"
                                         },
                                         "hlen_too_small": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to header smaller than minimum size"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to header smaller than minimum size"
                                         },
                                         "icmpv6": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to having an ICMPV6 header"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to having an ICMPV6 header"
                                         },
                                         "iplen_smaller_than_hlen": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to length being smaller than IP header size"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to length being smaller than IP header size"
                                         },
                                         "opt_duplicate": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets with duplicated IP options"
+                                            "description":
+                                                    "Number of IPv4 packets with duplicated IP options"
                                         },
                                         "opt_eol_required": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets with 'end of list' option not present, but required, in IP options"
+                                            "description":
+                                                    "Number of IPv4 packets with 'end of list' option not present, but required, in IP options"
                                         },
                                         "opt_invalid": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets with invalid IP options"
+                                            "description":
+                                                    "Number of IPv4 packets with invalid IP options"
                                         },
                                         "opt_invalid_len": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to IP options with invalid length"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to IP options with invalid length"
                                         },
                                         "opt_malformed": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to malformed IP options"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to malformed IP options"
                                         },
                                         "opt_pad_required": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets with padding bytes required in IP options"
+                                            "description":
+                                                    "Number of IPv4 packets with padding bytes required in IP options"
                                         },
                                         "opt_unknown": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to unknown IP option"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to unknown IP option"
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to size smaller than minimum header size"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to size smaller than minimum header size"
                                         },
                                         "trunc_pkt": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to truncated packet"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to truncated packet"
                                         },
                                         "unknown_protocol": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets with unknown protocol"
+                                            "description":
+                                                    "Number of IPv4 packets with unknown protocol"
                                         },
                                         "wrong_ip_version": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to having wrong IP version in IP options"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to having wrong IP version in IP options"
                                         }
                                     }
                                 },
@@ -7305,127 +7732,158 @@
                                     "properties": {
                                         "data_after_none_header": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with data after the 'none' header"
+                                            "description":
+                                                    "Number of IPv6 packets with data after the 'none' header"
                                         },
                                         "dstopts_only_padding": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with all DST options as only padding"
+                                            "description":
+                                                    "Number of IPv6 packets with all DST options as only padding"
                                         },
                                         "dstopts_unknown_opt": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with unknown DST option"
+                                            "description":
+                                                    "Number of IPv6 packets with unknown DST option"
                                         },
                                         "exthdr_ah_res_not_null": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with AH header reserved fields not null"
+                                            "description":
+                                                    "Number of IPv6 packets with AH header reserved fields not null"
                                         },
                                         "exthdr_dupl_ah": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated 'authentication' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated 'authentication' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_dh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated 'destination' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated 'destination' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_eh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated 'ESP' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated 'ESP' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_fh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated 'fragment' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated 'fragment' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_hh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated 'hop-by-hop' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated 'hop-by-hop' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_rh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated'routing' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated'routing' header in IPv6 extension headers"
                                         },
                                         "exthdr_invalid_optlen": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets flagged invalid due to invalid option length in a hop or dst extended header"
+                                            "description":
+                                                    "Number of IPv6 packets flagged invalid due to invalid option length in a hop or dst extended header"
                                         },
                                         "exthdr_useless_fh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with useless 'fragment header' in the extended headers"
+                                            "description":
+                                                    "Number of IPv6 packets with useless 'fragment header' in the extended headers"
                                         },
                                         "fh_non_zero_reserved_field": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with 'fragment header' with non-zero reserved field"
+                                            "description":
+                                                    "Number of IPv6 packets with 'fragment header' with non-zero reserved field"
                                         },
                                         "frag_ignored": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 fragments ignored due to resource allocation errors"
+                                            "description":
+                                                    "Number of IPv6 fragments ignored due to resource allocation errors"
                                         },
                                         "frag_invalid_length": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 fragments with invalid length"
+                                            "description":
+                                                    "Number of IPv6 fragments with invalid length"
                                         },
                                         "frag_overlap": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 fragments with overlapping data"
+                                            "description":
+                                                    "Number of IPv6 fragments with overlapping data"
                                         },
                                         "frag_pkt_too_large": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 fragments ignored due to being too large"
+                                            "description":
+                                                    "Number of IPv6 fragments ignored due to being too large"
                                         },
                                         "hopopts_only_padding": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with all HOP options as only padding"
+                                            "description":
+                                                    "Number of IPv6 packets with all HOP options as only padding"
                                         },
                                         "hopopts_unknown_opt": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with unknown HOP option"
+                                            "description":
+                                                    "Number of IPv6 packets with unknown HOP option"
                                         },
                                         "icmpv4": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with ICMPv4 header"
+                                            "description":
+                                                    "Number of IPv6 packets with ICMPv4 header"
                                         },
                                         "ipv4_in_ipv6_too_small": {
                                             "type": "integer",
-                                            "description":"Number of IPv4-in-IPv6 packets flagged invalid due to being too small"
+                                            "description":
+                                                    "Number of IPv4-in-IPv6 packets flagged invalid due to being too small"
                                         },
                                         "ipv4_in_ipv6_wrong_version": {
                                             "type": "integer",
-                                            "description": "Number of IPv4-in-IPv6 packets with wrong IP version"
+                                            "description":
+                                                    "Number of IPv4-in-IPv6 packets with wrong IP version"
                                         },
                                         "ipv6_in_ipv6_too_small": {
                                             "type": "integer",
-                                            "description": "Number of IPv6-in-IPv6 packets flagged invalid due to being too small"
+                                            "description":
+                                                    "Number of IPv6-in-IPv6 packets flagged invalid due to being too small"
                                         },
                                         "ipv6_in_ipv6_wrong_version": {
                                             "type": "integer",
-                                            "description": "Number of IPv6-in-IPv6 packets with wrong IP version"
+                                            "description":
+                                                    "Number of IPv6-in-IPv6 packets with wrong IP version"
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets flagged invalid due to size smaller than minimum header size"
+                                            "description":
+                                                    "Number of IPv6 packets flagged invalid due to size smaller than minimum header size"
                                         },
                                         "rh_type_0": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with extended header 'routing' with type 0"
+                                            "description":
+                                                    "Number of IPv6 packets with extended header 'routing' with type 0"
                                         },
                                         "trunc_exthdr": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets flagged invalid due to truncated extension header"
+                                            "description":
+                                                    "Number of IPv6 packets flagged invalid due to truncated extension header"
                                         },
                                         "trunc_pkt": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets flagged invalid due to truncated packet"
+                                            "description":
+                                                    "Number of IPv6 packets flagged invalid due to truncated packet"
                                         },
                                         "unknown_next_header": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with unknown next header"
+                                            "description":
+                                                    "Number of IPv6 packets with unknown next header"
                                         },
                                         "wrong_ip_version": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets flagged invalid due to wrong IP version"
+                                            "description":
+                                                    "Number of IPv6 packets flagged invalid due to wrong IP version"
                                         },
                                         "zero_len_padn": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with PadN option without data (length zero)"
+                                            "description":
+                                                    "Number of IPv6 packets with PadN option without data (length zero)"
                                         }
                                     }
                                 },
@@ -7572,7 +8030,8 @@
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "Number of SLL decoded packets that were too small"
+                                            "description":
+                                                    "Number of SLL decoded packets that were too small"
                                         }
                                     }
                                 },
@@ -7582,7 +8041,8 @@
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "The number of times the SLL2 header was too small to be valid"
+                                            "description":
+                                                    "The number of times the SLL2 header was too small to be valid"
                                         }
                                     }
                                 },
@@ -7717,11 +8177,13 @@
                         },
                         "max_mac_addrs_dst": {
                             "type": "integer",
-                            "description": "Maximum amount of destination MAC addresses seen per flow (only if ethernet header logging enabled)"
+                            "description":
+                                    "Maximum amount of destination MAC addresses seen per flow (only if ethernet header logging enabled)"
                         },
                         "max_mac_addrs_src": {
                             "type": "integer",
-                            "description": "Maximum amount of source MAC addresses seen per flow (only if ethernet header logging enabled)"
+                            "description":
+                                    "Maximum amount of source MAC addresses seen per flow (only if ethernet header logging enabled)"
                         },
                         "max_pkt_size": {
                             "type": "integer",
@@ -7777,7 +8239,8 @@
                         },
                         "too_many_layers": {
                             "type": "integer",
-                            "description": "Number of decoded packets that reach maximum layers for the engine"
+                            "description":
+                                    "Number of decoded packets that reach maximum layers for the engine"
                         },
                         "udp": {
                             "type": "integer",
@@ -7903,7 +8366,8 @@
                         },
                         "alerts_suppressed": {
                             "type": "integer",
-                            "description": "Count of alerts not logged due to noalert keyword usage or thresholding"
+                            "description":
+                                    "Count of alerts not logged due to noalert keyword usage or thresholding"
                         },
                         "engines": {
                             "type": "array",
@@ -7918,7 +8382,8 @@
                                     },
                                     "last_reload": {
                                         "type": "string",
-                                        "description": "Last time the rules were reloaded, in TimeString format"
+                                        "description":
+                                                "Last time the rules were reloaded, in TimeString format"
                                     },
                                     "rules_failed": {
                                         "type": "integer",
@@ -7930,7 +8395,8 @@
                                     },
                                     "rules_skipped": {
                                         "type": "integer",
-                                        "description": "Count of rules that were skipped due to missing requirements"
+                                        "description":
+                                                "Count of rules that were skipped due to missing requirements"
                                     }
                                 }
                             }
@@ -7961,11 +8427,13 @@
                         },
                         "match_list": {
                             "type": "integer",
-                            "description": "If profiling is enabled, average count of signature matched against a packet"
+                            "description":
+                                    "If profiling is enabled, average count of signature matched against a packet"
                         },
                         "mpm_list": {
                             "type": "integer",
-                            "description": "If profiling is enabled, average count of signatures in the mpm prefilter list"
+                            "description":
+                                    "If profiling is enabled, average count of signatures in the mpm prefilter list"
                         },
                         "thresholds": {
                             "type": "object",
@@ -8002,8 +8470,8 @@
                             "properties": {
                                 "error": {
                                     "description":
-                                        "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 }
                             }
                         },
@@ -8013,8 +8481,8 @@
                             "properties": {
                                 "memcap": {
                                     "description":
-                                        "How many times defrag memcap exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "How many times defrag memcap exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 }
                             }
                         },
@@ -8024,8 +8492,8 @@
                             "properties": {
                                 "memcap": {
                                     "description":
-                                        "How many times flow memcap exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "How many times flow memcap exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 }
                             }
                         },
@@ -8035,18 +8503,18 @@
                             "properties": {
                                 "midstream": {
                                     "description":
-                                        "How many times midstream exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "How many times midstream exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 },
                                 "reassembly": {
                                     "description":
-                                        "How many times reassembly memcap exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "How many times reassembly memcap exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 },
                                 "ssn_memcap": {
                                     "description":
-                                        "How many times session memcap exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "How many times session memcap exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 }
                             }
                         }
@@ -8161,29 +8629,35 @@
                                     "properties": {
                                         "capture_bypassed": {
                                             "type": "integer",
-                                            "description": "Number of flows bypassed at the capture level -- counted at the time of flow end"
+                                            "description":
+                                                    "Number of flows bypassed at the capture level -- counted at the time of flow end"
                                         },
                                         "closed": {
                                             "type": "integer",
-                                            "description": "Number of flows in 'closed' state at the time of flow end"
+                                            "description":
+                                                    "Number of flows in 'closed' state at the time of flow end"
                                         },
                                         "established": {
                                             "type": "integer",
-                                            "description": "Number of flows in 'established' state at the time of flow end"
+                                            "description":
+                                                    "Number of flows in 'established' state at the time of flow end"
                                         },
                                         "local_bypassed": {
                                             "type": "integer",
-                                            "description": "Number of flows bypassed internally -- counted at the time of flow end"
+                                            "description":
+                                                    "Number of flows bypassed internally -- counted at the time of flow end"
                                         },
                                         "new": {
                                             "type": "integer",
-                                            "description": "Number of flows in 'new' state at the time of flow end"
+                                            "description":
+                                                    "Number of flows in 'new' state at the time of flow end"
                                         }
                                     }
                                 },
                                 "tcp_liberal": {
                                     "type": "integer",
-                                    "description": "Number of TCP flows ended that had liberal state"
+                                    "description":
+                                            "Number of TCP flows ended that had liberal state"
                                 },
                                 "tcp_state": {
                                     "type": "object",
@@ -8191,7 +8665,8 @@
                                     "properties": {
                                         "close_wait": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in CLOSE_WAIT state"
+                                            "description":
+                                                    "Number of TCP sessions in CLOSE_WAIT state"
                                         },
                                         "closed": {
                                             "type": "integer",
@@ -8203,19 +8678,23 @@
                                         },
                                         "established": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in ESTABLISHED state"
+                                            "description":
+                                                    "Number of TCP sessions in ESTABLISHED state"
                                         },
                                         "fin_wait1": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in FIN_WAIT_1 state"
+                                            "description":
+                                                    "Number of TCP sessions in FIN_WAIT_1 state"
                                         },
                                         "fin_wait2": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in FIN_WAIT_2 state"
+                                            "description":
+                                                    "Number of TCP sessions in FIN_WAIT_2 state"
                                         },
                                         "last_ack": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in LAST_ACK state"
+                                            "description":
+                                                    "Number of TCP sessions in LAST_ACK state"
                                         },
                                         "none": {
                                             "type": "integer",
@@ -8223,15 +8702,18 @@
                                         },
                                         "syn_recv": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in SYN_RECV state"
+                                            "description":
+                                                    "Number of TCP sessions in SYN_RECV state"
                                         },
                                         "syn_sent": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in SYN_SENT state"
+                                            "description":
+                                                    "Number of TCP sessions in SYN_SENT state"
                                         },
                                         "time_wait": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in TIME_WAIT state"
+                                            "description":
+                                                    "Number of TCP sessions in TIME_WAIT state"
                                         }
                                     }
                                 }
@@ -8371,35 +8853,43 @@
                                 },
                                 "flows_evicted_needs_work": {
                                     "type": "integer",
-                                    "description": "Number of TCP flows that were returned to the workers in case reassembly, detection, logging still needs work"
+                                    "description":
+                                            "Number of TCP flows that were returned to the workers in case reassembly, detection, logging still needs work"
                                 },
                                 "flows_evicted_pkt_inject": {
                                     "type": "integer",
-                                    "description": "Number of pseudo packets injected into worker threads to complete flows' processing. For any flow this can be between 0-2, this is the total for all flows."
+                                    "description":
+                                            "Number of pseudo packets injected into worker threads to complete flows' processing. For any flow this can be between 0-2, this is the total for all flows."
                                 },
                                 "flows_injected": {
                                     "type": "integer",
-                                    "description": "Number of flows injected into the worker thread from another thread"
+                                    "description":
+                                            "Number of flows injected into the worker thread from another thread"
                                 },
                                 "flows_injected_max": {
                                     "type": "integer",
-                                    "description": "Maximum number of flows injected into the worker thread from another thread"
+                                    "description":
+                                            "Maximum number of flows injected into the worker thread from another thread"
                                 },
                                 "spare_sync": {
                                     "type": "integer",
-                                    "description": "Number of times the engine attempted to fetch flows from the master flow pool/spare queue"
+                                    "description":
+                                            "Number of times the engine attempted to fetch flows from the master flow pool/spare queue"
                                 },
                                 "spare_sync_avg": {
                                     "type": "integer",
-                                    "description": "Average number of flows a thread could fetch from the master flow pool/spare queue"
+                                    "description":
+                                            "Average number of flows a thread could fetch from the master flow pool/spare queue"
                                 },
                                 "spare_sync_empty": {
                                     "type": "integer",
-                                    "description": "Number of times the master spare pool was empty when requesting flows from it"
+                                    "description":
+                                            "Number of times the master spare pool was empty when requesting flows from it"
                                 },
                                 "spare_sync_incomplete": {
                                     "type": "integer",
-                                    "description": "Number of times spare flow syncs were incomplete (fetched with less than 100 flows in sync)"
+                                    "description":
+                                            "Number of times spare flow syncs were incomplete (fetched with less than 100 flows in sync)"
                                 }
                             }
                         }
@@ -8435,7 +8925,8 @@
                 },
                 "ftp": {
                     "type": "object",
-                    "description": "Performance statistics for global memory use and memory capacity for FTP app-layer parser",
+                    "description":
+                            "Performance statistics for global memory use and memory capacity for FTP app-layer parser",
                     "additionalProperties": false,
                     "properties": {
                         "memcap": {
@@ -8450,7 +8941,8 @@
                 },
                 "host": {
                     "type": "object",
-                    "description": "Performance statistics for global memory use and memory capacity for Host table",
+                    "description":
+                            "Performance statistics for global memory use and memory capacity for Host table",
                     "additionalProperties": false,
                     "properties": {
                         "memcap": {
@@ -8465,7 +8957,8 @@
                 },
                 "http": {
                     "type": "object",
-                    "description": "Performance statistics for global memory use and memory capacity for HTTP app-layer parser",
+                    "description":
+                            "Performance statistics for global memory use and memory capacity for HTTP app-layer parser",
                     "additionalProperties": false,
                     "properties": {
                         "byterange": {
@@ -8474,7 +8967,8 @@
                             "properties": {
                                 "memcap": {
                                     "type": "integer",
-                                    "description": "Global memory capacity reached for Byte Range containers"
+                                    "description":
+                                            "Global memory capacity reached for Byte Range containers"
                                 },
                                 "memuse": {
                                     "type": "integer",
@@ -8494,7 +8988,8 @@
                 },
                 "ippair": {
                     "type": "object",
-                    "description": "Performance statistics for global memory use and memory capacity for IP Pair table",
+                    "description":
+                            "Performance statistics for global memory use and memory capacity for IP Pair table",
                     "additionalProperties": false,
                     "properties": {
                         "memcap": {
@@ -8620,7 +9115,8 @@
                 },
                 "memcap": {
                     "type": "object",
-                    "description": "Performance statistics on global memory capacity / usage. Calculated for flow, stream, stream-reassembly, app-layer http, defrag, ippair and host",
+                    "description":
+                            "Performance statistics on global memory capacity / usage. Calculated for flow, stream, stream-reassembly, app-layer http, defrag, ippair and host",
                     "additionalProperties": false,
                     "properties": {
                         "pressure": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2166,6 +2166,19 @@
                 "type": {
                     "type": "string",
                     "description": "Executable format type identifier (e.g., \"windows_pe\")"
+                },
+                "version_info": {
+                    "type": "object",
+                    "description":
+                            "StringFileInfo key/value strings from the VERSIONINFO resource (e.g. CompanyName, ProductName, OriginalFilename)",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
                 }
             }
         },
@@ -2381,6 +2394,12 @@
                             },
                             "type": {
                                 "type": "string"
+                            },
+                            "version_info": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
                             }
                         }
                     },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1902,6 +1902,46 @@
                     "description":
                             "Human-readable architecture name derived from machine type (e.g., x86, x86-64, ARM, ARM64, or unknown)"
                 },
+                "cert_issuer": {
+                    "type": "string",
+                    "description":
+                            "Issuer (RFC4514) of the signing certificate embedded in the Authenticode signature",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "cert_serial": {
+                    "type": "string",
+                    "description":
+                            "Serial number of the signing certificate, as colon-separated uppercase hex",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "cert_subject": {
+                    "type": "string",
+                    "description":
+                            "Subject (RFC4514) of the signing certificate embedded in the Authenticode signature",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "cert_thumbprint": {
+                    "type": "string",
+                    "description":
+                            "SHA-1 thumbprint of the signing certificate (uppercase hex of the DER certificate)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
                 "characteristics": {
                     "type": "integer",
                     "description":
@@ -2213,6 +2253,18 @@
                                 "type": "string"
                             },
                             "arch_name": {
+                                "type": "string"
+                            },
+                            "cert_issuer": {
+                                "type": "string"
+                            },
+                            "cert_serial": {
+                                "type": "string"
+                            },
+                            "cert_subject": {
+                                "type": "string"
+                            },
+                            "cert_thumbprint": {
                                 "type": "string"
                             },
                             "characteristics": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1997,6 +1997,16 @@
                         ]
                     }
                 },
+                "file_version": {
+                    "type": "string",
+                    "description":
+                            "FileVersion from the VERSIONINFO resource, dotted major.minor.build.revision",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
                 "has_wx_section": {
                     "type": "boolean",
                     "description":
@@ -2286,6 +2296,9 @@
                                 "type": "integer"
                             },
                             "export_name": {
+                                "type": "string"
+                            },
+                            "file_version": {
                                 "type": "string"
                             },
                             "has_wx_section": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2081,6 +2081,16 @@
                         "type": "string"
                     }
                 },
+                "signed": {
+                    "type": "boolean",
+                    "description":
+                            "True if the PE has a non-empty Certificate Table (is Authenticode-signed). Presence only; the signature is not cryptographically verified",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
                 "size_of_headers": {
                     "type": "integer",
                     "description":
@@ -2304,6 +2314,9 @@
                                 "items": {
                                     "type": "string"
                                 }
+                            },
+                            "signed": {
+                                "type": "boolean"
                             },
                             "size_of_headers": {
                                 "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2062,6 +2062,16 @@
                         "type": "string"
                     }
                 },
+                "signed": {
+                    "type": "boolean",
+                    "description":
+                            "True if the PE has a non-empty Certificate Table (is Authenticode-signed). Presence only; the signature is not cryptographically verified",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
                 "size_of_headers": {
                     "type": "integer",
                     "description":
@@ -2285,6 +2295,9 @@
                                 "items": {
                                     "type": "string"
                                 }
+                            },
+                            "signed": {
+                                "type": "boolean"
                             },
                             "size_of_headers": {
                                 "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2016,6 +2016,16 @@
                         ]
                     }
                 },
+                "file_version": {
+                    "type": "string",
+                    "description":
+                            "FileVersion from the VERSIONINFO resource, dotted major.minor.build.revision",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
                 "has_wx_section": {
                     "type": "boolean",
                     "description":
@@ -2305,6 +2315,9 @@
                                 "type": "integer"
                             },
                             "export_name": {
+                                "type": "string"
+                            },
+                            "file_version": {
                                 "type": "string"
                             },
                             "has_wx_section": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1921,6 +1921,46 @@
                     "description":
                             "Human-readable architecture name derived from machine type (e.g., x86, x86-64, ARM, ARM64, or unknown)"
                 },
+                "cert_issuer": {
+                    "type": "string",
+                    "description":
+                            "Issuer (RFC4514) of the signing certificate embedded in the Authenticode signature",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "cert_serial": {
+                    "type": "string",
+                    "description":
+                            "Serial number of the signing certificate, as colon-separated uppercase hex",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "cert_subject": {
+                    "type": "string",
+                    "description":
+                            "Subject (RFC4514) of the signing certificate embedded in the Authenticode signature",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "cert_thumbprint": {
+                    "type": "string",
+                    "description":
+                            "SHA-1 thumbprint of the signing certificate (uppercase hex of the DER certificate)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
                 "characteristics": {
                     "type": "integer",
                     "description":
@@ -2232,6 +2272,18 @@
                                 "type": "string"
                             },
                             "arch_name": {
+                                "type": "string"
+                            },
+                            "cert_issuer": {
+                                "type": "string"
+                            },
+                            "cert_serial": {
+                                "type": "string"
+                            },
+                            "cert_subject": {
+                                "type": "string"
+                            },
+                            "cert_thumbprint": {
                                 "type": "string"
                             },
                             "characteristics": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2185,6 +2185,19 @@
                 "type": {
                     "type": "string",
                     "description": "Executable format type identifier (e.g., \"windows_pe\")"
+                },
+                "version_info": {
+                    "type": "object",
+                    "description":
+                            "StringFileInfo key/value strings from the VERSIONINFO resource (e.g. CompanyName, ProductName, OriginalFilename)",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
                 }
             }
         },
@@ -2400,6 +2413,12 @@
                             },
                             "type": {
                                 "type": "string"
+                            },
+                            "version_info": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
                             }
                         }
                     },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -19,7 +19,8 @@
                 "context": {
                     "type": "object",
                     "additionalProperties": true,
-                    "description": "Extra context data created by keywords such as dataset with JSON"
+                    "description":
+                            "Extra context data created by keywords such as dataset with JSON"
                 },
                 "engine": {
                     "type": "string",
@@ -191,14 +192,16 @@
         },
         "app_proto_expected": {
             "type": "string",
-            "description": "In case of a protocol change to a specific protocol, and this specific protocol was not recognised, this field will have the value of the expected protocol",
+            "description":
+                    "In case of a protocol change to a specific protocol, and this specific protocol was not recognised, this field will have the value of the expected protocol",
             "suricata": {
                 "$comment": "TODO implement keyword app-layer-protocol option"
             }
         },
         "app_proto_orig": {
             "type": "string",
-            "description": "Original application layer protocol of the flow after a protocol change",
+            "description":
+                    "Original application layer protocol of the flow after a protocol change",
             "suricata": {
                 "keywords": [
                     "app-layer-protocol"
@@ -1898,6 +1901,233 @@
         "event_type": {
             "type": "string"
         },
+        "executable": {
+            "type": "object",
+            "description": "[optional] Metadata from Windows Portable Executable (PE) files",
+            "additionalProperties": false,
+            "properties": {
+                "arch": {
+                    "type": "string",
+                    "description":
+                            "Machine type/architecture as hex string (e.g., \"0x14c\" for x86, \"0x8664\" for x86_64, \"0x1c0\" for ARM, \"0xaa64\" for ARM64)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "arch_name": {
+                    "type": "string",
+                    "description":
+                            "Human-readable architecture name derived from machine type (e.g., x86, x86-64, ARM, ARM64, or unknown)"
+                },
+                "characteristics": {
+                    "type": "integer",
+                    "description":
+                            "COFF characteristics flags (e.g., 0x0002 for EXECUTABLE_IMAGE, 0x2000 for DLL)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "characteristics_names": {
+                    "type": "array",
+                    "description":
+                            "Human-readable COFF characteristics (EXECUTABLE_IMAGE, DLL, LARGE_ADDRESS_AWARE, 32BIT_MACHINE)",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "checksum": {
+                    "type": "integer",
+                    "description": "Checksum from the optional header",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "dll_characteristics": {
+                    "type": "integer",
+                    "description":
+                            "DLL characteristics flags / security features (e.g., 0x0040 for ASLR, 0x0100 for DEP)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "entry_point": {
+                    "type": "integer",
+                    "description": "AddressOfEntryPoint RVA (Relative Virtual Address)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "export_name": {
+                    "type": "string",
+                    "description": "Internal DLL name from the export directory table",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "has_wx_section": {
+                    "type": "boolean",
+                    "description":
+                            "True if any section has both WRITE and EXECUTE permissions (suspicious)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "imports": {
+                    "type": "array",
+                    "description":
+                            "List of DLL names imported by the PE file (from the Import Directory Table)",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "magic": {
+                    "type": "integer",
+                    "description": "Optional header magic value (0x10b=PE32, 0x20b=PE32+)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "num_exports": {
+                    "type": "integer",
+                    "description": "Number of exported functions",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "num_imports": {
+                    "type": "integer",
+                    "description": "Number of imported DLLs",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "pe_offset": {
+                    "type": "integer",
+                    "description": "Offset to the PE signature in the file"
+                },
+                "pe_type": {
+                    "type": "string",
+                    "description": "PE type: PE32 (32-bit) or PE32+ (64-bit)"
+                },
+                "sections": {
+                    "type": "integer",
+                    "description": "Number of sections in the PE file",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "sections_detail": {
+                    "type": "array",
+                    "description": "Detailed per-section information",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "characteristics": {
+                                "type": "integer",
+                                "description": "Section characteristics flags"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Section name (up to 8 characters)"
+                            },
+                            "raw_data_size": {
+                                "type": "integer",
+                                "description": "Size of raw data on disk"
+                            },
+                            "virtual_address": {
+                                "type": "integer",
+                                "description": "Virtual address (RVA) of the section"
+                            },
+                            "virtual_size": {
+                                "type": "integer",
+                                "description": "Virtual size of the section"
+                            },
+                            "wx": {
+                                "type": "boolean",
+                                "description":
+                                        "True if section has both WRITE and EXECUTE permissions"
+                            }
+                        }
+                    }
+                },
+                "security_features": {
+                    "type": "array",
+                    "description":
+                            "Human-readable security features (HIGH_ENTROPY_VA, DYNAMIC_BASE, NX_COMPAT, NO_SEH, GUARD_CF)",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "size_of_headers": {
+                    "type": "integer",
+                    "description":
+                            "Combined size of DOS stub, PE header, and section headers rounded to FileAlignment",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "size_of_image": {
+                    "type": "integer",
+                    "description": "SizeOfImage field (total mapped size of the PE)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "subsystem": {
+                    "type": "string",
+                    "description": "PE subsystem (e.g., WINDOWS_GUI, WINDOWS_CUI, NATIVE)"
+                },
+                "subsystem_id": {
+                    "type": "integer",
+                    "description": "Numeric subsystem ID (2=GUI, 3=Console, 1=Native, etc.)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "timestamp": {
+                    "type": "integer",
+                    "description": "TimeDateStamp from COFF header (Unix epoch seconds)",
+                    "suricata": {
+                        "keywords": [
+                            "windows_pe"
+                        ]
+                    }
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Executable format type identifier (e.g., \"windows_pe\")"
+                }
+            }
+        },
         "fileinfo": {
             "type": "object",
             "additionalProperties": false,
@@ -1965,7 +2195,8 @@
                 },
                 "storing": {
                     "type": "boolean",
-                    "description": "Indicates whether the file is in the process of being stored; true when not yet stored"
+                    "description":
+                            "Indicates whether the file is in the process of being stored; true when not yet stored"
                 },
                 "tx_id": {
                     "type": "integer",
@@ -1982,6 +2213,117 @@
                 "properties": {
                     "end": {
                         "type": "integer"
+                    },
+                    "executable": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "arch": {
+                                "type": "string"
+                            },
+                            "arch_name": {
+                                "type": "string"
+                            },
+                            "characteristics": {
+                                "type": "integer"
+                            },
+                            "characteristics_names": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "checksum": {
+                                "type": "integer"
+                            },
+                            "dll_characteristics": {
+                                "type": "integer"
+                            },
+                            "entry_point": {
+                                "type": "integer"
+                            },
+                            "export_name": {
+                                "type": "string"
+                            },
+                            "has_wx_section": {
+                                "type": "boolean"
+                            },
+                            "imports": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "magic": {
+                                "type": "integer"
+                            },
+                            "num_exports": {
+                                "type": "integer"
+                            },
+                            "num_imports": {
+                                "type": "integer"
+                            },
+                            "pe_offset": {
+                                "type": "integer"
+                            },
+                            "pe_type": {
+                                "type": "string"
+                            },
+                            "sections": {
+                                "type": "integer"
+                            },
+                            "sections_detail": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "characteristics": {
+                                            "type": "integer"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "raw_data_size": {
+                                            "type": "integer"
+                                        },
+                                        "virtual_address": {
+                                            "type": "integer"
+                                        },
+                                        "virtual_size": {
+                                            "type": "integer"
+                                        },
+                                        "wx": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            },
+                            "security_features": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "size_of_headers": {
+                                "type": "integer"
+                            },
+                            "size_of_image": {
+                                "type": "integer"
+                            },
+                            "subsystem": {
+                                "type": "string"
+                            },
+                            "subsystem_id": {
+                                "type": "integer"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "file_id": {
                         "type": "integer"
@@ -2357,7 +2699,8 @@
                     "description": "The domain name of the server, the Host header",
                     "suricata": {
                         "keywords": [
-                            "http.host", "http.host.raw"
+                            "http.host",
+                            "http.host.raw"
                         ]
                     }
                 },
@@ -2448,7 +2791,8 @@
                 },
                 "http_content_type": {
                     "type": "string",
-                    "description": "The media type of the resource or data, the Content-Type header",
+                    "description":
+                            "The media type of the resource or data, the Content-Type header",
                     "suricata": {
                         "keywords": [
                             "http.content_type"
@@ -2470,7 +2814,8 @@
                 },
                 "http_refer": {
                     "type": "string",
-                    "description": "An absolute or partial address of the web page that makes the request, the Referer header",
+                    "description":
+                            "An absolute or partial address of the web page that makes the request, the Referer header",
                     "suricata": {
                         "keywords": [
                             "http.referer"
@@ -2505,7 +2850,8 @@
                 },
                 "http_user_agent": {
                     "type": "string",
-                    "description": "A characteristic string that lets servers and network peers identify the application, operating system, vendor, and/or version of the requesting user agent, the User-Agent header",
+                    "description":
+                            "A characteristic string that lets servers and network peers identify the application, operating system, vendor, and/or version of the requesting user agent, the User-Agent header",
                     "suricata": {
                         "keywords": [
                             "http.user_agent"
@@ -2605,7 +2951,9 @@
                     "description": "The HTTP request URI",
                     "suricata": {
                         "keywords": [
-                            "http.uri", "http.uri.raw", "urilen"
+                            "http.uri",
+                            "http.uri.raw",
+                            "urilen"
                         ]
                     }
                 },
@@ -2615,7 +2963,8 @@
                 },
                 "xff": {
                     "type": "string",
-                    "description": "A de-facto standard header for identifying the originating IP address of a client connecting to a web server through a proxy server, the X-Forwarded-For header request header"
+                    "description":
+                            "A de-facto standard header for identifying the originating IP address of a client connecting to a web server through a proxy server, the X-Forwarded-For header request header"
                 }
             }
         },
@@ -2680,7 +3029,10 @@
                                 ]
                             },
                             "raw": {
-                                "type": ["string", "number"]
+                                "type": [
+                                    "string",
+                                    "number"
+                                ]
                             },
                             "value": {
                                 "type": "string"
@@ -2749,7 +3101,10 @@
                                                 ]
                                             },
                                             "raw": {
-                                                "type": ["string", "number"]
+                                                "type": [
+                                                    "string",
+                                                    "number"
+                                                ]
                                             },
                                             "value": {
                                                 "type": "string"
@@ -2920,7 +3275,8 @@
                 },
                 "weak_encryption": {
                     "type": "boolean",
-                    "description": "Whether the encryption used in AS-REP or TGS-REP is a weak cipher",
+                    "description":
+                            "Whether the encryption used in AS-REP or TGS-REP is a weak cipher",
                     "suricata": {
                         "$comment": "TODO add keyword (rather option for encryption keyword)"
                     }
@@ -3822,7 +4178,8 @@
                             "rrname_truncated": {
                                 "description": "Name was truncated by Suricata due to length",
                                 "type": "boolean",
-                                "$comment": "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
+                                "$comment":
+                                        "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
                             },
                             "txt": {
                                 "type": "array",
@@ -3866,7 +4223,8 @@
                             "rrname_truncated": {
                                 "description": "Name was truncated by Suricata due to length",
                                 "type": "boolean",
-                                "$comment": "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
+                                "$comment":
+                                        "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
                             },
                             "txt": {
                                 "type": "array",
@@ -3900,7 +4258,8 @@
                             "rrname_truncated": {
                                 "description": "Name was truncated by Suricata due to length",
                                 "type": "boolean",
-                                "$comment": "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
+                                "$comment":
+                                        "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
                             }
                         }
                     }
@@ -3970,10 +4329,11 @@
                             "rrname_truncated": {
                                 "description": "Name was truncated by Suricata due to length",
                                 "type": "boolean",
-                                "$comment": "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
+                                "$comment":
+                                        "keyword: app-layer-event:mdns.name_too_long (https://redmine.openinfosecfoundation.org/issues/7784)"
                             },
                             "rrtype": {
-                                "type": "string", 
+                                "type": "string",
                                 "description": "Type of resource being requested"
                             }
                         }
@@ -4818,7 +5178,8 @@
             "properties": {
                 "age": {
                     "type": "integer",
-                    "description": "Duration of the flow (measured from timestamp of last packet and first packet)",
+                    "description":
+                            "Duration of the flow (measured from timestamp of last packet and first packet)",
                     "suricata": {
                         "keywords": [
                             "flow.age"
@@ -4865,7 +5226,8 @@
                 },
                 "tx_cnt": {
                     "type": "integer",
-                    "description": "Number of transactions seen in the flow (only present if flow has an application layer)"
+                    "description":
+                            "Number of transactions seen in the flow (only present if flow has an application layer)"
                 }
             }
         },
@@ -5048,11 +5410,13 @@
                             "properties": {
                                 "data_size": {
                                     "type": "integer",
-                                    "description": "Accumulated data size of all CopyData messages sent"
+                                    "description":
+                                            "Accumulated data size of all CopyData messages sent"
                                 },
                                 "msg_count": {
                                     "type": "integer",
-                                    "description": "How many CopyData messages were sent (does not necessarily match number of rows from the query)"
+                                    "description":
+                                            "How many CopyData messages were sent (does not necessarily match number of rows from the query)"
                                 }
                             }
                         },
@@ -5153,7 +5517,8 @@
                             "properties": {
                                 "data_size": {
                                     "type": "integer",
-                                    "description": "Accumulated data size of all CopyData messages sent"
+                                    "description":
+                                            "Accumulated data size of all CopyData messages sent"
                                 },
                                 "row_count": {
                                     "type": "integer",
@@ -5168,7 +5533,8 @@
                             "properties": {
                                 "columns": {
                                     "type": "integer",
-                                    "description": "Number of columns that will be copied in the CopyData message"
+                                    "description":
+                                            "Number of columns that will be copied in the CopyData message"
                                 }
                             }
                         },
@@ -5179,7 +5545,8 @@
                             "properties": {
                                 "columns": {
                                     "type": "integer",
-                                    "description": "Number of columns that will be copied in the CopyData message"
+                                    "description":
+                                            "Number of columns that will be copied in the CopyData message"
                                 }
                             }
                         },
@@ -6315,7 +6682,8 @@
             "properties": {
                 "app_layer": {
                     "type": "object",
-                    "description": "Module with observational and performance-related statistics from application layer protocol parsers and flows",
+                    "description":
+                            "Module with observational and performance-related statistics from application layer protocol parsers and flows",
                     "additionalProperties": false,
                     "properties": {
                         "error": {
@@ -6877,7 +7245,7 @@
                 },
                 "capture": {
                     "type": "object",
-                    "description":"Observational statistics for packet capture module",
+                    "description": "Observational statistics for packet capture module",
                     "additionalProperties": false,
                     "properties": {
                         "afpacket": {
@@ -6910,7 +7278,8 @@
                         },
                         "errors": {
                             "type": "integer",
-                            "description": "Number of Suricata errors reported while reading capture module"
+                            "description":
+                                    "Number of Suricata errors reported while reading capture module"
                         },
                         "kernel_drops": {
                             "type": "integer",
@@ -6985,7 +7354,8 @@
                                     "properties": {
                                         "invalid_hardware_size": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with invalid hardware size (valid size is 6)"
+                                            "description":
+                                                    "Number of ARP packets with invalid hardware size (valid size is 6)"
                                         },
                                         "invalid_pkt": {
                                             "type": "integer",
@@ -6993,23 +7363,28 @@
                                         },
                                         "invalid_protocol_size": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with invalid protocol size (valid size is 4)"
+                                            "description":
+                                                    "Number of ARP packets with invalid protocol size (valid size is 4)"
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with header length too small"
+                                            "description":
+                                                    "Number of ARP packets with header length too small"
                                         },
                                         "unsupported_hardware": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with unsupported hardware"
+                                            "description":
+                                                    "Number of ARP packets with unsupported hardware"
                                         },
                                         "unsupported_opcode": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with unsupported Operation Codes"
+                                            "description":
+                                                    "Number of ARP packets with unsupported Operation Codes"
                                         },
                                         "unsupported_protocol": {
                                             "type": "integer",
-                                            "description": "Number of ARP packets with unsupported protocol"
+                                            "description":
+                                                    "Number of ARP packets with unsupported protocol"
                                         }
                                     }
                                 },
@@ -7039,15 +7414,18 @@
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer",
-                                            "description": "Number of packets with header too small for ERSPAN"
+                                            "description":
+                                                    "Number of packets with header too small for ERSPAN"
                                         },
                                         "too_many_vlan_layers": {
                                             "type": "integer",
-                                            "description": "Number of packets with too many VLAN layers for ERSPAN"
+                                            "description":
+                                                    "Number of packets with too many VLAN layers for ERSPAN"
                                         },
                                         "unsupported_version": {
                                             "type": "integer",
-                                            "description": "Number of packets with unsupported version for ERSPAN"
+                                            "description":
+                                                    "Number of packets with unsupported version for ERSPAN"
                                         }
                                     }
                                 },
@@ -7067,11 +7445,13 @@
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer",
-                                            "description": "Number of packets with header too small for ETAG"
+                                            "description":
+                                                    "Number of packets with header too small for ETAG"
                                         },
                                         "unknown_type": {
                                             "type": "integer",
-                                            "description": "Number of ETAG packets with unknown type"
+                                            "description":
+                                                    "Number of ETAG packets with unknown type"
                                         }
                                     }
                                 },
@@ -7081,11 +7461,13 @@
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "Number of packets too small for Ethernet"
+                                            "description":
+                                                    "Number of packets too small for Ethernet"
                                         },
                                         "unknown_ethertype": {
                                             "type": "integer",
-                                            "description": "Number of packets with Unkonwn Ethertype for Ethernet"
+                                            "description":
+                                                    "Number of packets with Unkonwn Ethertype for Ethernet"
                                         }
                                     }
                                 },
@@ -7095,7 +7477,8 @@
                                     "properties": {
                                         "unknown_payload_type": {
                                             "type": "integer",
-                                            "description": "Number of packets with unknown payload type for Geneve"
+                                            "description":
+                                                    "Number of packets with unknown payload type for Geneve"
                                         }
                                     }
                                 },
@@ -7109,59 +7492,73 @@
                                         },
                                         "version0_flags": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 0 flags set for GRE"
+                                            "description":
+                                                    "Number of packets with version 0 flags set for GRE"
                                         },
                                         "version0_hdr_too_big": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 0 and header too big for GRE"
+                                            "description":
+                                                    "Number of packets with version 0 and header too big for GRE"
                                         },
                                         "version0_malformed_sre_hdr": {
                                             "type": "integer",
-                                            "description": "Number of packets of with version 0 and malformed SRE header for GRE"
+                                            "description":
+                                                    "Number of packets of with version 0 and malformed SRE header for GRE"
                                         },
                                         "version0_recur": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 0 and flag recursion control set for GRE"
+                                            "description":
+                                                    "Number of packets with version 0 and flag recursion control set for GRE"
                                         },
                                         "version1_chksum": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and checksum flag set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and checksum flag set for GRE"
                                         },
                                         "version1_flags": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 flags set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 flags set for GRE"
                                         },
                                         "version1_hdr_too_big": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and header too big for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and header too big for GRE"
                                         },
                                         "version1_malformed_sre_hdr": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and malformed SRE header for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and malformed SRE header for GRE"
                                         },
                                         "version1_no_key": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and no key flag set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and no key flag set for GRE"
                                         },
                                         "version1_recur": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and flag recursion control set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and flag recursion control set for GRE"
                                         },
                                         "version1_route": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and flag route set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and flag route set for GRE"
                                         },
                                         "version1_ssr": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and flag SSR set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and flag SSR set for GRE"
                                         },
                                         "version1_wrong_protocol": {
                                             "type": "integer",
-                                            "description": "Number of packets with version 1 and wrong protocol set for GRE"
+                                            "description":
+                                                    "Number of packets with version 1 and wrong protocol set for GRE"
                                         },
                                         "wrong_version": {
                                             "type": "integer",
-                                            "description": "Number of packets with wrong version set for GRE"
+                                            "description":
+                                                    "Number of packets with wrong version set for GRE"
                                         }
                                     }
                                 },
@@ -7175,7 +7572,8 @@
                                         },
                                         "ipv4_unknown_ver": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv4 packets with unknown version"
+                                            "description":
+                                                    "Number of ICMPv4 packets with unknown version"
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
@@ -7183,11 +7581,13 @@
                                         },
                                         "unknown_code": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv4 packets with unknown code"
+                                            "description":
+                                                    "Number of ICMPv4 packets with unknown code"
                                         },
                                         "unknown_type": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv4 packets with unknown type"
+                                            "description":
+                                                    "Number of ICMPv4 packets with unknown type"
                                         }
                                     }
                                 },
@@ -7197,7 +7597,8 @@
                                     "properties": {
                                         "experimentation_type": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with private experimentation type"
+                                            "description":
+                                                    "Number of ICMPv6 packets with private experimentation type"
                                         },
                                         "ipv6_trunc_pkt": {
                                             "type": "integer",
@@ -7205,11 +7606,13 @@
                                         },
                                         "ipv6_unknown_version": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with unknown version"
+                                            "description":
+                                                    "Number of ICMPv6 packets with unknown version"
                                         },
                                         "mld_message_with_invalid_hl": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with MLD messages and invalid HL (not 1)"
+                                            "description":
+                                                    "Number of ICMPv6 packets with MLD messages and invalid HL (not 1)"
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
@@ -7217,15 +7620,18 @@
                                         },
                                         "unassigned_type": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with unassigned type"
+                                            "description":
+                                                    "Number of ICMPv6 packets with unassigned type"
                                         },
                                         "unknown_code": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with unknown code"
+                                            "description":
+                                                    "Number of ICMPv6 packets with unknown code"
                                         },
                                         "unknown_type": {
                                             "type": "integer",
-                                            "description": "Number of ICMPv6 packets with unknown type"
+                                            "description":
+                                                    "Number of ICMPv6 packets with unknown type"
                                         }
                                     }
                                 },
@@ -7235,7 +7641,8 @@
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer",
-                                            "description": "Number of IEEE802.1ah packets with header too small"
+                                            "description":
+                                                    "Number of IEEE802.1ah packets with header too small"
                                         }
                                     }
                                 },
@@ -7249,11 +7656,13 @@
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "IGMP packets too small to fit a IGMP header"
+                                            "description":
+                                                    "IGMP packets too small to fit a IGMP header"
                                         },
                                         "v3_pkt_too_small": {
                                             "type": "integer",
-                                            "description": "IGMPv3 packets too small to fit a IGMP header"
+                                            "description":
+                                                    "IGMPv3 packets too small to fit a IGMP header"
                                         }
                                     }
                                 },
@@ -7263,7 +7672,8 @@
                                     "properties": {
                                         "invalid_ip_version": {
                                             "type": "integer",
-                                            "description": "Number of RAW packets with invalid IP version"
+                                            "description":
+                                                    "Number of RAW packets with invalid IP version"
                                         }
                                     }
                                 },
@@ -7273,71 +7683,88 @@
                                     "properties": {
                                         "frag_ignored": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 fragments ignored due to resource allocation errors"
+                                            "description":
+                                                    "Number of IPv6 fragments ignored due to resource allocation errors"
                                         },
                                         "frag_overlap": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 fragments with overlapping data"
+                                            "description":
+                                                    "Number of IPv4 fragments with overlapping data"
                                         },
                                         "frag_pkt_too_large": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 fragments ignored due to being too large"
+                                            "description":
+                                                    "Number of IPv4 fragments ignored due to being too large"
                                         },
                                         "hlen_too_small": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to header smaller than minimum size"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to header smaller than minimum size"
                                         },
                                         "icmpv6": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to having an ICMPV6 header"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to having an ICMPV6 header"
                                         },
                                         "iplen_smaller_than_hlen": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to length being smaller than IP header size"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to length being smaller than IP header size"
                                         },
                                         "opt_duplicate": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets with duplicated IP options"
+                                            "description":
+                                                    "Number of IPv4 packets with duplicated IP options"
                                         },
                                         "opt_eol_required": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets with 'end of list' option not present, but required, in IP options"
+                                            "description":
+                                                    "Number of IPv4 packets with 'end of list' option not present, but required, in IP options"
                                         },
                                         "opt_invalid": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets with invalid IP options"
+                                            "description":
+                                                    "Number of IPv4 packets with invalid IP options"
                                         },
                                         "opt_invalid_len": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to IP options with invalid length"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to IP options with invalid length"
                                         },
                                         "opt_malformed": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to malformed IP options"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to malformed IP options"
                                         },
                                         "opt_pad_required": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets with padding bytes required in IP options"
+                                            "description":
+                                                    "Number of IPv4 packets with padding bytes required in IP options"
                                         },
                                         "opt_unknown": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to unknown IP option"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to unknown IP option"
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to size smaller than minimum header size"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to size smaller than minimum header size"
                                         },
                                         "trunc_pkt": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to truncated packet"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to truncated packet"
                                         },
                                         "unknown_protocol": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets with unknown protocol"
+                                            "description":
+                                                    "Number of IPv4 packets with unknown protocol"
                                         },
                                         "wrong_ip_version": {
                                             "type": "integer",
-                                            "description": "Number of IPv4 packets flagged invalid due to having wrong IP version in IP options"
+                                            "description":
+                                                    "Number of IPv4 packets flagged invalid due to having wrong IP version in IP options"
                                         }
                                     }
                                 },
@@ -7347,127 +7774,158 @@
                                     "properties": {
                                         "data_after_none_header": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with data after the 'none' header"
+                                            "description":
+                                                    "Number of IPv6 packets with data after the 'none' header"
                                         },
                                         "dstopts_only_padding": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with all DST options as only padding"
+                                            "description":
+                                                    "Number of IPv6 packets with all DST options as only padding"
                                         },
                                         "dstopts_unknown_opt": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with unknown DST option"
+                                            "description":
+                                                    "Number of IPv6 packets with unknown DST option"
                                         },
                                         "exthdr_ah_res_not_null": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with AH header reserved fields not null"
+                                            "description":
+                                                    "Number of IPv6 packets with AH header reserved fields not null"
                                         },
                                         "exthdr_dupl_ah": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated 'authentication' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated 'authentication' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_dh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated 'destination' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated 'destination' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_eh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated 'ESP' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated 'ESP' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_fh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated 'fragment' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated 'fragment' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_hh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated 'hop-by-hop' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated 'hop-by-hop' header in IPv6 extension headers"
                                         },
                                         "exthdr_dupl_rh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with duplicated'routing' header in IPv6 extension headers"
+                                            "description":
+                                                    "Number of IPv6 packets with duplicated'routing' header in IPv6 extension headers"
                                         },
                                         "exthdr_invalid_optlen": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets flagged invalid due to invalid option length in a hop or dst extended header"
+                                            "description":
+                                                    "Number of IPv6 packets flagged invalid due to invalid option length in a hop or dst extended header"
                                         },
                                         "exthdr_useless_fh": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with useless 'fragment header' in the extended headers"
+                                            "description":
+                                                    "Number of IPv6 packets with useless 'fragment header' in the extended headers"
                                         },
                                         "fh_non_zero_reserved_field": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with 'fragment header' with non-zero reserved field"
+                                            "description":
+                                                    "Number of IPv6 packets with 'fragment header' with non-zero reserved field"
                                         },
                                         "frag_ignored": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 fragments ignored due to resource allocation errors"
+                                            "description":
+                                                    "Number of IPv6 fragments ignored due to resource allocation errors"
                                         },
                                         "frag_invalid_length": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 fragments with invalid length"
+                                            "description":
+                                                    "Number of IPv6 fragments with invalid length"
                                         },
                                         "frag_overlap": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 fragments with overlapping data"
+                                            "description":
+                                                    "Number of IPv6 fragments with overlapping data"
                                         },
                                         "frag_pkt_too_large": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 fragments ignored due to being too large"
+                                            "description":
+                                                    "Number of IPv6 fragments ignored due to being too large"
                                         },
                                         "hopopts_only_padding": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with all HOP options as only padding"
+                                            "description":
+                                                    "Number of IPv6 packets with all HOP options as only padding"
                                         },
                                         "hopopts_unknown_opt": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with unknown HOP option"
+                                            "description":
+                                                    "Number of IPv6 packets with unknown HOP option"
                                         },
                                         "icmpv4": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with ICMPv4 header"
+                                            "description":
+                                                    "Number of IPv6 packets with ICMPv4 header"
                                         },
                                         "ipv4_in_ipv6_too_small": {
                                             "type": "integer",
-                                            "description":"Number of IPv4-in-IPv6 packets flagged invalid due to being too small"
+                                            "description":
+                                                    "Number of IPv4-in-IPv6 packets flagged invalid due to being too small"
                                         },
                                         "ipv4_in_ipv6_wrong_version": {
                                             "type": "integer",
-                                            "description": "Number of IPv4-in-IPv6 packets with wrong IP version"
+                                            "description":
+                                                    "Number of IPv4-in-IPv6 packets with wrong IP version"
                                         },
                                         "ipv6_in_ipv6_too_small": {
                                             "type": "integer",
-                                            "description": "Number of IPv6-in-IPv6 packets flagged invalid due to being too small"
+                                            "description":
+                                                    "Number of IPv6-in-IPv6 packets flagged invalid due to being too small"
                                         },
                                         "ipv6_in_ipv6_wrong_version": {
                                             "type": "integer",
-                                            "description": "Number of IPv6-in-IPv6 packets with wrong IP version"
+                                            "description":
+                                                    "Number of IPv6-in-IPv6 packets with wrong IP version"
                                         },
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets flagged invalid due to size smaller than minimum header size"
+                                            "description":
+                                                    "Number of IPv6 packets flagged invalid due to size smaller than minimum header size"
                                         },
                                         "rh_type_0": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with extended header 'routing' with type 0"
+                                            "description":
+                                                    "Number of IPv6 packets with extended header 'routing' with type 0"
                                         },
                                         "trunc_exthdr": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets flagged invalid due to truncated extension header"
+                                            "description":
+                                                    "Number of IPv6 packets flagged invalid due to truncated extension header"
                                         },
                                         "trunc_pkt": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets flagged invalid due to truncated packet"
+                                            "description":
+                                                    "Number of IPv6 packets flagged invalid due to truncated packet"
                                         },
                                         "unknown_next_header": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with unknown next header"
+                                            "description":
+                                                    "Number of IPv6 packets with unknown next header"
                                         },
                                         "wrong_ip_version": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets flagged invalid due to wrong IP version"
+                                            "description":
+                                                    "Number of IPv6 packets flagged invalid due to wrong IP version"
                                         },
                                         "zero_len_padn": {
                                             "type": "integer",
-                                            "description": "Number of IPv6 packets with PadN option without data (length zero)"
+                                            "description":
+                                                    "Number of IPv6 packets with PadN option without data (length zero)"
                                         }
                                     }
                                 },
@@ -7614,7 +8072,8 @@
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "Number of SLL decoded packets that were too small"
+                                            "description":
+                                                    "Number of SLL decoded packets that were too small"
                                         }
                                     }
                                 },
@@ -7624,7 +8083,8 @@
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer",
-                                            "description": "The number of times the SLL2 header was too small to be valid"
+                                            "description":
+                                                    "The number of times the SLL2 header was too small to be valid"
                                         }
                                     }
                                 },
@@ -7759,11 +8219,13 @@
                         },
                         "max_mac_addrs_dst": {
                             "type": "integer",
-                            "description": "Maximum amount of destination MAC addresses seen per flow (only if ethernet header logging enabled)"
+                            "description":
+                                    "Maximum amount of destination MAC addresses seen per flow (only if ethernet header logging enabled)"
                         },
                         "max_mac_addrs_src": {
                             "type": "integer",
-                            "description": "Maximum amount of source MAC addresses seen per flow (only if ethernet header logging enabled)"
+                            "description":
+                                    "Maximum amount of source MAC addresses seen per flow (only if ethernet header logging enabled)"
                         },
                         "max_pkt_size": {
                             "type": "integer",
@@ -7819,7 +8281,8 @@
                         },
                         "too_many_layers": {
                             "type": "integer",
-                            "description": "Number of decoded packets that reach maximum layers for the engine"
+                            "description":
+                                    "Number of decoded packets that reach maximum layers for the engine"
                         },
                         "udp": {
                             "type": "integer",
@@ -7945,7 +8408,8 @@
                         },
                         "alerts_suppressed": {
                             "type": "integer",
-                            "description": "Count of alerts not logged due to noalert keyword usage or thresholding"
+                            "description":
+                                    "Count of alerts not logged due to noalert keyword usage or thresholding"
                         },
                         "engines": {
                             "type": "array",
@@ -7960,7 +8424,8 @@
                                     },
                                     "last_reload": {
                                         "type": "string",
-                                        "description": "Last time the rules were reloaded, in TimeString format"
+                                        "description":
+                                                "Last time the rules were reloaded, in TimeString format"
                                     },
                                     "rules_failed": {
                                         "type": "integer",
@@ -7972,7 +8437,8 @@
                                     },
                                     "rules_skipped": {
                                         "type": "integer",
-                                        "description": "Count of rules that were skipped due to missing requirements"
+                                        "description":
+                                                "Count of rules that were skipped due to missing requirements"
                                     }
                                 }
                             }
@@ -8003,11 +8469,13 @@
                         },
                         "match_list": {
                             "type": "integer",
-                            "description": "If profiling is enabled, average count of signature matched against a packet"
+                            "description":
+                                    "If profiling is enabled, average count of signature matched against a packet"
                         },
                         "mpm_list": {
                             "type": "integer",
-                            "description": "If profiling is enabled, average count of signatures in the mpm prefilter list"
+                            "description":
+                                    "If profiling is enabled, average count of signatures in the mpm prefilter list"
                         },
                         "thresholds": {
                             "type": "object",
@@ -8044,8 +8512,8 @@
                             "properties": {
                                 "error": {
                                     "description":
-                                        "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 }
                             }
                         },
@@ -8055,8 +8523,8 @@
                             "properties": {
                                 "memcap": {
                                     "description":
-                                        "How many times defrag memcap exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "How many times defrag memcap exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 }
                             }
                         },
@@ -8066,8 +8534,8 @@
                             "properties": {
                                 "memcap": {
                                     "description":
-                                        "How many times flow memcap exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "How many times flow memcap exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 }
                             }
                         },
@@ -8077,18 +8545,18 @@
                             "properties": {
                                 "midstream": {
                                     "description":
-                                        "How many times midstream exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "How many times midstream exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 },
                                 "reassembly": {
                                     "description":
-                                        "How many times reassembly memcap exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "How many times reassembly memcap exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 },
                                 "ssn_memcap": {
                                     "description":
-                                        "How many times session memcap exception policy was applied, and which one",
-                                        "$ref": "#/$defs/exceptionPolicy"
+                                            "How many times session memcap exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
                                 }
                             }
                         }
@@ -8203,29 +8671,35 @@
                                     "properties": {
                                         "capture_bypassed": {
                                             "type": "integer",
-                                            "description": "Number of flows bypassed at the capture level -- counted at the time of flow end"
+                                            "description":
+                                                    "Number of flows bypassed at the capture level -- counted at the time of flow end"
                                         },
                                         "closed": {
                                             "type": "integer",
-                                            "description": "Number of flows in 'closed' state at the time of flow end"
+                                            "description":
+                                                    "Number of flows in 'closed' state at the time of flow end"
                                         },
                                         "established": {
                                             "type": "integer",
-                                            "description": "Number of flows in 'established' state at the time of flow end"
+                                            "description":
+                                                    "Number of flows in 'established' state at the time of flow end"
                                         },
                                         "local_bypassed": {
                                             "type": "integer",
-                                            "description": "Number of flows bypassed internally -- counted at the time of flow end"
+                                            "description":
+                                                    "Number of flows bypassed internally -- counted at the time of flow end"
                                         },
                                         "new": {
                                             "type": "integer",
-                                            "description": "Number of flows in 'new' state at the time of flow end"
+                                            "description":
+                                                    "Number of flows in 'new' state at the time of flow end"
                                         }
                                     }
                                 },
                                 "tcp_liberal": {
                                     "type": "integer",
-                                    "description": "Number of TCP flows ended that had liberal state"
+                                    "description":
+                                            "Number of TCP flows ended that had liberal state"
                                 },
                                 "tcp_state": {
                                     "type": "object",
@@ -8233,7 +8707,8 @@
                                     "properties": {
                                         "close_wait": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in CLOSE_WAIT state"
+                                            "description":
+                                                    "Number of TCP sessions in CLOSE_WAIT state"
                                         },
                                         "closed": {
                                             "type": "integer",
@@ -8245,19 +8720,23 @@
                                         },
                                         "established": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in ESTABLISHED state"
+                                            "description":
+                                                    "Number of TCP sessions in ESTABLISHED state"
                                         },
                                         "fin_wait1": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in FIN_WAIT_1 state"
+                                            "description":
+                                                    "Number of TCP sessions in FIN_WAIT_1 state"
                                         },
                                         "fin_wait2": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in FIN_WAIT_2 state"
+                                            "description":
+                                                    "Number of TCP sessions in FIN_WAIT_2 state"
                                         },
                                         "last_ack": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in LAST_ACK state"
+                                            "description":
+                                                    "Number of TCP sessions in LAST_ACK state"
                                         },
                                         "none": {
                                             "type": "integer",
@@ -8265,15 +8744,18 @@
                                         },
                                         "syn_recv": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in SYN_RECV state"
+                                            "description":
+                                                    "Number of TCP sessions in SYN_RECV state"
                                         },
                                         "syn_sent": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in SYN_SENT state"
+                                            "description":
+                                                    "Number of TCP sessions in SYN_SENT state"
                                         },
                                         "time_wait": {
                                             "type": "integer",
-                                            "description": "Number of TCP sessions in TIME_WAIT state"
+                                            "description":
+                                                    "Number of TCP sessions in TIME_WAIT state"
                                         }
                                     }
                                 }
@@ -8413,35 +8895,43 @@
                                 },
                                 "flows_evicted_needs_work": {
                                     "type": "integer",
-                                    "description": "Number of TCP flows that were returned to the workers in case reassembly, detection, logging still needs work"
+                                    "description":
+                                            "Number of TCP flows that were returned to the workers in case reassembly, detection, logging still needs work"
                                 },
                                 "flows_evicted_pkt_inject": {
                                     "type": "integer",
-                                    "description": "Number of pseudo packets injected into worker threads to complete flows' processing. For any flow this can be between 0-2, this is the total for all flows."
+                                    "description":
+                                            "Number of pseudo packets injected into worker threads to complete flows' processing. For any flow this can be between 0-2, this is the total for all flows."
                                 },
                                 "flows_injected": {
                                     "type": "integer",
-                                    "description": "Number of flows injected into the worker thread from another thread"
+                                    "description":
+                                            "Number of flows injected into the worker thread from another thread"
                                 },
                                 "flows_injected_max": {
                                     "type": "integer",
-                                    "description": "Maximum number of flows injected into the worker thread from another thread"
+                                    "description":
+                                            "Maximum number of flows injected into the worker thread from another thread"
                                 },
                                 "spare_sync": {
                                     "type": "integer",
-                                    "description": "Number of times the engine attempted to fetch flows from the master flow pool/spare queue"
+                                    "description":
+                                            "Number of times the engine attempted to fetch flows from the master flow pool/spare queue"
                                 },
                                 "spare_sync_avg": {
                                     "type": "integer",
-                                    "description": "Average number of flows a thread could fetch from the master flow pool/spare queue"
+                                    "description":
+                                            "Average number of flows a thread could fetch from the master flow pool/spare queue"
                                 },
                                 "spare_sync_empty": {
                                     "type": "integer",
-                                    "description": "Number of times the master spare pool was empty when requesting flows from it"
+                                    "description":
+                                            "Number of times the master spare pool was empty when requesting flows from it"
                                 },
                                 "spare_sync_incomplete": {
                                     "type": "integer",
-                                    "description": "Number of times spare flow syncs were incomplete (fetched with less than 100 flows in sync)"
+                                    "description":
+                                            "Number of times spare flow syncs were incomplete (fetched with less than 100 flows in sync)"
                                 }
                             }
                         }
@@ -8477,7 +8967,8 @@
                 },
                 "ftp": {
                     "type": "object",
-                    "description": "Performance statistics for global memory use and memory capacity for FTP app-layer parser",
+                    "description":
+                            "Performance statistics for global memory use and memory capacity for FTP app-layer parser",
                     "additionalProperties": false,
                     "properties": {
                         "memcap": {
@@ -8492,7 +8983,8 @@
                 },
                 "host": {
                     "type": "object",
-                    "description": "Performance statistics for global memory use and memory capacity for Host table",
+                    "description":
+                            "Performance statistics for global memory use and memory capacity for Host table",
                     "additionalProperties": false,
                     "properties": {
                         "memcap": {
@@ -8507,7 +8999,8 @@
                 },
                 "http": {
                     "type": "object",
-                    "description": "Performance statistics for global memory use and memory capacity for HTTP app-layer parser",
+                    "description":
+                            "Performance statistics for global memory use and memory capacity for HTTP app-layer parser",
                     "additionalProperties": false,
                     "properties": {
                         "byterange": {
@@ -8516,7 +9009,8 @@
                             "properties": {
                                 "memcap": {
                                     "type": "integer",
-                                    "description": "Global memory capacity reached for Byte Range containers"
+                                    "description":
+                                            "Global memory capacity reached for Byte Range containers"
                                 },
                                 "memuse": {
                                     "type": "integer",
@@ -8536,7 +9030,8 @@
                 },
                 "ippair": {
                     "type": "object",
-                    "description": "Performance statistics for global memory use and memory capacity for IP Pair table",
+                    "description":
+                            "Performance statistics for global memory use and memory capacity for IP Pair table",
                     "additionalProperties": false,
                     "properties": {
                         "memcap": {
@@ -8662,7 +9157,8 @@
                 },
                 "memcap": {
                     "type": "object",
-                    "description": "Performance statistics on global memory capacity / usage. Calculated for flow, stream, stream-reassembly, app-layer http, defrag, ippair and host",
+                    "description":
+                            "Performance statistics on global memory capacity / usage. Calculated for flow, stream, stream-reassembly, app-layer http, defrag, ippair and host",
                     "additionalProperties": false,
                     "properties": {
                         "pressure": {

--- a/rust/ffi/src/detect.rs
+++ b/rust/ffi/src/detect.rs
@@ -21,7 +21,7 @@ use std::ffi::{c_int, CString};
 use suricata_sys::sys::{
     DetectEngineCtx, SCDetectHelperKeywordRegister, SCDetectHelperKeywordSetCleanCString,
     SCSigTableAppLiteElmt, Signature, SIGMATCH_INFO_MULTI_BUFFER, SIGMATCH_INFO_STICKY_BUFFER,
-    SIGMATCH_NOOPT,
+    SIGMATCH_NOOPT, SIGMATCH_OPTIONAL_OPT,
 };
 
 /// Rust app-layer light version of SigTableElmt for simple sticky buffer
@@ -73,4 +73,11 @@ pub fn helper_keyword_register_multi_buffer(kw: &SigTableElmtStickyBuffer) -> u1
 
 pub fn helper_keyword_register_sticky_buffer(kw: &SigTableElmtStickyBuffer) -> u16 {
     helper_keyword_register_buffer_flags(kw, SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER)
+}
+
+pub fn helper_keyword_register_multi_buffer_with_options(kw: &SigTableElmtStickyBuffer) -> u16 {
+    helper_keyword_register_buffer_flags(
+        kw,
+        SIGMATCH_OPTIONAL_OPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER,
+    )
 }

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -35,6 +35,8 @@ pub mod transforms;
 pub mod uint;
 pub mod uri;
 pub mod vlan;
+pub mod windows_pe;
+pub mod windows_pe_logger;
 
 use std::ffi::{c_void, CString};
 
@@ -59,8 +61,8 @@ pub trait EnumString<T> {
 }
 
 pub use suricata_ffi::detect::{
-    helper_keyword_register_multi_buffer, helper_keyword_register_sticky_buffer,
-    SigTableElmtStickyBuffer,
+    helper_keyword_register_multi_buffer, helper_keyword_register_multi_buffer_with_options,
+    helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer,
 };
 
 #[repr(C)]

--- a/rust/src/detect/windows_pe.rs
+++ b/rust/src/detect/windows_pe.rs
@@ -1,0 +1,2507 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! # Windows PE Detection Module
+//!
+//! This module provides the `windows_pe` detection keyword for identifying Windows Portable
+//! Executable (PE) files in network traffic. The keyword inspects file data buffers to validate
+//! PE structure and match on header metadata.
+//!
+//! ## Overview
+//!
+//! Windows PE files are the standard executable format for Windows operating systems. They consist of:
+//! - A DOS header beginning with the "MZ" signature (0x5A4D)
+//! - A DOS stub program
+//! - A PE header beginning with the "PE\0\0" signature (0x00004550)
+//! - COFF header and optional header containing metadata
+//! - Section headers and section data
+//!
+//! ## PE File Structure Validation
+//!
+//! A valid PE file must satisfy:
+//! 1. **DOS Header Magic**: First 2 bytes must be "MZ" (0x4D 0x5A)
+//! 2. **Minimum Size**: At least 64 bytes for the DOS header
+//! 3. **PE Offset**: Valid offset at bytes 60-63 (little-endian) pointing to PE signature
+//! 4. **PE Signature**: "PE\0\0" (0x50 0x45 0x00 0x00) at the PE offset location
+//! 5. **Reasonable Bounds**: PE offset must be within file size and not exceed 0x10000
+//!
+//! ## Use Cases
+//!
+//! - **Malware Detection**: Identify potential malware executables in HTTP/SMTP traffic
+//! - **Policy Enforcement**: Block executable downloads in corporate environments
+//! - **Threat Hunting**: Track PE file transfers for forensic analysis
+//! - **File Classification**: Categorize and log Windows executable traffic
+//!
+//! ## Performance Considerations
+//!
+//! - The keyword works best when combined with content matches to pre-filter data
+//! - Use with `file.data` buffer for HTTP/SMTP file transfers
+//! - Consider file size limits to avoid processing very large files
+//!
+//! ## References
+//!
+//! - Microsoft PE/COFF Specification
+//! - [PE Format Documentation](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format)
+
+use crate::detect::uint::{detect_match_uint, detect_parse_uint, DetectUintData};
+#[cfg(test)]
+use crate::jsonbuilder::{JsonBuilder, JsonError};
+use std::collections::HashSet;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+use suricata_sys::sys::{
+    DetectEngineCtx, DetectEngineThreadCtx, File, Flow, SCDetectHelperFileKeywordRegister,
+    SCDetectHelperGetFilesBufferId, SCDetectSignatureSetFileInspect, SCFileGetData,
+    SCSigMatchAppendSMToList, SCSigTableFileLiteElmt, SigMatchCtx, Signature,
+    SIGMATCH_OPTIONAL_OPT,
+};
+
+/// Flag: PE metadata has been parsed (valid or invalid).
+pub const SC_FILE_PE_META_F_PARSED: u16 = 1 << 0;
+/// Flag: PE metadata is valid (file is a valid PE).
+pub const SC_FILE_PE_META_F_VALID: u16 = 1 << 1;
+
+/// Cached Windows PE metadata stored in the `File` object.
+///
+/// Parsed once per file and cached to avoid redundant header parsing
+/// across multiple keyword evaluations and logging calls.  Fields map
+/// directly to COFF / Optional header values.
+///
+/// The `flags` field uses `SC_FILE_PE_META_F_PARSED` to indicate that
+/// parsing has been attempted, and `SC_FILE_PE_META_F_VALID` to indicate
+/// that the file is a valid PE.
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct SCFilePeMeta {
+    pub flags: u16,
+    pub architecture: u16,
+    pub num_sections: u16,
+    pub subsystem: u16,
+    pub characteristics: u16,
+    pub dll_characteristics: u16,
+    /// Optional header magic (0x10b = PE32, 0x20b = PE32+).
+    pub magic: u16,
+    /// Number of imported DLLs from the Import Directory Table.
+    pub num_imports: u16,
+    /// SizeOfImage from the optional header.
+    pub size_of_image: u32,
+    /// AddressOfEntryPoint RVA from the optional header.
+    pub entry_point_rva: u32,
+    /// Offset to the PE signature in the file.
+    pub pe_offset: u32,
+    /// TimeDateStamp from the COFF header (Unix epoch seconds).
+    pub timestamp: u32,
+    /// Checksum from the optional header.
+    pub checksum: u32,
+    /// SizeOfHeaders from the optional header.
+    pub size_of_headers: u32,
+    /// Number of exported functions from the Export Directory.
+    pub num_exports: u32,
+    /// Non-zero if any section has both WRITE and EXECUTE permissions.
+    pub has_wx_section: u8,
+    pub padding_: [u8; 3],
+}
+
+extern "C" {
+    fn FilePeMetaGet(file: *const File, meta: *mut SCFilePeMeta) -> bool;
+    fn FilePeMetaSet(file: *mut File, meta: *const SCFilePeMeta);
+    fn FilePeImportsGet(file: *const File) -> *const std::os::raw::c_void;
+    fn FilePeImportsSet(file: *mut File, imports: *mut std::os::raw::c_void);
+}
+
+/// Validate a PE file and return the PE header offset on success.
+///
+/// Returns `Some(pe_offset)` when the data contains a valid MZ + PE\0\0
+/// signature pair, `None` otherwise.  Callers should reuse the returned
+/// offset instead of re-reading bytes 60-63.
+pub(crate) fn pe_validate(data: &[u8]) -> Option<usize> {
+    if data.len() < 64 {
+        return None;
+    }
+    if data[0] != b'M' || data[1] != b'Z' {
+        return None;
+    }
+    let pe_offset = u32::from_le_bytes([data[60], data[61], data[62], data[63]]) as usize;
+    if pe_offset > 0x10000 || pe_offset + 4 > data.len() {
+        return None;
+    }
+    if &data[pe_offset..pe_offset + 4] != b"PE\0\0" {
+        return None;
+    }
+    Some(pe_offset)
+}
+
+/// Parse PE header and extract metadata.
+///
+/// Extracts COFF and Optional header information from a validated PE file.
+/// Uses bounds-checked reads so truncated files return zero for missing fields.
+/// Returns None if the data is not a valid PE.
+///
+/// Fields that require deep parsing (`num_imports`, `num_exports`,
+/// `has_wx_section`) are initialized to zero/false and must be filled
+/// by the caller if needed.
+pub(crate) fn parse_pe_metadata(data: &[u8]) -> Option<SCDetectPeMetadata> {
+    let pe_offset = pe_validate(data)?;
+
+    let safe_u16_at = |offset: usize| -> u16 {
+        if offset + 2 <= data.len() {
+            u16::from_le_bytes([data[offset], data[offset + 1]])
+        } else {
+            0
+        }
+    };
+    let safe_u32_at = |offset: usize| -> u32 {
+        if offset + 4 <= data.len() {
+            u32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ])
+        } else {
+            0
+        }
+    };
+
+    let optional_header_offset = pe_offset + 24;
+
+    Some(SCDetectPeMetadata {
+        valid: true,
+        pe_offset: pe_offset as u32,
+        architecture: safe_u16_at(pe_offset + 4),
+        num_sections: safe_u16_at(pe_offset + 6),
+        timestamp: safe_u32_at(pe_offset + 8),
+        characteristics: safe_u16_at(pe_offset + 22),
+        magic: safe_u16_at(optional_header_offset),
+        entry_point_rva: safe_u32_at(optional_header_offset + 0x10),
+        size_of_image: safe_u32_at(optional_header_offset + 0x38),
+        size_of_headers: safe_u32_at(optional_header_offset + 0x3C),
+        checksum: safe_u32_at(optional_header_offset + 0x40),
+        subsystem: safe_u16_at(optional_header_offset + 0x44),
+        dll_characteristics: safe_u16_at(optional_header_offset + 0x46),
+        num_imports: 0,
+        num_exports: 0,
+        has_wx_section: false,
+    })
+}
+
+// ============================================================================
+// PE Import Table Parsing
+// ============================================================================
+
+/// Minimal section header info needed for RVA-to-file-offset conversion.
+pub(crate) struct SectionInfo {
+    pub(crate) name: [u8; 8],
+    pub(crate) virtual_address: u32,
+    pub(crate) virtual_size: u32,
+    pub(crate) raw_data_offset: u32,
+    pub(crate) raw_data_size: u32,
+    pub(crate) characteristics: u32,
+}
+
+/// Convert an RVA to a file offset using section headers.
+///
+/// Walks the section table to find which section contains the RVA, then
+/// computes the file offset as: `rva - section.virtual_address + section.raw_data_offset`.
+fn rva_to_offset(rva: u32, sections: &[SectionInfo]) -> Option<usize> {
+    for section in sections {
+        if rva >= section.virtual_address
+            && rva < section.virtual_address.saturating_add(section.virtual_size)
+        {
+            let delta = rva - section.virtual_address;
+            if delta < section.raw_data_size {
+                return Some(section.raw_data_offset.wrapping_add(delta) as usize);
+            }
+        }
+    }
+    None
+}
+
+/// Parse section headers from a validated PE file.
+///
+/// Section headers start immediately after the optional header:
+/// `pe_offset + 24 + SizeOfOptionalHeader`.
+pub(crate) fn parse_section_headers(
+    data: &[u8], pe_offset: usize, num_sections: u16,
+) -> Vec<SectionInfo> {
+    if pe_offset + 24 > data.len() {
+        return Vec::new();
+    }
+    let size_of_optional_header =
+        u16::from_le_bytes([data[pe_offset + 20], data[pe_offset + 21]]) as usize;
+    let sections_start = pe_offset + 24 + size_of_optional_header;
+    let count = (num_sections as usize).min(96); // safety cap
+    let mut out = Vec::with_capacity(count);
+    for i in 0..count {
+        let base = sections_start + i * 40;
+        if base + 40 > data.len() {
+            break;
+        }
+        let mut name = [0u8; 8];
+        name.copy_from_slice(&data[base..base + 8]);
+        out.push(SectionInfo {
+            name,
+            virtual_size: u32::from_le_bytes([
+                data[base + 8],
+                data[base + 9],
+                data[base + 10],
+                data[base + 11],
+            ]),
+            virtual_address: u32::from_le_bytes([
+                data[base + 12],
+                data[base + 13],
+                data[base + 14],
+                data[base + 15],
+            ]),
+            raw_data_size: u32::from_le_bytes([
+                data[base + 16],
+                data[base + 17],
+                data[base + 18],
+                data[base + 19],
+            ]),
+            raw_data_offset: u32::from_le_bytes([
+                data[base + 20],
+                data[base + 21],
+                data[base + 22],
+                data[base + 23],
+            ]),
+            characteristics: u32::from_le_bytes([
+                data[base + 36],
+                data[base + 37],
+                data[base + 38],
+                data[base + 39],
+            ]),
+        });
+    }
+    out
+}
+
+/// Inner import parser that takes a pre-validated PE offset and section headers.
+///
+/// Avoids redundant `pe_validate` and `parse_section_headers` when the caller
+/// has already performed them.
+pub(crate) fn parse_pe_imports_with_offset(
+    data: &[u8], pe_offset: usize, sections: &[SectionInfo],
+) -> Option<Vec<String>> {
+    let optional_header_offset = pe_offset + 24;
+
+    // Need at least 2 bytes for Magic
+    if optional_header_offset + 2 > data.len() {
+        return None;
+    }
+    let magic = u16::from_le_bytes([
+        data[optional_header_offset],
+        data[optional_header_offset + 1],
+    ]);
+
+    // Determine offsets that depend on PE32 vs PE32+
+    let (num_rva_off, data_dir_off) = match magic {
+        0x10b => (optional_header_offset + 0x5C, optional_header_offset + 0x60), // PE32
+        0x20b => (optional_header_offset + 0x6C, optional_header_offset + 0x70), // PE32+
+        _ => return None,
+    };
+
+    // NumberOfRvaAndSizes must be >= 2 (export + import)
+    if num_rva_off + 4 > data.len() {
+        return None;
+    }
+    let num_rva_and_sizes = u32::from_le_bytes([
+        data[num_rva_off],
+        data[num_rva_off + 1],
+        data[num_rva_off + 2],
+        data[num_rva_off + 3],
+    ]);
+    if num_rva_and_sizes < 2 {
+        return None;
+    }
+
+    // Import Directory is data-directory entry index 1 (each entry = 8 bytes)
+    let import_entry = data_dir_off + 8;
+    if import_entry + 8 > data.len() {
+        return None;
+    }
+    let import_rva = u32::from_le_bytes([
+        data[import_entry],
+        data[import_entry + 1],
+        data[import_entry + 2],
+        data[import_entry + 3],
+    ]);
+    let import_size = u32::from_le_bytes([
+        data[import_entry + 4],
+        data[import_entry + 5],
+        data[import_entry + 6],
+        data[import_entry + 7],
+    ]);
+    if import_rva == 0 || import_size == 0 {
+        return Some(Vec::new()); // PE has no imports
+    }
+
+    let import_off = rva_to_offset(import_rva, sections)?;
+
+    let mut dlls = Vec::new();
+    let max_entries: usize = 256; // safety limit
+
+    for i in 0..max_entries {
+        let ent = import_off + i * 20;
+        if ent + 20 > data.len() {
+            break;
+        }
+
+        // Import Directory entry bytes 12..16 = Name RVA
+        let name_rva = u32::from_le_bytes([
+            data[ent + 12],
+            data[ent + 13],
+            data[ent + 14],
+            data[ent + 15],
+        ]);
+
+        // All-zero entry terminates the table
+        if data[ent..ent + 20].iter().all(|&b| b == 0) {
+            break;
+        }
+        if name_rva == 0 {
+            continue;
+        }
+
+        let name_off = match rva_to_offset(name_rva, sections) {
+            Some(o) => o,
+            None => continue,
+        };
+        if name_off >= data.len() {
+            continue;
+        }
+
+        // Read null-terminated ASCII DLL name (max 260 chars)
+        let max_len = 260.min(data.len() - name_off);
+        let name_bytes = &data[name_off..name_off + max_len];
+        let end = name_bytes.iter().position(|&b| b == 0).unwrap_or(max_len);
+        if end > 0 {
+            if let Ok(name) = std::str::from_utf8(&name_bytes[..end]) {
+                dlls.push(name.to_ascii_lowercase());
+            }
+        }
+    }
+
+    Some(dlls)
+}
+
+/// Parse the export directory to extract the DLL name and number of exported functions.
+///
+/// Returns `(export_name, num_exports)`.  The export name is the internal
+/// DLL name from the export directory (lowercased).
+pub(crate) fn parse_pe_exports(
+    data: &[u8], pe_offset: usize, sections: &[SectionInfo],
+) -> (Option<String>, u32) {
+    let optional_header_offset = pe_offset + 24;
+    if optional_header_offset + 2 > data.len() {
+        return (None, 0);
+    }
+    let magic = u16::from_le_bytes([
+        data[optional_header_offset],
+        data[optional_header_offset + 1],
+    ]);
+    let (num_rva_off, data_dir_off) = match magic {
+        0x10b => (optional_header_offset + 0x5C, optional_header_offset + 0x60),
+        0x20b => (optional_header_offset + 0x6C, optional_header_offset + 0x70),
+        _ => return (None, 0),
+    };
+
+    if num_rva_off + 4 > data.len() {
+        return (None, 0);
+    }
+    let num_rva_sizes = u32::from_le_bytes([
+        data[num_rva_off],
+        data[num_rva_off + 1],
+        data[num_rva_off + 2],
+        data[num_rva_off + 3],
+    ]);
+    // Export directory is data directory index 0
+    if num_rva_sizes < 1 || data_dir_off + 8 > data.len() {
+        return (None, 0);
+    }
+    let export_rva = u32::from_le_bytes([
+        data[data_dir_off],
+        data[data_dir_off + 1],
+        data[data_dir_off + 2],
+        data[data_dir_off + 3],
+    ]);
+    if export_rva == 0 {
+        return (None, 0);
+    }
+
+    let export_off = match rva_to_offset(export_rva, sections) {
+        Some(o) => o,
+        None => return (None, 0),
+    };
+
+    // Export directory table: 40 bytes minimum
+    if export_off + 40 > data.len() {
+        return (None, 0);
+    }
+
+    let num_functions = u32::from_le_bytes([
+        data[export_off + 20],
+        data[export_off + 21],
+        data[export_off + 22],
+        data[export_off + 23],
+    ]);
+    let name_rva = u32::from_le_bytes([
+        data[export_off + 12],
+        data[export_off + 13],
+        data[export_off + 14],
+        data[export_off + 15],
+    ]);
+
+    let export_name = if name_rva != 0 {
+        rva_to_offset(name_rva, sections).and_then(|off| {
+            if off >= data.len() {
+                return None;
+            }
+            let max_len = 260.min(data.len() - off);
+            let end = data[off..off + max_len]
+                .iter()
+                .position(|&b| b == 0)
+                .unwrap_or(max_len);
+            if end > 0 {
+                std::str::from_utf8(&data[off..off + end])
+                    .ok()
+                    .map(|s| s.to_ascii_lowercase())
+            } else {
+                None
+            }
+        })
+    } else {
+        None
+    };
+
+    (export_name, num_functions)
+}
+
+/// Check if any section has both WRITE and EXECUTE characteristics.
+pub(crate) const IMAGE_SCN_MEM_EXECUTE: u32 = 0x2000_0000;
+pub(crate) const IMAGE_SCN_MEM_WRITE: u32 = 0x8000_0000;
+
+pub(crate) fn has_wx_section(sections: &[SectionInfo]) -> bool {
+    sections.iter().any(|s| {
+        s.characteristics & IMAGE_SCN_MEM_WRITE != 0
+            && s.characteristics & IMAGE_SCN_MEM_EXECUTE != 0
+    })
+}
+
+/// Get the printable name of a section header (up to 8 bytes, null-trimmed).
+pub(crate) fn section_name_str(name: &[u8; 8]) -> &str {
+    let end = name.iter().position(|&b| b == 0).unwrap_or(8);
+    std::str::from_utf8(&name[..end]).unwrap_or("")
+}
+
+/// Cached PE metadata used to avoid redundant header parsing across
+/// multiple sub-keyword evaluations on the same file.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub(crate) struct SCDetectPeMetadata {
+    pub(crate) valid: bool,
+    pub(crate) architecture: u16,
+    pub(crate) num_sections: u16,
+    pub(crate) subsystem: u16,
+    pub(crate) characteristics: u16,
+    pub(crate) dll_characteristics: u16,
+    pub(crate) magic: u16,
+    pub(crate) num_imports: u16,
+    pub(crate) size_of_image: u32,
+    pub(crate) entry_point_rva: u32,
+    pub(crate) pe_offset: u32,
+    pub(crate) timestamp: u32,
+    pub(crate) checksum: u32,
+    pub(crate) size_of_headers: u32,
+    pub(crate) num_exports: u32,
+    pub(crate) has_wx_section: bool,
+}
+
+impl Default for SCDetectPeMetadata {
+    fn default() -> Self {
+        Self {
+            valid: false,
+            architecture: 0,
+            num_sections: 0,
+            subsystem: 0,
+            characteristics: 0,
+            dll_characteristics: 0,
+            magic: 0,
+            num_imports: 0,
+            size_of_image: 0,
+            entry_point_rva: 0,
+            pe_offset: 0,
+            timestamp: 0,
+            checksum: 0,
+            size_of_headers: 0,
+            num_exports: 0,
+            has_wx_section: false,
+        }
+    }
+}
+
+// ============================================================================
+// Keyword context: parsed options for the windows_pe keyword
+// ============================================================================
+
+/// Context structure for the `windows_pe` keyword.
+///
+/// All options are parsed in Rust by [`SCDetectWindowsPEParse`].
+/// The C `FileMatch` callback calls matching logic in Rust.
+///
+/// Uint filter data is owned by this struct and stored as boxed types.
+/// Using `detect_parse_uint::<T>()` directly avoids FFI overhead.
+pub struct DetectWindowsPEData {
+    architecture: u16,
+    pe_type: u16, // magic filter: 0x10b=PE32, 0x20b=PE32+ (0 = no filter)
+    size: *mut DetectUintData<u32>,
+    sections: *mut DetectUintData<u16>,
+    entry_point: *mut DetectUintData<u32>,
+    subsystem: *mut DetectUintData<u16>,
+    characteristics: *mut DetectUintData<u16>,
+    dll_characteristics: *mut DetectUintData<u16>,
+    timestamp: *mut DetectUintData<u32>,
+    checksum: *mut DetectUintData<u32>,
+    size_of_headers: *mut DetectUintData<u32>,
+    num_imports: *mut DetectUintData<u16>,
+    num_exports: *mut DetectUintData<u32>,
+    import_dlls: Option<Vec<String>>,
+    section_name: Option<String>,
+    export_name: Option<String>,
+    section_wx: bool,
+    has_filters: bool,
+    /// True when the rule uses options that require expensive parsing
+    /// (imports, exports, section headers) beyond the basic COFF/Optional header.
+    needs_deep_parse: bool,
+}
+
+impl Default for DetectWindowsPEData {
+    fn default() -> Self {
+        Self {
+            architecture: 0,
+            pe_type: 0,
+            size: std::ptr::null_mut(),
+            sections: std::ptr::null_mut(),
+            entry_point: std::ptr::null_mut(),
+            subsystem: std::ptr::null_mut(),
+            characteristics: std::ptr::null_mut(),
+            dll_characteristics: std::ptr::null_mut(),
+            timestamp: std::ptr::null_mut(),
+            checksum: std::ptr::null_mut(),
+            size_of_headers: std::ptr::null_mut(),
+            num_imports: std::ptr::null_mut(),
+            num_exports: std::ptr::null_mut(),
+            import_dlls: None,
+            section_name: None,
+            export_name: None,
+            section_wx: false,
+            has_filters: false,
+            needs_deep_parse: false,
+        }
+    }
+}
+
+impl Drop for DetectWindowsPEData {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.size.is_null() {
+                let _ = Box::from_raw(self.size);
+            }
+            if !self.sections.is_null() {
+                let _ = Box::from_raw(self.sections);
+            }
+            if !self.entry_point.is_null() {
+                let _ = Box::from_raw(self.entry_point);
+            }
+            if !self.subsystem.is_null() {
+                let _ = Box::from_raw(self.subsystem);
+            }
+            if !self.characteristics.is_null() {
+                let _ = Box::from_raw(self.characteristics);
+            }
+            if !self.dll_characteristics.is_null() {
+                let _ = Box::from_raw(self.dll_characteristics);
+            }
+            if !self.timestamp.is_null() {
+                let _ = Box::from_raw(self.timestamp);
+            }
+            if !self.checksum.is_null() {
+                let _ = Box::from_raw(self.checksum);
+            }
+            if !self.size_of_headers.is_null() {
+                let _ = Box::from_raw(self.size_of_headers);
+            }
+            if !self.num_imports.is_null() {
+                let _ = Box::from_raw(self.num_imports);
+            }
+            if !self.num_exports.is_null() {
+                let _ = Box::from_raw(self.num_exports);
+            }
+            // import_dlls, section_name, export_name are Option types and drop automatically
+        }
+    }
+}
+
+/// Parse a uint value and store it as a boxed raw pointer in the given field.
+macro_rules! parse_uint_field {
+    ($data:expr, $field:ident, $ty:ty, $val:expr) => {
+        if let Ok((_, ctx)) = detect_parse_uint::<$ty>($val) {
+            $data.$field = Box::into_raw(Box::new(ctx));
+        } else {
+            return None;
+        }
+    };
+}
+
+fn process_executable_option(data: &mut DetectWindowsPEData, key: &str, val: &str) -> Option<()> {
+    match key {
+        "arch" => {
+            let v = val.to_ascii_lowercase();
+            data.architecture = match v.as_str() {
+                "x86" | "i386" | "i686" => 0x014C,
+                "x86_64" | "x64" | "amd64" => 0x8664,
+                "arm" => 0x01C0,
+                "arm64" | "aarch64" => 0xAA64,
+                _ => return None,
+            };
+        }
+        "size" => parse_uint_field!(data, size, u32, val),
+        "sections" => parse_uint_field!(data, sections, u16, val),
+        "entry_point" => parse_uint_field!(data, entry_point, u32, val),
+        "subsystem" => parse_uint_field!(data, subsystem, u16, val),
+        "characteristics" => parse_uint_field!(data, characteristics, u16, val),
+        "dll_characteristics" => parse_uint_field!(data, dll_characteristics, u16, val),
+        "timestamp" => parse_uint_field!(data, timestamp, u32, val),
+        "checksum" => parse_uint_field!(data, checksum, u32, val),
+        "size_of_headers" => parse_uint_field!(data, size_of_headers, u32, val),
+        "num_imports" => parse_uint_field!(data, num_imports, u16, val),
+        "num_exports" => parse_uint_field!(data, num_exports, u32, val),
+        "pe_type" => {
+            let v = val.trim().to_ascii_lowercase();
+            data.pe_type = match v.as_str() {
+                "pe32" => 0x10b,
+                "pe32+" | "pe32plus" | "pe64" => 0x20b,
+                _ => return None,
+            };
+        }
+        "section_name" => {
+            data.section_name = Some(val.trim().to_lowercase());
+        }
+        "export_name" => {
+            data.export_name = Some(val.trim().to_ascii_lowercase());
+        }
+        "section_wx" => {
+            data.section_wx = true;
+        }
+        _ => return None,
+    }
+    Some(())
+}
+
+/// Parse all options from the windows_pe keyword argument string.
+///
+/// Handles comma-separated `key value` pairs (standard Suricata style).
+/// Tokens that do not start with an identifier character are treated as
+/// continuations of the previous value, which supports uint range
+/// expressions like `size >1000, <5000`.
+///
+/// Returns `None` on any parse error; partially-allocated C uint data
+/// is freed automatically via the `Drop` impl on [`DetectWindowsPEData`].
+fn parse_executable_options(input: &str) -> Option<DetectWindowsPEData> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Some(DetectWindowsPEData::default());
+    }
+
+    let mut data = DetectWindowsPEData::default();
+    let mut cur_key = String::new();
+    let mut cur_val = String::new();
+    let mut have_kv = false;
+
+    for tok_raw in trimmed.split(',') {
+        let tok = tok_raw.trim();
+        if tok.is_empty() {
+            continue;
+        }
+
+        // A token that starts with a letter or underscore is a new key-value
+        // pair: split on the first whitespace to separate key from value.
+        if tok.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_') {
+            if let Some(space_pos) = tok.find(|c: char| c.is_ascii_whitespace()) {
+                // Flush previous key-value pair
+                if have_kv {
+                    process_executable_option(&mut data, &cur_key, &cur_val)?;
+                }
+                cur_key = tok[..space_pos].trim().to_ascii_lowercase();
+                cur_val = tok[space_pos..].trim().to_string();
+                have_kv = true;
+                continue;
+            }
+            // Bare flag keywords (no value required)
+            let bare_key = tok.to_ascii_lowercase();
+            if bare_key == "section_wx" {
+                if have_kv {
+                    process_executable_option(&mut data, &cur_key, &cur_val)?;
+                }
+                process_executable_option(&mut data, &bare_key, "")?;
+                cur_key.clear();
+                cur_val.clear();
+                have_kv = false;
+                continue;
+            }
+            // A bare token containing a dot (e.g. "kernel32.dll") is a
+            // DLL import name to match in the PE Import Directory Table.
+            if tok.contains('.') {
+                if have_kv {
+                    process_executable_option(&mut data, &cur_key, &cur_val)?;
+                }
+                let name = tok.to_ascii_lowercase();
+                match &mut data.import_dlls {
+                    Some(dlls) => dlls.push(name),
+                    None => data.import_dlls = Some(vec![name]),
+                }
+                cur_key.clear();
+                cur_val.clear();
+                have_kv = false;
+                continue;
+            }
+        }
+
+        // No key-value pair found — treat as continuation of previous value
+        // (e.g. "<5000" after "size >1000")
+        if !have_kv {
+            return None;
+        }
+        cur_val.push(',');
+        cur_val.push_str(tok);
+    }
+
+    // Flush final key-value pair
+    if have_kv {
+        process_executable_option(&mut data, &cur_key, &cur_val)?;
+    }
+
+    data.has_filters = data.architecture != 0
+        || !data.size.is_null()
+        || !data.sections.is_null()
+        || !data.entry_point.is_null()
+        || !data.subsystem.is_null()
+        || !data.characteristics.is_null()
+        || !data.dll_characteristics.is_null()
+        || data.import_dlls.is_some()
+        || data.pe_type != 0
+        || !data.timestamp.is_null()
+        || !data.checksum.is_null()
+        || !data.size_of_headers.is_null()
+        || !data.num_imports.is_null()
+        || !data.num_exports.is_null()
+        || data.section_name.is_some()
+        || data.export_name.is_some()
+        || data.section_wx;
+
+    data.needs_deep_parse = data.import_dlls.is_some()
+        || !data.num_imports.is_null()
+        || !data.num_exports.is_null()
+        || data.export_name.is_some()
+        || data.section_name.is_some()
+        || data.section_wx;
+
+    Some(data)
+}
+
+/// Parse windows_pe keyword options from a C string.
+///
+/// Follows the bytemath pattern: Rust owns the context struct.
+/// C calls this from `DetectWindowsPESetup`, stores the returned pointer,
+/// and later frees it with [`SCDetectWindowsPEFree`].
+///
+/// A NULL `c_arg` means bare `windows_pe;` with no options (default PE
+/// validation, no metadata filters).
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectWindowsPEParse(c_arg: *const c_char) -> *mut DetectWindowsPEData {
+    if c_arg.is_null() {
+        // No options -> default PE validation only
+        return Box::into_raw(Box::new(DetectWindowsPEData::default()));
+    }
+
+    let arg = match CStr::from_ptr(c_arg).to_str() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    match parse_executable_options(arg) {
+        Some(data) => Box::into_raw(Box::new(data)),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Free a [`DetectWindowsPEData`] allocated by [`SCDetectWindowsPEParse`].
+///
+/// The `Drop` impl on `DetectWindowsPEData` takes care of freeing any
+/// boxed uint filter data (`DetectUintData<u32>`, `DetectUintData<u16>`).
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectWindowsPEFree(ptr: *mut DetectWindowsPEData) {
+    if !ptr.is_null() {
+        let _ = Box::from_raw(ptr);
+    }
+}
+
+/// Convert File-level cached PE metadata to detection metadata.
+pub(crate) fn detect_meta_from_file_meta(meta: &SCFilePeMeta) -> SCDetectPeMetadata {
+    SCDetectPeMetadata {
+        valid: (meta.flags & SC_FILE_PE_META_F_VALID) != 0,
+        architecture: meta.architecture,
+        num_sections: meta.num_sections,
+        subsystem: meta.subsystem,
+        characteristics: meta.characteristics,
+        dll_characteristics: meta.dll_characteristics,
+        magic: meta.magic,
+        num_imports: meta.num_imports,
+        size_of_image: meta.size_of_image,
+        entry_point_rva: meta.entry_point_rva,
+        pe_offset: meta.pe_offset,
+        timestamp: meta.timestamp,
+        checksum: meta.checksum,
+        size_of_headers: meta.size_of_headers,
+        num_exports: meta.num_exports,
+        has_wx_section: meta.has_wx_section != 0,
+    }
+}
+
+pub(crate) fn file_meta_from_detect_meta(meta: &SCDetectPeMetadata) -> SCFilePeMeta {
+    let mut flags = SC_FILE_PE_META_F_PARSED;
+    if meta.valid {
+        flags |= SC_FILE_PE_META_F_VALID;
+    }
+    SCFilePeMeta {
+        flags,
+        architecture: meta.architecture,
+        num_sections: meta.num_sections,
+        subsystem: meta.subsystem,
+        characteristics: meta.characteristics,
+        dll_characteristics: meta.dll_characteristics,
+        magic: meta.magic,
+        num_imports: meta.num_imports,
+        size_of_image: meta.size_of_image,
+        entry_point_rva: meta.entry_point_rva,
+        pe_offset: meta.pe_offset,
+        timestamp: meta.timestamp,
+        checksum: meta.checksum,
+        size_of_headers: meta.size_of_headers,
+        num_exports: meta.num_exports,
+        has_wx_section: if meta.has_wx_section { 1 } else { 0 },
+        padding_: [0; 3],
+    }
+}
+
+pub(crate) unsafe fn file_meta_get(file: *const File) -> Option<SCDetectPeMetadata> {
+    if file.is_null() {
+        return None;
+    }
+    let mut raw: SCFilePeMeta = unsafe { std::mem::zeroed() };
+    if !FilePeMetaGet(file, &mut raw) {
+        return None;
+    }
+    if (raw.flags & SC_FILE_PE_META_F_PARSED) == 0 {
+        return None;
+    }
+    Some(detect_meta_from_file_meta(&raw))
+}
+
+pub(crate) unsafe fn file_meta_set(file: *mut File, meta: &SCDetectPeMetadata) {
+    if file.is_null() {
+        return;
+    }
+    let raw = file_meta_from_detect_meta(meta);
+    FilePeMetaSet(file, &raw);
+}
+
+/// Fill supplementary fields (sections, imports, exports) on an existing metadata struct.
+pub(crate) fn detect_meta_full(
+    meta: &mut SCDetectPeMetadata, sections: &[SectionInfo], num_imports: u16, num_exports: u32,
+) {
+    meta.has_wx_section = has_wx_section(sections);
+    meta.num_imports = num_imports;
+    meta.num_exports = num_exports;
+}
+
+// ============================================================================
+// Import list caching in the File object
+// ============================================================================
+
+/// Retrieve cached import list from File (opaque pointer → `Vec<String>`).
+///
+/// Returns `None` if no imports have been cached yet.
+pub(crate) unsafe fn file_imports_get(file: *const File) -> Option<&'static [String]> {
+    if file.is_null() {
+        return None;
+    }
+    let ptr = FilePeImportsGet(file);
+    if ptr.is_null() {
+        return None;
+    }
+    let vec = &*(ptr as *const Vec<String>);
+    Some(vec.as_slice())
+}
+
+/// Store a parsed import list in the File object.
+///
+/// The `Vec<String>` is heap-allocated and ownership is transferred to the
+/// File; it will be freed by `SCFilePeImportsFree` when the File is freed.
+pub(crate) unsafe fn file_imports_set(file: *mut File, imports: Vec<String>) {
+    if file.is_null() {
+        return;
+    }
+    let boxed = Box::new(imports);
+    FilePeImportsSet(file, Box::into_raw(boxed) as *mut std::os::raw::c_void);
+}
+
+/// Retrieve or parse+cache the import list for a file.
+///
+/// If the File already has cached imports, returns a reference to them.
+/// Otherwise parses from `file_data`, caches the result, and returns it.
+unsafe fn get_pe_imports_by_file<'a>(
+    file_ptr: *mut File, file_data: &[u8], pe_offset: usize, sections: &[SectionInfo],
+) -> Option<&'a [String]> {
+    // Try cache first.
+    if let Some(cached) = file_imports_get(file_ptr as *const File) {
+        return Some(cached);
+    }
+    // Parse, cache, and return.
+    let imports = parse_pe_imports_with_offset(file_data, pe_offset, sections)?;
+    file_imports_set(file_ptr, imports);
+    // Re-read from cache to get a stable reference.
+    file_imports_get(file_ptr as *const File)
+}
+
+/// Free a Rust-allocated `Vec<String>` stored as an opaque pointer in File.
+///
+/// Called from C's `FileFree` via `SCFilePeImportsFree`.
+#[no_mangle]
+pub unsafe extern "C" fn SCFilePeImportsFree(ptr: *mut std::os::raw::c_void) {
+    if !ptr.is_null() {
+        let _ = Box::from_raw(ptr as *mut Vec<String>);
+    }
+}
+
+// SCPeLogJsonByFile lives in windows_pe_logger.rs.
+
+/// Check if PE metadata matches the filter criteria.
+///
+/// Returns `true` if all criteria match, `false` if any don't match.
+/// NULL pointers for optional uint fields are treated as "any value OK".
+///
+/// # Safety
+/// All `*mut DetectUintData<T>` pointers in `ctx` must be valid or null.
+unsafe fn pe_match(meta: &SCDetectPeMetadata, ctx: &DetectWindowsPEData) -> bool {
+    if !meta.valid {
+        return false;
+    }
+
+    if ctx.architecture != 0 && meta.architecture != ctx.architecture {
+        return false;
+    }
+
+    macro_rules! check_uint {
+        ($ptr:expr, $val:expr) => {
+            if !$ptr.is_null() && !detect_match_uint(&*$ptr, $val) {
+                return false;
+            }
+        };
+    }
+
+    check_uint!(ctx.size, meta.size_of_image);
+    check_uint!(ctx.sections, meta.num_sections);
+    check_uint!(ctx.entry_point, meta.entry_point_rva);
+    check_uint!(ctx.subsystem, meta.subsystem);
+    check_uint!(ctx.characteristics, meta.characteristics);
+    check_uint!(ctx.dll_characteristics, meta.dll_characteristics);
+
+    if ctx.pe_type != 0 && meta.magic != ctx.pe_type {
+        return false;
+    }
+
+    check_uint!(ctx.timestamp, meta.timestamp);
+    check_uint!(ctx.checksum, meta.checksum);
+    check_uint!(ctx.size_of_headers, meta.size_of_headers);
+    check_uint!(ctx.num_imports, meta.num_imports);
+    check_uint!(ctx.num_exports, meta.num_exports);
+
+    if ctx.section_wx && !meta.has_wx_section {
+        return false;
+    }
+
+    true
+}
+
+/// Combined file match operation: retrieve PE metadata and check if it matches.
+///
+/// This combines two operations into a single FFI call for efficiency:
+/// 1. Retrieve PE metadata from file data (cached in `File`)
+/// 2. Check if metadata matches the filter criteria
+/// 3. Check import filters against cached import list
+///
+/// Imports are parsed once per file and cached in the `File` object so
+/// that multiple rules with import filters share the same parsed result.
+/// For small needle counts (≤ 4 DLLs), a linear scan is used instead of
+/// building a `HashSet`, which avoids heap allocation and hashing overhead.
+///
+/// Returns 1 if metadata is valid and all criteria match, 0 otherwise.
+///
+/// # Safety
+/// - `file_ptr` must be a valid non-null pointer to a File object
+/// - `data` must point to `data_len` valid bytes from the file
+/// - `ctx` must point to a valid `DetectWindowsPEData` struct
+/// - All pointers in `ctx` must be valid or NULL
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectWindowsPEFileMatch(
+    file_ptr: *mut File, data: *const u8, data_len: u32, ctx: *const DetectWindowsPEData,
+) -> i32 {
+    if file_ptr.is_null() || data.is_null() || data_len < 64 || ctx.is_null() {
+        return 0;
+    }
+
+    let ctx_ref = &*ctx;
+    let file_data = std::slice::from_raw_parts(data, data_len as usize);
+
+    // No filters — just validate PE signature without full header parse.
+    // Full metadata will be parsed later by the logging path if needed.
+    if !ctx_ref.has_filters {
+        return if pe_validate(file_data).is_some() {
+            1
+        } else {
+            0
+        };
+    }
+
+    // --- Phase 1: cheap COFF/Optional header check ---
+    // Parse only the fixed-size PE headers (no section/import/export tables).
+    // This satisfies rules that filter only on arch, subsystem, size, etc.
+    let mut meta = match parse_pe_metadata(file_data) {
+        Some(m) => m,
+        None => {
+            // Cache the negative result so logging won't re-attempt.
+            file_meta_set(file_ptr, &SCDetectPeMetadata::default());
+            return 0;
+        }
+    };
+
+    // --- Phase 2: expensive parsing only if needed ---
+    // Parse section headers, imports, and exports only when the rule
+    // actually uses options that require them (import_dlls, num_imports,
+    // num_exports, section_name, section_wx, export_name).
+    if ctx_ref.needs_deep_parse {
+        let sections = parse_section_headers(file_data, meta.pe_offset as usize, meta.num_sections);
+        meta.has_wx_section = has_wx_section(&sections);
+
+        let imports = parse_pe_imports_with_offset(file_data, meta.pe_offset as usize, &sections);
+        meta.num_imports = imports
+            .as_ref()
+            .map_or(0, |v| v.len().min(u16::MAX as usize) as u16);
+
+        let (export_name_parsed, num_exports) =
+            parse_pe_exports(file_data, meta.pe_offset as usize, &sections);
+        meta.num_exports = num_exports;
+
+        // Cache the full metadata and imports in File for subsequent
+        // rules and for the logging path.
+        file_meta_set(file_ptr, &meta);
+        if let Some(imp) = imports {
+            file_imports_set(file_ptr, imp);
+        }
+
+        // Check header-level filters first (cheap).
+        if !pe_match(&meta, ctx_ref) {
+            return 0;
+        }
+
+        // Import DLL name filter.
+        if let Some(ref needles) = ctx_ref.import_dlls {
+            let cached_imports = match get_pe_imports_by_file(
+                file_ptr,
+                file_data,
+                meta.pe_offset as usize,
+                &sections,
+            ) {
+                Some(dlls) => dlls,
+                None => return 0,
+            };
+
+            if needles.len() <= 4 {
+                for needle in needles.iter() {
+                    if !cached_imports.iter().any(|dll| dll == needle) {
+                        return 0;
+                    }
+                }
+            } else {
+                let import_set: HashSet<&str> = cached_imports.iter().map(|s| s.as_str()).collect();
+                for needle in needles.iter() {
+                    if !import_set.contains(needle.as_str()) {
+                        return 0;
+                    }
+                }
+            }
+        }
+
+        // Section name filter (reuse already-parsed sections).
+        if let Some(ref needle) = ctx_ref.section_name {
+            let found = sections
+                .iter()
+                .any(|s| section_name_str(&s.name).eq_ignore_ascii_case(needle.as_str()));
+            if !found {
+                return 0;
+            }
+        }
+
+        // Export name filter (reuse already-parsed export name).
+        if let Some(ref needle) = ctx_ref.export_name {
+            match export_name_parsed {
+                Some(ref name) if name == needle.as_str() => {}
+                _ => return 0,
+            }
+        }
+    } else {
+        // Header-only rule — check metadata and cache for logging.
+        file_meta_set(file_ptr, &meta);
+
+        if !pe_match(&meta, ctx_ref) {
+            return 0;
+        }
+    }
+
+    1
+}
+
+// ============================================================================
+// Keyword registration
+// ============================================================================
+
+static mut G_WINDOWS_PE_KW_ID: u16 = 0;
+static mut G_WINDOWS_PE_FILE_LIST_ID: c_int = 0;
+
+unsafe extern "C" fn windows_pe_file_match(
+    _det_ctx: *mut DetectEngineThreadCtx, _flow: *mut Flow, _flags: u8, file: *mut File,
+    _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let pe_ctx = ctx as *const DetectWindowsPEData;
+    let mut data_len: u32 = 0;
+    let mut offset: u64 = 0;
+    let data = SCFileGetData(file as *const File, &mut data_len, &mut offset);
+    if data.is_null() || offset != 0 || data_len < 64 {
+        return 0;
+    }
+    SCDetectWindowsPEFileMatch(file, data, data_len, pe_ctx)
+}
+
+unsafe extern "C" fn windows_pe_setup(
+    de_ctx: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    let data = SCDetectWindowsPEParse(raw);
+    if data.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de_ctx,
+        s,
+        G_WINDOWS_PE_KW_ID,
+        data as *mut SigMatchCtx,
+        G_WINDOWS_PE_FILE_LIST_ID,
+    )
+    .is_null()
+    {
+        SCDetectWindowsPEFree(data);
+        return -1;
+    }
+    SCDetectSignatureSetFileInspect(s);
+    0
+}
+
+unsafe extern "C" fn windows_pe_free(
+    _de_ctx: *mut DetectEngineCtx, ptr: *mut std::os::raw::c_void,
+) {
+    if !ptr.is_null() {
+        SCDetectWindowsPEFree(ptr as *mut DetectWindowsPEData);
+    }
+}
+
+/// Register the `windows_pe` keyword and its file-match callback.
+///
+/// Called from `DetectWindowsPERegister` in detect-windows-pe.c during
+/// engine initialisation.
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectWindowsPERegister() {
+    G_WINDOWS_PE_FILE_LIST_ID = SCDetectHelperGetFilesBufferId();
+
+    let kw = SCSigTableFileLiteElmt {
+        name: b"windows_pe\0".as_ptr() as *const c_char,
+        desc: b"match Windows PE file format and metadata (arch, size, sections, entry_point, subsystem, characteristics, dll_characteristics, imported DLL names)\0".as_ptr() as *const c_char,
+        url: b"/rules/file-keywords.html#windows-pe\0".as_ptr() as *const c_char,
+        FileMatch: Some(windows_pe_file_match),
+        Setup: Some(windows_pe_setup),
+        Free: Some(windows_pe_free),
+        flags: SIGMATCH_OPTIONAL_OPT,
+    };
+    G_WINDOWS_PE_KW_ID = SCDetectHelperFileKeywordRegister(&kw);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse the list of imported DLL names from a PE file's Import Directory.
+    fn parse_pe_imports(data: &[u8]) -> Option<Vec<String>> {
+        let pe_offset = pe_validate(data)?;
+        let num_sections = u16::from_le_bytes([data[pe_offset + 6], data[pe_offset + 7]]);
+        let sections = parse_section_headers(data, pe_offset, num_sections);
+        parse_pe_imports_with_offset(data, pe_offset, &sections)
+    }
+
+    /// Parse raw PE bytes and log all metadata as JSON (test helper).
+    fn pe_log_json(data: &[u8], js: &mut JsonBuilder) -> Result<(), JsonError> {
+        let mut meta = match parse_pe_metadata(data) {
+            Some(m) => m,
+            None => return Ok(()),
+        };
+        let sections = parse_section_headers(data, meta.pe_offset as usize, meta.num_sections);
+        let imports = parse_pe_imports_with_offset(data, meta.pe_offset as usize, &sections);
+        let num_imports = imports
+            .as_ref()
+            .map_or(0, |v| v.len().min(u16::MAX as usize) as u16);
+        let (export_name, num_exports) = parse_pe_exports(data, meta.pe_offset as usize, &sections);
+        detect_meta_full(&mut meta, &sections, num_imports, num_exports);
+        crate::detect::windows_pe_logger::pe_log_json_fields(
+            &meta,
+            imports.as_deref(),
+            Some(&sections),
+            export_name.as_deref(),
+            js,
+        )
+    }
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_pe_validate_minimal_pe() {
+        // Minimal valid PE: DOS header with MZ and PE offset pointing to a valid PE
+        let mut buf = vec![0u8; 100];
+
+        // Set DOS header magic "MZ"
+        buf[0] = b'M';
+        buf[1] = b'Z';
+
+        // Set PE offset (at bytes 60-63) to point to byte 64
+        let pe_offset = 64u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        // Set PE signature at offset 64
+        buf[64..68].copy_from_slice(b"PE\0\0");
+
+        assert!(pe_validate(&buf).is_some());
+    }
+
+    #[test]
+    fn test_pe_validate_real_pe_structure() {
+        // Simulate a more realistic PE structure
+        let mut buf = vec![0u8; 512];
+
+        // DOS header
+        buf[0..2].copy_from_slice(b"MZ");
+
+        // PE offset at 60-63: point to offset 128
+        let pe_offset = 128u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        // DOS stub (PE offset - 64 bytes of DOS header)
+        for (i, b) in buf[64..128].iter_mut().enumerate() {
+            *b = ((i + 64) % 256) as u8;
+        }
+
+        // PE header at offset 128
+        buf[128..132].copy_from_slice(b"PE\0\0");
+        // Machine type (little-endian, e.g., 0x014C for x86)
+        buf[132..134].copy_from_slice(&0x014Cu32.to_le_bytes()[..2]);
+
+        assert!(pe_validate(&buf).is_some());
+    }
+
+    #[test]
+    fn test_pe_validate_no_mz() {
+        let mut buf = vec![0u8; 100];
+        buf[0] = b'Z';
+        buf[1] = b'M'; // Wrong order
+
+        let pe_offset = 64u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        buf[64..68].copy_from_slice(b"PE\0\0");
+
+        assert!(pe_validate(&buf).is_none());
+    }
+
+    #[test]
+    fn test_pe_validate_no_pe_signature() {
+        let mut buf = vec![0u8; 100];
+
+        buf[0..2].copy_from_slice(b"MZ");
+
+        let pe_offset = 64u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        buf[64..68].copy_from_slice(b"XX\0\0"); // Wrong signature
+
+        assert!(pe_validate(&buf).is_none());
+    }
+
+    #[test]
+    fn test_pe_validate_invalid_pe_offset() {
+        let mut buf = vec![0u8; 100];
+
+        buf[0..2].copy_from_slice(b"MZ");
+
+        // PE offset beyond reasonable range
+        let pe_offset = 0x20000u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        assert!(pe_validate(&buf).is_none());
+    }
+
+    #[test]
+    fn test_pe_validate_pe_offset_past_eof() {
+        let mut buf = vec![0u8; 100];
+
+        buf[0..2].copy_from_slice(b"MZ");
+
+        // PE offset beyond buffer size
+        let pe_offset = 200u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        assert!(pe_validate(&buf).is_none());
+    }
+
+    #[test]
+    fn test_pe_validate_too_small() {
+        let buf = vec![0u8; 63]; // Less than 64 bytes
+        assert!(pe_validate(&buf).is_none());
+    }
+
+    #[test]
+    fn test_pe_validate_exact_boundary() {
+        let mut buf = vec![0u8; 68]; // Exactly 68 bytes (64 + 4 for signature)
+
+        buf[0..2].copy_from_slice(b"MZ");
+
+        let pe_offset = 64u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        buf[64..68].copy_from_slice(b"PE\0\0");
+
+        assert!(pe_validate(&buf).is_some());
+    }
+
+    #[test]
+    fn test_parse_pe_metadata_minimal() {
+        let mut buf = vec![0u8; 300];
+
+        // DOS header
+        buf[0] = b'M';
+        buf[1] = b'Z';
+
+        // PE offset (64 bytes)
+        let pe_offset = 64u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        // PE signature
+        buf[64..68].copy_from_slice(b"PE\0\0");
+
+        // Machine type (x86)
+        buf[68..70].copy_from_slice(&0x014Cu16.to_le_bytes());
+
+        // Number of sections
+        buf[70..72].copy_from_slice(&0x0003u16.to_le_bytes());
+
+        // Characteristics (executable)
+        buf[86..88].copy_from_slice(&0x0102u16.to_le_bytes());
+
+        let metadata = parse_pe_metadata(&buf).unwrap();
+        assert_eq!(metadata.architecture, 0x014C);
+        assert_eq!(metadata.num_sections, 3);
+        assert_eq!(metadata.pe_offset, 64);
+    }
+
+    #[test]
+    fn test_parse_pe_metadata_with_optional_header() {
+        let mut buf = vec![0u8; 400];
+
+        // DOS header
+        buf[0..2].copy_from_slice(b"MZ");
+
+        // PE offset
+        let pe_offset = 128u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        // PE signature at offset 128
+        buf[128..132].copy_from_slice(b"PE\0\0");
+
+        // Machine type (x64)
+        buf[132..134].copy_from_slice(&0x8664u16.to_le_bytes());
+
+        // Number of sections
+        buf[134..136].copy_from_slice(&0x0005u16.to_le_bytes());
+
+        // Characteristics
+        buf[150..152].copy_from_slice(&0x0022u16.to_le_bytes());
+
+        // SizeOfOptionalHeader
+        buf[148..150].copy_from_slice(&0x00F0u16.to_le_bytes());
+
+        // Optional header starts at 152 (128 + 24)
+        // SizeOfImage at optional_header + 0x38 = 152 + 56 = offset 208
+        buf[208..212].copy_from_slice(&0x10000u32.to_le_bytes());
+
+        // AddressOfEntryPoint at optional_header + 0x10 = 152 + 16 = offset 168
+        buf[168..172].copy_from_slice(&0x4000u32.to_le_bytes());
+
+        let metadata = parse_pe_metadata(&buf).unwrap();
+        assert_eq!(metadata.architecture, 0x8664);
+        assert_eq!(metadata.num_sections, 5);
+        assert_eq!(metadata.size_of_image, 0x10000);
+        assert_eq!(metadata.entry_point_rva, 0x4000);
+    }
+
+    #[test]
+    fn test_parse_pe_metadata_invalid() {
+        let buf = vec![0u8; 100];
+        let metadata = parse_pe_metadata(&buf);
+        assert!(metadata.is_none());
+    }
+
+    #[test]
+    fn test_parse_machine_types() {
+        // Test common machine types
+        let machine_types: [(u16, &str); 4] = [
+            (0x014C, "x86"),
+            (0x8664, "x64"),
+            (0x01C0, "ARM"),
+            (0xAA64, "ARM64"),
+        ];
+
+        for (machine_type, _arch) in &machine_types {
+            let mut buf = vec![0u8; 300];
+            buf[0..2].copy_from_slice(b"MZ");
+            buf[60..64].copy_from_slice(&64u32.to_le_bytes());
+            buf[64..68].copy_from_slice(b"PE\0\0");
+            buf[68..70].copy_from_slice(&(*machine_type).to_le_bytes());
+            buf[70..72].copy_from_slice(&0x0001u16.to_le_bytes());
+
+            let metadata = parse_pe_metadata(&buf).unwrap();
+            assert_eq!(metadata.architecture, *machine_type);
+        }
+    }
+
+    #[test]
+    fn test_pe_log_json_type_field() {
+        // Build a minimal valid PE buffer that pe_log_json can parse.
+        let mut buf = vec![0u8; 300];
+
+        // DOS header: MZ magic
+        buf[0..2].copy_from_slice(b"MZ");
+        // e_lfanew = 64 (PE header at offset 64)
+        let pe_offset = 64u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        // PE signature at offset 64
+        buf[64..68].copy_from_slice(b"PE\0\0");
+
+        // COFF header: machine = 0x014C (x86), num_sections = 1
+        buf[68..70].copy_from_slice(&0x014Cu16.to_le_bytes());
+        buf[70..72].copy_from_slice(&0x0001u16.to_le_bytes());
+
+        // Run pe_log_json and capture output
+        let mut js = JsonBuilder::try_new_object().expect("JsonBuilder::try_new_object failed");
+        pe_log_json(&buf, &mut js).expect("pe_log_json failed");
+        js.close().expect("close failed");
+        let output = unsafe {
+            let ptr = crate::jsonbuilder::SCJbPtr(&mut js);
+            let len = crate::jsonbuilder::SCJbLen(&js);
+            std::str::from_utf8(std::slice::from_raw_parts(ptr, len))
+                .unwrap()
+                .to_string()
+        };
+
+        // Verify the `type` field is present and set to "windows_pe"
+        assert!(
+            output.contains("\"type\":\"windows_pe\""),
+            "Expected '\"type\":\"windows_pe\"' in JSON output, got: {}",
+            output
+        );
+    }
+
+    /// Helper: build a minimal PE32 buffer with an import table that imports
+    /// the given list of DLL names.  The buffer layout is:
+    ///
+    ///   0x000  DOS header (64 bytes, MZ magic, e_lfanew = 0x40)
+    ///   0x040  PE signature + COFF header (24 bytes)
+    ///   0x058  PE32 Optional header (0x60 = 96 bytes standard fields)
+    ///          • Magic = 0x10b (PE32)
+    ///          • NumberOfRvaAndSizes = 16 at +0x5C
+    ///          • Import Directory RVA/Size at data dir index 1
+    ///   0x0B8  Data directories (16 × 8 = 128 bytes)
+    ///   0x138  Section headers (1 section, 40 bytes)
+    ///          • VirtualAddress = 0x1000, VirtualSize = 0x2000
+    ///          • PointerToRawData = 0x200, SizeOfRawData = 0x2000
+    ///   0x200  Raw section data
+    ///          • Import Directory entries at section-relative offset 0
+    ///          • DLL name strings placed after the entries
+    fn build_pe_with_imports(dll_names: &[&str]) -> Vec<u8> {
+        let mut buf = vec![0u8; 0x2200]; // plenty of room
+
+        // DOS header
+        buf[0..2].copy_from_slice(b"MZ");
+        let pe_offset: u32 = 0x40;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        // PE signature
+        buf[0x40..0x44].copy_from_slice(b"PE\0\0");
+
+        // COFF header
+        buf[0x44..0x46].copy_from_slice(&0x014Cu16.to_le_bytes()); // Machine: x86
+        buf[0x46..0x48].copy_from_slice(&1u16.to_le_bytes()); // NumberOfSections
+                                                              // SizeOfOptionalHeader: 96 standard + 128 data dirs = 224 = 0xE0
+        buf[0x54..0x56].copy_from_slice(&0x00E0u16.to_le_bytes());
+        buf[0x56..0x58].copy_from_slice(&0x0102u16.to_le_bytes()); // Characteristics
+
+        // Optional header
+        let opt = 0x58usize; // pe_offset + 24
+        buf[opt..opt + 2].copy_from_slice(&0x010bu16.to_le_bytes()); // Magic: PE32
+
+        // NumberOfRvaAndSizes at opt + 0x5C
+        buf[opt + 0x5C..opt + 0x60].copy_from_slice(&16u32.to_le_bytes());
+
+        // Data directory index 1 = Import Directory (each entry 8 bytes, index 1 starts at opt+0x60+8)
+        let import_dd = opt + 0x60 + 8;
+        // Import table lives at the start of our section: RVA = 0x1000
+        let import_rva: u32 = 0x1000;
+        let num_entries = dll_names.len();
+        let import_size: u32 = ((num_entries + 1) * 20) as u32; // +1 for null terminator entry
+        buf[import_dd..import_dd + 4].copy_from_slice(&import_rva.to_le_bytes());
+        buf[import_dd + 4..import_dd + 8].copy_from_slice(&import_size.to_le_bytes());
+
+        // Section header at 0x138 (opt + 0xE0)
+        let sh = opt + 0xE0;
+        buf[sh..sh + 8].copy_from_slice(b".idata\0\0");
+        buf[sh + 8..sh + 12].copy_from_slice(&0x2000u32.to_le_bytes()); // VirtualSize
+        buf[sh + 12..sh + 16].copy_from_slice(&0x1000u32.to_le_bytes()); // VirtualAddress
+        buf[sh + 16..sh + 20].copy_from_slice(&0x2000u32.to_le_bytes()); // SizeOfRawData
+        buf[sh + 20..sh + 24].copy_from_slice(&0x0200u32.to_le_bytes()); // PointerToRawData
+
+        // Section raw data starts at file offset 0x200.
+        // Import directory entries at the beginning, names follow after.
+        let raw_base = 0x200usize;
+        let names_start_rva = import_rva + import_size; // right after entries
+        let mut name_cursor = (import_size) as usize; // section-relative offset for names
+
+        for (i, dll) in dll_names.iter().enumerate() {
+            let ent = raw_base + i * 20;
+            // Bytes 12..16 = Name RVA
+            let name_rva = names_start_rva + (name_cursor - import_size as usize) as u32;
+            buf[ent + 12..ent + 16].copy_from_slice(&name_rva.to_le_bytes());
+
+            // Write the DLL name string at the computed offset
+            let name_file_off = raw_base + name_cursor;
+            buf[name_file_off..name_file_off + dll.len()].copy_from_slice(dll.as_bytes());
+            buf[name_file_off + dll.len()] = 0; // null terminator
+            name_cursor += dll.len() + 1;
+        }
+        // The null terminator entry (all zeros) is already present since buf is zero-initialized.
+
+        buf
+    }
+
+    #[test]
+    fn test_parse_pe_imports_basic() {
+        let buf = build_pe_with_imports(&["KERNEL32.dll", "USER32.dll", "WS2_32.dll"]);
+        let imports = parse_pe_imports(&buf).expect("should parse imports");
+        assert_eq!(imports.len(), 3);
+        assert!(imports.contains(&"kernel32.dll".to_string()));
+        assert!(imports.contains(&"user32.dll".to_string()));
+        assert!(imports.contains(&"ws2_32.dll".to_string()));
+    }
+
+    #[test]
+    fn test_parse_pe_imports_empty() {
+        // Build a PE with import directory RVA=0 (no imports)
+        let mut buf = vec![0u8; 0x400];
+        buf[0..2].copy_from_slice(b"MZ");
+        buf[60..64].copy_from_slice(&0x40u32.to_le_bytes());
+        buf[0x40..0x44].copy_from_slice(b"PE\0\0");
+        buf[0x44..0x46].copy_from_slice(&0x014Cu16.to_le_bytes());
+        buf[0x46..0x48].copy_from_slice(&1u16.to_le_bytes());
+        buf[0x54..0x56].copy_from_slice(&0x00E0u16.to_le_bytes());
+        let opt = 0x58usize;
+        buf[opt..opt + 2].copy_from_slice(&0x010bu16.to_le_bytes());
+        buf[opt + 0x5C..opt + 0x60].copy_from_slice(&16u32.to_le_bytes());
+        // Import dir RVA = 0 → no imports
+        let imports = parse_pe_imports(&buf).expect("should return empty vec");
+        assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn test_parse_pe_imports_case_insensitive() {
+        let buf = build_pe_with_imports(&["Kernel32.DLL"]);
+        let imports = parse_pe_imports(&buf).unwrap();
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0], "kernel32.dll"); // lowercased
+    }
+
+    #[test]
+    fn test_parse_pe_imports_not_pe() {
+        let buf = vec![0u8; 100];
+        assert!(parse_pe_imports(&buf).is_none());
+    }
+
+    #[test]
+    fn test_rva_to_offset_basic() {
+        let sections = vec![SectionInfo {
+            name: [0; 8],
+            virtual_address: 0x1000,
+            virtual_size: 0x2000,
+            raw_data_offset: 0x400,
+            raw_data_size: 0x2000,
+            characteristics: 0,
+        }];
+        assert_eq!(rva_to_offset(0x1000, &sections), Some(0x400));
+        assert_eq!(rva_to_offset(0x1100, &sections), Some(0x500));
+        assert_eq!(rva_to_offset(0x0FFF, &sections), None); // before section
+        assert_eq!(rva_to_offset(0x3000, &sections), None); // after section
+    }
+
+    #[test]
+    fn test_parse_option_import_bare() {
+        // Bare DLL name (new syntax)
+        let data = parse_executable_options("kernel32.dll").unwrap();
+        let dlls = data.import_dlls.as_ref().unwrap();
+        assert_eq!(dlls.as_slice(), &["kernel32.dll"]);
+    }
+
+    #[test]
+    fn test_parse_option_import_bare_mixed_case() {
+        let data = parse_executable_options("WS2_32.DLL").unwrap();
+        let dlls = data.import_dlls.as_ref().unwrap();
+        assert_eq!(dlls.as_slice(), &["ws2_32.dll"]); // lowercased
+    }
+
+    #[test]
+    fn test_parse_option_import_bare_combined() {
+        // Bare DLL name combined with other options
+        let data = parse_executable_options("arch x86, ws2_32.dll").unwrap();
+        let dlls = data.import_dlls.as_ref().unwrap();
+        assert_eq!(dlls.as_slice(), &["ws2_32.dll"]);
+    }
+
+    #[test]
+    fn test_parse_option_import_multi_bare() {
+        // Multiple DLL names comma-separated
+        let data = parse_executable_options("ws2_32.dll, wininet.dll, kernel32.dll").unwrap();
+        let dlls = data.import_dlls.as_ref().unwrap();
+        assert_eq!(dlls.len(), 3);
+        assert!(dlls.contains(&"ws2_32.dll".to_string()));
+        assert!(dlls.contains(&"wininet.dll".to_string()));
+        assert!(dlls.contains(&"kernel32.dll".to_string()));
+    }
+
+    #[test]
+    fn test_parse_option_import_multi_with_options() {
+        // Multiple DLLs mixed with other keyword options
+        let data = parse_executable_options("arch x86, ws2_32.dll, wininet.dll").unwrap();
+        assert_eq!(data.architecture, 0x014C);
+        let dlls = data.import_dlls.as_ref().unwrap();
+        assert_eq!(dlls.len(), 2);
+        assert!(dlls.contains(&"ws2_32.dll".to_string()));
+        assert!(dlls.contains(&"wininet.dll".to_string()));
+    }
+
+    #[test]
+    fn test_parse_option_import_prefix_rejected() {
+        // The "import" prefix is no longer supported — bare DLL names only.
+        assert!(parse_executable_options("import kernel32.dll").is_none());
+    }
+
+    #[test]
+    fn test_pe_log_json_includes_imports() {
+        let buf = build_pe_with_imports(&["KERNEL32.dll", "ADVAPI32.dll"]);
+        let mut js = JsonBuilder::try_new_object().expect("JsonBuilder::try_new_object failed");
+        pe_log_json(&buf, &mut js).expect("pe_log_json failed");
+        js.close().expect("close failed");
+        let output = unsafe {
+            let ptr = crate::jsonbuilder::SCJbPtr(&mut js);
+            let len = crate::jsonbuilder::SCJbLen(&js);
+            std::str::from_utf8(std::slice::from_raw_parts(ptr, len))
+                .unwrap()
+                .to_string()
+        };
+        assert!(
+            output.contains("\"imports\""),
+            "Expected 'imports' array in JSON output, got: {}",
+            output
+        );
+        assert!(
+            output.contains("kernel32.dll"),
+            "Expected 'kernel32.dll' in imports, got: {}",
+            output
+        );
+        assert!(
+            output.contains("advapi32.dll"),
+            "Expected 'advapi32.dll' in imports, got: {}",
+            output
+        );
+    }
+
+    // ================================================================
+    // PE32+ (64-bit) import parsing tests
+    // ================================================================
+
+    /// Build a PE32+ (x86_64) binary with the given import DLL names.
+    fn build_pe32plus_with_imports(dll_names: &[&str]) -> Vec<u8> {
+        let mut buf = vec![0u8; 0x2200];
+
+        // DOS header
+        buf[0..2].copy_from_slice(b"MZ");
+        let pe_offset: u32 = 0x40;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        // PE signature
+        buf[0x40..0x44].copy_from_slice(b"PE\0\0");
+
+        // COFF header
+        buf[0x44..0x46].copy_from_slice(&0x8664u16.to_le_bytes()); // Machine: x86_64
+        buf[0x46..0x48].copy_from_slice(&1u16.to_le_bytes()); // NumberOfSections
+                                                              // SizeOfOptionalHeader: 112 standard + 128 data dirs = 240 = 0xF0
+        buf[0x54..0x56].copy_from_slice(&0x00F0u16.to_le_bytes());
+        buf[0x56..0x58].copy_from_slice(&0x0022u16.to_le_bytes()); // Characteristics
+
+        // Optional header
+        let opt = 0x58usize;
+        buf[opt..opt + 2].copy_from_slice(&0x020bu16.to_le_bytes()); // Magic: PE32+
+
+        // NumberOfRvaAndSizes at opt + 0x6C (PE32+)
+        buf[opt + 0x6C..opt + 0x70].copy_from_slice(&16u32.to_le_bytes());
+
+        // Import directory data directory at opt + 0x70 + 8 (index 1)
+        let import_dd = opt + 0x70 + 8;
+        let import_rva: u32 = 0x1000;
+        let num_entries = dll_names.len();
+        let import_size: u32 = ((num_entries + 1) * 20) as u32;
+        buf[import_dd..import_dd + 4].copy_from_slice(&import_rva.to_le_bytes());
+        buf[import_dd + 4..import_dd + 8].copy_from_slice(&import_size.to_le_bytes());
+
+        // Section header at opt + 0xF0
+        let sh = opt + 0xF0;
+        buf[sh..sh + 8].copy_from_slice(b".idata\0\0");
+        buf[sh + 8..sh + 12].copy_from_slice(&0x2000u32.to_le_bytes());
+        buf[sh + 12..sh + 16].copy_from_slice(&0x1000u32.to_le_bytes());
+        buf[sh + 16..sh + 20].copy_from_slice(&0x2000u32.to_le_bytes());
+        buf[sh + 20..sh + 24].copy_from_slice(&0x0200u32.to_le_bytes());
+
+        let raw_base = 0x200usize;
+        let names_start_rva = import_rva + import_size;
+        let mut name_cursor = import_size as usize;
+
+        for (i, dll) in dll_names.iter().enumerate() {
+            let ent = raw_base + i * 20;
+            let name_rva = names_start_rva + (name_cursor - import_size as usize) as u32;
+            buf[ent + 12..ent + 16].copy_from_slice(&name_rva.to_le_bytes());
+
+            let name_file_off = raw_base + name_cursor;
+            buf[name_file_off..name_file_off + dll.len()].copy_from_slice(dll.as_bytes());
+            buf[name_file_off + dll.len()] = 0;
+            name_cursor += dll.len() + 1;
+        }
+
+        buf
+    }
+
+    #[test]
+    fn test_parse_pe_imports_pe32plus() {
+        let buf = build_pe32plus_with_imports(&["KERNEL32.dll", "ntdll.dll"]);
+        let imports = parse_pe_imports(&buf).expect("PE32+ imports should parse");
+        assert_eq!(imports.len(), 2);
+        assert!(imports.contains(&"kernel32.dll".to_string()));
+        assert!(imports.contains(&"ntdll.dll".to_string()));
+    }
+
+    #[test]
+    fn test_parse_pe_imports_pe32plus_single() {
+        let buf = build_pe32plus_with_imports(&["VCRUNTIME140.dll"]);
+        let imports = parse_pe_imports(&buf).expect("single PE32+ import");
+        assert_eq!(imports, vec!["vcruntime140.dll"]);
+    }
+
+    #[test]
+    fn test_parse_pe_imports_pe32plus_many() {
+        // 10 DLLs in a PE32+ binary
+        let names: Vec<&str> = vec![
+            "KERNEL32.dll",
+            "ntdll.dll",
+            "USER32.dll",
+            "GDI32.dll",
+            "ADVAPI32.dll",
+            "SHELL32.dll",
+            "ole32.dll",
+            "OLEAUT32.dll",
+            "WS2_32.dll",
+            "WININET.dll",
+        ];
+        let buf = build_pe32plus_with_imports(&names);
+        let imports = parse_pe_imports(&buf).expect("many PE32+ imports");
+        assert_eq!(imports.len(), 10);
+        assert!(imports.contains(&"kernel32.dll".to_string()));
+        assert!(imports.contains(&"wininet.dll".to_string()));
+        assert!(imports.contains(&"oleaut32.dll".to_string()));
+    }
+
+    // ================================================================
+    // Single-import and DLL name edge cases
+    // ================================================================
+
+    #[test]
+    fn test_parse_pe_imports_single_dll() {
+        let buf = build_pe_with_imports(&["msvcrt.dll"]);
+        let imports = parse_pe_imports(&buf).unwrap();
+        assert_eq!(imports, vec!["msvcrt.dll"]);
+    }
+
+    #[test]
+    fn test_parse_pe_imports_duplicate_dlls() {
+        // A PE with the same DLL listed twice (unusual, but valid per format)
+        let buf = build_pe_with_imports(&["KERNEL32.dll", "KERNEL32.dll"]);
+        let imports = parse_pe_imports(&buf).unwrap();
+        assert_eq!(imports.len(), 2);
+        assert!(imports.iter().all(|d| d == "kernel32.dll"));
+    }
+
+    #[test]
+    fn test_parse_pe_imports_long_dll_name() {
+        // DLL name near the 260-char max
+        let long_name = format!("{}.dll", "A".repeat(250));
+        let buf = build_pe_with_imports(&[&long_name]);
+        let imports = parse_pe_imports(&buf).unwrap();
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0], long_name.to_ascii_lowercase());
+    }
+
+    // ================================================================
+    // Invalid / truncated PE import table scenarios
+    // ================================================================
+
+    #[test]
+    fn test_parse_pe_imports_bad_magic() {
+        // Valid MZ+PE signature, but bogus optional header magic
+        let mut buf = build_pe_with_imports(&["KERNEL32.dll"]);
+        buf[0x58..0x5A].copy_from_slice(&0xFFFFu16.to_le_bytes()); // corrupt magic
+        assert!(parse_pe_imports(&buf).is_none());
+    }
+
+    #[test]
+    fn test_parse_pe_imports_import_size_zero() {
+        // import_rva is nonzero but import_size is zero → no imports
+        let mut buf = build_pe_with_imports(&["KERNEL32.dll"]);
+        // Import DD size field: opt(0x58) + 0x60 + 8 + 4 = 0xC4
+        let import_dd_size = 0x58 + 0x60 + 8 + 4;
+        buf[import_dd_size..import_dd_size + 4].copy_from_slice(&0u32.to_le_bytes());
+        let imports = parse_pe_imports(&buf).unwrap();
+        assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn test_parse_pe_imports_num_rva_too_small() {
+        // NumberOfRvaAndSizes < 2 → no import directory accessible
+        let mut buf = build_pe_with_imports(&["KERNEL32.dll"]);
+        // NumberOfRvaAndSizes at opt + 0x5C = 0x58 + 0x5C = 0xB4
+        buf[0xB4..0xB8].copy_from_slice(&1u32.to_le_bytes());
+        assert!(parse_pe_imports(&buf).is_none());
+    }
+
+    #[test]
+    fn test_parse_pe_imports_truncated_at_entries() {
+        // Truncate the file so import directory entries are partially present
+        let buf = build_pe_with_imports(&["KERNEL32.dll", "USER32.dll"]);
+        // Import entries start at file offset 0x200; truncate in the middle
+        let truncated = buf[..0x210].to_vec(); // only 16 bytes of first entry (need 20)
+                                               // rva_to_offset will resolve, but entry will be cut short → loop breaks
+        let imports = parse_pe_imports(&truncated);
+        // May return Some with 0 entries or None depending on section bounds
+        if let Some(dlls) = imports {
+            // Should have parsed 0 entries since first entry is incomplete
+            assert!(dlls.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_parse_pe_imports_name_rva_unresolvable() {
+        // Set a DLL's Name RVA to a value outside any section
+        let mut buf = build_pe_with_imports(&["KERNEL32.dll", "USER32.dll"]);
+        // First entry Name RVA at file offset 0x200 + 12
+        // Point it to an RVA that doesn't map to any section
+        buf[0x200 + 12..0x200 + 16].copy_from_slice(&0xFFFF0000u32.to_le_bytes());
+        let imports = parse_pe_imports(&buf).unwrap();
+        // First entry skipped (bad RVA), second entry still parsed
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0], "user32.dll");
+    }
+
+    // ================================================================
+    // rva_to_offset with multiple sections
+    // ================================================================
+
+    #[test]
+    fn test_rva_to_offset_multiple_sections() {
+        let sections = vec![
+            SectionInfo {
+                name: [0; 8],
+                virtual_address: 0x1000,
+                virtual_size: 0x1000,
+                raw_data_offset: 0x400,
+                raw_data_size: 0x1000,
+                characteristics: 0,
+            },
+            SectionInfo {
+                name: [0; 8],
+                virtual_address: 0x2000,
+                virtual_size: 0x2000,
+                raw_data_offset: 0x1400,
+                raw_data_size: 0x2000,
+                characteristics: 0,
+            },
+            SectionInfo {
+                name: [0; 8],
+                virtual_address: 0x5000,
+                virtual_size: 0x1000,
+                raw_data_offset: 0x3400,
+                raw_data_size: 0x800,
+                characteristics: 0,
+            },
+        ];
+        // First section
+        assert_eq!(rva_to_offset(0x1000, &sections), Some(0x400));
+        assert_eq!(rva_to_offset(0x1FFF, &sections), Some(0x13FF));
+        // Second section
+        assert_eq!(rva_to_offset(0x2000, &sections), Some(0x1400));
+        assert_eq!(rva_to_offset(0x2500, &sections), Some(0x1900));
+        // Third section
+        assert_eq!(rva_to_offset(0x5000, &sections), Some(0x3400));
+        // Third section — delta exceeds raw_data_size (0x800)
+        assert_eq!(rva_to_offset(0x5900, &sections), None);
+        // Gap between sections
+        assert_eq!(rva_to_offset(0x4000, &sections), None);
+        // Before all sections
+        assert_eq!(rva_to_offset(0x0500, &sections), None);
+    }
+
+    #[test]
+    fn test_rva_to_offset_empty_sections() {
+        let sections: Vec<SectionInfo> = vec![];
+        assert_eq!(rva_to_offset(0x1000, &sections), None);
+    }
+
+    // ================================================================
+    // parse_section_headers edge cases
+    // ================================================================
+
+    #[test]
+    fn test_parse_section_headers_multiple() {
+        let buf = build_pe_with_imports(&["KERNEL32.dll"]);
+        // This PE has 1 section; verify parsing returns it
+        let pe_offset = u32::from_le_bytes([buf[60], buf[61], buf[62], buf[63]]) as usize;
+        let num_sections = u16::from_le_bytes([buf[pe_offset + 6], buf[pe_offset + 7]]);
+        let sections = parse_section_headers(&buf, pe_offset, num_sections);
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].virtual_address, 0x1000);
+        assert_eq!(sections[0].raw_data_offset, 0x200);
+    }
+
+    #[test]
+    fn test_parse_section_headers_truncated() {
+        // Build a PE but truncate before section headers complete
+        let buf = build_pe_with_imports(&["KERNEL32.dll"]);
+        let pe_offset = u32::from_le_bytes([buf[60], buf[61], buf[62], buf[63]]) as usize;
+        // Claim 5 sections but only provide data for 1
+        let sections = parse_section_headers(&buf[..0x160], pe_offset, 5);
+        // Should parse only 1 section (the one that fits)
+        assert_eq!(sections.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_section_headers_zero_sections() {
+        let buf = build_pe_with_imports(&["KERNEL32.dll"]);
+        let pe_offset = u32::from_le_bytes([buf[60], buf[61], buf[62], buf[63]]) as usize;
+        let sections = parse_section_headers(&buf, pe_offset, 0);
+        assert!(sections.is_empty());
+    }
+
+    // ================================================================
+    // Parser + parsed-object matching integration tests
+    // ================================================================
+
+    /// Helper: parse options and return whether a PE with the given DLLs
+    /// would match the import filter (simulates detection logic).
+    fn imports_match(option_str: &str, pe_dlls: &[&str]) -> bool {
+        let data = match parse_executable_options(option_str) {
+            Some(d) => d,
+            None => return false,
+        };
+        let needles = match &data.import_dlls {
+            None => return true, // no import filter
+            Some(dlls) => dlls,
+        };
+        let lowered: Vec<String> = pe_dlls.iter().map(|s| s.to_ascii_lowercase()).collect();
+        let import_set: HashSet<&str> = lowered.iter().map(|s| s.as_str()).collect();
+        needles.iter().all(|n| import_set.contains(n.as_str()))
+    }
+
+    #[test]
+    fn test_match_single_dll_present() {
+        assert!(imports_match(
+            "kernel32.dll",
+            &["kernel32.dll", "user32.dll"]
+        ));
+    }
+
+    #[test]
+    fn test_match_single_dll_absent() {
+        assert!(!imports_match(
+            "ws2_32.dll",
+            &["kernel32.dll", "user32.dll"]
+        ));
+    }
+
+    #[test]
+    fn test_match_multi_dll_all_present() {
+        assert!(imports_match(
+            "ws2_32.dll, wininet.dll",
+            &["kernel32.dll", "ws2_32.dll", "wininet.dll", "advapi32.dll"],
+        ));
+    }
+
+    #[test]
+    fn test_match_multi_dll_one_missing() {
+        assert!(!imports_match(
+            "ws2_32.dll, urlmon.dll",
+            &["kernel32.dll", "ws2_32.dll", "wininet.dll"],
+        ));
+    }
+
+    #[test]
+    fn test_match_multi_dll_all_missing() {
+        assert!(!imports_match(
+            "urlmon.dll, wldap32.dll",
+            &["kernel32.dll", "user32.dll"],
+        ));
+    }
+
+    #[test]
+    fn test_match_case_insensitive() {
+        assert!(imports_match("KERNEL32.DLL", &["kernel32.dll"]));
+        assert!(imports_match("kernel32.dll", &["KERNEL32.DLL"]));
+    }
+
+    #[test]
+    fn test_match_no_import_filter() {
+        // No DLLs in keyword → matches any PE
+        assert!(imports_match("arch x86", &["kernel32.dll"]));
+    }
+
+    #[test]
+    fn test_match_against_empty_imports() {
+        // PE has no imports, but rule requires one
+        assert!(!imports_match("kernel32.dll", &[]));
+    }
+
+    #[test]
+    fn test_match_combined_options_with_dlls() {
+        // Verifies parsed object has both arch and DLL filters populated
+        let data = parse_executable_options("arch x86_64, ws2_32.dll, advapi32.dll, sections <10")
+            .unwrap();
+        assert_eq!(data.architecture, 0x8664);
+        assert!(!data.sections.is_null());
+        let dlls = data.import_dlls.as_ref().unwrap();
+        assert_eq!(dlls.len(), 2);
+        assert_eq!(dlls[0], "ws2_32.dll");
+        assert_eq!(dlls[1], "advapi32.dll");
+    }
+
+    #[test]
+    fn test_match_dlls_interspersed_with_options() {
+        // DLLs interspersed with keyword options
+        let data =
+            parse_executable_options("kernel32.dll, arch x86, ws2_32.dll, subsystem 3").unwrap();
+        assert_eq!(data.architecture, 0x014C);
+        assert!(!data.subsystem.is_null());
+        let dlls = data.import_dlls.as_ref().unwrap();
+        assert_eq!(dlls.len(), 2);
+        assert!(dlls.contains(&"kernel32.dll".to_string()));
+        assert!(dlls.contains(&"ws2_32.dll".to_string()));
+    }
+
+    #[test]
+    fn test_parse_and_check_pe32_imports() {
+        // End-to-end: build a PE32, parse its imports, match against parsed options
+        let pe = build_pe_with_imports(&["KERNEL32.dll", "WS2_32.dll", "ADVAPI32.dll"]);
+        let imports = parse_pe_imports(&pe).unwrap();
+
+        // Rule: ws2_32.dll, advapi32.dll — should match
+        let data = parse_executable_options("ws2_32.dll, advapi32.dll").unwrap();
+        let needles = data.import_dlls.as_ref().unwrap();
+        let import_set: HashSet<&str> = imports.iter().map(|s| s.as_str()).collect();
+        assert!(needles.iter().all(|n| import_set.contains(n.as_str())));
+    }
+
+    #[test]
+    fn test_parse_and_check_pe32plus_imports() {
+        // End-to-end: build a PE32+, parse its imports, match against parsed options
+        let pe = build_pe32plus_with_imports(&["ntdll.dll", "KERNEL32.dll", "WININET.dll"]);
+        let imports = parse_pe_imports(&pe).unwrap();
+
+        // Rule: wininet.dll — should match
+        let data = parse_executable_options("wininet.dll").unwrap();
+        let needles = data.import_dlls.as_ref().unwrap();
+        let import_set: HashSet<&str> = imports.iter().map(|s| s.as_str()).collect();
+        assert!(needles.iter().all(|n| import_set.contains(n.as_str())));
+
+        // Rule: urlmon.dll — should NOT match
+        let data2 = parse_executable_options("urlmon.dll").unwrap();
+        let needles2 = data2.import_dlls.as_ref().unwrap();
+        assert!(!needles2.iter().all(|n| import_set.contains(n.as_str())));
+    }
+
+    #[test]
+    fn test_parse_and_check_partial_match_fails() {
+        // Only 2 of 3 requested DLLs are present → must fail
+        let pe = build_pe_with_imports(&["KERNEL32.dll", "WS2_32.dll"]);
+        let imports = parse_pe_imports(&pe).unwrap();
+        let data = parse_executable_options("kernel32.dll, ws2_32.dll, wininet.dll").unwrap();
+        let needles = data.import_dlls.as_ref().unwrap();
+        let import_set: HashSet<&str> = imports.iter().map(|s| s.as_str()).collect();
+        assert!(!needles.iter().all(|n| import_set.contains(n.as_str())));
+    }
+
+    // ================================================================
+    // New fields: parsing and option tests
+    // ================================================================
+
+    #[test]
+    fn test_parse_pe_metadata_new_fields() {
+        let mut buf = vec![0u8; 300];
+        buf[0..2].copy_from_slice(b"MZ");
+        let pe_offset = 64u32;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+        buf[64..68].copy_from_slice(b"PE\0\0");
+        buf[68..70].copy_from_slice(&0x014Cu16.to_le_bytes()); // machine
+        buf[70..72].copy_from_slice(&1u16.to_le_bytes()); // num_sections
+
+        // Timestamp at pe_offset+8
+        buf[72..76].copy_from_slice(&0x5F3B4C00u32.to_le_bytes());
+        // Characteristics
+        buf[86..88].copy_from_slice(&0x0102u16.to_le_bytes());
+
+        // Optional header at pe_offset+24 = 88
+        let opt = 88;
+        buf[opt..opt + 2].copy_from_slice(&0x010bu16.to_le_bytes()); // magic PE32
+                                                                     // SizeOfHeaders at opt+0x3C
+        buf[opt + 0x3C..opt + 0x40].copy_from_slice(&0x400u32.to_le_bytes());
+        // Checksum at opt+0x40
+        buf[opt + 0x40..opt + 0x44].copy_from_slice(&0xDEADBEEFu32.to_le_bytes());
+
+        let meta = parse_pe_metadata(&buf).unwrap();
+        assert_eq!(meta.magic, 0x10b);
+        assert_eq!(meta.timestamp, 0x5F3B4C00);
+        assert_eq!(meta.checksum, 0xDEADBEEF);
+        assert_eq!(meta.size_of_headers, 0x400);
+    }
+
+    #[test]
+    fn test_parse_option_pe_type() {
+        let data = parse_executable_options("pe_type pe32").unwrap();
+        assert_eq!(data.pe_type, 0x10b);
+
+        let data = parse_executable_options("pe_type pe32+").unwrap();
+        assert_eq!(data.pe_type, 0x20b);
+
+        let data = parse_executable_options("pe_type pe64").unwrap();
+        assert_eq!(data.pe_type, 0x20b);
+
+        assert!(parse_executable_options("pe_type invalid").is_none());
+    }
+
+    #[test]
+    fn test_parse_option_timestamp() {
+        let data = parse_executable_options("timestamp >0").unwrap();
+        assert!(!data.timestamp.is_null());
+    }
+
+    #[test]
+    fn test_parse_option_checksum() {
+        let data = parse_executable_options("checksum 0").unwrap();
+        assert!(!data.checksum.is_null());
+    }
+
+    #[test]
+    fn test_parse_option_size_of_headers() {
+        let data = parse_executable_options("size_of_headers >0x200").unwrap();
+        assert!(!data.size_of_headers.is_null());
+    }
+
+    #[test]
+    fn test_parse_option_num_imports() {
+        let data = parse_executable_options("num_imports >5").unwrap();
+        assert!(!data.num_imports.is_null());
+    }
+
+    #[test]
+    fn test_parse_option_num_exports() {
+        let data = parse_executable_options("num_exports >0").unwrap();
+        assert!(!data.num_exports.is_null());
+    }
+
+    #[test]
+    fn test_parse_option_section_name() {
+        let data = parse_executable_options("section_name .text").unwrap();
+        assert_eq!(data.section_name.as_deref(), Some(".text"));
+
+        // Verify case-insensitive: needle is lowercased at parse time
+        let data2 = parse_executable_options("section_name .UPX0").unwrap();
+        assert_eq!(data2.section_name.as_deref(), Some(".upx0"));
+    }
+
+    #[test]
+    fn test_parse_option_export_name() {
+        let data = parse_executable_options("export_name mydll.dll").unwrap();
+        assert_eq!(data.export_name.as_deref(), Some("mydll.dll"));
+    }
+
+    #[test]
+    fn test_parse_option_section_wx() {
+        let data = parse_executable_options("section_wx").unwrap();
+        assert!(data.section_wx);
+    }
+
+    #[test]
+    fn test_parse_option_combined_new_fields() {
+        let data = parse_executable_options(
+            "arch x86, pe_type pe32, timestamp >0, section_wx, num_imports >3",
+        )
+        .unwrap();
+        assert_eq!(data.architecture, 0x014C);
+        assert_eq!(data.pe_type, 0x10b);
+        assert!(!data.timestamp.is_null());
+        assert!(data.section_wx);
+        assert!(!data.num_imports.is_null());
+    }
+
+    #[test]
+    fn test_has_wx_section_true() {
+        let sections = vec![SectionInfo {
+            name: *b".text\0\0\0",
+            virtual_address: 0x1000,
+            virtual_size: 0x1000,
+            raw_data_offset: 0x400,
+            raw_data_size: 0x1000,
+            characteristics: IMAGE_SCN_MEM_WRITE | IMAGE_SCN_MEM_EXECUTE,
+        }];
+        assert!(has_wx_section(&sections));
+    }
+
+    #[test]
+    fn test_has_wx_section_false() {
+        let sections = vec![
+            SectionInfo {
+                name: *b".text\0\0\0",
+                virtual_address: 0x1000,
+                virtual_size: 0x1000,
+                raw_data_offset: 0x400,
+                raw_data_size: 0x1000,
+                characteristics: IMAGE_SCN_MEM_EXECUTE, // execute only, no write
+            },
+            SectionInfo {
+                name: *b".data\0\0\0",
+                virtual_address: 0x2000,
+                virtual_size: 0x1000,
+                raw_data_offset: 0x1400,
+                raw_data_size: 0x1000,
+                characteristics: IMAGE_SCN_MEM_WRITE, // write only, no execute
+            },
+        ];
+        assert!(!has_wx_section(&sections));
+    }
+
+    #[test]
+    fn test_section_name_str() {
+        assert_eq!(section_name_str(b".text\0\0\0"), ".text");
+        assert_eq!(section_name_str(b".reloc\0\0"), ".reloc");
+        assert_eq!(section_name_str(b"12345678"), "12345678"); // full 8 chars, no null
+        assert_eq!(section_name_str(b"\0\0\0\0\0\0\0\0"), "");
+    }
+
+    #[test]
+    fn test_parse_section_headers_names_and_characteristics() {
+        // Build a PE with imports and check section name/characteristics parsing
+        let buf = build_pe_with_imports(&["KERNEL32.dll"]);
+        let pe_offset = u32::from_le_bytes([buf[60], buf[61], buf[62], buf[63]]) as usize;
+        let num_sections = u16::from_le_bytes([buf[pe_offset + 6], buf[pe_offset + 7]]);
+        let sections = parse_section_headers(&buf, pe_offset, num_sections);
+        assert_eq!(sections.len(), 1);
+        assert_eq!(section_name_str(&sections[0].name), ".idata");
+    }
+
+    /// Build a PE32 with an export directory.
+    fn build_pe_with_exports(dll_name: &str, num_functions: u32) -> Vec<u8> {
+        let mut buf = vec![0u8; 0x2200];
+
+        // DOS header
+        buf[0..2].copy_from_slice(b"MZ");
+        let pe_offset: u32 = 0x40;
+        buf[60..64].copy_from_slice(&pe_offset.to_le_bytes());
+
+        // PE signature
+        buf[0x40..0x44].copy_from_slice(b"PE\0\0");
+
+        // COFF header
+        buf[0x44..0x46].copy_from_slice(&0x014Cu16.to_le_bytes()); // Machine: x86
+        buf[0x46..0x48].copy_from_slice(&1u16.to_le_bytes()); // NumberOfSections
+        buf[0x54..0x56].copy_from_slice(&0x00E0u16.to_le_bytes()); // SizeOfOptionalHeader
+        buf[0x56..0x58].copy_from_slice(&0x0102u16.to_le_bytes()); // Characteristics
+
+        // Optional header
+        let opt = 0x58usize;
+        buf[opt..opt + 2].copy_from_slice(&0x010bu16.to_le_bytes()); // Magic: PE32
+        buf[opt + 0x5C..opt + 0x60].copy_from_slice(&16u32.to_le_bytes()); // NumberOfRvaAndSizes
+
+        // Export directory data directory at index 0 (opt+0x60)
+        let export_dd = opt + 0x60;
+        let export_rva: u32 = 0x1000;
+        buf[export_dd..export_dd + 4].copy_from_slice(&export_rva.to_le_bytes());
+        buf[export_dd + 4..export_dd + 8].copy_from_slice(&40u32.to_le_bytes()); // size
+
+        // Section header at opt+0xE0
+        let sh = opt + 0xE0;
+        buf[sh..sh + 8].copy_from_slice(b".edata\0\0");
+        buf[sh + 8..sh + 12].copy_from_slice(&0x2000u32.to_le_bytes()); // VirtualSize
+        buf[sh + 12..sh + 16].copy_from_slice(&0x1000u32.to_le_bytes()); // VirtualAddress
+        buf[sh + 16..sh + 20].copy_from_slice(&0x2000u32.to_le_bytes()); // SizeOfRawData
+        buf[sh + 20..sh + 24].copy_from_slice(&0x0200u32.to_le_bytes()); // PointerToRawData
+
+        // Export directory at file offset 0x200 (section base)
+        let exp = 0x200usize;
+        // NumberOfFunctions at +20
+        buf[exp + 20..exp + 24].copy_from_slice(&num_functions.to_le_bytes());
+        // Name RVA at +12 — point to after the export dir table
+        let name_rva: u32 = 0x1000 + 40; // section_va + 40
+        buf[exp + 12..exp + 16].copy_from_slice(&name_rva.to_le_bytes());
+
+        // Write DLL name at file offset 0x200 + 40
+        let name_off = exp + 40;
+        buf[name_off..name_off + dll_name.len()].copy_from_slice(dll_name.as_bytes());
+        buf[name_off + dll_name.len()] = 0;
+
+        buf
+    }
+
+    #[test]
+    fn test_parse_pe_exports_basic() {
+        let buf = build_pe_with_exports("mylib.dll", 42);
+        let pe_offset = 0x40;
+        let sections = parse_section_headers(&buf, pe_offset, 1);
+        let (name, count) = parse_pe_exports(&buf, pe_offset, &sections);
+        assert_eq!(name.as_deref(), Some("mylib.dll"));
+        assert_eq!(count, 42);
+    }
+
+    #[test]
+    fn test_parse_pe_exports_no_exports() {
+        // Build a PE with no export directory (RVA=0)
+        let mut buf = vec![0u8; 0x400];
+        buf[0..2].copy_from_slice(b"MZ");
+        buf[60..64].copy_from_slice(&0x40u32.to_le_bytes());
+        buf[0x40..0x44].copy_from_slice(b"PE\0\0");
+        buf[0x44..0x46].copy_from_slice(&0x014Cu16.to_le_bytes());
+        buf[0x46..0x48].copy_from_slice(&1u16.to_le_bytes());
+        buf[0x54..0x56].copy_from_slice(&0x00E0u16.to_le_bytes());
+        let opt = 0x58usize;
+        buf[opt..opt + 2].copy_from_slice(&0x010bu16.to_le_bytes());
+        buf[opt + 0x5C..opt + 0x60].copy_from_slice(&16u32.to_le_bytes());
+        let sections = parse_section_headers(&buf, 0x40, 1);
+        let (name, count) = parse_pe_exports(&buf, 0x40, &sections);
+        assert!(name.is_none());
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_pe_log_json_new_fields() {
+        let mut buf = vec![0u8; 300];
+        buf[0..2].copy_from_slice(b"MZ");
+        buf[60..64].copy_from_slice(&64u32.to_le_bytes());
+        buf[64..68].copy_from_slice(b"PE\0\0");
+        buf[68..70].copy_from_slice(&0x014Cu16.to_le_bytes());
+        buf[70..72].copy_from_slice(&1u16.to_le_bytes());
+        // timestamp
+        buf[72..76].copy_from_slice(&12345u32.to_le_bytes());
+        // optional header at 88
+        let opt = 88;
+        buf[opt..opt + 2].copy_from_slice(&0x010bu16.to_le_bytes()); // PE32
+        buf[opt + 0x3C..opt + 0x40].copy_from_slice(&0x200u32.to_le_bytes()); // size_of_headers
+        buf[opt + 0x40..opt + 0x44].copy_from_slice(&0xABCDu32.to_le_bytes()); // checksum
+
+        let mut js = JsonBuilder::try_new_object().expect("new");
+        pe_log_json(&buf, &mut js).expect("log");
+        js.close().expect("close");
+        let output = unsafe {
+            let ptr = crate::jsonbuilder::SCJbPtr(&mut js);
+            let len = crate::jsonbuilder::SCJbLen(&js);
+            std::str::from_utf8(std::slice::from_raw_parts(ptr, len))
+                .unwrap()
+                .to_string()
+        };
+        assert!(
+            output.contains("\"pe_type\":\"PE32\""),
+            "pe_type missing: {}",
+            output
+        );
+        assert!(
+            output.contains("\"magic\":267"),
+            "magic missing: {}",
+            output
+        ); // 0x10b = 267
+        assert!(
+            output.contains("\"timestamp\":12345"),
+            "timestamp missing: {}",
+            output
+        );
+        assert!(
+            output.contains("\"checksum\":43981"),
+            "checksum missing: {}",
+            output
+        ); // 0xABCD
+        assert!(
+            output.contains("\"size_of_headers\":512"),
+            "size_of_headers missing: {}",
+            output
+        );
+        assert!(
+            output.contains("\"has_wx_section\":false"),
+            "has_wx_section missing: {}",
+            output
+        );
+    }
+}

--- a/rust/src/detect/windows_pe.rs
+++ b/rust/src/detect/windows_pe.rs
@@ -60,8 +60,11 @@
 use crate::detect::uint::{detect_match_uint, detect_parse_uint, DetectUintData};
 #[cfg(test)]
 use crate::jsonbuilder::{JsonBuilder, JsonError};
+use der_parser::asn1_rs::{Any, Class, FromDer};
+use sha1::{Digest, Sha1};
 use std::collections::HashSet;
 use std::ffi::CStr;
+use std::fmt::Write as _;
 use std::os::raw::{c_char, c_int};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, File, Flow, SCDetectHelperFileKeywordRegister,
@@ -69,6 +72,7 @@ use suricata_sys::sys::{
     SCSigMatchAppendSMToList, SCSigTableFileLiteElmt, SigMatchCtx, Signature,
     SIGMATCH_OPTIONAL_OPT,
 };
+use x509_parser::prelude::X509Certificate;
 
 /// Flag: PE metadata has been parsed (valid or invalid).
 pub const SC_FILE_PE_META_F_PARSED: u16 = 1 << 0;
@@ -125,6 +129,8 @@ extern "C" {
     fn FilePeMetaSet(file: *mut File, meta: *const SCFilePeMeta);
     fn FilePeImportsGet(file: *const File) -> *const std::os::raw::c_void;
     fn FilePeImportsSet(file: *mut File, imports: *mut std::os::raw::c_void);
+    fn FilePeSignatureGet(file: *const File) -> *const std::os::raw::c_void;
+    fn FilePeSignatureSet(file: *mut File, sig: *mut std::os::raw::c_void);
 }
 
 /// Validate a PE file and return the PE header offset on success.
@@ -250,6 +256,199 @@ pub(crate) fn parse_pe_cert_table(data: &[u8], pe_offset: usize) -> Option<(usiz
         return None;
     }
     Some((cert_off, cert_size))
+}
+
+// ============================================================================
+// Authenticode signing-certificate parsing
+// ============================================================================
+
+/// Identity fields extracted from one embedded signing certificate.
+///
+/// Values match the conventions used by Suricata's TLS certificate keywords:
+/// `serial` is colon-separated uppercase hex of the raw serial bytes, and
+/// `thumbprint` is the uppercase hex SHA-1 of the DER certificate (the
+/// Windows "thumbprint").  `subject`/`issuer` are RFC4514 name strings.
+#[derive(Debug, Clone)]
+pub(crate) struct PeCertInfo {
+    pub(crate) subject: String,
+    pub(crate) issuer: String,
+    pub(crate) serial: String,
+    pub(crate) thumbprint: String,
+}
+
+fn cert_info_from_x509(cert: &X509Certificate, der: &[u8]) -> PeCertInfo {
+    // Strip the leading ASN.1 sign byte so the serial matches the display form
+    // used by openssl, Windows, and threat-intel feeds (a leading 0x00 is only
+    // present to keep the DER INTEGER positive).
+    let mut raw = cert.raw_serial();
+    while raw.len() > 1 && raw[0] == 0 {
+        raw = &raw[1..];
+    }
+    let serial = raw
+        .iter()
+        .map(|b| format!("{:02X}", b))
+        .collect::<Vec<_>>()
+        .join(":");
+    let mut thumbprint = String::new();
+    for b in Sha1::digest(der).iter() {
+        let _ = write!(thumbprint, "{:02X}", b);
+    }
+    PeCertInfo {
+        subject: cert.subject().to_string(),
+        issuer: cert.issuer().to_string(),
+        serial,
+        thumbprint,
+    }
+}
+
+/// Extract the embedded X.509 certificates from a PKCS#7 SignedData blob.
+///
+/// Authenticode wraps a PKCS#7 `SignedData` whose `certificates [0] IMPLICIT
+/// SET OF Certificate` field carries the signing cert (and usually its chain).
+/// x509-parser 0.16 has no PKCS#7 helper, so we walk the ASN.1 with `der-parser`
+/// to reach that SET, then parse each concatenated `Certificate` with
+/// `X509Certificate::from_der`.  Structure:
+///
+/// ```text
+/// ContentInfo ::= SEQUENCE { contentType OID, content [0] EXPLICIT SignedData }
+/// SignedData  ::= SEQUENCE { version, digestAlgorithms SET, encapContentInfo,
+///                            certificates [0] IMPLICIT SET OPTIONAL, ... }
+/// ```
+///
+/// The certificates borrow `p7`, so it must outlive the returned `X509Certificate`
+/// values; we convert each into an owned [`PeCertInfo`] before returning.
+pub(crate) fn parse_pkcs7_certs(p7: &[u8]) -> Vec<PeCertInfo> {
+    let mut out = Vec::new();
+
+    // ContentInfo SEQUENCE.
+    let ci = match Any::from_der(p7) {
+        Ok((_, a)) if a.header.tag().0 == 16 => a,
+        _ => return out,
+    };
+    // contentType OID, then content [0] EXPLICIT.
+    let (rem, _oid) = match Any::from_der(ci.data) {
+        Ok(v) => v,
+        Err(_) => return out,
+    };
+    let c0 = match Any::from_der(rem) {
+        Ok((_, a)) if a.header.class() == Class::ContextSpecific && a.header.tag().0 == 0 => a,
+        _ => return out,
+    };
+    // Inside [0] EXPLICIT is the SignedData SEQUENCE.
+    let sd = match Any::from_der(c0.data) {
+        Ok((_, a)) if a.header.tag().0 == 16 => a,
+        _ => return out,
+    };
+    // Walk SignedData fields, capturing the [0] IMPLICIT certificates SET and the
+    // signerInfos SET (the trailing universal SET; digestAlgorithms is an earlier
+    // SET, so keeping the last one selects signerInfos).
+    let mut rem = sd.data;
+    let mut cert_bytes: Option<&[u8]> = None;
+    let mut signer_infos: Option<&[u8]> = None;
+    while let Ok((next, elem)) = Any::from_der(rem) {
+        if elem.header.class() == Class::ContextSpecific && elem.header.tag().0 == 0 {
+            cert_bytes = Some(elem.data);
+        } else if elem.header.class() == Class::Universal && elem.header.tag().0 == 17 {
+            signer_infos = Some(elem.data);
+        }
+        if next.len() >= rem.len() {
+            break; // no forward progress; bail
+        }
+        rem = next;
+    }
+    let mut certs = match cert_bytes {
+        Some(b) => b,
+        None => return out,
+    };
+
+    // The signer's issuerAndSerialNumber identifies the leaf certificate.
+    let signer_serial = signer_infos.and_then(parse_signer_serial);
+    let mut signer_idx: Option<usize> = None;
+
+    // The SET content is concatenated Certificate SEQUENCEs.
+    let mut guard = 0;
+    while !certs.is_empty() && guard < 64 {
+        guard += 1;
+        let before = certs.len();
+        match X509Certificate::from_der(certs) {
+            Ok((rest, cert)) => {
+                let der = &certs[..before - rest.len()];
+                if signer_idx.is_none() {
+                    if let Some(ref s) = signer_serial {
+                        if cert.raw_serial() == s.as_slice() {
+                            signer_idx = Some(out.len());
+                        }
+                    }
+                }
+                out.push(cert_info_from_x509(&cert, der));
+                certs = rest;
+            }
+            Err(_) => break,
+        }
+    }
+
+    // Put the signer (leaf) certificate first so logging reports the actual
+    // signer rather than an arbitrary chain/root certificate.
+    if let Some(i) = signer_idx {
+        if i != 0 {
+            out.swap(0, i);
+        }
+    }
+    out
+}
+
+/// Extract the signer's certificate serial number from a PKCS#7 `signerInfos`
+/// SET, via the first `SignerInfo`'s `issuerAndSerialNumber`.
+///
+/// ```text
+/// SignerInfo ::= SEQUENCE { version, sid SignerIdentifier, ... }
+/// SignerIdentifier ::= CHOICE { issuerAndSerialNumber IssuerAndSerialNumber,
+///                               subjectKeyIdentifier [0] ... }
+/// IssuerAndSerialNumber ::= SEQUENCE { issuer Name, serialNumber INTEGER }
+/// ```
+///
+/// Returns the raw serial INTEGER bytes (comparable to `X509Certificate::raw_serial`),
+/// or `None` for the `subjectKeyIdentifier` choice or on any parse error.
+fn parse_signer_serial(signer_infos: &[u8]) -> Option<Vec<u8>> {
+    // First SignerInfo (SEQUENCE).
+    let (_, si) = Any::from_der(signer_infos).ok()?;
+    if si.header.tag().0 != 16 {
+        return None;
+    }
+    // version INTEGER, then sid.
+    let (rem, _ver) = Any::from_der(si.data).ok()?;
+    let (_, sid) = Any::from_der(rem).ok()?;
+    // issuerAndSerialNumber is a universal SEQUENCE; the SKI choice is [0] context.
+    if sid.header.class() != Class::Universal || sid.header.tag().0 != 16 {
+        return None;
+    }
+    // issuer Name, then serialNumber INTEGER.
+    let (rem2, _issuer) = Any::from_der(sid.data).ok()?;
+    let (_, serial) = Any::from_der(rem2).ok()?;
+    if serial.header.tag().0 != 2 {
+        return None;
+    }
+    Some(serial.data.to_vec())
+}
+
+/// Locate and parse the Authenticode signing certificates of a PE, if present.
+///
+/// Returns the embedded certificate identities, or `None` when the file is
+/// unsigned or the certificate bytes are not (yet) present in the buffer.
+pub(crate) fn extract_pe_signature(data: &[u8], pe_offset: usize) -> Option<Vec<PeCertInfo>> {
+    let (cert_off, cert_size) = parse_pe_cert_table(data, pe_offset)?;
+    // WIN_CERTIFICATE: dwLength(4) + wRevision(2) + wCertificateType(2) + PKCS#7 DER.
+    if cert_off + 8 > data.len() || cert_size < 8 {
+        return None;
+    }
+    let end = (cert_off + cert_size).min(data.len());
+    let p7 = &data[cert_off + 8..end];
+    let certs = parse_pkcs7_certs(p7);
+    if certs.is_empty() {
+        None
+    } else {
+        Some(certs)
+    }
 }
 
 // ============================================================================
@@ -640,6 +839,11 @@ pub struct DetectWindowsPEData {
     section_wx: bool,
     /// Bare flag: require the PE to be Authenticode-signed (non-empty cert table).
     signature: bool,
+    /// Signing-certificate identity filters (matched against any embedded cert).
+    cert_thumbprint: Option<String>,
+    cert_serial: Option<String>,
+    cert_subject: Option<String>,
+    cert_issuer: Option<String>,
     has_filters: bool,
     /// True when the rule uses options that require expensive parsing
     /// (imports, exports, section headers) beyond the basic COFF/Optional header.
@@ -667,6 +871,10 @@ impl Default for DetectWindowsPEData {
             export_name: None,
             section_wx: false,
             signature: false,
+            cert_thumbprint: None,
+            cert_serial: None,
+            cert_subject: None,
+            cert_issuer: None,
             has_filters: false,
             needs_deep_parse: false,
         }
@@ -725,6 +933,16 @@ macro_rules! parse_uint_field {
     };
 }
 
+/// Normalize a hex identifier (thumbprint/serial) to uppercase with all
+/// non-alphanumeric separators (colons, spaces) removed, so a rule value
+/// pasted in any common form compares equal to the parsed certificate value.
+fn normalize_hex(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_uppercase()
+}
+
 fn process_executable_option(data: &mut DetectWindowsPEData, key: &str, val: &str) -> Option<()> {
     match key {
         "arch" => {
@@ -767,6 +985,18 @@ fn process_executable_option(data: &mut DetectWindowsPEData, key: &str, val: &st
         }
         "signature" => {
             data.signature = true;
+        }
+        "cert_thumbprint" => {
+            data.cert_thumbprint = Some(normalize_hex(val));
+        }
+        "cert_serial" => {
+            data.cert_serial = Some(normalize_hex(val));
+        }
+        "cert_subject" => {
+            data.cert_subject = Some(val.trim().trim_matches('"').to_lowercase());
+        }
+        "cert_issuer" => {
+            data.cert_issuer = Some(val.trim().trim_matches('"').to_lowercase());
         }
         _ => return None,
     }
@@ -873,14 +1103,22 @@ fn parse_executable_options(input: &str) -> Option<DetectWindowsPEData> {
         || data.section_name.is_some()
         || data.export_name.is_some()
         || data.section_wx
-        || data.signature;
+        || data.signature
+        || data.cert_thumbprint.is_some()
+        || data.cert_serial.is_some()
+        || data.cert_subject.is_some()
+        || data.cert_issuer.is_some();
 
     data.needs_deep_parse = data.import_dlls.is_some()
         || !data.num_imports.is_null()
         || !data.num_exports.is_null()
         || data.export_name.is_some()
         || data.section_name.is_some()
-        || data.section_wx;
+        || data.section_wx
+        || data.cert_thumbprint.is_some()
+        || data.cert_serial.is_some()
+        || data.cert_subject.is_some()
+        || data.cert_issuer.is_some();
 
     Some(data)
 }
@@ -1065,6 +1303,90 @@ pub unsafe extern "C" fn SCFilePeImportsFree(ptr: *mut std::os::raw::c_void) {
     }
 }
 
+// ============================================================================
+// Signing-certificate caching in the File object
+// ============================================================================
+
+/// Retrieve cached signing certificates from File (opaque pointer → `Vec<PeCertInfo>`).
+pub(crate) unsafe fn file_signature_get(file: *const File) -> Option<&'static [PeCertInfo]> {
+    if file.is_null() {
+        return None;
+    }
+    let ptr = FilePeSignatureGet(file);
+    if ptr.is_null() {
+        return None;
+    }
+    let vec = &*(ptr as *const Vec<PeCertInfo>);
+    Some(vec.as_slice())
+}
+
+/// Store parsed signing certificates in the File object (ownership transferred).
+pub(crate) unsafe fn file_signature_set(file: *mut File, certs: Vec<PeCertInfo>) {
+    if file.is_null() {
+        return;
+    }
+    let boxed = Box::new(certs);
+    FilePeSignatureSet(file, Box::into_raw(boxed) as *mut std::os::raw::c_void);
+}
+
+/// Free a Rust-allocated `Vec<PeCertInfo>` stored as an opaque pointer in File.
+///
+/// Called from C's `FileFree` via `SCFilePeSignatureFree`.
+#[no_mangle]
+pub unsafe extern "C" fn SCFilePeSignatureFree(ptr: *mut std::os::raw::c_void) {
+    if !ptr.is_null() {
+        let _ = Box::from_raw(ptr as *mut Vec<PeCertInfo>);
+    }
+}
+
+/// Retrieve or parse+cache the signing certificates for a file.
+unsafe fn get_pe_signature_by_file<'a>(
+    file_ptr: *mut File, file_data: &[u8], pe_offset: usize,
+) -> Option<&'a [PeCertInfo]> {
+    if let Some(cached) = file_signature_get(file_ptr as *const File) {
+        return Some(cached);
+    }
+    let certs = extract_pe_signature(file_data, pe_offset)?;
+    file_signature_set(file_ptr, certs);
+    file_signature_get(file_ptr as *const File)
+}
+
+/// Check the certificate-identity filters against the embedded certificates.
+///
+/// Thumbprint and serial are matched exactly (after normalizing separators);
+/// subject and issuer are case-insensitive substring matches.  A filter is
+/// satisfied when *any* embedded certificate matches, so tracking a known-bad
+/// cert works whether it is the signer or elsewhere in the embedded chain.
+fn signature_matches(certs: &[PeCertInfo], ctx: &DetectWindowsPEData) -> bool {
+    if let Some(ref tp) = ctx.cert_thumbprint {
+        if !certs.iter().any(|c| &c.thumbprint == tp) {
+            return false;
+        }
+    }
+    if let Some(ref sn) = ctx.cert_serial {
+        if !certs.iter().any(|c| normalize_hex(&c.serial) == *sn) {
+            return false;
+        }
+    }
+    if let Some(ref sub) = ctx.cert_subject {
+        if !certs
+            .iter()
+            .any(|c| c.subject.to_lowercase().contains(sub.as_str()))
+        {
+            return false;
+        }
+    }
+    if let Some(ref iss) = ctx.cert_issuer {
+        if !certs
+            .iter()
+            .any(|c| c.issuer.to_lowercase().contains(iss.as_str()))
+        {
+            return false;
+        }
+    }
+    true
+}
+
 // SCPeLogJsonByFile lives in windows_pe_logger.rs.
 
 /// Check if PE metadata matches the filter criteria.
@@ -1245,6 +1567,22 @@ pub unsafe extern "C" fn SCDetectWindowsPEFileMatch(
                 _ => return 0,
             }
         }
+
+        // Signing-certificate identity filters.
+        if ctx_ref.cert_thumbprint.is_some()
+            || ctx_ref.cert_serial.is_some()
+            || ctx_ref.cert_subject.is_some()
+            || ctx_ref.cert_issuer.is_some()
+        {
+            let certs = match get_pe_signature_by_file(file_ptr, file_data, meta.pe_offset as usize)
+            {
+                Some(c) => c,
+                None => return 0,
+            };
+            if !signature_matches(certs, ctx_ref) {
+                return 0;
+            }
+        }
     } else {
         // Header-only rule — check metadata and cache for logging.
         file_meta_set(file_ptr, &meta);
@@ -1359,6 +1697,7 @@ mod tests {
             imports.as_deref(),
             Some(&sections),
             export_name.as_deref(),
+            None,
             js,
         )
     }

--- a/rust/src/detect/windows_pe.rs
+++ b/rust/src/detect/windows_pe.rs
@@ -122,6 +122,9 @@ pub struct SCFilePeMeta {
     /// Non-zero if the PE has a non-empty Certificate Table (Authenticode-signed).
     pub signed: u8,
     pub padding_: [u8; 2],
+    /// Packed FileVersion from the VERSIONINFO resource
+    /// (major<<48 | minor<<32 | build<<16 | revision); 0 if absent.
+    pub file_version: u64,
 }
 
 extern "C" {
@@ -207,6 +210,7 @@ pub(crate) fn parse_pe_metadata(data: &[u8]) -> Option<SCDetectPeMetadata> {
         num_exports: 0,
         has_wx_section: false,
         has_signature: parse_pe_cert_table(data, pe_offset).is_some(),
+        file_version: 0,
     })
 }
 
@@ -449,6 +453,157 @@ pub(crate) fn extract_pe_signature(data: &[u8], pe_offset: usize) -> Option<Vec<
     } else {
         Some(certs)
     }
+}
+
+// ============================================================================
+// VERSIONINFO resource parsing (file_version)
+// ============================================================================
+
+/// Find a child entry in an `IMAGE_RESOURCE_DIRECTORY` at `dir_off`.
+///
+/// When `want_id` is set, returns the ID entry matching it; otherwise the first
+/// entry.  Returns `(child_offset_relative_to_resource_base, is_subdirectory)`.
+fn resource_dir_find(data: &[u8], dir_off: usize, want_id: Option<u16>) -> Option<(u32, bool)> {
+    let ru16 = |o: usize| -> Option<u16> {
+        if o + 2 <= data.len() {
+            Some(u16::from_le_bytes([data[o], data[o + 1]]))
+        } else {
+            None
+        }
+    };
+    let ru32 = |o: usize| -> Option<u32> {
+        if o + 4 <= data.len() {
+            Some(u32::from_le_bytes([
+                data[o],
+                data[o + 1],
+                data[o + 2],
+                data[o + 3],
+            ]))
+        } else {
+            None
+        }
+    };
+    // IMAGE_RESOURCE_DIRECTORY: 12-byte header, then NamedEntries/IdEntries counts.
+    let named = ru16(dir_off + 12)?;
+    let ids = ru16(dir_off + 14)?;
+    let total = (named as usize + ids as usize).min(1024);
+    let entries = dir_off + 16;
+    for i in 0..total {
+        let e = entries + i * 8;
+        let name = ru32(e)?;
+        let offset = ru32(e + 4)?;
+        let is_subdir = offset & 0x8000_0000 != 0;
+        let child = offset & 0x7fff_ffff;
+        match want_id {
+            // ID entries have the high bit of `name` clear (named entries set it).
+            Some(id) => {
+                if name & 0x8000_0000 == 0 && (name as u16) == id {
+                    return Some((child, is_subdir));
+                }
+            }
+            None => return Some((child, is_subdir)),
+        }
+    }
+    None
+}
+
+/// Parse the FileVersion from the PE's VERSIONINFO resource, packed into a u64
+/// (major<<48 | minor<<32 | build<<16 | revision).
+///
+/// Walks the resource directory (data directory entry 2) down type `RT_VERSION`
+/// (16) → name → language → data entry, then scans the `VS_VERSIONINFO` blob for
+/// the `VS_FIXEDFILEINFO` signature `0xFEEF04BD` and reads `dwFileVersionMS/LS`.
+/// The `.rsrc` section typically sits at the end of the file, so this returns
+/// `None` on a partially reassembled buffer.
+pub(crate) fn parse_pe_file_version(
+    data: &[u8], pe_offset: usize, sections: &[SectionInfo],
+) -> Option<u64> {
+    let optional_header_offset = pe_offset + 24;
+    if optional_header_offset + 2 > data.len() {
+        return None;
+    }
+    let magic = u16::from_le_bytes([
+        data[optional_header_offset],
+        data[optional_header_offset + 1],
+    ]);
+    let data_dir_off = match magic {
+        0x10b => optional_header_offset + 0x60,
+        0x20b => optional_header_offset + 0x70,
+        _ => return None,
+    };
+    // Resource Table is data directory entry 2 (an RVA).
+    let res_entry = data_dir_off + 2 * 8;
+    if res_entry + 4 > data.len() {
+        return None;
+    }
+    let res_rva = u32::from_le_bytes([
+        data[res_entry],
+        data[res_entry + 1],
+        data[res_entry + 2],
+        data[res_entry + 3],
+    ]);
+    if res_rva == 0 {
+        return None;
+    }
+    let res_base = rva_to_offset(res_rva, sections)?;
+
+    // Level 1 (type) → RT_VERSION, Level 2 (name), Level 3 (language) → leaf.
+    let (l2, s1) = resource_dir_find(data, res_base, Some(16))?;
+    if !s1 {
+        return None;
+    }
+    let (l3, s2) = resource_dir_find(data, res_base + l2 as usize, None)?;
+    if !s2 {
+        return None;
+    }
+    let (leaf, s3) = resource_dir_find(data, res_base + l3 as usize, None)?;
+    if s3 {
+        return None; // expected a data-entry leaf, not another directory
+    }
+    // IMAGE_RESOURCE_DATA_ENTRY: OffsetToData (RVA), Size, CodePage, Reserved.
+    let leaf_off = res_base + leaf as usize;
+    if leaf_off + 8 > data.len() {
+        return None;
+    }
+    let data_rva = u32::from_le_bytes([
+        data[leaf_off],
+        data[leaf_off + 1],
+        data[leaf_off + 2],
+        data[leaf_off + 3],
+    ]);
+    let size = u32::from_le_bytes([
+        data[leaf_off + 4],
+        data[leaf_off + 5],
+        data[leaf_off + 6],
+        data[leaf_off + 7],
+    ]) as usize;
+    let vi_off = rva_to_offset(data_rva, sections)?;
+    let end = (vi_off + size).min(data.len());
+    if vi_off >= end {
+        return None;
+    }
+    // Scan the VS_VERSIONINFO blob for the VS_FIXEDFILEINFO signature.
+    let sig = 0xFEEF_04BDu32.to_le_bytes();
+    let blob = &data[vi_off..end];
+    let pos = blob.windows(4).position(|w| w == sig)?;
+    let fixed = vi_off + pos;
+    // dwFileVersionMS at +8, dwFileVersionLS at +12 from the signature.
+    if fixed + 16 > data.len() {
+        return None;
+    }
+    let ms = u32::from_le_bytes([
+        data[fixed + 8],
+        data[fixed + 9],
+        data[fixed + 10],
+        data[fixed + 11],
+    ]);
+    let ls = u32::from_le_bytes([
+        data[fixed + 12],
+        data[fixed + 13],
+        data[fixed + 14],
+        data[fixed + 15],
+    ]);
+    Some(((ms as u64) << 32) | (ls as u64))
 }
 
 // ============================================================================
@@ -782,6 +937,7 @@ pub(crate) struct SCDetectPeMetadata {
     pub(crate) num_exports: u32,
     pub(crate) has_wx_section: bool,
     pub(crate) has_signature: bool,
+    pub(crate) file_version: u64,
 }
 
 impl Default for SCDetectPeMetadata {
@@ -804,6 +960,7 @@ impl Default for SCDetectPeMetadata {
             num_exports: 0,
             has_wx_section: false,
             has_signature: false,
+            file_version: 0,
         }
     }
 }
@@ -833,6 +990,8 @@ pub struct DetectWindowsPEData {
     size_of_headers: *mut DetectUintData<u32>,
     num_imports: *mut DetectUintData<u16>,
     num_exports: *mut DetectUintData<u32>,
+    /// Packed FileVersion filter (VERSIONINFO resource); see `parse_version_filter`.
+    file_version: *mut DetectUintData<u64>,
     import_dlls: Option<Vec<String>>,
     section_name: Option<String>,
     export_name: Option<String>,
@@ -866,6 +1025,7 @@ impl Default for DetectWindowsPEData {
             size_of_headers: std::ptr::null_mut(),
             num_imports: std::ptr::null_mut(),
             num_exports: std::ptr::null_mut(),
+            file_version: std::ptr::null_mut(),
             import_dlls: None,
             section_name: None,
             export_name: None,
@@ -917,6 +1077,9 @@ impl Drop for DetectWindowsPEData {
             if !self.num_exports.is_null() {
                 let _ = Box::from_raw(self.num_exports);
             }
+            if !self.file_version.is_null() {
+                let _ = Box::from_raw(self.file_version);
+            }
             // import_dlls, section_name, export_name are Option types and drop automatically
         }
     }
@@ -943,6 +1106,66 @@ fn normalize_hex(s: &str) -> String {
         .to_ascii_uppercase()
 }
 
+/// Pack a dotted "major.minor.build.revision" string into the same u64 layout
+/// used for the parsed FileVersion (missing components default to 0).
+fn parse_dotted_version(s: &str) -> Option<u64> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let mut nums = [0u16; 4];
+    for (i, part) in s.split('.').enumerate() {
+        if i >= 4 {
+            return None;
+        }
+        nums[i] = part.trim().parse::<u16>().ok()?;
+    }
+    Some(
+        ((nums[0] as u64) << 48)
+            | ((nums[1] as u64) << 32)
+            | ((nums[2] as u64) << 16)
+            | (nums[3] as u64),
+    )
+}
+
+/// Parse a `file_version` filter value into `DetectUintData<u64>`.
+///
+/// Accepts the standard uint operators/ranges but with dotted version operands,
+/// e.g. `>6.1.0.0`, `<10.0.0.0`, `6.0.0.0-7.0.0.0`, `=6.1.7601.17514`, or a bare
+/// version (equality).  Each dotted operand is packed to its u64 value and the
+/// result reassembled into the canonical decimal form understood by
+/// [`detect_parse_uint`], reusing its operator/range logic.
+fn parse_version_filter(val: &str) -> Option<DetectUintData<u64>> {
+    let v = val.trim();
+    let (op, rest) = if let Some(r) = v.strip_prefix(">=") {
+        (">=", r)
+    } else if let Some(r) = v.strip_prefix("<=") {
+        ("<=", r)
+    } else if let Some(r) = v.strip_prefix("!=") {
+        ("!=", r)
+    } else if let Some(r) = v.strip_prefix('>') {
+        (">", r)
+    } else if let Some(r) = v.strip_prefix('<') {
+        ("<", r)
+    } else if let Some(r) = v.strip_prefix('=') {
+        ("=", r)
+    } else {
+        ("", v)
+    };
+
+    let canon = if op.is_empty() {
+        if let Some((a, b)) = rest.split_once("<>").or_else(|| rest.split_once('-')) {
+            format!("{}-{}", parse_dotted_version(a)?, parse_dotted_version(b)?)
+        } else {
+            format!("{}", parse_dotted_version(rest)?)
+        }
+    } else {
+        format!("{}{}", op, parse_dotted_version(rest)?)
+    };
+
+    detect_parse_uint::<u64>(&canon).ok().map(|(_, ctx)| ctx)
+}
+
 fn process_executable_option(data: &mut DetectWindowsPEData, key: &str, val: &str) -> Option<()> {
     match key {
         "arch" => {
@@ -966,6 +1189,10 @@ fn process_executable_option(data: &mut DetectWindowsPEData, key: &str, val: &st
         "size_of_headers" => parse_uint_field!(data, size_of_headers, u32, val),
         "num_imports" => parse_uint_field!(data, num_imports, u16, val),
         "num_exports" => parse_uint_field!(data, num_exports, u32, val),
+        "file_version" => match parse_version_filter(val) {
+            Some(ctx) => data.file_version = Box::into_raw(Box::new(ctx)),
+            None => return None,
+        },
         "pe_type" => {
             let v = val.trim().to_ascii_lowercase();
             data.pe_type = match v.as_str() {
@@ -1107,7 +1334,8 @@ fn parse_executable_options(input: &str) -> Option<DetectWindowsPEData> {
         || data.cert_thumbprint.is_some()
         || data.cert_serial.is_some()
         || data.cert_subject.is_some()
-        || data.cert_issuer.is_some();
+        || data.cert_issuer.is_some()
+        || !data.file_version.is_null();
 
     data.needs_deep_parse = data.import_dlls.is_some()
         || !data.num_imports.is_null()
@@ -1118,7 +1346,8 @@ fn parse_executable_options(input: &str) -> Option<DetectWindowsPEData> {
         || data.cert_thumbprint.is_some()
         || data.cert_serial.is_some()
         || data.cert_subject.is_some()
-        || data.cert_issuer.is_some();
+        || data.cert_issuer.is_some()
+        || !data.file_version.is_null();
 
     Some(data)
 }
@@ -1180,6 +1409,7 @@ pub(crate) fn detect_meta_from_file_meta(meta: &SCFilePeMeta) -> SCDetectPeMetad
         num_exports: meta.num_exports,
         has_wx_section: meta.has_wx_section != 0,
         has_signature: (meta.flags & SC_FILE_PE_META_F_SIGNED) != 0,
+        file_version: meta.file_version,
     }
 }
 
@@ -1210,6 +1440,7 @@ pub(crate) fn file_meta_from_detect_meta(meta: &SCDetectPeMetadata) -> SCFilePeM
         has_wx_section: if meta.has_wx_section { 1 } else { 0 },
         signed: if meta.has_signature { 1 } else { 0 },
         padding_: [0; 2],
+        file_version: meta.file_version,
     }
 }
 
@@ -1430,6 +1661,14 @@ unsafe fn pe_match(meta: &SCDetectPeMetadata, ctx: &DetectWindowsPEData) -> bool
     check_uint!(ctx.num_imports, meta.num_imports);
     check_uint!(ctx.num_exports, meta.num_exports);
 
+    // A file_version filter only matches files that actually carry a version
+    // resource; file_version == 0 means "no VERSIONINFO", not "0.0.0.0".
+    if !ctx.file_version.is_null()
+        && (meta.file_version == 0 || !detect_match_uint(&*ctx.file_version, meta.file_version))
+    {
+        return false;
+    }
+
     if ctx.section_wx && !meta.has_wx_section {
         return false;
     }
@@ -1500,6 +1739,8 @@ pub unsafe extern "C" fn SCDetectWindowsPEFileMatch(
     if ctx_ref.needs_deep_parse {
         let sections = parse_section_headers(file_data, meta.pe_offset as usize, meta.num_sections);
         meta.has_wx_section = has_wx_section(&sections);
+        meta.file_version =
+            parse_pe_file_version(file_data, meta.pe_offset as usize, &sections).unwrap_or(0);
 
         let imports = parse_pe_imports_with_offset(file_data, meta.pe_offset as usize, &sections);
         meta.num_imports = imports

--- a/rust/src/detect/windows_pe.rs
+++ b/rust/src/detect/windows_pe.rs
@@ -1898,7 +1898,7 @@ pub unsafe extern "C" fn SCDetectWindowsPERegister() {
 
     let kw = SCSigTableFileLiteElmt {
         name: b"windows_pe\0".as_ptr() as *const c_char,
-        desc: b"match Windows PE file format and metadata (arch, size, sections, entry_point, subsystem, characteristics, dll_characteristics, imported DLL names)\0".as_ptr() as *const c_char,
+        desc: b"match Windows PE file format and metadata (arch, size, sections, entry_point, subsystem, characteristics, dll_characteristics, imported DLL names, signing certificate, file_version)\0".as_ptr() as *const c_char,
         url: b"/rules/file-keywords.html#windows-pe\0".as_ptr() as *const c_char,
         FileMatch: Some(windows_pe_file_match),
         Setup: Some(windows_pe_setup),

--- a/rust/src/detect/windows_pe.rs
+++ b/rust/src/detect/windows_pe.rs
@@ -74,6 +74,8 @@ use suricata_sys::sys::{
 pub const SC_FILE_PE_META_F_PARSED: u16 = 1 << 0;
 /// Flag: PE metadata is valid (file is a valid PE).
 pub const SC_FILE_PE_META_F_VALID: u16 = 1 << 1;
+/// Flag: PE has a non-empty Certificate Table (is Authenticode-signed).
+pub const SC_FILE_PE_META_F_SIGNED: u16 = 1 << 2;
 
 /// Cached Windows PE metadata stored in the `File` object.
 ///
@@ -113,7 +115,9 @@ pub struct SCFilePeMeta {
     pub num_exports: u32,
     /// Non-zero if any section has both WRITE and EXECUTE permissions.
     pub has_wx_section: u8,
-    pub padding_: [u8; 3],
+    /// Non-zero if the PE has a non-empty Certificate Table (Authenticode-signed).
+    pub signed: u8,
+    pub padding_: [u8; 2],
 }
 
 extern "C" {
@@ -196,7 +200,56 @@ pub(crate) fn parse_pe_metadata(data: &[u8]) -> Option<SCDetectPeMetadata> {
         num_imports: 0,
         num_exports: 0,
         has_wx_section: false,
+        has_signature: parse_pe_cert_table(data, pe_offset).is_some(),
     })
+}
+
+/// Locate the Certificate Table (optional-header data directory entry 4).
+///
+/// Unlike every other data directory entry, the Certificate Table's first
+/// dword is a **file offset** (not an RVA) to the `WIN_CERTIFICATE` structure,
+/// and the second dword is its total size.  Because the entry lives in the
+/// optional header near the front of the file, presence is detectable even on
+/// a partial capture (the certificate bytes themselves sit at the file's end).
+///
+/// Returns `Some((file_offset, size))` when a non-empty certificate table is
+/// present, `None` otherwise.
+pub(crate) fn parse_pe_cert_table(data: &[u8], pe_offset: usize) -> Option<(usize, usize)> {
+    let optional_header_offset = pe_offset + 24;
+    if optional_header_offset + 2 > data.len() {
+        return None;
+    }
+    let magic = u16::from_le_bytes([
+        data[optional_header_offset],
+        data[optional_header_offset + 1],
+    ]);
+    // Data directory base depends on PE32 vs PE32+.
+    let data_dir_off = match magic {
+        0x10b => optional_header_offset + 0x60, // PE32
+        0x20b => optional_header_offset + 0x70, // PE32+
+        _ => return None,
+    };
+    // Certificate Table is data directory entry 4 (each entry = 8 bytes).
+    let cert_entry = data_dir_off + 4 * 8;
+    if cert_entry + 8 > data.len() {
+        return None;
+    }
+    let cert_off = u32::from_le_bytes([
+        data[cert_entry],
+        data[cert_entry + 1],
+        data[cert_entry + 2],
+        data[cert_entry + 3],
+    ]) as usize;
+    let cert_size = u32::from_le_bytes([
+        data[cert_entry + 4],
+        data[cert_entry + 5],
+        data[cert_entry + 6],
+        data[cert_entry + 7],
+    ]) as usize;
+    if cert_off == 0 || cert_size == 0 {
+        return None;
+    }
+    Some((cert_off, cert_size))
 }
 
 // ============================================================================
@@ -529,6 +582,7 @@ pub(crate) struct SCDetectPeMetadata {
     pub(crate) size_of_headers: u32,
     pub(crate) num_exports: u32,
     pub(crate) has_wx_section: bool,
+    pub(crate) has_signature: bool,
 }
 
 impl Default for SCDetectPeMetadata {
@@ -550,6 +604,7 @@ impl Default for SCDetectPeMetadata {
             size_of_headers: 0,
             num_exports: 0,
             has_wx_section: false,
+            has_signature: false,
         }
     }
 }
@@ -583,6 +638,8 @@ pub struct DetectWindowsPEData {
     section_name: Option<String>,
     export_name: Option<String>,
     section_wx: bool,
+    /// Bare flag: require the PE to be Authenticode-signed (non-empty cert table).
+    signature: bool,
     has_filters: bool,
     /// True when the rule uses options that require expensive parsing
     /// (imports, exports, section headers) beyond the basic COFF/Optional header.
@@ -609,6 +666,7 @@ impl Default for DetectWindowsPEData {
             section_name: None,
             export_name: None,
             section_wx: false,
+            signature: false,
             has_filters: false,
             needs_deep_parse: false,
         }
@@ -707,6 +765,9 @@ fn process_executable_option(data: &mut DetectWindowsPEData, key: &str, val: &st
         "section_wx" => {
             data.section_wx = true;
         }
+        "signature" => {
+            data.signature = true;
+        }
         _ => return None,
     }
     Some(())
@@ -753,7 +814,7 @@ fn parse_executable_options(input: &str) -> Option<DetectWindowsPEData> {
             }
             // Bare flag keywords (no value required)
             let bare_key = tok.to_ascii_lowercase();
-            if bare_key == "section_wx" {
+            if bare_key == "section_wx" || bare_key == "signature" {
                 if have_kv {
                     process_executable_option(&mut data, &cur_key, &cur_val)?;
                 }
@@ -811,7 +872,8 @@ fn parse_executable_options(input: &str) -> Option<DetectWindowsPEData> {
         || !data.num_exports.is_null()
         || data.section_name.is_some()
         || data.export_name.is_some()
-        || data.section_wx;
+        || data.section_wx
+        || data.signature;
 
     data.needs_deep_parse = data.import_dlls.is_some()
         || !data.num_imports.is_null()
@@ -879,6 +941,7 @@ pub(crate) fn detect_meta_from_file_meta(meta: &SCFilePeMeta) -> SCDetectPeMetad
         size_of_headers: meta.size_of_headers,
         num_exports: meta.num_exports,
         has_wx_section: meta.has_wx_section != 0,
+        has_signature: (meta.flags & SC_FILE_PE_META_F_SIGNED) != 0,
     }
 }
 
@@ -886,6 +949,9 @@ pub(crate) fn file_meta_from_detect_meta(meta: &SCDetectPeMetadata) -> SCFilePeM
     let mut flags = SC_FILE_PE_META_F_PARSED;
     if meta.valid {
         flags |= SC_FILE_PE_META_F_VALID;
+    }
+    if meta.has_signature {
+        flags |= SC_FILE_PE_META_F_SIGNED;
     }
     SCFilePeMeta {
         flags,
@@ -904,7 +970,8 @@ pub(crate) fn file_meta_from_detect_meta(meta: &SCDetectPeMetadata) -> SCFilePeM
         size_of_headers: meta.size_of_headers,
         num_exports: meta.num_exports,
         has_wx_section: if meta.has_wx_section { 1 } else { 0 },
-        padding_: [0; 3],
+        signed: if meta.has_signature { 1 } else { 0 },
+        padding_: [0; 2],
     }
 }
 
@@ -1042,6 +1109,10 @@ unsafe fn pe_match(meta: &SCDetectPeMetadata, ctx: &DetectWindowsPEData) -> bool
     check_uint!(ctx.num_exports, meta.num_exports);
 
     if ctx.section_wx && !meta.has_wx_section {
+        return false;
+    }
+
+    if ctx.signature && !meta.has_signature {
         return false;
     }
 

--- a/rust/src/detect/windows_pe.rs
+++ b/rust/src/detect/windows_pe.rs
@@ -61,6 +61,7 @@ use crate::detect::uint::{detect_match_uint, detect_parse_uint, DetectUintData};
 #[cfg(test)]
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 use der_parser::asn1_rs::{Any, Class, FromDer};
+use regex::{Regex, RegexBuilder};
 use sha1::{Digest, Sha1};
 use std::collections::HashSet;
 use std::ffi::CStr;
@@ -134,6 +135,8 @@ extern "C" {
     fn FilePeImportsSet(file: *mut File, imports: *mut std::os::raw::c_void);
     fn FilePeSignatureGet(file: *const File) -> *const std::os::raw::c_void;
     fn FilePeSignatureSet(file: *mut File, sig: *mut std::os::raw::c_void);
+    fn FilePeVersionInfoGet(file: *const File) -> *const std::os::raw::c_void;
+    fn FilePeVersionInfoSet(file: *mut File, vi: *mut std::os::raw::c_void);
 }
 
 /// Validate a PE file and return the PE header offset on success.
@@ -515,9 +518,14 @@ fn resource_dir_find(data: &[u8], dir_off: usize, want_id: Option<u16>) -> Optio
 /// the `VS_FIXEDFILEINFO` signature `0xFEEF04BD` and reads `dwFileVersionMS/LS`.
 /// The `.rsrc` section typically sits at the end of the file, so this returns
 /// `None` on a partially reassembled buffer.
-pub(crate) fn parse_pe_file_version(
+/// Locate the `VS_VERSIONINFO` blob in the resource directory.
+///
+/// Walks data directory entry 2 (resources) down `RT_VERSION` (16) → name →
+/// language to the leaf `IMAGE_RESOURCE_DATA_ENTRY`, and returns the file
+/// `(start, end)` of the `VS_VERSIONINFO` structure, or `None` if absent.
+fn locate_version_resource(
     data: &[u8], pe_offset: usize, sections: &[SectionInfo],
-) -> Option<u64> {
+) -> Option<(usize, usize)> {
     let optional_header_offset = pe_offset + 24;
     if optional_header_offset + 2 > data.len() {
         return None;
@@ -582,6 +590,13 @@ pub(crate) fn parse_pe_file_version(
     if vi_off >= end {
         return None;
     }
+    Some((vi_off, end))
+}
+
+pub(crate) fn parse_pe_file_version(
+    data: &[u8], pe_offset: usize, sections: &[SectionInfo],
+) -> Option<u64> {
+    let (vi_off, end) = locate_version_resource(data, pe_offset, sections)?;
     // Scan the VS_VERSIONINFO blob for the VS_FIXEDFILEINFO signature.
     let sig = 0xFEEF_04BDu32.to_le_bytes();
     let blob = &data[vi_off..end];
@@ -604,6 +619,174 @@ pub(crate) fn parse_pe_file_version(
         data[fixed + 15],
     ]);
     Some(((ms as u64) << 32) | (ls as u64))
+}
+
+/// Round `x` up to a 4-byte boundary (VERSIONINFO nodes are DWORD-aligned).
+fn align4(x: usize) -> usize {
+    (x + 3) & !3
+}
+
+/// Decode a little-endian UTF-16 byte slice to a String, stopping at the first
+/// NUL. Lossy on malformed input so a hostile resource cannot cause an error.
+fn utf16le_to_string(bytes: &[u8]) -> String {
+    let units: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    let end = units.iter().position(|&u| u == 0).unwrap_or(units.len());
+    String::from_utf16_lossy(&units[..end])
+}
+
+/// Parse one VERSIONINFO node header at `p` (bounded by `end`).
+///
+/// Every node is `wLength(2) wValueLength(2) wType(2)` then a NUL-terminated
+/// UTF-16 `szKey`, padded to a DWORD. Returns
+/// `(w_length, w_value_length, key, value_offset)` where `value_offset` is the
+/// DWORD-aligned start of the node's Value/children.
+fn vi_node_header(data: &[u8], p: usize, end: usize) -> Option<(usize, usize, String, usize)> {
+    if p + 6 > end {
+        return None;
+    }
+    let w_length = u16::from_le_bytes([data[p], data[p + 1]]) as usize;
+    let w_value_length = u16::from_le_bytes([data[p + 2], data[p + 3]]) as usize;
+    let key_start = p + 6;
+    let mut k = key_start;
+    while k + 2 <= end {
+        if u16::from_le_bytes([data[k], data[k + 1]]) == 0 {
+            break;
+        }
+        k += 2;
+    }
+    let key = utf16le_to_string(&data[key_start..k]);
+    Some((w_length, w_value_length, key, align4(k + 2)))
+}
+
+/// Parse the StringFileInfo key/value strings from the PE VERSIONINFO resource.
+///
+/// Walks `VS_VERSIONINFO` → `StringFileInfo` → `StringTable`(s) → `String`
+/// entries, returning `(key, value)` pairs (e.g. `("CompanyName", "...")`).
+/// Values are read as NUL-terminated UTF-16 (robust to the words-vs-bytes
+/// ambiguity of `wValueLength`). Everything is bounds-checked and capped.
+pub(crate) fn parse_pe_version_strings(
+    data: &[u8], pe_offset: usize, sections: &[SectionInfo],
+) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let (vi_off, end) = match locate_version_resource(data, pe_offset, sections) {
+        Some(v) => v,
+        None => return out,
+    };
+    // VS_VERSIONINFO node: Value is VS_FIXEDFILEINFO (w_value_length bytes).
+    let (vi_len, vi_vlen, _vi_key, vi_after_key) = match vi_node_header(data, vi_off, end) {
+        Some(v) => v,
+        None => return out,
+    };
+    let vi_end = (vi_off + vi_len).min(end);
+    // Children (StringFileInfo / VarFileInfo) follow the fixed-info value.
+    let mut cp = align4(vi_after_key + vi_vlen);
+    let mut cg = 0;
+    while cp + 6 <= vi_end && cg < 32 {
+        cg += 1;
+        let (clen, _cvlen, ckey, cafter) = match vi_node_header(data, cp, vi_end) {
+            Some(v) => v,
+            None => break,
+        };
+        if clen == 0 {
+            break;
+        }
+        let cend = (cp + clen).min(vi_end);
+        if ckey == "StringFileInfo" {
+            // Children are StringTable nodes (one per language/codepage).
+            let mut tp = cafter;
+            let mut tg = 0;
+            while tp + 6 <= cend && tg < 64 {
+                tg += 1;
+                let (tlen, _tvlen, _tkey, tafter) = match vi_node_header(data, tp, cend) {
+                    Some(v) => v,
+                    None => break,
+                };
+                if tlen == 0 {
+                    break;
+                }
+                let tend = (tp + tlen).min(cend);
+                // Children are String nodes: szKey = name, Value = UTF-16 string.
+                let mut sp = tafter;
+                let mut sg = 0;
+                while sp + 6 <= tend && sg < 256 && out.len() < 256 {
+                    sg += 1;
+                    let (slen, _svlen, skey, safter) = match vi_node_header(data, sp, tend) {
+                        Some(v) => v,
+                        None => break,
+                    };
+                    if slen == 0 {
+                        break;
+                    }
+                    let send = (sp + slen).min(tend);
+                    let value = if safter < send {
+                        utf16le_to_string(&data[safter..send])
+                    } else {
+                        String::new()
+                    };
+                    if !skey.is_empty() {
+                        out.push((skey, value));
+                    }
+                    sp = align4(sp + slen);
+                }
+                tp = align4(tp + tlen);
+            }
+        }
+        cp = align4(cp + clen);
+    }
+    out
+}
+
+/// A string-match filter: a case-insensitive substring or a compiled regex.
+///
+/// Rule values wrapped as `/pattern/flags` (flags `i`/`s`/`m`/`x`) compile to a
+/// regex; anything else is a lowercased substring. Used by `version_info`.
+pub(crate) enum StrMatch {
+    Substr(String),
+    Regex(Regex),
+}
+
+impl StrMatch {
+    fn parse(val: &str) -> Option<StrMatch> {
+        let v = val.trim().trim_matches('"');
+        // Regex form: /pattern/flags with at least the two delimiters.
+        if v.len() >= 2 && v.starts_with('/') {
+            if let Some(last) = v.rfind('/') {
+                if last >= 1 {
+                    let pattern = &v[1..last];
+                    let mut b = RegexBuilder::new(pattern);
+                    for f in v[last + 1..].chars() {
+                        match f {
+                            'i' => {
+                                b.case_insensitive(true);
+                            }
+                            's' => {
+                                b.dot_matches_new_line(true);
+                            }
+                            'm' => {
+                                b.multi_line(true);
+                            }
+                            'x' => {
+                                b.ignore_whitespace(true);
+                            }
+                            _ => return None,
+                        }
+                    }
+                    return b.build().ok().map(StrMatch::Regex);
+                }
+            }
+        }
+        Some(StrMatch::Substr(v.to_lowercase()))
+    }
+
+    fn is_match(&self, haystack: &str) -> bool {
+        match self {
+            StrMatch::Substr(s) => haystack.to_lowercase().contains(s.as_str()),
+            StrMatch::Regex(re) => re.is_match(haystack),
+        }
+    }
 }
 
 // ============================================================================
@@ -1003,6 +1186,8 @@ pub struct DetectWindowsPEData {
     cert_serial: Option<String>,
     cert_subject: Option<String>,
     cert_issuer: Option<String>,
+    /// VERSIONINFO StringFileInfo filters (each must match a "Key: Value" entry).
+    version_info: Vec<StrMatch>,
     has_filters: bool,
     /// True when the rule uses options that require expensive parsing
     /// (imports, exports, section headers) beyond the basic COFF/Optional header.
@@ -1035,6 +1220,7 @@ impl Default for DetectWindowsPEData {
             cert_serial: None,
             cert_subject: None,
             cert_issuer: None,
+            version_info: Vec::new(),
             has_filters: false,
             needs_deep_parse: false,
         }
@@ -1225,6 +1411,9 @@ fn process_executable_option(data: &mut DetectWindowsPEData, key: &str, val: &st
         "cert_issuer" => {
             data.cert_issuer = Some(val.trim().trim_matches('"').to_lowercase());
         }
+        "version_info" => {
+            data.version_info.push(StrMatch::parse(val)?);
+        }
         _ => return None,
     }
     Some(())
@@ -1335,7 +1524,8 @@ fn parse_executable_options(input: &str) -> Option<DetectWindowsPEData> {
         || data.cert_serial.is_some()
         || data.cert_subject.is_some()
         || data.cert_issuer.is_some()
-        || !data.file_version.is_null();
+        || !data.file_version.is_null()
+        || !data.version_info.is_empty();
 
     data.needs_deep_parse = data.import_dlls.is_some()
         || !data.num_imports.is_null()
@@ -1347,7 +1537,8 @@ fn parse_executable_options(input: &str) -> Option<DetectWindowsPEData> {
         || data.cert_serial.is_some()
         || data.cert_subject.is_some()
         || data.cert_issuer.is_some()
-        || !data.file_version.is_null();
+        || !data.file_version.is_null()
+        || !data.version_info.is_empty();
 
     Some(data)
 }
@@ -1580,6 +1771,67 @@ unsafe fn get_pe_signature_by_file<'a>(
     let certs = extract_pe_signature(file_data, pe_offset)?;
     file_signature_set(file_ptr, certs);
     file_signature_get(file_ptr as *const File)
+}
+
+// ============================================================================
+// VERSIONINFO string caching in the File object
+// ============================================================================
+
+/// Retrieve cached version-info strings from File (opaque → `Vec<(String,String)>`).
+pub(crate) unsafe fn file_version_info_get(
+    file: *const File,
+) -> Option<&'static [(String, String)]> {
+    if file.is_null() {
+        return None;
+    }
+    let ptr = FilePeVersionInfoGet(file);
+    if ptr.is_null() {
+        return None;
+    }
+    let vec = &*(ptr as *const Vec<(String, String)>);
+    Some(vec.as_slice())
+}
+
+/// Store parsed version-info strings in the File object (ownership transferred).
+pub(crate) unsafe fn file_version_info_set(file: *mut File, vi: Vec<(String, String)>) {
+    if file.is_null() {
+        return;
+    }
+    let boxed = Box::new(vi);
+    FilePeVersionInfoSet(file, Box::into_raw(boxed) as *mut std::os::raw::c_void);
+}
+
+/// Free a Rust-allocated `Vec<(String,String)>` stored as an opaque pointer in File.
+///
+/// Called from C's `FileFree` via `SCFilePeVersionInfoFree`.
+#[no_mangle]
+pub unsafe extern "C" fn SCFilePeVersionInfoFree(ptr: *mut std::os::raw::c_void) {
+    if !ptr.is_null() {
+        let _ = Box::from_raw(ptr as *mut Vec<(String, String)>);
+    }
+}
+
+/// Retrieve or parse+cache the version-info strings for a file.
+unsafe fn get_pe_version_info_by_file<'a>(
+    file_ptr: *mut File, file_data: &[u8], pe_offset: usize, sections: &[SectionInfo],
+) -> &'a [(String, String)] {
+    if let Some(cached) = file_version_info_get(file_ptr as *const File) {
+        return cached;
+    }
+    let vi = parse_pe_version_strings(file_data, pe_offset, sections);
+    file_version_info_set(file_ptr, vi);
+    file_version_info_get(file_ptr as *const File).unwrap_or(&[])
+}
+
+/// Check the `version_info` filters against the parsed StringFileInfo entries.
+///
+/// Each filter must match at least one `"Key: Value"` entry (AND across filters).
+fn version_info_matches(entries: &[(String, String)], filters: &[StrMatch]) -> bool {
+    filters.iter().all(|f| {
+        entries
+            .iter()
+            .any(|(k, v)| f.is_match(&format!("{}: {}", k, v)))
+    })
 }
 
 /// Check the certificate-identity filters against the embedded certificates.
@@ -1824,6 +2076,19 @@ pub unsafe extern "C" fn SCDetectWindowsPEFileMatch(
                 return 0;
             }
         }
+
+        // VERSIONINFO StringFileInfo filters.
+        if !ctx_ref.version_info.is_empty() {
+            let entries = get_pe_version_info_by_file(
+                file_ptr,
+                file_data,
+                meta.pe_offset as usize,
+                &sections,
+            );
+            if !version_info_matches(entries, &ctx_ref.version_info) {
+                return 0;
+            }
+        }
     } else {
         // Header-only rule — check metadata and cache for logging.
         file_meta_set(file_ptr, &meta);
@@ -1898,7 +2163,7 @@ pub unsafe extern "C" fn SCDetectWindowsPERegister() {
 
     let kw = SCSigTableFileLiteElmt {
         name: b"windows_pe\0".as_ptr() as *const c_char,
-        desc: b"match Windows PE file format and metadata (arch, size, sections, entry_point, subsystem, characteristics, dll_characteristics, imported DLL names, signing certificate, file_version)\0".as_ptr() as *const c_char,
+        desc: b"match Windows PE file format and metadata (arch, size, sections, entry_point, subsystem, characteristics, dll_characteristics, imported DLL names, signing certificate, file_version, version_info)\0".as_ptr() as *const c_char,
         url: b"/rules/file-keywords.html#windows-pe\0".as_ptr() as *const c_char,
         FileMatch: Some(windows_pe_file_match),
         Setup: Some(windows_pe_setup),
@@ -1938,6 +2203,7 @@ mod tests {
             imports.as_deref(),
             Some(&sections),
             export_name.as_deref(),
+            None,
             None,
             js,
         )

--- a/rust/src/detect/windows_pe_logger.rs
+++ b/rust/src/detect/windows_pe_logger.rs
@@ -1,0 +1,267 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! Windows PE JSON logging.
+//!
+//! Separated from the detection module (`windows_pe`) so that detection
+//! and output concerns do not mix.
+
+use crate::detect::windows_pe::{
+    detect_meta_full, file_imports_get, file_imports_set, file_meta_get, file_meta_set,
+    parse_pe_exports, parse_pe_imports_with_offset, parse_pe_metadata, parse_section_headers,
+    section_name_str, SCDetectPeMetadata, SectionInfo, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_WRITE,
+};
+use crate::jsonbuilder::{JsonBuilder, JsonError};
+use suricata_sys::sys::File;
+
+/// Build JSON representation of PE metadata.
+///
+/// Called for both raw-buffer parsing and File-cache fallback paths.
+pub(crate) fn pe_log_json_fields(
+    meta: &SCDetectPeMetadata, imports: Option<&[String]>, sections: Option<&[SectionInfo]>,
+    export_name: Option<&str>, js: &mut JsonBuilder,
+) -> Result<(), JsonError> {
+    js.open_object("executable")?;
+    js.set_string("type", "windows_pe")?;
+
+    // Architecture (machine type) - hex value and human-readable name
+    let (arch_hex, arch_name) = match meta.architecture {
+        0x014C => ("0x014c", "x86"),
+        0x8664 => ("0x8664", "x86-64"),
+        0x01C0 => ("0x01c0", "ARM"),
+        0xAA64 => ("0xaa64", "ARM64"),
+        _ => ("", "unknown"),
+    };
+    if arch_hex.is_empty() {
+        let s = format!("0x{:04x}", meta.architecture);
+        js.set_string("arch", &s)?;
+    } else {
+        js.set_string("arch", arch_hex)?;
+    }
+    js.set_string("arch_name", arch_name)?;
+
+    js.set_uint("sections", meta.num_sections as u64)?;
+
+    let subsystem_name = match meta.subsystem {
+        0 => "UNKNOWN",
+        1 => "NATIVE",
+        2 => "WINDOWS_GUI",
+        3 => "WINDOWS_CUI",
+        5 => "OS2_CUI",
+        7 => "POSIX_CUI",
+        9 => "WINDOWS_CE_GUI",
+        10 => "EFI_APPLICATION",
+        11 => "EFI_BOOT_SERVICE_DRIVER",
+        12 => "EFI_RUNTIME_DRIVER",
+        13 => "EFI_ROM",
+        14 => "XBOX",
+        16 => "WINDOWS_BOOT_APPLICATION",
+        _ => "UNKNOWN",
+    };
+    js.set_string("subsystem", subsystem_name)?;
+    js.set_uint("subsystem_id", meta.subsystem as u64)?;
+
+    js.set_uint("characteristics", meta.characteristics as u64)?;
+    let mut char_traits: [&str; 5] = [""; 5];
+    let mut char_count = 0;
+    if meta.characteristics & 0x0002 != 0 {
+        char_traits[char_count] = "EXECUTABLE_IMAGE";
+        char_count += 1;
+    }
+    if meta.characteristics & 0x2000 != 0 {
+        char_traits[char_count] = "DLL";
+        char_count += 1;
+    }
+    if meta.characteristics & 0x0020 != 0 {
+        char_traits[char_count] = "LARGE_ADDRESS_AWARE";
+        char_count += 1;
+    }
+    if meta.characteristics & 0x0100 != 0 {
+        char_traits[char_count] = "32BIT_MACHINE";
+        char_count += 1;
+    }
+    if char_count > 0 {
+        js.open_array("characteristics_names")?;
+        for trait_name in &char_traits[..char_count] {
+            js.append_string(trait_name)?;
+        }
+        js.close()?;
+    }
+
+    js.set_uint("dll_characteristics", meta.dll_characteristics as u64)?;
+    let mut sec_features: [&str; 5] = [""; 5];
+    let mut sec_count = 0;
+    if meta.dll_characteristics & 0x0020 != 0 {
+        sec_features[sec_count] = "HIGH_ENTROPY_VA";
+        sec_count += 1;
+    }
+    if meta.dll_characteristics & 0x0040 != 0 {
+        sec_features[sec_count] = "DYNAMIC_BASE";
+        sec_count += 1;
+    }
+    if meta.dll_characteristics & 0x0100 != 0 {
+        sec_features[sec_count] = "NX_COMPAT";
+        sec_count += 1;
+    }
+    if meta.dll_characteristics & 0x0400 != 0 {
+        sec_features[sec_count] = "NO_SEH";
+        sec_count += 1;
+    }
+    if meta.dll_characteristics & 0x4000 != 0 {
+        sec_features[sec_count] = "GUARD_CF";
+        sec_count += 1;
+    }
+    if sec_count > 0 {
+        js.open_array("security_features")?;
+        for feature in &sec_features[..sec_count] {
+            js.append_string(feature)?;
+        }
+        js.close()?;
+    }
+
+    js.set_uint("entry_point", meta.entry_point_rva as u64)?;
+    js.set_uint("size_of_image", meta.size_of_image as u64)?;
+    js.set_uint("pe_offset", meta.pe_offset as u64)?;
+
+    let pe_type_name = match meta.magic {
+        0x10b => "PE32",
+        0x20b => "PE32+",
+        _ => "unknown",
+    };
+    js.set_string("pe_type", pe_type_name)?;
+    js.set_uint("magic", meta.magic as u64)?;
+
+    js.set_uint("timestamp", meta.timestamp as u64)?;
+    js.set_uint("checksum", meta.checksum as u64)?;
+    js.set_uint("size_of_headers", meta.size_of_headers as u64)?;
+
+    js.set_uint("num_imports", meta.num_imports as u64)?;
+    js.set_uint("num_exports", meta.num_exports as u64)?;
+
+    js.set_bool("has_wx_section", meta.has_wx_section)?;
+
+    if let Some(name) = export_name {
+        js.set_string("export_name", name)?;
+    }
+
+    if let Some(dlls) = imports {
+        if !dlls.is_empty() {
+            js.open_array("imports")?;
+            for dll in dlls {
+                js.append_string(dll)?;
+            }
+            js.close()?;
+        }
+    }
+
+    if let Some(secs) = sections {
+        if !secs.is_empty() {
+            js.open_array("sections_detail")?;
+            for s in secs {
+                js.start_object()?;
+                js.set_string("name", section_name_str(&s.name))?;
+                js.set_uint("virtual_size", s.virtual_size as u64)?;
+                js.set_uint("virtual_address", s.virtual_address as u64)?;
+                js.set_uint("raw_data_size", s.raw_data_size as u64)?;
+                js.set_uint("characteristics", s.characteristics as u64)?;
+                let wx = s.characteristics & IMAGE_SCN_MEM_WRITE != 0
+                    && s.characteristics & IMAGE_SCN_MEM_EXECUTE != 0;
+                js.set_bool("wx", wx)?;
+                js.close()?;
+            }
+            js.close()?;
+        }
+    }
+
+    js.close()?;
+    Ok(())
+}
+
+/// Log PE metadata as JSON from cached `File` metadata.
+///
+/// Section details and export name are not available from the cached metadata
+/// alone (they require raw file data), so they are omitted in this path.
+fn pe_log_json_from_sc_meta(
+    meta: &SCDetectPeMetadata, imports: Option<&[String]>, js: &mut JsonBuilder,
+) -> Result<(), JsonError> {
+    pe_log_json_fields(meta, imports, None, None, js)
+}
+
+/// Cache-aware FFI entry point: log PE metadata as JSON for a given file.
+///
+/// Checks the File cache first to avoid redundant parsing when detection
+/// already populated the cache. Falls back to raw-buffer parsing when the
+/// cache is empty and the streaming buffer still starts at offset 0.
+///
+/// # Safety
+/// - `file` must be a valid non-null pointer to the File object
+/// - `data` / `data_len` / `offset` come from `StreamingBufferGetData` on the file's sb
+/// - `js` must be a valid `JsonBuilder`
+#[no_mangle]
+pub unsafe extern "C" fn SCPeLogJsonByFile(
+    file: *const File, data: *const u8, data_len: u32, offset: u64, js: &mut JsonBuilder,
+) -> bool {
+    // Try File-cached metadata first (detection may have already parsed).
+    if let Some(meta) = file_meta_get(file) {
+        if meta.valid {
+            let cached_imports = file_imports_get(file);
+            return pe_log_json_from_sc_meta(&meta, cached_imports, js).is_ok();
+        }
+        // Parsed but invalid — not a PE.
+        return false;
+    }
+
+    // Cache miss: parse from raw buffer if it starts at offset 0.
+    if offset == 0 && !data.is_null() && data_len >= 64 {
+        let file_data = std::slice::from_raw_parts(data, data_len as usize);
+        if file_data[0] == b'M' && file_data[1] == b'Z' {
+            let mut meta = match parse_pe_metadata(file_data) {
+                Some(m) => m,
+                None => {
+                    file_meta_set(file as *mut File, &SCDetectPeMetadata::default());
+                    return true;
+                }
+            };
+            let sections =
+                parse_section_headers(file_data, meta.pe_offset as usize, meta.num_sections);
+            let imports =
+                parse_pe_imports_with_offset(file_data, meta.pe_offset as usize, &sections);
+            let num_imports = imports
+                .as_ref()
+                .map_or(0, |v| v.len().min(u16::MAX as usize) as u16);
+            let (export_name, num_exports) =
+                parse_pe_exports(file_data, meta.pe_offset as usize, &sections);
+
+            detect_meta_full(&mut meta, &sections, num_imports, num_exports);
+            if let Some(imp) = imports {
+                file_imports_set(file as *mut File, imp);
+            }
+            file_meta_set(file as *mut File, &meta);
+
+            let cached_imports = file_imports_get(file);
+            return pe_log_json_fields(
+                &meta,
+                cached_imports,
+                Some(&sections),
+                export_name.as_deref(),
+                js,
+            )
+            .is_ok();
+        }
+    }
+    false
+}

--- a/rust/src/detect/windows_pe_logger.rs
+++ b/rust/src/detect/windows_pe_logger.rs
@@ -154,6 +154,8 @@ pub(crate) fn pe_log_json_fields(
 
     js.set_bool("has_wx_section", meta.has_wx_section)?;
 
+    js.set_bool("signed", meta.has_signature)?;
+
     if let Some(name) = export_name {
         js.set_string("export_name", name)?;
     }

--- a/rust/src/detect/windows_pe_logger.rs
+++ b/rust/src/detect/windows_pe_logger.rs
@@ -21,9 +21,10 @@
 //! and output concerns do not mix.
 
 use crate::detect::windows_pe::{
-    detect_meta_full, file_imports_get, file_imports_set, file_meta_get, file_meta_set,
-    parse_pe_exports, parse_pe_imports_with_offset, parse_pe_metadata, parse_section_headers,
-    section_name_str, SCDetectPeMetadata, SectionInfo, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_WRITE,
+    detect_meta_full, extract_pe_signature, file_imports_get, file_imports_set, file_meta_get,
+    file_meta_set, file_signature_get, file_signature_set, parse_pe_exports,
+    parse_pe_imports_with_offset, parse_pe_metadata, parse_section_headers, section_name_str,
+    PeCertInfo, SCDetectPeMetadata, SectionInfo, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_WRITE,
 };
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 use suricata_sys::sys::File;
@@ -33,7 +34,7 @@ use suricata_sys::sys::File;
 /// Called for both raw-buffer parsing and File-cache fallback paths.
 pub(crate) fn pe_log_json_fields(
     meta: &SCDetectPeMetadata, imports: Option<&[String]>, sections: Option<&[SectionInfo]>,
-    export_name: Option<&str>, js: &mut JsonBuilder,
+    export_name: Option<&str>, signature: Option<&[PeCertInfo]>, js: &mut JsonBuilder,
 ) -> Result<(), JsonError> {
     js.open_object("executable")?;
     js.set_string("type", "windows_pe")?;
@@ -156,6 +157,14 @@ pub(crate) fn pe_log_json_fields(
 
     js.set_bool("signed", meta.has_signature)?;
 
+    // Signing-certificate identity (first embedded certificate).
+    if let Some(cert) = signature.and_then(|c| c.first()) {
+        js.set_string("cert_subject", &cert.subject)?;
+        js.set_string("cert_issuer", &cert.issuer)?;
+        js.set_string("cert_serial", &cert.serial)?;
+        js.set_string("cert_thumbprint", &cert.thumbprint)?;
+    }
+
     if let Some(name) = export_name {
         js.set_string("export_name", name)?;
     }
@@ -198,9 +207,10 @@ pub(crate) fn pe_log_json_fields(
 /// Section details and export name are not available from the cached metadata
 /// alone (they require raw file data), so they are omitted in this path.
 fn pe_log_json_from_sc_meta(
-    meta: &SCDetectPeMetadata, imports: Option<&[String]>, js: &mut JsonBuilder,
+    meta: &SCDetectPeMetadata, imports: Option<&[String]>, signature: Option<&[PeCertInfo]>,
+    js: &mut JsonBuilder,
 ) -> Result<(), JsonError> {
-    pe_log_json_fields(meta, imports, None, None, js)
+    pe_log_json_fields(meta, imports, None, None, signature, js)
 }
 
 /// Cache-aware FFI entry point: log PE metadata as JSON for a given file.
@@ -221,7 +231,17 @@ pub unsafe extern "C" fn SCPeLogJsonByFile(
     if let Some(meta) = file_meta_get(file) {
         if meta.valid {
             let cached_imports = file_imports_get(file);
-            return pe_log_json_from_sc_meta(&meta, cached_imports, js).is_ok();
+            // Use the cached signature if a cert_* rule parsed it; otherwise
+            // parse it now if the file is signed and the buffer is present.
+            let mut sig = file_signature_get(file);
+            if sig.is_none() && meta.has_signature && offset == 0 && !data.is_null() {
+                let file_data = std::slice::from_raw_parts(data, data_len as usize);
+                if let Some(certs) = extract_pe_signature(file_data, meta.pe_offset as usize) {
+                    file_signature_set(file as *mut File, certs);
+                    sig = file_signature_get(file);
+                }
+            }
+            return pe_log_json_from_sc_meta(&meta, cached_imports, sig, js).is_ok();
         }
         // Parsed but invalid — not a PE.
         return false;
@@ -252,14 +272,22 @@ pub unsafe extern "C" fn SCPeLogJsonByFile(
             if let Some(imp) = imports {
                 file_imports_set(file as *mut File, imp);
             }
+            // Parse and cache the signing certificates for signed PEs.
+            if meta.has_signature {
+                if let Some(certs) = extract_pe_signature(file_data, meta.pe_offset as usize) {
+                    file_signature_set(file as *mut File, certs);
+                }
+            }
             file_meta_set(file as *mut File, &meta);
 
             let cached_imports = file_imports_get(file);
+            let cached_sig = file_signature_get(file);
             return pe_log_json_fields(
                 &meta,
                 cached_imports,
                 Some(&sections),
                 export_name.as_deref(),
+                cached_sig,
                 js,
             )
             .is_ok();

--- a/rust/src/detect/windows_pe_logger.rs
+++ b/rust/src/detect/windows_pe_logger.rs
@@ -22,7 +22,7 @@
 
 use crate::detect::windows_pe::{
     detect_meta_full, extract_pe_signature, file_imports_get, file_imports_set, file_meta_get,
-    file_meta_set, file_signature_get, file_signature_set, parse_pe_exports,
+    file_meta_set, file_signature_get, file_signature_set, parse_pe_exports, parse_pe_file_version,
     parse_pe_imports_with_offset, parse_pe_metadata, parse_section_headers, section_name_str,
     PeCertInfo, SCDetectPeMetadata, SectionInfo, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_WRITE,
 };
@@ -165,6 +165,19 @@ pub(crate) fn pe_log_json_fields(
         js.set_string("cert_thumbprint", &cert.thumbprint)?;
     }
 
+    // FileVersion from the VERSIONINFO resource (dotted form), if present.
+    if meta.file_version != 0 {
+        let v = meta.file_version;
+        let ver = format!(
+            "{}.{}.{}.{}",
+            (v >> 48) & 0xffff,
+            (v >> 32) & 0xffff,
+            (v >> 16) & 0xffff,
+            v & 0xffff
+        );
+        js.set_string("file_version", &ver)?;
+    }
+
     if let Some(name) = export_name {
         js.set_string("export_name", name)?;
     }
@@ -269,6 +282,8 @@ pub unsafe extern "C" fn SCPeLogJsonByFile(
                 parse_pe_exports(file_data, meta.pe_offset as usize, &sections);
 
             detect_meta_full(&mut meta, &sections, num_imports, num_exports);
+            meta.file_version =
+                parse_pe_file_version(file_data, meta.pe_offset as usize, &sections).unwrap_or(0);
             if let Some(imp) = imports {
                 file_imports_set(file as *mut File, imp);
             }

--- a/rust/src/detect/windows_pe_logger.rs
+++ b/rust/src/detect/windows_pe_logger.rs
@@ -22,8 +22,9 @@
 
 use crate::detect::windows_pe::{
     detect_meta_full, extract_pe_signature, file_imports_get, file_imports_set, file_meta_get,
-    file_meta_set, file_signature_get, file_signature_set, parse_pe_exports, parse_pe_file_version,
-    parse_pe_imports_with_offset, parse_pe_metadata, parse_section_headers, section_name_str,
+    file_meta_set, file_signature_get, file_signature_set, file_version_info_get,
+    file_version_info_set, parse_pe_exports, parse_pe_file_version, parse_pe_imports_with_offset,
+    parse_pe_metadata, parse_pe_version_strings, parse_section_headers, section_name_str,
     PeCertInfo, SCDetectPeMetadata, SectionInfo, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_WRITE,
 };
 use crate::jsonbuilder::{JsonBuilder, JsonError};
@@ -34,7 +35,8 @@ use suricata_sys::sys::File;
 /// Called for both raw-buffer parsing and File-cache fallback paths.
 pub(crate) fn pe_log_json_fields(
     meta: &SCDetectPeMetadata, imports: Option<&[String]>, sections: Option<&[SectionInfo]>,
-    export_name: Option<&str>, signature: Option<&[PeCertInfo]>, js: &mut JsonBuilder,
+    export_name: Option<&str>, signature: Option<&[PeCertInfo]>,
+    version_info: Option<&[(String, String)]>, js: &mut JsonBuilder,
 ) -> Result<(), JsonError> {
     js.open_object("executable")?;
     js.set_string("type", "windows_pe")?;
@@ -178,6 +180,19 @@ pub(crate) fn pe_log_json_fields(
         js.set_string("file_version", &ver)?;
     }
 
+    // VERSIONINFO StringFileInfo strings (CompanyName, OriginalFilename, ...).
+    if let Some(entries) = version_info {
+        if !entries.is_empty() {
+            js.open_object("version_info")?;
+            for (k, v) in entries {
+                if !k.is_empty() {
+                    js.set_string(k, v)?;
+                }
+            }
+            js.close()?;
+        }
+    }
+
     if let Some(name) = export_name {
         js.set_string("export_name", name)?;
     }
@@ -221,9 +236,9 @@ pub(crate) fn pe_log_json_fields(
 /// alone (they require raw file data), so they are omitted in this path.
 fn pe_log_json_from_sc_meta(
     meta: &SCDetectPeMetadata, imports: Option<&[String]>, signature: Option<&[PeCertInfo]>,
-    js: &mut JsonBuilder,
+    version_info: Option<&[(String, String)]>, js: &mut JsonBuilder,
 ) -> Result<(), JsonError> {
-    pe_log_json_fields(meta, imports, None, None, signature, js)
+    pe_log_json_fields(meta, imports, None, None, signature, version_info, js)
 }
 
 /// Cache-aware FFI entry point: log PE metadata as JSON for a given file.
@@ -247,14 +262,30 @@ pub unsafe extern "C" fn SCPeLogJsonByFile(
             // Use the cached signature if a cert_* rule parsed it; otherwise
             // parse it now if the file is signed and the buffer is present.
             let mut sig = file_signature_get(file);
-            if sig.is_none() && meta.has_signature && offset == 0 && !data.is_null() {
+            let mut vi = file_version_info_get(file);
+            if offset == 0 && !data.is_null() {
                 let file_data = std::slice::from_raw_parts(data, data_len as usize);
-                if let Some(certs) = extract_pe_signature(file_data, meta.pe_offset as usize) {
-                    file_signature_set(file as *mut File, certs);
-                    sig = file_signature_get(file);
+                if sig.is_none() && meta.has_signature {
+                    if let Some(certs) = extract_pe_signature(file_data, meta.pe_offset as usize) {
+                        file_signature_set(file as *mut File, certs);
+                        sig = file_signature_get(file);
+                    }
+                }
+                if vi.is_none() {
+                    let sections = parse_section_headers(
+                        file_data,
+                        meta.pe_offset as usize,
+                        meta.num_sections,
+                    );
+                    let entries =
+                        parse_pe_version_strings(file_data, meta.pe_offset as usize, &sections);
+                    if !entries.is_empty() {
+                        file_version_info_set(file as *mut File, entries);
+                        vi = file_version_info_get(file);
+                    }
                 }
             }
-            return pe_log_json_from_sc_meta(&meta, cached_imports, sig, js).is_ok();
+            return pe_log_json_from_sc_meta(&meta, cached_imports, sig, vi, js).is_ok();
         }
         // Parsed but invalid — not a PE.
         return false;
@@ -293,16 +324,24 @@ pub unsafe extern "C" fn SCPeLogJsonByFile(
                     file_signature_set(file as *mut File, certs);
                 }
             }
+            // Parse and cache the VERSIONINFO strings.
+            let vi_entries =
+                parse_pe_version_strings(file_data, meta.pe_offset as usize, &sections);
+            if !vi_entries.is_empty() {
+                file_version_info_set(file as *mut File, vi_entries);
+            }
             file_meta_set(file as *mut File, &meta);
 
             let cached_imports = file_imports_get(file);
             let cached_sig = file_signature_get(file);
+            let cached_vi = file_version_info_get(file);
             return pe_log_json_fields(
                 &meta,
                 cached_imports,
                 Some(&sections),
                 export_name.as_deref(),
                 cached_sig,
+                cached_vi,
                 js,
             )
             .is_ok();

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -748,6 +748,12 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct File_ {
+    _unused: [u8; 0],
+}
+pub type File = File_;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct SigMatchCtx_ {
     _unused: [u8; 0],
 }
@@ -939,6 +945,60 @@ extern "C" {
 extern "C" {
     pub fn SCDetectRegisterBufferLowerMd5Callbacks(name: *const ::std::os::raw::c_char);
 }
+#[doc = " Lite keyword registration struct for file-match keywords."]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SCSigTableFileLiteElmt_ {
+    pub name: *const ::std::os::raw::c_char,
+    pub desc: *const ::std::os::raw::c_char,
+    pub url: *const ::std::os::raw::c_char,
+    pub flags: u32,
+    pub FileMatch: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut DetectEngineThreadCtx,
+            arg2: *mut Flow,
+            flags: u8,
+            arg3: *mut File,
+            arg4: *const Signature,
+            arg5: *const SigMatchCtx,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub Setup: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut DetectEngineCtx,
+            arg2: *mut Signature,
+            arg3: *const ::std::os::raw::c_char,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub Free: ::std::option::Option<
+        unsafe extern "C" fn(arg1: *mut DetectEngineCtx, arg2: *mut ::std::os::raw::c_void),
+    >,
+}
+impl Default for SCSigTableFileLiteElmt_ {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[doc = " Lite keyword registration struct for file-match keywords."]
+pub type SCSigTableFileLiteElmt = SCSigTableFileLiteElmt_;
+extern "C" {
+    pub fn SCDetectHelperFileKeywordRegister(kw: *const SCSigTableFileLiteElmt) -> u16;
+}
+extern "C" {
+    pub fn SCDetectHelperGetFilesBufferId() -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SCFileGetData(
+        file: *const File, data_len_out: *mut u32, offset_out: *mut u64,
+    ) -> *const u8;
+}
+extern "C" {
+    pub fn SCDetectSignatureSetFileInspect(s: *mut Signature);
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct DeStateStoreItem_ {
@@ -1114,12 +1174,6 @@ pub struct StreamingBufferConfig_ {
         ::std::option::Option<unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void, size: usize)>,
 }
 pub type StreamingBufferConfig = StreamingBufferConfig_;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct File_ {
-    _unused: [u8; 0],
-}
-pub type File = File_;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct FileContainer_ {

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -752,6 +752,12 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct File_ {
+    _unused: [u8; 0],
+}
+pub type File = File_;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct SigMatchCtx_ {
     _unused: [u8; 0],
 }
@@ -943,6 +949,60 @@ extern "C" {
 extern "C" {
     pub fn SCDetectRegisterBufferLowerMd5Callbacks(name: *const ::std::os::raw::c_char);
 }
+#[doc = " Lite keyword registration struct for file-match keywords."]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SCSigTableFileLiteElmt_ {
+    pub name: *const ::std::os::raw::c_char,
+    pub desc: *const ::std::os::raw::c_char,
+    pub url: *const ::std::os::raw::c_char,
+    pub flags: u32,
+    pub FileMatch: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut DetectEngineThreadCtx,
+            arg2: *mut Flow,
+            flags: u8,
+            arg3: *mut File,
+            arg4: *const Signature,
+            arg5: *const SigMatchCtx,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub Setup: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut DetectEngineCtx,
+            arg2: *mut Signature,
+            arg3: *const ::std::os::raw::c_char,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub Free: ::std::option::Option<
+        unsafe extern "C" fn(arg1: *mut DetectEngineCtx, arg2: *mut ::std::os::raw::c_void),
+    >,
+}
+impl Default for SCSigTableFileLiteElmt_ {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[doc = " Lite keyword registration struct for file-match keywords."]
+pub type SCSigTableFileLiteElmt = SCSigTableFileLiteElmt_;
+extern "C" {
+    pub fn SCDetectHelperFileKeywordRegister(kw: *const SCSigTableFileLiteElmt) -> u16;
+}
+extern "C" {
+    pub fn SCDetectHelperGetFilesBufferId() -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SCFileGetData(
+        file: *const File, data_len_out: *mut u32, offset_out: *mut u64,
+    ) -> *const u8;
+}
+extern "C" {
+    pub fn SCDetectSignatureSetFileInspect(s: *mut Signature);
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct DeStateStoreItem_ {
@@ -1118,12 +1178,6 @@ pub struct StreamingBufferConfig_ {
         ::std::option::Option<unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void, size: usize)>,
 }
 pub type StreamingBufferConfig = StreamingBufferConfig_;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct File_ {
-    _unused: [u8; 0],
-}
-pub type File = File_;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct FileContainer_ {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -308,6 +308,7 @@ noinst_HEADERS = \
 	detect-uricontent.h \
 	detect-urilen.h \
 	detect-vlan.h \
+	detect-windows-pe.h \
 	detect-within.h \
 	detect-xbits.h \
 	detect.h \
@@ -885,6 +886,7 @@ libsuricata_c_a_SOURCES = \
 	detect-uricontent.c \
 	detect-urilen.c \
 	detect-vlan.c \
+	detect-windows-pe.c \
 	detect-within.c \
 	detect-xbits.c \
 	detect.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -307,6 +307,7 @@ noinst_HEADERS = \
 	detect-uricontent.h \
 	detect-urilen.h \
 	detect-vlan.h \
+	detect-windows-pe.h \
 	detect-within.h \
 	detect-xbits.h \
 	detect.h \
@@ -883,6 +884,7 @@ libsuricata_c_a_SOURCES = \
 	detect-uricontent.c \
 	detect-urilen.c \
 	detect-vlan.c \
+	detect-windows-pe.c \
 	detect-within.c \
 	detect-xbits.c \
 	detect.c \

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -29,6 +29,8 @@
 #include "detect-engine-prefilter.h"
 #include "detect-parse.h"
 #include "detect-engine-content-inspection.h"
+#include "util-file.h"
+#include "util-streaming-buffer.h"
 #include "rust.h"
 #include "app-layer-parser.h"
 #include "util-validate.h"
@@ -233,4 +235,60 @@ void SCDetectRegisterBufferLowerMd5Callbacks(const char *name)
 {
     DetectBufferTypeRegisterSetupCallback(name, DetectLowerSetupCallback);
     DetectBufferTypeRegisterValidateCallback(name, DetectMd5ValidateCallback);
+}
+
+uint16_t SCDetectHelperFileKeywordRegister(const SCSigTableFileLiteElmt *kw)
+{
+    int keyword_id = SCDetectHelperNewKeywordId();
+    if (keyword_id < 0) {
+        return (uint16_t)-1;
+    }
+
+    sigmatch_table[keyword_id].name = kw->name;
+    sigmatch_table[keyword_id].desc = kw->desc;
+    sigmatch_table[keyword_id].url = kw->url;
+    sigmatch_table[keyword_id].flags = kw->flags;
+    sigmatch_table[keyword_id].FileMatch = kw->FileMatch;
+    sigmatch_table[keyword_id].Setup =
+            (int (*)(DetectEngineCtx *de, Signature *s, const char *raw))kw->Setup;
+    sigmatch_table[keyword_id].Free = (void (*)(DetectEngineCtx *de, void *ptr))kw->Free;
+
+    return (uint16_t)keyword_id;
+}
+
+int SCDetectHelperGetFilesBufferId(void)
+{
+    return DetectBufferTypeRegister("files");
+}
+
+const uint8_t *SCFileGetData(const File *file, uint32_t *data_len_out, uint64_t *offset_out)
+{
+    if (data_len_out == NULL || offset_out == NULL) {
+        return NULL;
+    }
+    if (file == NULL || file->sb == NULL) {
+        *data_len_out = 0;
+        *offset_out = 0;
+        return NULL;
+    }
+
+    const uint8_t *data = NULL;
+    uint32_t len = 0;
+    uint64_t offset = 0;
+
+    StreamingBufferGetData(file->sb, &data, &len, &offset);
+    if (data == NULL) {
+        *data_len_out = 0;
+        *offset_out = offset;
+        return NULL;
+    }
+
+    *data_len_out = len;
+    *offset_out = offset;
+    return data;
+}
+
+void SCDetectSignatureSetFileInspect(Signature *s)
+{
+    s->file_flags |= FILE_SIG_NEED_FILE | FILE_SIG_NEED_FILECONTENT;
 }

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -29,6 +29,8 @@
 
 // type from flow.h with only forward declarations for bindgen
 typedef struct Flow_ Flow;
+// type from util-file.h
+typedef struct File_ File;
 // types from detect.h with only forward declarations for bindgen
 // could be #ifndef SURICATA_BINDGEN_H #include "detect.h" #endif
 typedef struct DetectEngineCtx_ DetectEngineCtx;
@@ -103,5 +105,22 @@ int SCDetectHelperMultiBufferProgressMpmRegisterSubState(const char *name, const
 int SCDetectHelperTransformRegister(const SCTransformTableElmt *kw);
 
 void SCDetectRegisterBufferLowerMd5Callbacks(const char *name);
+
+/** Lite keyword registration struct for file-match keywords. */
+typedef struct SCSigTableFileLiteElmt_ {
+    const char *name;
+    const char *desc;
+    const char *url;
+    uint32_t flags;
+    int (*FileMatch)(DetectEngineThreadCtx *, Flow *, uint8_t flags, File *, const Signature *,
+            const SigMatchCtx *);
+    int (*Setup)(DetectEngineCtx *, Signature *, const char *);
+    void (*Free)(DetectEngineCtx *, void *);
+} SCSigTableFileLiteElmt;
+
+uint16_t SCDetectHelperFileKeywordRegister(const SCSigTableFileLiteElmt *kw);
+int SCDetectHelperGetFilesBufferId(void);
+const uint8_t *SCFileGetData(const File *file, uint32_t *data_len_out, uint64_t *offset_out);
+void SCDetectSignatureSetFileInspect(Signature *s);
 
 #endif /* SURICATA_DETECT_ENGINE_HELPER_H */

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -202,6 +202,7 @@
 #include "detect-ja4-hash.h"
 #include "detect-ftp-command.h"
 #include "detect-entropy.h"
+#include "detect-windows-pe.h"
 #include "detect-ftp-command-data.h"
 #include "detect-ftp-completion-code.h"
 #include "detect-ftp-reply.h"
@@ -623,6 +624,7 @@ void SigTableSetup(void)
     DetectBytejumpRegister();
     DetectBytemathRegister();
     DetectEntropyRegister();
+    DetectWindowsPERegister();
     DetectSameipRegister();
     DetectGeoipRegister();
     DetectL3ProtoRegister();

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -202,6 +202,7 @@
 #include "detect-ja4-hash.h"
 #include "detect-ftp-command.h"
 #include "detect-entropy.h"
+#include "detect-windows-pe.h"
 #include "detect-ftp-command-data.h"
 #include "detect-ftp-completion-code.h"
 #include "detect-ftp-reply.h"
@@ -621,6 +622,7 @@ void SigTableSetup(void)
     DetectBytejumpRegister();
     DetectBytemathRegister();
     DetectEntropyRegister();
+    DetectWindowsPERegister();
     DetectSameipRegister();
     DetectGeoipRegister();
     DetectL3ProtoRegister();

--- a/src/detect-windows-pe.c
+++ b/src/detect-windows-pe.c
@@ -1,0 +1,74 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jlucovsky@oisf.net>
+ *
+ * Implements the windows_pe keyword for detecting Windows PE files in
+ * network traffic with optional metadata matching.
+ *
+ * The windows_pe keyword can be used alone or with option(s):
+ *
+ *   windows_pe;
+ *   windows_pe: arch <arch>
+ *               [, size <uint32>][, sections <uint16>]
+ *               [, entry_point <uint32>]
+ *               [, subsystem <uint16>][, characteristics <uint16>]
+ *               [, dll_characteristics <uint16>];
+ *
+ * Option parsing is performed in Rust (SCDetectWindowsPEParse) following
+ * the pattern established by detect-bytemath.c / byte_math.rs.
+ */
+
+#include "suricata-common.h"
+#include "detect-windows-pe.h"
+#include "util-file.h"
+#include "rust.h"
+
+/* Forward declaration for Rust FFI */
+extern void SCDetectWindowsPERegister(void);
+
+void DetectWindowsPERegister(void)
+{
+    SCDetectWindowsPERegister();
+}
+
+/* Stub implementations for File PE metadata caching.
+ * These satisfy the linker until util-file.c provides the real
+ * implementations backed by pe_meta/pe_imports fields on File. */
+
+typedef struct SCFilePeMeta SCFilePeMeta;
+
+bool FilePeMetaGet(const File *file, SCFilePeMeta *meta)
+{
+    return false;
+}
+
+void FilePeMetaSet(File *file, const SCFilePeMeta *meta)
+{
+}
+
+const void *FilePeImportsGet(const File *file)
+{
+    return NULL;
+}
+
+void FilePeImportsSet(File *file, void *imports)
+{
+}

--- a/src/detect-windows-pe.c
+++ b/src/detect-windows-pe.c
@@ -38,7 +38,6 @@
 
 #include "suricata-common.h"
 #include "detect-windows-pe.h"
-#include "util-file.h"
 #include "rust.h"
 
 /* Forward declaration for Rust FFI */
@@ -47,28 +46,4 @@ extern void SCDetectWindowsPERegister(void);
 void DetectWindowsPERegister(void)
 {
     SCDetectWindowsPERegister();
-}
-
-/* Stub implementations for File PE metadata caching.
- * These satisfy the linker until util-file.c provides the real
- * implementations backed by pe_meta/pe_imports fields on File. */
-
-typedef struct SCFilePeMeta SCFilePeMeta;
-
-bool FilePeMetaGet(const File *file, SCFilePeMeta *meta)
-{
-    return false;
-}
-
-void FilePeMetaSet(File *file, const SCFilePeMeta *meta)
-{
-}
-
-const void *FilePeImportsGet(const File *file)
-{
-    return NULL;
-}
-
-void FilePeImportsSet(File *file, void *imports)
-{
 }

--- a/src/detect-windows-pe.h
+++ b/src/detect-windows-pe.h
@@ -1,0 +1,23 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef SURICATA_DETECT_WINDOWS_PE_H
+#define SURICATA_DETECT_WINDOWS_PE_H
+
+void DetectWindowsPERegister(void);
+
+#endif /* SURICATA_DETECT_WINDOWS_PE_H */

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -66,6 +66,7 @@
 #include "util-optimize.h"
 #include "util-buffer.h"
 #include "util-reference-config.h"
+#include "util-streaming-buffer.h"
 #include "util-validate.h"
 
 #include "action-globals.h"
@@ -490,6 +491,10 @@ static void AlertAddFiles(const Packet *p, SCJsonBuilder *jb, const uint64_t tx_
             }
             SCJbStartObject(jb);
             EveFileInfo(jb, file, tx_id, file->flags);
+
+            /* Log PE metadata if this file starts with MZ */
+            EveFilePeMetadataLog(file, jb);
+
             SCJbClose(jb);
             file = file->next;
         }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -65,6 +65,7 @@
 #include "util-optimize.h"
 #include "util-buffer.h"
 #include "util-reference-config.h"
+#include "util-streaming-buffer.h"
 #include "util-validate.h"
 
 #include "action-globals.h"
@@ -489,6 +490,10 @@ static void AlertAddFiles(const Packet *p, SCJsonBuilder *jb, const uint64_t tx_
             }
             SCJbStartObject(jb);
             EveFileInfo(jb, file, tx_id, file->flags);
+
+            /* Log PE metadata if this file starts with MZ */
+            EveFilePeMetadataLog(file, jb);
+
             SCJbClose(jb);
             file = file->next;
         }

--- a/src/output-json-common.c
+++ b/src/output-json-common.c
@@ -25,6 +25,8 @@
 #include "output.h"
 #include "output-json.h"
 #include "util-buffer.h"
+#include "util-file.h"
+#include "util-streaming-buffer.h"
 
 OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx)
 {
@@ -125,4 +127,29 @@ TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data)
     OutputJsonThreadCtx *thread = (OutputJsonThreadCtx *)data;
     FreeEveThreadCtx(thread);
     return TM_ECODE_OK;
+}
+
+/**
+ * \brief Log PE metadata for a file.
+ *
+ * Extracts raw file data from the streaming buffer and delegates to
+ * the Rust SCPeLogJsonByFile function, which handles PE validation,
+ * parsing, and JSON output.
+ *
+ * \param file The File object
+ * \param jb The JSON builder to append PE metadata to
+ */
+void EveFilePeMetadataLog(const File *file, SCJsonBuilder *jb)
+{
+    if (file == NULL || file->sb == NULL) {
+        return;
+    }
+
+    const uint8_t *data = NULL;
+    uint32_t data_len = 0;
+    uint64_t offset = 0;
+    StreamingBufferGetData(file->sb, &data, &data_len, &offset);
+
+    /* Log PE metadata: try direct parse first, fall back to File cache if buffer was pruned */
+    SCPeLogJsonByFile(file, data, data_len, offset, jb);
 }

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -65,8 +65,10 @@
 #include "app-layer-htp.h"
 #include "app-layer-htp-xff.h"
 #include "util-memcmp.h"
+#include "util-streaming-buffer.h"
 #include "stream-tcp-reassemble.h"
 #include "flow-bindgen.h"
+#include "rust.h"
 
 typedef struct OutputFileCtx_ {
     uint32_t file_cnt;
@@ -201,6 +203,9 @@ SCJsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, void *tx
         EveFileInfo(js, ff, tx_id, ff->flags);
     }
     SCJbClose(js);
+
+    /* Log PE metadata if this file starts with MZ */
+    EveFilePeMetadataLog(ff, js);
 
     /* xff header */
     if (have_xff_ip && xff_cfg->flags & XFF_EXTRADATA) {

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -65,8 +65,11 @@
 #include "app-layer-htp.h"
 #include "app-layer-htp-xff.h"
 #include "util-memcmp.h"
+#include "util-streaming-buffer.h"
 #include "stream-tcp-reassemble.h"
 #include "flow.h"
+#include "flow-bindgen.h"
+#include "rust.h"
 
 typedef struct OutputFileCtx_ {
     uint32_t file_cnt;
@@ -201,6 +204,9 @@ SCJsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, void *tx
         EveFileInfo(js, ff, tx_id, ff->flags);
     }
     SCJbClose(js);
+
+    /* Log PE metadata if this file starts with MZ */
+    EveFilePeMetadataLog(ff, js);
 
     /* xff header */
     if (have_xff_ip && xff_cfg->flags & XFF_EXTRADATA) {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -118,4 +118,9 @@ OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx);
 void FreeEveThreadCtx(OutputJsonThreadCtx *ctx);
 void JSONFormatAndAddMACAddr(SCJsonBuilder *js, const char *key, const uint8_t *val, bool is_array);
 
+/* PE metadata logging */
+bool SCPeLogJsonByFile(const File *file, const uint8_t *data, uint32_t data_len, uint64_t offset,
+        SCJsonBuilder *jb);
+void EveFilePeMetadataLog(const File *file, SCJsonBuilder *jb);
+
 #endif /* SURICATA_OUTPUT_JSON_H */

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -330,6 +330,57 @@ uint64_t FileTrackedSize(const File *file)
     return 0;
 }
 
+bool FilePeMetaGet(const File *file, SCFilePeMeta *meta)
+{
+    if (file == NULL || meta == NULL) {
+        return false;
+    }
+    if (file->pe_meta == NULL) {
+        return false;
+    }
+    if (!(file->pe_meta->flags & SC_FILE_PE_META_F_PARSED)) {
+        return false;
+    }
+    *meta = *file->pe_meta;
+    return true;
+}
+
+void FilePeMetaSet(File *file, const SCFilePeMeta *meta)
+{
+    if (file == NULL || meta == NULL) {
+        return;
+    }
+
+    if (file->pe_meta == NULL) {
+        file->pe_meta = SCCalloc(1, sizeof(SCFilePeMeta));
+        if (unlikely(file->pe_meta == NULL)) {
+            return;
+        }
+    }
+    *file->pe_meta = *meta;
+    file->pe_meta->flags |= SC_FILE_PE_META_F_PARSED;
+}
+
+const void *FilePeImportsGet(const File *file)
+{
+    if (file == NULL) {
+        return NULL;
+    }
+    return file->pe_imports;
+}
+
+void FilePeImportsSet(File *file, void *imports)
+{
+    if (file == NULL) {
+        return;
+    }
+    /* Free any previous cached imports. */
+    if (file->pe_imports != NULL) {
+        SCFilePeImportsFree(file->pe_imports);
+    }
+    file->pe_imports = imports;
+}
+
 /** \brief test if file is ready to be pruned
  *
  *  If a file is in the 'CLOSED' state, it means it has been processed
@@ -588,6 +639,10 @@ static void FileFree(File *ff, const StreamingBufferConfig *sbcfg)
         SCSha1Free(ff->sha1_ctx);
     if (ff->sha256_ctx)
         SCSha256Free(ff->sha256_ctx);
+    if (ff->pe_imports != NULL)
+        SCFilePeImportsFree(ff->pe_imports);
+    if (ff->pe_meta != NULL)
+        SCFree(ff->pe_meta);
     SCFree(ff);
 }
 

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -381,6 +381,26 @@ void FilePeImportsSet(File *file, void *imports)
     file->pe_imports = imports;
 }
 
+const void *FilePeSignatureGet(const File *file)
+{
+    if (file == NULL) {
+        return NULL;
+    }
+    return file->pe_signature;
+}
+
+void FilePeSignatureSet(File *file, void *sig)
+{
+    if (file == NULL) {
+        return;
+    }
+    /* Free any previous cached signature. */
+    if (file->pe_signature != NULL) {
+        SCFilePeSignatureFree(file->pe_signature);
+    }
+    file->pe_signature = sig;
+}
+
 /** \brief test if file is ready to be pruned
  *
  *  If a file is in the 'CLOSED' state, it means it has been processed
@@ -641,6 +661,8 @@ static void FileFree(File *ff, const StreamingBufferConfig *sbcfg)
         SCSha256Free(ff->sha256_ctx);
     if (ff->pe_imports != NULL)
         SCFilePeImportsFree(ff->pe_imports);
+    if (ff->pe_signature != NULL)
+        SCFilePeSignatureFree(ff->pe_signature);
     if (ff->pe_meta != NULL)
         SCFree(ff->pe_meta);
     SCFree(ff);

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -401,6 +401,26 @@ void FilePeSignatureSet(File *file, void *sig)
     file->pe_signature = sig;
 }
 
+const void *FilePeVersionInfoGet(const File *file)
+{
+    if (file == NULL) {
+        return NULL;
+    }
+    return file->pe_version_info;
+}
+
+void FilePeVersionInfoSet(File *file, void *vi)
+{
+    if (file == NULL) {
+        return;
+    }
+    /* Free any previous cached version info. */
+    if (file->pe_version_info != NULL) {
+        SCFilePeVersionInfoFree(file->pe_version_info);
+    }
+    file->pe_version_info = vi;
+}
+
 /** \brief test if file is ready to be pruned
  *
  *  If a file is in the 'CLOSED' state, it means it has been processed
@@ -663,6 +683,8 @@ static void FileFree(File *ff, const StreamingBufferConfig *sbcfg)
         SCFilePeImportsFree(ff->pe_imports);
     if (ff->pe_signature != NULL)
         SCFilePeSignatureFree(ff->pe_signature);
+    if (ff->pe_version_info != NULL)
+        SCFilePeVersionInfoFree(ff->pe_version_info);
     if (ff->pe_meta != NULL)
         SCFree(ff->pe_meta);
     SCFree(ff);

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -143,6 +143,11 @@ typedef enum FileState_ {
     FILE_STATE_MAX
 } FileState;
 
+/* SCFilePeMeta is defined in Rust (detect/windows_pe.rs) and exported
+ * via cbindgen into rust-bindings.h.  Only a forward declaration is
+ * needed here because the File struct stores a pointer. */
+typedef struct SCFilePeMeta SCFilePeMeta;
+
 typedef struct File_ {
     uint16_t flags;
     uint16_t name_len;
@@ -172,10 +177,50 @@ typedef struct File_ {
     uint64_t start;
     uint64_t end;
 
+    /* Cached Windows PE metadata (parsed once per file, heap-allocated).
+     * NULL until first PE parse; freed in FileFree. */
+    SCFilePeMeta *pe_meta;
+
+    /* Cached PE import DLL names (opaque, owned by Rust).
+     * NULL until first import-table parse; freed in FileFree via
+     * SCFilePeImportsFree(). */
+    void *pe_imports;
+
     uint32_t *sid; /* signature id of a rule that triggered the filestore event */
     uint32_t sid_cnt;
     uint32_t sid_max;
 } File;
+
+/**
+ * \brief Read cached PE metadata from File.
+ *
+ * \retval true if metadata has been parsed (valid or invalid)
+ * \retval false if no metadata cache exists yet
+ */
+bool FilePeMetaGet(const File *file, SCFilePeMeta *meta);
+
+/**
+ * \brief Store cached PE metadata in File.
+ *
+ * Stores metadata and marks it as parsed.
+ */
+void FilePeMetaSet(File *file, const SCFilePeMeta *meta);
+
+/**
+ * \brief Get cached PE import names from File (opaque pointer).
+ * \retval opaque pointer (NULL if not yet cached)
+ */
+const void *FilePeImportsGet(const File *file);
+
+/**
+ * \brief Store cached PE import names in File (takes ownership).
+ */
+void FilePeImportsSet(File *file, void *imports);
+
+/**
+ * \brief Free cached PE import names (Rust-allocated).
+ */
+void SCFilePeImportsFree(void *imports);
 
 FileContainer *FileContainerAlloc(void);
 void FileContainerFree(FileContainer *, const StreamingBufferConfig *cfg);

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -186,6 +186,11 @@ typedef struct File_ {
      * SCFilePeImportsFree(). */
     void *pe_imports;
 
+    /* Cached PE signing-certificate identities (opaque, owned by Rust).
+     * NULL until first certificate-table parse; freed in FileFree via
+     * SCFilePeSignatureFree(). */
+    void *pe_signature;
+
     uint32_t *sid; /* signature id of a rule that triggered the filestore event */
     uint32_t sid_cnt;
     uint32_t sid_max;
@@ -221,6 +226,22 @@ void FilePeImportsSet(File *file, void *imports);
  * \brief Free cached PE import names (Rust-allocated).
  */
 void SCFilePeImportsFree(void *imports);
+
+/**
+ * \brief Get cached PE signing certificates from File (opaque pointer).
+ * \retval opaque pointer (NULL if not yet cached)
+ */
+const void *FilePeSignatureGet(const File *file);
+
+/**
+ * \brief Store cached PE signing certificates in File (takes ownership).
+ */
+void FilePeSignatureSet(File *file, void *sig);
+
+/**
+ * \brief Free cached PE signing certificates (Rust-allocated).
+ */
+void SCFilePeSignatureFree(void *sig);
 
 FileContainer *FileContainerAlloc(void);
 void FileContainerFree(FileContainer *, const StreamingBufferConfig *cfg);

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -191,6 +191,11 @@ typedef struct File_ {
      * SCFilePeSignatureFree(). */
     void *pe_signature;
 
+    /* Cached PE VERSIONINFO StringFileInfo key/value strings (opaque, owned by
+     * Rust). NULL until first version-resource parse; freed in FileFree via
+     * SCFilePeVersionInfoFree(). */
+    void *pe_version_info;
+
     uint32_t *sid; /* signature id of a rule that triggered the filestore event */
     uint32_t sid_cnt;
     uint32_t sid_max;
@@ -242,6 +247,22 @@ void FilePeSignatureSet(File *file, void *sig);
  * \brief Free cached PE signing certificates (Rust-allocated).
  */
 void SCFilePeSignatureFree(void *sig);
+
+/**
+ * \brief Get cached PE VERSIONINFO strings from File (opaque pointer).
+ * \retval opaque pointer (NULL if not yet cached)
+ */
+const void *FilePeVersionInfoGet(const File *file);
+
+/**
+ * \brief Store cached PE VERSIONINFO strings in File (takes ownership).
+ */
+void FilePeVersionInfoSet(File *file, void *vi);
+
+/**
+ * \brief Free cached PE VERSIONINFO strings (Rust-allocated).
+ */
+void SCFilePeVersionInfoFree(void *vi);
 
 FileContainer *FileContainerAlloc(void);
 void FileContainerFree(FileContainer *, const StreamingBufferConfig *cfg);


### PR DESCRIPTION
Continuation of #15120  

Add the `windows_pe` keyword for structured inspection of Windows portable executables. PE headers are processed once with cached results.

The keyword is meant to replace the  `content:"MZ" / byte_jump / content:"PE|00 00|" / byte_test` pattern used in existing rulesets with a keyword and options allowing for more precision

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- Added windows_pe keyword and options.
- PE metadata logged
- Documentation
Updates:
- Rebased and fixed commit-check issue

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2970
SU_REPO=
SU_BRANCH=
