### PR TITLE
respond/reject: use livedev in bridge mode

### DIFF
--- a/plugins/pfring/source-pfring.c
+++ b/plugins/pfring/source-pfring.c
@@ -185,7 +185,7 @@ static inline void PfringProcessPacket(void *user, struct pfring_pkthdr *h, Pack
 
     ptv->bytes += h->caplen;
     ptv->pkts++;
-    p->livedev = ptv->livedev;
+    p->livedev_id = LiveDeviceGetId(ptv->livedev);
 
     /* PF_RING may fail to set timestamp */
     if (h->ts.tv_sec == 0) {

--- a/src/decode.c
+++ b/src/decode.c
@@ -423,7 +423,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     p->ts = parent->ts;
     p->datalink = DLT_RAW;
     p->tenant_id = parent->tenant_id;
-    p->livedev = parent->livedev;
+    p->livedev_id = parent->livedev_id;
 
     /* set the root ptr to the lowest layer */
     if (parent->root != NULL) {
@@ -506,7 +506,7 @@ Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, u
     p->tenant_id = parent->tenant_id;
     memcpy(&p->vlan_id[0], &parent->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = parent->vlan_idx;
-    p->livedev = parent->livedev;
+    p->livedev_id = parent->livedev_id;
 
     SCReturnPtr(p, "Packet");
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -619,7 +619,7 @@ typedef struct Packet_
     uint8_t *ext_pkt;
 
     /* Incoming interface */
-    struct LiveDevice_ *livedev;
+    uint16_t livedev_id;
 
     PacketAlerts alerts;
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -4516,7 +4516,7 @@ static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet 
 static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet *p)
 {
     const DetectEngineThreadCtx *det_ctx = ctx;
-    const LiveDevice *ld = p->livedev;
+    const LiveDevice *ld = LiveDeviceGetById(p->livedev_id);
 
     if (ld == NULL || det_ctx == NULL)
         return 0;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -409,6 +409,11 @@ static inline bool CmpLiveDevIds(const LiveDevice *livedev, const uint16_t id)
     return (((devid ^ id) & g_livedev_mask) == 0);
 }
 
+static inline bool CmpLiveDevIds2(const uint16_t id1, const uint16_t id2)
+{
+    return (((id1 ^ id2) & g_livedev_mask) == 0);
+}
+
 /* Since two or more flows can have the same hash key, we need to compare
  * the flow with the current packet or flow key. */
 static inline bool CmpFlowPacket(const Flow *f, const Packet *p)
@@ -420,7 +425,7 @@ static inline bool CmpFlowPacket(const Flow *f, const Packet *p)
     return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, p_src, p_dst, p->sp, p->dp) &&
            f->proto == p->proto &&
            (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, p->vlan_id) && (f->livedev == p->livedev || g_livedev_mask == 0);
+           CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev, f->livedev_id);
 }
 
 static inline bool CmpFlowKey(const Flow *f, const FlowKey *k)
@@ -432,7 +437,7 @@ static inline bool CmpFlowKey(const Flow *f, const FlowKey *k)
     return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, k_src, k_dst, k->sp, k->dp) &&
            f->proto == k->proto &&
            (f->recursion_level == k->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, k->vlan_id) && CmpLiveDevIds(f->livedev, k->livedev_id);
+           CmpVlanIds(f->vlan_id, k->vlan_id) && CmpLiveDevIds2(f->livedev_id, k->livedev_id);
 }
 
 static inline bool CmpAddrsAndICMPTypes(const uint32_t src1[4],
@@ -459,7 +464,7 @@ static inline bool CmpFlowICMPPacket(const Flow *f, const Packet *p)
                    p->icmp_s.type, p->icmp_d.type) &&
            f->proto == p->proto &&
            (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, p->vlan_id) && (f->livedev == p->livedev || g_livedev_mask == 0);
+           CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev, f->livedev_id);
 }
 
 /**
@@ -483,8 +488,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                 f->sp == p->l4.vars.icmpv4.emb_sport && f->dp == p->l4.vars.icmpv4.emb_dport &&
                 f->proto == ICMPV4_GET_EMB_PROTO(p) &&
                 (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-                CmpVlanIds(f->vlan_id, p->vlan_id) &&
-                (f->livedev == p->livedev || g_livedev_mask == 0)) {
+                CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev, f->livedev_id)) {
             return 1;
 
         /* check the less likely case where the ICMP error was a response to
@@ -494,8 +498,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                    f->dp == p->l4.vars.icmpv4.emb_sport && f->sp == p->l4.vars.icmpv4.emb_dport &&
                    f->proto == ICMPV4_GET_EMB_PROTO(p) &&
                    (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-                   CmpVlanIds(f->vlan_id, p->vlan_id) &&
-                   (f->livedev == p->livedev || g_livedev_mask == 0)) {
+                   CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev, f->livedev_id)) {
             return 1;
         }
 
@@ -527,7 +530,7 @@ static inline int FlowCompareESP(Flow *f, const Packet *p)
     return CmpAddrs(f_src, p_src) && CmpAddrs(f_dst, p_dst) && f->proto == p->proto &&
            (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
            CmpVlanIds(f->vlan_id, p->vlan_id) && f->esp.spi == ESP_GET_SPI(PacketGetESP(p)) &&
-           (f->livedev == p->livedev || g_livedev_mask == 0);
+           CmpLiveDevIds(p->livedev, f->livedev_id);
 }
 
 void FlowSetupPacket(Packet *p)

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -214,7 +214,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.recur = p->recursion_level & g_recurlvl_mask;
             /* g_livedev_mask sets the livedev ids to 0 if livedev.use-for-tracking
              * is disabled. */
-            uint16_t devid = p->livedev ? p->livedev->id : 0;
+            uint16_t devid = p->livedev_id;
             fhk.livedev = devid & g_livedev_mask;
             /* g_vlan_mask sets the vlan_ids to 0 if vlan.use-for-tracking
              * is disabled. */
@@ -239,7 +239,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
 
             fhk.proto = ICMPV4_GET_EMB_PROTO(p);
             fhk.recur = p->recursion_level & g_recurlvl_mask;
-            uint16_t devid = p->livedev ? p->livedev->id : 0;
+            uint16_t devid = p->livedev_id;
             fhk.livedev = devid & g_livedev_mask;
             fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
             fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
