### PR TITLE
detect/xor: support byte_extract variables as XOR keys

### DIFF
--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -186,14 +186,39 @@ xor
 
 Takes the buffer, applies xor decoding.
 
-.. note:: this transform requires a mandatory option which is the hexadecimal encoded xor key.
+The key can be specified as a hexadecimal string or as a ``byte_extract``
+variable name. When a ``byte_extract`` variable is used, the key bytes are
+read directly from the inspection buffer at the variable's offset. Only
+``byte_extract`` variables with absolute (non-relative) offsets are supported.
 
+An optional ``offset`` parameter specifies where in the buffer XOR decoding
+begins. Bytes before this offset are copied unchanged. This is useful when
+the key is embedded in the buffer and should be skipped during decoding.
 
-This example alerts if ``http.uri`` contains ``password=`` xored with 4-bytes key ``0d0ac8ff``
-Example::
+Syntax::
+
+    xor:"<hex_key>"
+    xor:"<byte_extract_variable>"
+    xor:offset <N>,"<hex_key>"
+    xor:offset <N>,"<byte_extract_variable>"
+
+This example alerts if ``http.uri`` contains ``password=`` xored with 4-bytes key ``0d0ac8ff``::
 
     alert http any any -> any any (msg:"HTTP with xor"; http.uri; \
         xor:"0d0ac8ff"; content:"password="; sid:1;)
+
+This example extracts a 1-byte XOR key from offset 0 of the request body,
+then decodes the buffer starting at offset 1 (skipping the key byte) and
+matches ``infected`` in the decoded data::
+
+    alert http any any -> any any (msg:"XOR with variable key"; \
+        http.request_body; byte_extract:1,0,xor_key; \
+        xor:offset 1,"xor_key"; content:"infected"; sid:2;)
+
+.. note:: When using a ``byte_extract`` variable whose name is also a valid
+   hexadecimal string (e.g. ``aabb``), the transform first checks for a
+   matching variable and falls back to interpreting the value as a hex key.
+   To avoid ambiguity, use descriptive variable names.
 
 header_lowercase
 ----------------

--- a/rust/src/detect/transforms/mod.rs
+++ b/rust/src/detect/transforms/mod.rs
@@ -17,6 +17,89 @@
 
 //! Module for transforms
 
+use std::ffi::CString;
+use std::os::raw::c_char;
+use suricata_sys::sys::Signature;
+
+extern "C" {
+    fn SCDetectByteRetrieveVarInfo(
+        name: *const c_char,
+        s: *const Signature,
+        index: *mut u8,
+    ) -> bool;
+
+    fn SCDetectByteExtractGetBufferOffset(
+        name: *const c_char,
+        s: *const Signature,
+        offset: *mut i16,
+        nbytes: *mut u8,
+    ) -> bool;
+}
+
+/// Error returned when a byte variable cannot be resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ByteVarError {
+    /// No variable with this name exists in the signature.
+    NotFound,
+    /// The variable name contains an interior NUL byte.
+    InvalidName,
+}
+
+/// Look up a `byte_extract` or `byte_math` variable by name and return its
+/// `byte_values` index.
+///
+/// # Safety
+///
+/// `s` must be a valid pointer to a `Signature` that is currently being set up.
+pub(crate) unsafe fn resolve_byte_var(
+    name: &str, s: *const Signature,
+) -> Result<u8, ByteVarError> {
+    let c_name = CString::new(name).map_err(|_| ByteVarError::InvalidName)?;
+    let mut index: u8 = 0;
+
+    if !SCDetectByteRetrieveVarInfo(c_name.as_ptr(), s, &mut index) {
+        return Err(ByteVarError::NotFound);
+    }
+    Ok(index)
+}
+
+/// Byte_extract buffer location resolved at setup time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ByteExtractLocation {
+    /// Absolute byte offset in the inspection buffer.
+    pub offset: u16,
+    /// Number of bytes to read starting at `offset`.
+    pub nbytes: u8,
+}
+
+/// Get a byte_extract variable's absolute buffer offset and byte width on the
+/// current buffer. Returns `None` if the variable is not a byte_extract on the
+/// same buffer, uses a relative offset, or does not exist.
+///
+/// This is a workaround until a general pre-transform extraction phase is
+/// added to the detection engine.
+///
+/// # Safety
+///
+/// `s` must be a valid pointer to a `Signature` that is currently being set up.
+pub(crate) unsafe fn get_byte_extract_buffer_location(
+    name: &str, s: *const Signature,
+) -> Option<ByteExtractLocation> {
+    let c_name = CString::new(name).ok()?;
+    let mut offset: i16 = 0;
+    let mut nbytes: u8 = 0;
+    if !SCDetectByteExtractGetBufferOffset(c_name.as_ptr(), s, &mut offset, &mut nbytes) {
+        return None;
+    }
+    if offset < 0 {
+        return None;
+    }
+    Some(ByteExtractLocation {
+        offset: offset as u16,
+        nbytes,
+    })
+}
+
 pub mod base64;
 pub mod casechange;
 pub mod compress_whitespace;

