### PR TITLE
detect/doh2: prefilter does not use dns engine progress

### DIFF
--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -153,10 +153,13 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
                     engine->ctx.tx_min_progress, AppProtoToString(engine->alproto), pname,
                     det_ctx->pmq.rule_id_array_cnt - old);
 
-            if (tx->tx_progress > engine->ctx.tx_min_progress && engine->is_last_for_progress) {
+            if (tx->tx_progress > engine->ctx.tx_min_progress && engine->is_last_for_progress &&
+                    tx->tx_ptr == tx_ptr) {
                 /* track with an offset of one, so that tx->progress 0 complete is tracked
                  * as 1, progress 1 as 2, etc. This is to allow 0 to mean: nothing tracked, even
                  * though a parser may use 0 as a valid value. */
+                // tx->tx_ptr == tx_ptr ensures we do not use a dns engine progress
+                // to update a HTTP2 tx detect_progress in case of DOH2
                 tx->detect_progress = engine->ctx.tx_min_progress + 1;
                 SCLogDebug("tx->tx_progress %d engine->ctx.tx_min_progress %d "
                            "engine->is_last_for_progress %d => tx->detect_progress updated to %02x",


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8454

Describe changes:
- detect/doh2: prefilter does not use dns engine progress to update HTTP2 tx progress

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3009

#15159 with better commit message