@@ -256,7 +256,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.ports[1] = 0xbeef;
             fhk.proto = p->proto;
             fhk.recur = p->recursion_level & g_recurlvl_mask;
-            uint16_t devid = p->livedev ? p->livedev->id : 0;
+            uint16_t devid = p->livedev_id;
             fhk.livedev = devid & g_livedev_mask;
             fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
             fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
@@ -291,7 +291,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
         fhk.ports[pi] = p->dp;
         fhk.proto = p->proto;
         fhk.recur = p->recursion_level & g_recurlvl_mask;
-        uint16_t devid = p->livedev ? p->livedev->id : 0;
+        uint16_t devid = p->livedev_id;
         fhk.livedev = devid & g_livedev_mask;
         fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
@@ -403,13 +403,7 @@ static inline bool CmpVlanIds(
            ((vlan_id1[2] ^ vlan_id2[2]) & g_vlan_mask) == 0;
 }
 
-static inline bool CmpLiveDevIds(const LiveDevice *livedev, const uint16_t id)
-{
-    uint16_t devid = livedev ? livedev->id : 0;
-    return (((devid ^ id) & g_livedev_mask) == 0);
-}
-
-static inline bool CmpLiveDevIds2(const uint16_t id1, const uint16_t id2)
+static inline bool CmpLiveDevIds(const uint16_t id1, const uint16_t id2)
 {
     return (((id1 ^ id2) & g_livedev_mask) == 0);
 }
@@ -425,7 +419,7 @@ static inline bool CmpFlowPacket(const Flow *f, const Packet *p)
     return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, p_src, p_dst, p->sp, p->dp) &&
            f->proto == p->proto &&
            (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev, f->livedev_id);
+           CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev_id, f->livedev_id);
 }
 
 static inline bool CmpFlowKey(const Flow *f, const FlowKey *k)
@@ -437,7 +431,7 @@ static inline bool CmpFlowKey(const Flow *f, const FlowKey *k)
     return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, k_src, k_dst, k->sp, k->dp) &&
            f->proto == k->proto &&
            (f->recursion_level == k->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, k->vlan_id) && CmpLiveDevIds2(f->livedev_id, k->livedev_id);
+           CmpVlanIds(f->vlan_id, k->vlan_id) && CmpLiveDevIds(f->livedev_id, k->livedev_id);
 }
 
 static inline bool CmpAddrsAndICMPTypes(const uint32_t src1[4],
@@ -464,7 +458,7 @@ static inline bool CmpFlowICMPPacket(const Flow *f, const Packet *p)
                    p->icmp_s.type, p->icmp_d.type) &&
            f->proto == p->proto &&
            (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev, f->livedev_id);
+           CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev_id, f->livedev_id);
 }
 
 /**
@@ -488,7 +482,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                 f->sp == p->l4.vars.icmpv4.emb_sport && f->dp == p->l4.vars.icmpv4.emb_dport &&
                 f->proto == ICMPV4_GET_EMB_PROTO(p) &&
                 (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-                CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev, f->livedev_id)) {
+                CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev_id, f->livedev_id)) {
             return 1;
 
         /* check the less likely case where the ICMP error was a response to
@@ -498,7 +492,8 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                    f->dp == p->l4.vars.icmpv4.emb_sport && f->sp == p->l4.vars.icmpv4.emb_dport &&
                    f->proto == ICMPV4_GET_EMB_PROTO(p) &&
                    (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-                   CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev, f->livedev_id)) {
+                   CmpVlanIds(f->vlan_id, p->vlan_id) &&
+                   CmpLiveDevIds(p->livedev_id, f->livedev_id)) {
             return 1;
         }
 
@@ -530,7 +525,7 @@ static inline int FlowCompareESP(Flow *f, const Packet *p)
     return CmpAddrs(f_src, p_src) && CmpAddrs(f_dst, p_dst) && f->proto == p->proto &&
            (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
            CmpVlanIds(f->vlan_id, p->vlan_id) && f->esp.spi == ESP_GET_SPI(PacketGetESP(p)) &&
-           CmpLiveDevIds(p->livedev, f->livedev_id);
+           CmpLiveDevIds(p->livedev_id, f->livedev_id);
 }
 
 void FlowSetupPacket(Packet *p)

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -240,6 +240,7 @@ static inline bool FlowBypassedTimeout(Flow *f, SCTime_t ts, FlowTimeoutCounters
 
     FlowBypassInfo *fc = FlowGetStorageById(f, GetFlowBypassInfoID());
     if (fc && fc->BypassUpdate) {
+        LiveDevice *dev = LiveDeviceGetById(f->livedev_id);
         /* flow will be possibly updated */
         uint64_t pkts_tosrc = fc->tosrcpktcnt;
         uint64_t bytes_tosrc = fc->tosrcbytecnt;