--- a/rust/src/detect/transforms/xor.rs
+++ b/rust/src/detect/transforms/xor.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2024 Open Information Security Foundation
+/* Copyright (C) 2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,74 +15,185 @@
  * 02110-1301, USA.
  */
 
-use crate::detect::SIGMATCH_QUOTES_MANDATORY;
+use crate::detect::transforms::{
+    get_byte_extract_buffer_location, resolve_byte_var, ByteExtractLocation, ByteVarError,
+};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, InspectionBuffer, SCDetectHelperTransformRegister,
     SCDetectSignatureAddTransform, SCInspectionBufferCheckAndExpand, SCInspectionBufferTruncate,
-    SCTransformTableElmt, Signature,
+    SCTransformTableElmt, Signature, SIGMATCH_QUOTES_OPTIONAL,
 };
 
 use std::ffi::CStr;
-use std::os::raw::{c_int, c_void};
+use std::os::raw::{c_char, c_int, c_void};
 
 static mut G_TRANSFORM_XOR_ID: c_int = 0;
 
-#[derive(Debug, PartialEq)]
+/// Where to obtain the XOR key at transform time.
+#[derive(Debug)]
+enum XorKeySource {
+    /// A static hex key provided in the rule.
+    Static(Vec<u8>),
+    /// Key from a byte_extract variable. The transform reads raw bytes from
+    /// the buffer at the variable's location.
+    Variable(ByteExtractLocation),
+}
+
+#[derive(Debug)]
 struct DetectTransformXorData {
-    key: Vec<u8>,
+    key_source: XorKeySource,
+    /// Offset in the buffer where XOR decoding starts. Bytes before this
+    /// offset are copied unchanged. This allows skipping embedded key bytes.
+    xor_offset: u32,
 }
 
