### PR TITLE
suricata: add warning about missing runmode

### DIFF
--- a/examples/lib/cplusplus/main.cpp
+++ b/examples/lib/cplusplus/main.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv)
     SCParseCommandLine(argc, argv);
 
     /* Validate/finalize the runmode. */
-    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+    if (SCFinalizeRunMode(argc) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/examples/lib/custom/main.c
+++ b/examples/lib/custom/main.c
@@ -204,7 +204,7 @@ int main(int argc, char **argv)
     SCRunmodeSet(RUNMODE_LIB);
 
     /* Validate/finalize the runmode. */
-    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+    if (SCFinalizeRunMode(argc) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/examples/lib/live/main.c
+++ b/examples/lib/live/main.c
@@ -264,7 +264,7 @@ int main(int argc, char **argv)
     SCRunmodeSet(RUNMODE_LIB);
 
     /* Validate/finalize the runmode. */
-    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+    if (SCFinalizeRunMode(suricata_argc) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv)
     SCParseCommandLine(argc, argv);
 
     /* Validate/finalize the runmode. */
-    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+    if (SCFinalizeRunMode(argc) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+    if (SCFinalizeRunMode(argc) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2493,11 +2493,16 @@ int SCStartInternalRunMode(int argc, char **argv)
     return TM_ECODE_OK;
 }
 
-int SCFinalizeRunMode(void)
+int SCFinalizeRunMode(int argc)
 {
     SCInstance *suri = &suricata;
     switch (suri->run_mode) {
         case RUNMODE_UNKNOWN:
+            /* Only warn if user passed arguments */
+            if (argc > 1) {
+                SCLogError("Please specify a runmode or capture option. "
+                           "Use --list-runmodes to see available runmodes.");
+            }
             PrintUsage(suri->progname);
             return TM_ECODE_FAILED;
         default:

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -232,7 +232,7 @@ int InitGlobal(void);
 void GlobalsDestroy(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
-int SCFinalizeRunMode(void);
+int SCFinalizeRunMode(int argc);
 TmEcode SCParseCommandLine(int argc, char **argv);
 int SCStartInternalRunMode(int argc, char **argv);
 TmEcode SCLoadYamlConfig(void);


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/15148

Last PR by the original author: https://github.com/OISF/suricata/pull/14417

Changes since v2:
- fixed new library example fn call
- rebased on top of latest `main`

Link to ticket: https://redmine.openinfosecfoundation.org/issues/5711

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3006