@@ -252,20 +253,19 @@ static inline bool FlowBypassedTimeout(Flow *f, SCTime_t ts, FlowTimeoutCounters
             bytes_tosrc = fc->tosrcbytecnt - bytes_tosrc;
             pkts_todst = fc->todstpktcnt - pkts_todst;
             bytes_todst = fc->todstbytecnt - bytes_todst;
-            if (f->livedev) {
-                SC_ATOMIC_ADD(f->livedev->bypassed,
-                        pkts_tosrc + pkts_todst);
+            if (dev) {
+                SC_ATOMIC_ADD(dev->bypassed, pkts_tosrc + pkts_todst);
             }
             counters->bypassed_pkts += pkts_tosrc + pkts_todst;
             counters->bypassed_bytes += bytes_tosrc + bytes_todst;
             return false;
         }
         SCLogDebug("No new packet, dead flow %" PRIu64 "", FlowGetId(f));
-        if (f->livedev) {
+        if (dev) {
             if (FLOW_IS_IPV4(f)) {
-                LiveDevSubBypassStats(f->livedev, 1, AF_INET);
+                LiveDevSubBypassStats(dev, 1, AF_INET);
             } else if (FLOW_IS_IPV6(f)) {
-                LiveDevSubBypassStats(f->livedev, 1, AF_INET6);
+                LiveDevSubBypassStats(dev, 1, AF_INET6);
             }
         }
         counters->bypassed_count++;

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -93,7 +93,7 @@ static inline Packet *FlowPseudoPacketSetup(
     p->flags |= PKT_PSEUDO_STREAM_END;
     memcpy(&p->vlan_id[0], &f->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = f->vlan_idx;
-    p->livedev = LiveDeviceGetById(f->livedev_id);
+    p->livedev_id = f->livedev_id;
 
     if (f->flags & FLOW_NOPAYLOAD_INSPECTION) {
         DecodeSetNoPayloadInspectionFlag(p);

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -54,6 +54,7 @@
 #include "util-debug.h"
 #include "util-privs.h"
 #include "util-datalink.h"
+#include "util-device.h"
 
 #include "detect.h"
 #include "detect-engine-state.h"
@@ -92,7 +93,7 @@ static inline Packet *FlowPseudoPacketSetup(
     p->flags |= PKT_PSEUDO_STREAM_END;
     memcpy(&p->vlan_id[0], &f->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = f->vlan_idx;
-    p->livedev = (struct LiveDevice_ *)f->livedev;
+    p->livedev = LiveDeviceGetById(f->livedev_id);
 
     if (f->flags & FLOW_NOPAYLOAD_INSPECTION) {
         DecodeSetNoPayloadInspectionFlag(p);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -157,8 +157,7 @@ void FlowInit(ThreadVars *tv, Flow *f, const Packet *p)
 
     f->thread_id[0] = (FlowThreadId)tv->id;
 
-    LiveDevice *packet_ld = p->livedev;
-    f->livedev_id = packet_ld ? packet_ld->id : 0;
+    f->livedev_id = p->livedev_id;
 
     if (PacketIsIPv4(p)) {
         const IPV4Hdr *ip4h = PacketGetIPv4(p);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -44,6 +44,7 @@
 
 #include "decode-icmpv4.h"
 
+#include "util-device-private.h"
 #include "util-validate.h"
 
 /** \brief allocate a flow
@@ -156,7 +157,8 @@ void FlowInit(ThreadVars *tv, Flow *f, const Packet *p)
 
     f->thread_id[0] = (FlowThreadId)tv->id;
 
-    f->livedev = p->livedev;
+    LiveDevice *packet_ld = p->livedev;
+    f->livedev_id = packet_ld ? packet_ld->id : 0;
 
     if (PacketIsIPv4(p)) {
         const IPV4Hdr *ip4h = PacketGetIPv4(p);

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -40,7 +40,7 @@
         (f)->sp = 0;                                                                               \
         (f)->dp = 0;                                                                               \
         (f)->proto = 0;                                                                            \
-        (f)->livedev = NULL;                                                                       \
+        (f)->livedev_id = 0;                                                                       \
         (f)->timeout_policy = 0;                                                                   \
         (f)->vlan_idx = 0;                                                                         \
         (f)->next = NULL;                                                                          \
@@ -83,7 +83,7 @@
         (f)->sp = 0;                                                                               \
         (f)->dp = 0;                                                                               \
         (f)->proto = 0;                                                                            \
-        (f)->livedev = NULL;                                                                       \
+        (f)->livedev_id = 0;                                                                       \
         (f)->vlan_idx = 0;                                                                         \
         (f)->ffr = 0;                                                                              \
         (f)->next = NULL;                                                                          \

--- a/src/flow.h
+++ b/src/flow.h
@@ -389,7 +389,7 @@ typedef struct Flow_
     uint32_t flow_hash;
 
     /** Incoming interface */
-    struct LiveDevice_ *livedev;
+    uint16_t livedev_id;
 
     struct Flow_ *next; /* (hash) list next */
 

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -106,8 +106,9 @@ static SCJsonBuilder *CreateEveHeaderFromFlow(const Flow *f, OutputJsonCommonSet
 #endif
 
     /* input interface */
-    if (f->livedev) {
-        SCJbSetString(jb, "in_iface", f->livedev->dev);
+    LiveDevice *dev = LiveDeviceGetById(f->livedev_id);
+    if (dev) {
+        SCJbSetString(jb, "in_iface", dev->dev);
     }
 
     JB_SET_STRING(jb, "event_type", "flow");

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -110,8 +110,9 @@ static SCJsonBuilder *CreateEveHeaderFromNetFlow(
 #endif
 
     /* input interface */
-    if (f->livedev) {
-        SCJbSetString(js, "in_iface", f->livedev->dev);
+    LiveDevice *dev = LiveDeviceGetById(f->livedev_id);
+    if (dev) {
+        SCJbSetString(js, "in_iface", dev->dev);
     }
 
     JB_SET_STRING(js, "event_type", "netflow");

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -839,8 +839,9 @@ SCJsonBuilder *CreateEveHeader(const Packet *p, enum SCOutputJsonLogDirection di
     }
 
     /* input interface */
-    if (p->livedev) {
-        SCJbSetString(js, "in_iface", p->livedev->dev);
+    LiveDevice *dev = LiveDeviceGetById(p->livedev_id);
+    if (dev) {
+        SCJbSetString(js, "in_iface", dev->dev);
     }
 
     /* pcap_cnt */

--- a/src/packet.c
+++ b/src/packet.c
@@ -24,6 +24,7 @@
 #include "action-globals.h"
 #include "rust.h"
 #include "app-layer-events.h"
+#include "util-device-private.h"
 
 /** \brief issue drop action
  *
@@ -74,7 +75,7 @@ void PacketInit(Packet *p)
 {
     SCSpinInit(&p->persistent.tunnel_lock, 0);
     p->alerts.alerts = PacketAlertCreate();
-    p->livedev = NULL;
+    p->livedev_id = 0;
 }
 
 void PacketReleaseRefs(Packet *p)
@@ -150,7 +151,7 @@ void PacketReinit(Packet *p)
     p->prev = NULL;
     p->tunnel_verdicted = false;
     p->root = NULL;
-    p->livedev = NULL;
+    p->livedev_id = 0;
     PACKET_PROFILING_RESET(p);
     p->tenant_id = 0;
     p->nb_decoded_layers = 0;
@@ -185,7 +186,7 @@ inline void SCPacketSetReleasePacket(Packet *p, void (*ReleasePacket)(Packet *p)
 
 inline void SCPacketSetLiveDevice(Packet *p, LiveDevice *device)
 {
-    p->livedev = device;
+    p->livedev_id = device ? device->id : 0;
 }
 
 inline void SCPacketSetDatalink(Packet *p, int datalink)

--- a/src/respond-reject-libnet11.c
+++ b/src/respond-reject-libnet11.c
@@ -92,8 +92,7 @@ static inline libnet_t *GetCtx(const Packet *p, int injection_type)
     /* slow path: setup a new ctx */
     bool store_ctx = false;
     const char *devname = NULL;
-    extern uint8_t host_mode;
-    if (IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode)) {
+    if (EngineHostModeIsSniffer()) {
         if (g_reject_dev != NULL) {
             if (p->datalink == LINKTYPE_ETHERNET)
                 injection_type = t_inject_mode = LIBNET_LINK;
@@ -102,6 +101,12 @@ static inline libnet_t *GetCtx(const Packet *p, int injection_type)
         } else {
             devname = p->livedev ? p->livedev->dev : NULL;
         }
+        SCLogDebug("sniffer: devname %s", devname);
+    } else if (EngineHostModeIsBridge()) {
+        devname = p->livedev ? p->livedev->dev : NULL;
+        SCLogDebug("bridge: devname %s", devname);
+    } else {
+        SCLogDebug("router: devname %s", devname);
     }
 
     char ebuf[LIBNET_ERRBUF_SIZE];

--- a/src/respond-reject-libnet11.c
+++ b/src/respond-reject-libnet11.c
@@ -99,11 +99,13 @@ static inline libnet_t *GetCtx(const Packet *p, int injection_type)
             devname = g_reject_dev;
             store_ctx = true;
         } else {
-            devname = p->livedev ? p->livedev->dev : NULL;
+            LiveDevice *dev = LiveDeviceGetById(p->livedev_id);
+            devname = dev ? dev->dev : NULL;
         }
         SCLogDebug("sniffer: devname %s", devname);
     } else if (EngineHostModeIsBridge()) {
-        devname = p->livedev ? p->livedev->dev : NULL;
+        LiveDevice *dev = LiveDeviceGetById(p->livedev_id);
+        devname = dev ? dev->dev : NULL;
         SCLogDebug("bridge: devname %s", devname);
     } else {
         SCLogDebug("router: devname %s", devname);

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -125,7 +125,7 @@ static int AFPRunModeEnableIPS(void)
     bool r = AFPRunModeIsIPS();
     if (r) {
         SCLogInfo("Setting IPS mode");
-        EngineModeSetIPS();
+        EngineModeSetIPS(ENGINE_HOST_IS_BRIDGE);
     }
     return r;
 }

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -1929,7 +1929,7 @@ static int DPDKRunModeEnableIPS(void)
     int r = DPDKRunModeIsIPS();
     if (r == 1) {
         SCLogInfo("Setting IPS mode");
-        EngineModeSetIPS();
+        EngineModeSetIPS(ENGINE_HOST_IS_BRIDGE);
     }
     return r;
 }

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -119,7 +119,7 @@ static int NetmapRunModeEnableIPS(void)
     int r = NetmapRunModeIsIPS();
     if (r == 1) {
         SCLogInfo("Netmap: Setting IPS mode");
-        EngineModeSetIPS();
+        EngineModeSetIPS(ENGINE_HOST_IS_BRIDGE);
     }
     return r;
 }

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -767,7 +767,7 @@ static void AFPReadFromRingSetupPacket(
      * acts as an indicator that we've reached a frame that is not yet released by
      * us in autofp mode. It will be cleared when the frame gets released to the kernel. */
     h.h2->tp_status |= TP_STATUS_USER_BUSY;
-    p->livedev = ptv->livedev;
+    p->livedev_id = ptv->livedev->id;
     p->datalink = ptv->datalink;
     ptv->pkts++;
 
@@ -966,7 +966,7 @@ static inline int AFPParsePacketV3(AFPThreadVars *ptv, struct tpacket_block_desc
     AFPReadApplyBypass(ptv, p);
 
     ptv->pkts++;
-    p->livedev = ptv->livedev;
+    p->livedev_id = ptv->livedev->id;
     p->datalink = ptv->datalink;
 
     if ((ptv->flags & AFP_VLAN_IN_HEADER) &&
@@ -2200,6 +2200,7 @@ static int AFPInsertHalfFlow(int mapd, void *key, unsigned int nr_cpus)
 static int AFPSetFlowStorage(Packet *p, int map_fd, void *key0, void* key1,
                              int family)
 {
+    LiveDevice *dev = LiveDeviceGetById(p->livedev_id);
     FlowBypassInfo *fc = FlowGetStorageById(p->flow, GetFlowBypassInfoID());
     if (fc) {
         if (fc->bypass_data != NULL) {
@@ -2212,7 +2213,7 @@ static int AFPSetFlowStorage(Packet *p, int map_fd, void *key0, void* key1,
         if (eb == NULL) {
             EBPFDeleteKey(map_fd, key0);
             EBPFDeleteKey(map_fd, key1);
-            LiveDevAddBypassFail(p->livedev, 1, family);
+            LiveDevAddBypassFail(dev, 1, family);
             SCFree(key0);
             SCFree(key1);
             return 0;
@@ -2227,14 +2228,14 @@ static int AFPSetFlowStorage(Packet *p, int map_fd, void *key0, void* key1,
     } else {
         EBPFDeleteKey(map_fd, key0);
         EBPFDeleteKey(map_fd, key1);
-        LiveDevAddBypassFail(p->livedev, 1, family);
+        LiveDevAddBypassFail(dev, 1, family);
         SCFree(key0);
         SCFree(key1);
         return 0;
     }
 
-    LiveDevAddBypassStats(p->livedev, 1, family);
-    LiveDevAddBypassSuccess(p->livedev, 1, family);
+    LiveDevAddBypassStats(dev, 1, family);
+    LiveDevAddBypassSuccess(dev, 1, family);
     return 1;
 }
 
@@ -2272,6 +2273,7 @@ static int AFPBypassCallback(Packet *p)
     if (PacketIsTunnel(p)) {
         return 0;
     }
+    LiveDevice *dev = LiveDeviceGetById(p->livedev_id);
     if (PacketIsIPv4(p)) {
         SCLogDebug("add an IPv4");
         if (p->afp_v.v4_map_fd == -1) {
@@ -2296,14 +2298,14 @@ static int AFPBypassCallback(Packet *p)
         }
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[0],
                               p->afp_v.nr_cpus) == 0) {
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET);
+            LiveDevAddBypassFail(dev, 1, AF_INET);
             SCFree(keys[0]);
             return 0;
         }
         keys[1]= SCCalloc(1, sizeof(struct flowv4_keys));
         if (keys[1] == NULL) {
             EBPFDeleteKey(p->afp_v.v4_map_fd, keys[0]);
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET);
+            LiveDevAddBypassFail(dev, 1, AF_INET);
             SCFree(keys[0]);
             return 0;
         }
@@ -2318,7 +2320,7 @@ static int AFPBypassCallback(Packet *p)
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
             EBPFDeleteKey(p->afp_v.v4_map_fd, keys[0]);
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET);
+            LiveDevAddBypassFail(dev, 1, AF_INET);
             SCFree(keys[0]);
             SCFree(keys[1]);
             return 0;
@@ -2336,7 +2338,7 @@ static int AFPBypassCallback(Packet *p)
         struct flowv6_keys *keys[2];
         keys[0] = SCCalloc(1, sizeof(struct flowv6_keys));
         if (keys[0] == NULL) {
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET6);
+            LiveDevAddBypassFail(dev, 1, AF_INET6);
             return 0;
         }
         for (i = 0; i < 4; i++) {
@@ -2355,14 +2357,14 @@ static int AFPBypassCallback(Packet *p)
         }
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[0],
                               p->afp_v.nr_cpus) == 0) {
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET6);
+            LiveDevAddBypassFail(dev, 1, AF_INET6);
             SCFree(keys[0]);
             return 0;
         }
         keys[1]= SCCalloc(1, sizeof(struct flowv6_keys));
         if (keys[1] == NULL) {
             EBPFDeleteKey(p->afp_v.v6_map_fd, keys[0]);
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET6);
+            LiveDevAddBypassFail(dev, 1, AF_INET6);
             SCFree(keys[0]);
             return 0;
         }
@@ -2379,7 +2381,7 @@ static int AFPBypassCallback(Packet *p)
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
             EBPFDeleteKey(p->afp_v.v6_map_fd, keys[0]);
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET6);
+            LiveDevAddBypassFail(dev, 1, AF_INET6);
             SCFree(keys[0]);
             SCFree(keys[1]);
             return 0;
@@ -2422,11 +2424,12 @@ static int AFPXDPBypassCallback(Packet *p)
     if (PacketIsTunnel(p)) {
         return 0;
     }
+    LiveDevice *dev = LiveDeviceGetById(p->livedev_id);
     if (PacketIsIPv4(p)) {
         struct flowv4_keys *keys[2];
         keys[0]= SCCalloc(1, sizeof(struct flowv4_keys));
         if (keys[0] == NULL) {
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET);
+            LiveDevAddBypassFail(dev, 1, AF_INET);
             return 0;
         }
         if (p->afp_v.v4_map_fd == -1) {
@@ -2448,14 +2451,14 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[0],
                               p->afp_v.nr_cpus) == 0) {
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET);
+            LiveDevAddBypassFail(dev, 1, AF_INET);
             SCFree(keys[0]);
             return 0;
         }
         keys[1]= SCCalloc(1, sizeof(struct flowv4_keys));
         if (keys[1] == NULL) {
             EBPFDeleteKey(p->afp_v.v4_map_fd, keys[0]);
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET);
+            LiveDevAddBypassFail(dev, 1, AF_INET);
             SCFree(keys[0]);
             return 0;
         }
@@ -2469,7 +2472,7 @@ static int AFPXDPBypassCallback(Packet *p)
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
             EBPFDeleteKey(p->afp_v.v4_map_fd, keys[0]);
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET);
+            LiveDevAddBypassFail(dev, 1, AF_INET);
             SCFree(keys[0]);
             SCFree(keys[1]);
             return 0;
@@ -2504,14 +2507,14 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[0],
                               p->afp_v.nr_cpus) == 0) {
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET6);
+            LiveDevAddBypassFail(dev, 1, AF_INET6);
             SCFree(keys[0]);
             return 0;
         }
         keys[1]= SCCalloc(1, sizeof(struct flowv6_keys));
         if (keys[1] == NULL) {
             EBPFDeleteKey(p->afp_v.v6_map_fd, keys[0]);
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET6);
+            LiveDevAddBypassFail(dev, 1, AF_INET6);
             SCFree(keys[0]);
             return 0;
         }