-fn xor_parse_do(i: &str) -> Option<DetectTransformXorData> {
-    if i.len() % 2 != 0 {
-        SCLogError!("XOR transform key's length must be an even number");
-        return None;
-    }
-    if i.len() / 2 > usize::from(u8::MAX) {
-        SCLogError!("Key length too big for XOR transform");
-        return None;
-    }
-    if let Ok(key) = hex::decode(i) {
-        return Some(DetectTransformXorData { key });
-    }
-    SCLogError!("XOR transform key must be hexadecimal characters only");
-    return None;
+/// Intermediate parse result before variable resolution.
+#[derive(Debug, PartialEq)]
+struct XorParseResult {
+    /// The key specifier — either a hex string or a variable name.
+    key_str: String,
+    /// Optional offset where XOR decoding starts.
+    xor_offset: Option<u32>,
 }
 
-unsafe fn xor_parse(raw: *const std::os::raw::c_char) -> *mut c_void {
-    let raw: &CStr = CStr::from_ptr(raw); //unsafe
-    if let Ok(s) = raw.to_str() {
-        if let Some(ctx) = xor_parse_do(s) {
-            let boxed = Box::new(ctx);
-            return Box::into_raw(boxed) as *mut _;
+/// Parse the xor option string. Accepts:
+///   - `"<hex_or_varname>"`
+///   - `"offset <N>,<hex_or_varname>"`
+fn xor_parse_options(input: &str) -> Option<XorParseResult> {
+    let input = input.trim();
+    if input.is_empty() {
+        SCLogError!("XOR transform: empty argument");
+        return None;
+    }
+
+    // Check for "offset" keyword followed by whitespace.
+    if let Some(rest) = input
+        .strip_prefix("offset")
+        .filter(|r| r.starts_with(|c: char| c.is_ascii_whitespace()))
+    {
+        let rest = rest.trim_start();
+        if let Some((offset_str, key_str)) = rest.split_once(',') {
+            let offset_str = offset_str.trim();
+            let key_str = key_str.trim();
+            let offset: u32 = match offset_str.parse() {
+                Ok(v) => v,
+                Err(_) => {
+                    SCLogError!("XOR transform: invalid offset value '{}'", offset_str);
+                    return None;
+                }
+            };
+            let key_str = strip_quotes(key_str);
+            if key_str.is_empty() {
+                SCLogError!("XOR transform: missing key after offset");
+                return None;
+            }
+            return Some(XorParseResult {
+                key_str: key_str.to_string(),
+                xor_offset: Some(offset),
+            });
         }
+        SCLogError!("XOR transform: 'offset' requires format 'offset <N>,<key>'");
+        return None;
     }
-    return std::ptr::null_mut();
+
+    Some(XorParseResult {
+        key_str: input.to_string(),
+        xor_offset: None,
+    })
+}
+
+/// Strip surrounding double quotes from a string if present.
+fn strip_quotes(s: &str) -> &str {
+    s.strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(s)
+}
+
+/// Try to decode a string as a hex key. Returns `None` if the string is not
+/// valid even-length hexadecimal or exceeds the maximum key length.
+fn try_parse_hex_key(s: &str) -> Option<Vec<u8>> {
+    if s.len() % 2 != 0 || !s.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    hex::decode(s)
+        .ok()
+        .filter(|k| k.len() <= usize::from(u8::MAX))
 }
 
 unsafe extern "C" fn xor_setup(
-    de: *mut DetectEngineCtx, s: *mut Signature, opt_str: *const std::os::raw::c_char,
+    de: *mut DetectEngineCtx, s: *mut Signature, opt_str: *const c_char,
 ) -> c_int {
-    let ctx = xor_parse(opt_str);
-    if ctx.is_null() {
-        return -1;
-    }
+    let input = match CStr::from_ptr(opt_str).to_str() {
+        Ok(s) => s,
+        Err(_) => return -1,
+    };
+
+    let parsed = match xor_parse_options(input) {
+        Some(p) => p,
+        None => return -1,
+    };
+
+    let xor_offset = parsed.xor_offset.unwrap_or(0);
+
+    // Try resolving as a byte variable first (avoids hex/variable ambiguity).
+    let key_source = match resolve_byte_var(&parsed.key_str, s) {
+        Ok(_index) => {
+            // Get the buffer location for pre-transform extraction.
+            match get_byte_extract_buffer_location(&parsed.key_str, s) {
+                Some(location) => XorKeySource::Variable(location),
+                None => {
+                    SCLogError!(
+                        "XOR transform: variable '{}' not found on the same buffer with an \
+                         absolute offset (only byte_extract with absolute offset on the same \
+                         buffer is currently supported)",
+                        parsed.key_str
+                    );
+                    return -1;
+                }
+            }
+        }
+        Err(ByteVarError::NotFound) => {
+            // Not a variable — try as a hex key.
+            match try_parse_hex_key(&parsed.key_str) {
+                Some(key) => XorKeySource::Static(key),
+                None => {
+                    SCLogError!(
+                        "XOR transform: '{}' is not a known byte variable or valid hex key",
+                        parsed.key_str
+                    );
+                    return -1;
+                }
+            }
+        }
+        Err(ByteVarError::InvalidName) => return -1,
+    };
+
+    let data = DetectTransformXorData {
+        key_source,
+        xor_offset,
+    };
+    let ctx = Box::into_raw(Box::new(data)) as *mut c_void;
     let r = SCDetectSignatureAddTransform(s, G_TRANSFORM_XOR_ID, ctx);
     if r != 0 {
         xor_free(de, ctx);
     }
-    return r;
+    r
 }
 
-fn xor_transform_do(input: &[u8], output: &mut [u8], ctx: &DetectTransformXorData) {
-    let mut ki = 0;
-    for (i, o) in input.iter().zip(output.iter_mut()) {
-        *o = (*i) ^ ctx.key[ki];
-        ki = (ki + 1) % ctx.key.len();
+/// Apply XOR to `input[xor_offset..]`, copying `input[..xor_offset]` unchanged.
+fn xor_transform_do(input: &[u8], output: &mut [u8], key: &[u8], xor_offset: usize) {
+    output[..xor_offset].copy_from_slice(&input[..xor_offset]);
+    let input = &input[xor_offset..];
+    let output = &mut output[xor_offset..];
+    for (chunk_in, chunk_out) in input.chunks(key.len()).zip(output.chunks_mut(key.len())) {
+        for (inp, (out, k)) in chunk_in.iter().zip(chunk_out.iter_mut().zip(key.iter())) {
+            *out = *inp ^ *k;
+        }
     }
 }
 
 unsafe extern "C" fn xor_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *mut c_void,
+    _det_ctx: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *mut c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -93,19 +204,35 @@ unsafe extern "C" fn xor_transform(
 
     let output = SCInspectionBufferCheckAndExpand(buffer, input_len);
     if output.is_null() {
-        // allocation failure
         return;
     }
     let output = std::slice::from_raw_parts_mut(output, input_len as usize);
 
     let ctx = cast_pointer!(ctx, DetectTransformXorData);
-    xor_transform_do(input, output, ctx);
+    let xor_offset = ctx.xor_offset as usize;
 
+    if xor_offset > input.len() {
+        return;
+    }
+
+    let key: &[u8] = match &ctx.key_source {
+        XorKeySource::Static(key) => key,
+        XorKeySource::Variable(location) => {
+            let start = location.offset as usize;
+            let end = start + location.nbytes as usize;
+            if location.nbytes == 0 || end > input.len() {
+                return;
+            }
+            &input[start..end]
+        }
+    };
+
+    xor_transform_do(input, output, key, xor_offset);
     SCInspectionBufferTruncate(buffer, input_len);
 }
 
 unsafe extern "C" fn xor_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
-    std::mem::drop(Box::from_raw(ctx as *mut DetectTransformXorData));
+    drop(Box::from_raw(ctx as *mut DetectTransformXorData));
 }
 
 unsafe extern "C" fn xor_id(data: *mut *const u8, length: *mut u32, ctx: *mut c_void) {
@@ -114,8 +241,16 @@ unsafe extern "C" fn xor_id(data: *mut *const u8, length: *mut u32, ctx: *mut c_
     }
 
     let ctx = cast_pointer!(ctx, DetectTransformXorData);
-    *data = ctx.key.as_ptr();
-    *length = ctx.key.len() as u32;
+    match &ctx.key_source {
+        XorKeySource::Static(key) => {
+            *data = key.as_ptr();
+            *length = key.len() as u32;
+        }
+        _ => {
+            *data = std::ptr::null();
+            *length = 0;
+        }
+    }
 }
 
 #[no_mangle]
@@ -125,7 +260,7 @@ pub unsafe extern "C" fn DetectTransformXorRegister() {
         desc: b"modify buffer via XOR decoding before inspection\0".as_ptr() as *const libc::c_char,
         url: b"/rules/transforms.html#xor\0".as_ptr() as *const libc::c_char,
         Setup: Some(xor_setup),
-        flags: SIGMATCH_QUOTES_MANDATORY,
+        flags: SIGMATCH_QUOTES_OPTIONAL,
         Transform: Some(xor_transform),
         Free: Some(xor_free),
         TransformValidate: None,
@@ -144,19 +279,102 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_xor_parse() {
-        assert!(xor_parse_do("nohexa").is_none());
-        let key = b"\x0a\x0d\xc8\xff";
+    fn test_parse_hex_key() {
+        let r = xor_parse_options("0a0DC8ff").unwrap();
+        assert_eq!(r.key_str, "0a0DC8ff");
+        assert_eq!(r.xor_offset, None);
         assert_eq!(
-            xor_parse_do("0a0DC8ff"),
-            Some(DetectTransformXorData { key: key.to_vec() })
+            try_parse_hex_key(&r.key_str),
+            Some(vec![0x0a, 0x0d, 0xc8, 0xff])
         );
+    }
+
+    #[test]
+    fn test_parse_variable() {
+        let r = xor_parse_options("xor_key").unwrap();
+        assert_eq!(r.key_str, "xor_key");
+        assert_eq!(r.xor_offset, None);
+        assert!(try_parse_hex_key(&r.key_str).is_none());
+    }
+
+    #[test]
+    fn test_parse_offset_variable() {
+        let r = xor_parse_options("offset 1,xor_key").unwrap();
+        assert_eq!(r.key_str, "xor_key");
+        assert_eq!(r.xor_offset, Some(1));
+    }
+
+    #[test]
+    fn test_parse_offset_quoted_variable() {
+        let r = xor_parse_options("offset 1,\"xor_key\"").unwrap();
+        assert_eq!(r.key_str, "xor_key");
+        assert_eq!(r.xor_offset, Some(1));
+    }
+
+    #[test]
+    fn test_parse_offset_hex() {
+        let r = xor_parse_options("offset 4,0d0ac8ff").unwrap();
+        assert_eq!(r.key_str, "0d0ac8ff");
+        assert_eq!(r.xor_offset, Some(4));
+        assert!(try_parse_hex_key(&r.key_str).is_some());
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        assert!(xor_parse_options("").is_none());
+    }
+
+    #[test]
+    fn test_parse_offset_missing_key() {
+        assert!(xor_parse_options("offset 1,").is_none());
+    }
+
+    #[test]
+    fn test_parse_offset_no_comma() {
+        assert!(xor_parse_options("offset 1").is_none());
+    }
+
+    #[test]
+    fn test_xor_transform_no_offset() {
+        let input = b"example.com";
+        let mut out = vec![0u8; input.len()];
+        let key = hex::decode("0a0DC8ff").unwrap();
+        xor_transform_do(input, &mut out, &key, 0);
+        assert_eq!(out, b"ou\xa9\x92za\xad\xd1ib\xa5");
+    }
+
+    #[test]
+    fn test_xor_transform_with_offset() {
+        let key_byte = 0x42u8;
+        let plaintext = b"hello";
+        let mut body = vec![key_byte];
+        for &b in plaintext {
+            body.push(b ^ key_byte);
+        }
+        let mut out = vec![0u8; body.len()];
+        xor_transform_do(&body, &mut out, &[key_byte], 1);
+        assert_eq!(out[0], key_byte);
+        assert_eq!(&out[1..], plaintext);
+    }
+
+    #[test]
+    fn test_xor_transform_inplace() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"example.com");
+        let mut out = vec![0; buf.len()];
+        let key = hex::decode("0a0DC8ff").unwrap();
+        xor_transform_do(&buf, &mut out, &key, 0);
+        assert_eq!(out, b"ou\xa9\x92za\xad\xd1ib\xa5");
+        let still_buf = unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) };
+        xor_transform_do(still_buf, &mut buf, &key, 0);
+        assert_eq!(&still_buf, b"ou\xa9\x92za\xad\xd1ib\xa5");
     }
 
     #[test]
     fn test_xor_id() {
         let ctx = Box::new(DetectTransformXorData {
-            key: vec![1, 2, 3, 4, 5],
+            key_source: XorKeySource::Static(vec![1, 2, 3, 4, 5]),
+            xor_offset: 0,
         });
 
         let ctx_ptr: *const c_void = &*ctx as *const _ as *const c_void;
@@ -177,19 +395,5 @@ mod tests {
             let actual = std::slice::from_raw_parts(data_ptr, length as usize);
             assert_eq!(actual, &[1, 2, 3, 4, 5]);
         }
-    }
-
-    #[test]
-    fn test_xor_transform() {
-        let mut buf = Vec::new();
-        buf.extend_from_slice(b"example.com");
-        let mut out = vec![0; buf.len()];
-        let ctx = xor_parse_do("0a0DC8ff").unwrap();
-        xor_transform_do(&buf, &mut out, &ctx);
-        assert_eq!(out, b"ou\xa9\x92za\xad\xd1ib\xa5");
-        // test in place
-        let still_buf = unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) };
-        xor_transform_do(still_buf, &mut buf, &ctx);
-        assert_eq!(&still_buf, b"ou\xa9\x92za\xad\xd1ib\xa5");
     }
 }

