### PR TITLE
decode: use inner packet drop reason

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -7908,11 +7908,6 @@
                                     "type": "integer",
                                     "description":
                                             "Number of packets dropped due to threshold detection filter"
-                                },
-                                "tunnel_packet_drop": {
-                                    "type": "integer",
-                                    "description":
-                                            "Number of packets dropped due to inner tunnel packet being dropped"
                                 }
                             },
                             "description": "Number of dropped packets, grouped by drop reason"

--- a/src/decode.c
+++ b/src/decode.c
@@ -954,8 +954,6 @@ const char *PacketDropReasonToString(enum PacketDropReason r)
             return "threshold detection_filter";
         case PKT_DROP_REASON_NFQ_ERROR:
             return "nfq error";
-        case PKT_DROP_REASON_INNER_PACKET:
-            return "tunnel packet drop";
         case PKT_DROP_REASON_DEFAULT_PACKET_POLICY:
             return "default packet policy";
         case PKT_DROP_REASON_DEFAULT_APP_POLICY:
@@ -1004,8 +1002,6 @@ static const char *PacketDropReasonToJsonString(enum PacketDropReason r)
             return "ips.drop_reason.threshold_detection_filter";
         case PKT_DROP_REASON_NFQ_ERROR:
             return "ips.drop_reason.nfq_error";
-        case PKT_DROP_REASON_INNER_PACKET:
-            return "ips.drop_reason.tunnel_packet_drop";
         case PKT_DROP_REASON_DEFAULT_PACKET_POLICY:
             return "ips.drop_reason.default_packet_policy";
         case PKT_DROP_REASON_DEFAULT_APP_POLICY:

--- a/src/decode.h
+++ b/src/decode.h
@@ -395,7 +395,6 @@ enum PacketDropReason {
     PKT_DROP_REASON_STREAM_REASSEMBLY,
     PKT_DROP_REASON_STREAM_URG,
     PKT_DROP_REASON_NFQ_ERROR,             /**< no nfq verdict, must be error */
-    PKT_DROP_REASON_INNER_PACKET,          /**< drop issued by inner (tunnel) packet */
     PKT_DROP_REASON_DEFAULT_PACKET_POLICY, /**< drop issued by default packet policy */
     PKT_DROP_REASON_DEFAULT_APP_POLICY,    /**< drop issued by default app policy */
     PKT_DROP_REASON_STREAM_PRE_HOOK,       /**< drop issued in the pre_stream hook */

--- a/src/packet.c
+++ b/src/packet.c
@@ -41,7 +41,7 @@ void PacketDrop(Packet *p, const uint8_t action, enum PacketDropReason r)
     if (p->root) {
         p->root->action |= action;
         if (p->root->drop_reason == PKT_DROP_REASON_NOT_SET) {
-            p->root->drop_reason = PKT_DROP_REASON_INNER_PACKET;
+            p->root->drop_reason = (uint8_t)r;
         }
     }
     p->action |= action;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7216

Describe changes:
- decode: use inner packet drop reason

Draft : missing SV test

And I bet this is not the solution we want