@@ -2527,7 +2530,7 @@ static int AFPXDPBypassCallback(Packet *p)
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
             EBPFDeleteKey(p->afp_v.v6_map_fd, keys[0]);
-            LiveDevAddBypassFail(p->livedev, 1, AF_INET6);
+            LiveDevAddBypassFail(dev, 1, AF_INET6);
             SCFree(keys[0]);
             SCFree(keys[1]);
             return 0;

--- a/src/source-af-xdp.c
+++ b/src/source-af-xdp.c
@@ -791,7 +791,7 @@ static TmEcode ReceiveAFXDPLoop(ThreadVars *tv, void *data, void *slot)
 
             PKT_SET_SRC(p, PKT_SRC_WIRE);
             p->datalink = LINKTYPE_ETHERNET;
-            p->livedev = ptv->livedev;
+            p->livedev_id = ptv->livedev->id;
             p->ReleasePacket = AFXDPReleasePacket;
             p->flags |= PKT_IGNORE_CHECKSUM;
 

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -431,7 +431,7 @@ static inline Packet *PacketInitFromMbuf(DPDKThreadVars *ptv, struct rte_mbuf *m
     p->dpdk_v.copy_mode = ptv->copy_mode;
     p->dpdk_v.out_port_id = ptv->out_port_id;
     p->dpdk_v.out_queue_id = ptv->queue_id;
-    p->livedev = ptv->livedev;
+    p->livedev_id = ptv->livedev->id;
 
     if (ptv->checksum_mode == CHECKSUM_VALIDATION_DISABLE) {
         p->flags |= PKT_IGNORE_CHECKSUM;
@@ -643,7 +643,12 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
     ptv->tv = tv;
     ptv->pkts = 0;
     ptv->bytes = 0;
+
     ptv->livedev = LiveGetDevice(dpdk_config->iface);
+    if (unlikely(ptv->livedev == NULL)) {
+        SCLogError("Unable to allocate memory for livedev %s", dpdk_config->iface);
+        goto fail;
+    }
 
     ptv->capture_dpdk_packets = StatsRegisterCounter("capture.packets", &ptv->tv->stats);
     ptv->capture_dpdk_rx_errs = StatsRegisterCounter("capture.rx_errors", &ptv->tv->stats);

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -678,7 +678,7 @@ static void NetmapProcessPacket(NetmapThreadVars *ntv, const struct nm_pkthdr *p
     }
 
     PKT_SET_SRC(p, PKT_SRC_WIRE);
-    p->livedev = ntv->livedev;
+    p->livedev_id = ntv->livedev->id;
     p->datalink = LINKTYPE_ETHERNET;
     p->ts = SCTIME_FROM_TIMEVAL(&ph->ts);
     ntv->pkts++;

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -340,7 +340,7 @@ static void PcapCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     ptv->pkts++;
     ptv->bytes += h->caplen;
     (void) SC_ATOMIC_ADD(ptv->livedev->pkts, 1);
-    p->livedev = ptv->livedev;
+    p->livedev_id = ptv->livedev->id;
 
     if (unlikely(PacketCopyData(p, pkt, h->caplen))) {
         TmqhOutputPacketpool(ptv->tv, p);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5909,8 +5909,9 @@ static inline int StreamTcpValidateChecksum(Packet *p)
 
     if (p->l4.csum != 0) {
         ret = 0;
-        if (p->livedev) {
-            (void) SC_ATOMIC_ADD(p->livedev->invalid_checksums, 1);
+        LiveDevice *dev = LiveDeviceGetById(p->livedev_id);
+        if (dev) {
+            (void)SC_ATOMIC_ADD(dev->invalid_checksums, 1);
         } else if (PcapPacketCntGet(p)) {
             PcapIncreaseInvalidChecksum();
         }
@@ -6935,7 +6936,7 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->flags |= PKT_PSEUDO_DETECTLOG_FLUSH;
     memcpy(&np->vlan_id[0], &f->vlan_id[0], sizeof(np->vlan_id));
     np->vlan_idx = f->vlan_idx;
-    np->livedev = LiveDeviceGetById(f->livedev_id);
+    np->livedev_id = f->livedev_id;
 
     if (parent->flags & PKT_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(np);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6935,7 +6935,7 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->flags |= PKT_PSEUDO_DETECTLOG_FLUSH;
     memcpy(&np->vlan_id[0], &f->vlan_id[0], sizeof(np->vlan_id));
     np->vlan_idx = f->vlan_idx;
-    np->livedev = (struct LiveDevice_ *)f->livedev;
+    np->livedev = LiveDeviceGetById(f->livedev_id);
 
     if (parent->flags & PKT_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(np);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -181,7 +181,7 @@ static enum EngineMode g_engine_mode = ENGINE_MODE_UNKNOWN;
 
 /** Host mode: set if box is sniffing only
  * or is a router */
-uint8_t host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+enum EngineHostMode g_engine_host_mode = ENGINE_HOST_IS_SNIFFER_ONLY;
 
 /** Maximum packets to simultaneously process. */
 uint32_t max_pending_packets;
@@ -255,13 +255,15 @@ int EngineModeIsIDS(void)
     return (g_engine_mode == ENGINE_MODE_IDS);
 }
 
-void EngineModeSetFirewall(void)
+void EngineModeSetFirewall(const enum EngineHostMode mode)
 {
+    g_engine_host_mode = mode;
     g_engine_mode = ENGINE_MODE_FIREWALL;
 }
 
-void EngineModeSetIPS(void)
+void EngineModeSetIPS(const enum EngineHostMode mode)
 {
+    g_engine_host_mode = mode;
 #ifndef UNITTESTS
     if (g_engine_mode == ENGINE_MODE_UNKNOWN)
         g_engine_mode = ENGINE_MODE_IPS;
@@ -274,6 +276,16 @@ void EngineModeSetIPS(void)
 void EngineModeSetIDS(void)
 {
     g_engine_mode = ENGINE_MODE_IDS;
+}
+
+bool EngineHostModeIsSniffer(void)
+{
+    return (g_engine_host_mode == ENGINE_HOST_IS_SNIFFER_ONLY);
+}
+
+bool EngineHostModeIsBridge(void)
+{
+    return (g_engine_host_mode == ENGINE_HOST_IS_BRIDGE);
 }
 
 #ifdef UNITTESTS
@@ -1611,7 +1623,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
                 }
             } else if (strcmp((long_opts[option_index]).name, "simulate-ips") == 0) {
                 SCLogInfo("Setting IPS mode");
-                EngineModeSetIPS();
+                EngineModeSetIPS(ENGINE_HOST_IS_ROUTER);
             } else if (strcmp((long_opts[option_index]).name, "init-errors-fatal") == 0) {
                 if (SCConfSetFinal("engine.init-failure-fatal", "1") != 1) {
                     SCLogError("failed to set engine init-failure-fatal");
@@ -1995,7 +2007,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
 #ifdef NFQ
             if (suri->run_mode == RUNMODE_UNKNOWN) {
                 suri->run_mode = RUNMODE_NFQ;
-                EngineModeSetIPS();
+                EngineModeSetIPS(ENGINE_HOST_IS_ROUTER);
                 if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else if (suri->run_mode == RUNMODE_NFQ) {
@@ -2017,7 +2029,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
 #ifdef IPFW
             if (suri->run_mode == RUNMODE_UNKNOWN) {
                 suri->run_mode = RUNMODE_IPFW;
-                EngineModeSetIPS();
+                EngineModeSetIPS(ENGINE_HOST_IS_ROUTER);
                 if (IPFWRegisterQueue(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else if (suri->run_mode == RUNMODE_IPFW) {
@@ -2711,26 +2723,38 @@ static void PostConfLoadedSetupHostMode(void)
 
     if (SCConfGet("host-mode", &hostmode) == 1) {
         if (!strcmp(hostmode, "router")) {
-            host_mode = SURI_HOST_IS_ROUTER;
+            g_engine_host_mode = ENGINE_HOST_IS_ROUTER;
+        } else if (!strcmp(hostmode, "bridge")) {
+            g_engine_host_mode = ENGINE_HOST_IS_BRIDGE;
         } else if (!strcmp(hostmode, "sniffer-only")) {
-            host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+            g_engine_host_mode = ENGINE_HOST_IS_SNIFFER_ONLY;
         } else {
             if (strcmp(hostmode, "auto") != 0) {
                 WarnInvalidConfEntry("host-mode", "%s", "auto");
             }
             if (EngineModeIsIPS()) {
-                host_mode = SURI_HOST_IS_ROUTER;
+                /* only set if not already set by the runmode */
+                if (g_engine_host_mode == ENGINE_HOST_IS_SNIFFER_ONLY) {
+                    SCLogDebug("host mode set to %u setting to %u", g_engine_host_mode,
+                            ENGINE_HOST_IS_ROUTER);
+                    g_engine_host_mode = ENGINE_HOST_IS_ROUTER;
+                }
             } else {
-                host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+                g_engine_host_mode = ENGINE_HOST_IS_SNIFFER_ONLY;
             }
         }
     } else {
         if (EngineModeIsIPS()) {
-            host_mode = SURI_HOST_IS_ROUTER;
-            SCLogInfo("No 'host-mode': suricata is in IPS mode, using "
-                      "default setting 'router'");
+            /* only set if not already set by the runmode */
+            if (g_engine_host_mode == ENGINE_HOST_IS_SNIFFER_ONLY) {
+                SCLogDebug("host mode set to %u setting to %u", g_engine_host_mode,
+                        ENGINE_HOST_IS_ROUTER);
+                g_engine_host_mode = ENGINE_HOST_IS_ROUTER;
+                SCLogInfo("No 'host-mode': suricata is in IPS mode, using "
+                          "default setting 'router'");
+            }
         } else {
-            host_mode = SURI_HOST_IS_SNIFFER_ONLY;
+            g_engine_host_mode = ENGINE_HOST_IS_SNIFFER_ONLY;
             SCLogInfo("No 'host-mode': suricata is in IDS mode, using "
                       "default setting 'sniffer-only'");
         }
@@ -2774,7 +2798,7 @@ int PostConfLoadedSetup(SCInstance *suri)
     }
     if (suri->is_firewall) {
         SCLogWarning("firewall mode is EXPERIMENTAL and subject to change");
-        EngineModeSetFirewall();
+        EngineModeSetFirewall(g_engine_host_mode);
     }
 
     /* load the pattern matchers */

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -111,22 +111,23 @@ enum EngineMode {
     ENGINE_MODE_FIREWALL,
 };
 
+/* Engine is acting as router */
+enum EngineHostMode {
+    ENGINE_HOST_IS_SNIFFER_ONLY,
+    ENGINE_HOST_IS_ROUTER,
+    ENGINE_HOST_IS_BRIDGE,
+};
+
 /* superset of IPS mode */
-void EngineModeSetFirewall(void);
-void EngineModeSetIPS(void);
+void EngineModeSetFirewall(const enum EngineHostMode);
+void EngineModeSetIPS(const enum EngineHostMode);
 void EngineModeSetIDS(void);
 int EngineModeIsUnknown(void);
 bool EngineModeIsFirewall(void);
 int EngineModeIsIPS(void);
 int EngineModeIsIDS(void);
-
-/* Box is acting as router */
-enum {
-    SURI_HOST_IS_SNIFFER_ONLY,
-    SURI_HOST_IS_ROUTER,
-};
-
-#define IS_SURI_HOST_MODE_SNIFFER_ONLY(host_mode) ((host_mode) == SURI_HOST_IS_SNIFFER_ONLY)
+bool EngineHostModeIsSniffer(void);
+bool EngineHostModeIsBridge(void);
 
 #include "runmodes.h"
 

--- a/src/tests/detect-http-server-body.c
+++ b/src/tests/detect-http-server-body.c
@@ -93,7 +93,7 @@ static int RunTest(struct TestSteps *steps, const char *sig, const char *yaml)
 
         SCConfYamlLoadString(yaml, strlen(yaml));
         HTPConfigure();
-        EngineModeSetIPS();
+        EngineModeSetIPS(ENGINE_HOST_IS_ROUTER);
     }
 
     StreamTcpInitConfig(true);

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -4276,7 +4276,7 @@ static int SigTestDropFlow03(void)
     uint32_t http_buf2_len = sizeof(http_buf1) - 1;
 
     /* Set the engine mode to IPS */
-    EngineModeSetIPS();
+    EngineModeSetIPS(ENGINE_HOST_IS_ROUTER);
 
     TcpSession ssn;
     Packet *p1 = NULL;

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -449,6 +449,14 @@ static void LiveDeviceFreeArray(void)
     g_livedev_array_size = 0;
 }
 
+uint16_t LiveDeviceGetId(const LiveDevice *dev)
+{
+    if (dev) {
+        return dev->id;
+    }
+    return 0;
+}
+
 LiveDevice *LiveDeviceGetById(const int id)
 {
     if (g_livedev_array != NULL && id < g_livedev_array_size) {

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2011-2021 Open Information Security Foundation
+/* Copyright (C) 2011-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -68,7 +68,7 @@ typedef struct BypassInfo_ {
 /** if set to 0 when we don't have real devices */
 static int live_devices_stats = 1;
 
-
+static void LiveDeviceFreeArray(void);
 static int LiveSafeDeviceName(const char *devname,
                               char *newdevname, size_t destlen);
 
@@ -334,6 +334,7 @@ void LiveDeviceHasNoStats(void)
 int LiveDeviceListClean(void)
 {
     SCEnter();
+    LiveDeviceFreeArray();
     LiveDevice *pd, *tpd;
 
     /* dpdk: need to close all devices before freeing them. */
@@ -437,6 +438,24 @@ TmEcode LiveDeviceIfaceList(json_t *cmd, json_t *answer, void *data)
 
 #endif /* BUILD_UNIX_SOCKET */
 
+static LiveDevice **g_livedev_array = NULL;
+static int g_livedev_array_size = 0;
+
+static void LiveDeviceFreeArray(void)
+{
+    if (g_livedev_array)
+        SCFree(g_livedev_array);
+    g_livedev_array_size = 0;
+}
+
+LiveDevice *LiveDeviceGetById(const int id)
+{
+    if (g_livedev_array != NULL && id < g_livedev_array_size) {
+        return g_livedev_array[id];
+    }
+    return NULL;
+}
+
 LiveDevice *LiveDeviceForEach(LiveDevice **ldev, LiveDevice **ndev)
 {
     if (*ldev == NULL) {
@@ -451,6 +470,24 @@ LiveDevice *LiveDeviceForEach(LiveDevice **ldev, LiveDevice **ndev)
         return *ldev;
     }
     return NULL;
+}
+
+static void LiveDeviceFinalizeBuildArray(void)
+{
+    BUG_ON(g_livedev_array);
+    int max_id = LiveGetDeviceCount();
+    if (max_id <= 0)
+        return;
+
+    g_livedev_array = SCCalloc(max_id + 1, sizeof(LiveDevice *));
+    if (g_livedev_array == NULL)
+        FatalError("failed to alloc livedev array");
+    g_livedev_array_size = max_id + 1;
+
+    LiveDevice *ldev = NULL, *ndev = NULL;
+    while (LiveDeviceForEach(&ldev, &ndev)) {
+        g_livedev_array[ldev->id] = ldev;
+    }
 }
 
 /**
@@ -471,6 +508,7 @@ void LiveDeviceFinalize(void)
         }
         SCFree(ld);
     }
+    LiveDeviceFinalizeBuildArray();
 }
 
 static void LiveDevExtensionFree(void *x)

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -138,7 +138,8 @@ int LiveRegisterDevice(const char *dev)
         return -1;
     }
 
-    int id = LiveGetDeviceCount();
+    /* +1 as the id space starts at 1 */
+    int id = LiveGetDeviceCount() + 1;
     if (id > UINT16_MAX) {
         SCFree(pd);
         return -1;
@@ -475,8 +476,9 @@ LiveDevice *LiveDeviceForEach(LiveDevice **ldev, LiveDevice **ndev)
 static void LiveDeviceFinalizeBuildArray(void)
 {
     BUG_ON(g_livedev_array);
-    int max_id = LiveGetDeviceCount();
-    if (max_id <= 0)
+    /* +1 as the id space starts at 1 */
+    int max_id = LiveGetDeviceCount() + 1;
+    if (max_id <= 1)
         return;
 
     g_livedev_array = SCCalloc(max_id + 1, sizeof(LiveDevice *));

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2011-2025 Open Information Security Foundation
+/* Copyright (C) 2011-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -56,6 +56,7 @@ int LiveGetDeviceCountWithoutAssignedThreading(void);
 int LiveGetDeviceCount(void);
 const char *LiveGetDeviceName(int number);
 LiveDevice *LiveGetDevice(const char *dev);
+LiveDevice *LiveDeviceGetById(const int id);
 const char *LiveGetShortName(const char *dev);
 int LiveBuildDeviceList(const char *base);
 void LiveDeviceHasNoStats(void);

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -56,6 +56,7 @@ int LiveGetDeviceCountWithoutAssignedThreading(void);
 int LiveGetDeviceCount(void);
 const char *LiveGetDeviceName(int number);
 LiveDevice *LiveGetDevice(const char *dev);
+uint16_t LiveDeviceGetId(const LiveDevice *dev);
 LiveDevice *LiveDeviceGetById(const int id);
 const char *LiveGetShortName(const char *dev);
 int LiveBuildDeviceList(const char *base);

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -537,7 +537,7 @@ static bool EBPFCreateFlowForKey(struct flows_stats *flowstats, LiveDevice *dev,
             fc->BypassFree = EBPFBypassFree;
             fc->todstpktcnt = pkts_cnt;
             fc->todstbytecnt = bytes_cnt;
-            f->livedev = dev;
+            f->livedev_id = dev->id;
             EBPFBypassData *eb = SCCalloc(1, sizeof(EBPFBypassData));
             if (eb == NULL) {
                 SCFree(fc);
@@ -583,7 +583,7 @@ static bool EBPFCreateFlowForKey(struct flows_stats *flowstats, LiveDevice *dev,
         memcpy(mkey, key, skey);
         eb->key[1] = mkey;
     }
-    f->livedev = dev;
+    f->livedev_id = dev->id;
     FLOWLOCK_UNLOCK(f);
     return false;
 }

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -1055,14 +1055,14 @@ int EBPFUpdateFlow(Flow *f, Packet *p, void *data)
         if (ifl == NULL) {
             return 0;
         }
-        ifl->dev = p->livedev;
+        ifl->dev = LiveDeviceGetById(p->livedev_id);
         FlowSetStorageById(f, g_flow_storage_id, ifl);
         return 1;
     }
     /* Look for packet iface in the list */
     BypassedIfaceList *ldev = ifl;
     while (ldev) {
-        if (p->livedev == ldev->dev) {
+        if (p->livedev_id == LiveDeviceGetId(ldev->dev)) {
             return 1;
         }
         ldev = ldev->next;
@@ -1075,7 +1075,7 @@ int EBPFUpdateFlow(Flow *f, Packet *p, void *data)
     if (nifl == NULL) {
         return 0;
     }
-    nifl->dev = p->livedev;
+    nifl->dev = LiveDeviceGetById(p->livedev_id);
     nifl->next = ifl;
     FlowSetStorageById(f, g_flow_storage_id, nifl);
     return 1;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1386,10 +1386,12 @@ security:
 coredump:
   max-dump: unlimited
 
-# If the Suricata box is a router for the sniffed networks, set it to 'router'. If
-# it is a pure sniffing setup, set it to 'sniffer-only'.
-# If set to auto, the variable is internally switched to 'router' in IPS mode
-# and 'sniffer-only' in IDS mode.
+# If Suricata acts as a router for the network, set it to 'router'. If
+# it is a pure sniffing setup, set it to 'sniffer-only'. For 'bridge' setups like
+# AF_PACKET IPS, use 'bridge'.
+# If set to auto, the mode is 'sniffer-only' in IDS mode, and 'router' or 'bridge'
+# for IPS modes, depending on which is used. E.g. AF_PACKET IPS uses the bridge
+# mode, while NFQ uses the router mode.
 # This feature is currently only used by the reject* keywords.
 host-mode: auto
 


### PR DESCRIPTION
Clean up host mode tracking, which is used by reject to control how rejects are sent. Before this patch there were 2 modes: sniffer only and router. This patch introduces a bridge mode that is automatically set by the bridge modes. In bridge mode the `Packet::livedev` is used.

Ticket: #8390.