--- a/src/detect-byte.c
+++ b/src/detect-byte.c
@@ -54,3 +54,68 @@ bool DetectByteRetrieveSMVar(
     }
     return false;
 }
+
+/**
+ * \brief Resolve a byte_extract or byte_math variable by name.
+ *
+ * Wrapper around DetectByteRetrieveSMVar that searches all buffers.
+ *
+ * \param name Variable name to look up
+ * \param s The signature containing the variable
+ * \param index Output: local_id index into byte_values
+ *
+ * \retval true if the variable was found
+ * \retval false otherwise
+ */
+bool SCDetectByteRetrieveVarInfo(const char *name, const Signature *s, DetectByteIndexType *index)
+{
+    return DetectByteRetrieveSMVar(name, s, -1, index);
+}
+
+/**
+ * \brief Get a byte_extract variable's buffer offset for pre-transform extraction.
+ *
+ * Searches only the current buffer (s->init_data->curbuf) to ensure the
+ * byte_extract variable is on the same buffer as the transform referencing it.
+ *
+ * Returns the byte_extract's absolute buffer offset so the xor transform
+ * can read key bytes directly from the inspection buffer. This is a
+ * workaround until a general pre-transform extraction phase is added
+ * to the detection engine.
+ *
+ * Only works for byte_extract variables with absolute (non-relative) offsets
+ * on the same buffer as the calling transform.
+ *
+ * \param name Variable name to look up
+ * \param s The signature being set up (uses curbuf for buffer matching)
+ * \param offset Output: the absolute buffer offset
+ * \param nbytes Output: the number of bytes to extract
+ *
+ * \retval true if the variable was found on the current buffer with an absolute offset
+ * \retval false otherwise
+ */
+bool SCDetectByteExtractGetBufferOffset(
+        const char *name, const Signature *s, int16_t *offset, uint8_t *nbytes)
+{
+    if (s->init_data == NULL || s->init_data->curbuf == NULL)
+        return false;
+
+    /* Search only the current buffer's SigMatch chain to ensure the
+     * byte_extract variable is on the same buffer as the transform. */
+    SigMatch *sm = s->init_data->curbuf->head;
+    while (sm != NULL) {
+        if (sm->type == DETECT_BYTE_EXTRACT) {
+            const SCDetectByteExtractData *bed = (const SCDetectByteExtractData *)sm->ctx;
+            if (strcmp(bed->name, name) == 0) {
+                if (bed->flags & DETECT_BYTE_EXTRACT_FLAG_RELATIVE) {
+                    return false;
+                }
+                *offset = bed->offset;
+                *nbytes = bed->nbytes;
+                return true;
+            }
+        }
+        sm = sm->next;
+    }
+    return false;
+}

--- a/src/detect-byte.h
+++ b/src/detect-byte.h
@@ -29,4 +29,8 @@ typedef uint8_t DetectByteIndexType;
 
 bool DetectByteRetrieveSMVar(const char *, const Signature *, int sm_list, DetectByteIndexType *);
 
+bool SCDetectByteRetrieveVarInfo(const char *name, const Signature *s, DetectByteIndexType *index);
+bool SCDetectByteExtractGetBufferOffset(
+        const char *name, const Signature *s, int16_t *offset, uint8_t *nbytes);
+
 #endif /* SURICATA_DETECT_BYTE_H */


### PR DESCRIPTION
Continuation of #15115 

Allows rules to extract a key from the buffer at runtime using byte_extract and apply it as the XOR key:
-   `xor:"<hex_key>"`
-   `xor:"<variable>"`
-   `xor:offset <N>,"<variable>"`

The `byte_extract` variable must be on the same buffer and use an absolute offset. The transform reads key bytes directly from the raw buffer (pre-transform), since transforms run before content inspection has populated the byte values; this is why a relative offset can't be used.

Describe changes:
- Add FFI functions for transforms to resolve byte_extract/byte_math variables from C
- Extend the xor transform to accept a byte_extract variable name as the key, with an optional offset parameter to skip key bytes in the buffer
- Document the new xor transform syntax variants

Updates:
- Rebase

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2993
SU_REPO=
SU_BRANCH=
