### PR TITLE
Feat/detect detection filter unique on ips

### DIFF
--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -574,22 +574,14 @@ static int DetectDetectionFilterDistinctAllocFailFallback(void)
     Packet *p2 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
     Packet *p3 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
 
-    int result = 0;
-
     /* Classic detection_filter alerts when current_count > count (i.e., 3rd packet) */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
-    if (PacketAlertCheck(p1, 27))
-        goto end;
+    FAIL_IF(PacketAlertCheck(p1, 27));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
-    if (PacketAlertCheck(p2, 27))
-        goto end;
+    FAIL_IF(PacketAlertCheck(p2, 27));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p3);
-    if (!PacketAlertCheck(p3, 27))
-        goto end;
+    FAIL_IF_NOT(PacketAlertCheck(p3, 27));
 
-    result = 1;
-
-end:
     /* cleanup and restore hook */
     ThresholdForceAllocFail(0);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
@@ -599,7 +591,7 @@ end:
     UTHFreePackets(&p3, 1);
     ThresholdDestroy();
     StatsThreadCleanup(&th_v.stats);
-    return result;
+    PASS;
 }
 
 /**

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -51,7 +51,7 @@
     "^\\s*(track|count|seconds)\\s+(by_src|by_dst|by_flow|\\d+)\\s*,\\s*(track|count|seconds)\\s+" \
     "(by_src|"                                                                                     \
     "by_dst|by_flow|\\d+)\\s*,\\s*(track|count|seconds)\\s+(by_src|by_dst|by_flow|\\d+)"           \
-    "(?:\\s*,\\s*unique_on\\s+(src_port|dst_port))?\\s*$"
+    "(?:\\s*,\\s*unique_on\\s+(src_port|dst_port|src_ip|dst_ip))?\\s*$"
 
 /* minimum number of PCRE submatches expected for detection_filter parse */
 #define DF_PARSE_MIN_SUBMATCHES 5
@@ -173,10 +173,21 @@ static DetectThresholdData *DetectDetectionFilterParse(const char *rawstr)
             count_pos = i + 1;
         if (strncasecmp(args[i], "seconds", strlen("seconds")) == 0)
             seconds_pos = i + 1;
-        if (strcasecmp(args[i], "src_port") == 0)
-            df->unique_on = DF_UNIQUE_SRC_PORT;
-        if (strcasecmp(args[i], "dst_port") == 0)
-            df->unique_on = DF_UNIQUE_DST_PORT;
+        if (strcasecmp(args[i], "src_port") == 0 || strcasecmp(args[i], "dst_port") == 0 ||
+                strcasecmp(args[i], "src_ip") == 0 || strcasecmp(args[i], "dst_ip") == 0) {
+            if (df->unique_on != DF_UNIQUE_NONE) {
+                SCLogError("detection_filter: only one unique_on is allowed");
+                goto error;
+            }
+            if (strcasecmp(args[i], "src_port") == 0)
+                df->unique_on = DF_UNIQUE_SRC_PORT;
+            else if (strcasecmp(args[i], "dst_port") == 0)
+                df->unique_on = DF_UNIQUE_DST_PORT;
+            else if (strcasecmp(args[i], "src_ip") == 0)
+                df->unique_on = DF_UNIQUE_SRC_IP;
+            else
+                df->unique_on = DF_UNIQUE_DST_IP;
+        }
     }
 
     if (args[count_pos] == NULL || args[seconds_pos] == NULL) {
@@ -252,13 +263,14 @@ static int DetectDetectionFilterSetup(DetectEngineCtx *de_ctx, Signature *s, con
     if (df == NULL)
         goto error;
 
-    /* unique_on requires a ported L4 protocol: tcp/udp/sctp */
-    if (df->unique_on != DF_UNIQUE_NONE) {
+    /* unique_on src_port/dst_port requires a ported L4 protocol: tcp/udp/sctp */
+    if (df->unique_on == DF_UNIQUE_SRC_PORT || df->unique_on == DF_UNIQUE_DST_PORT) {
         const bool has_tcp = DetectProtoHasExplicitProto(&s->init_data->proto, IPPROTO_TCP);
         const bool has_udp = DetectProtoHasExplicitProto(&s->init_data->proto, IPPROTO_UDP);
         const bool has_sctp = DetectProtoHasExplicitProto(&s->init_data->proto, IPPROTO_SCTP);
         if (!(has_tcp || has_udp || has_sctp)) {
-            SCLogError("detection_filter unique_on requires protocol tcp/udp/sctp");
+            SCLogError(
+                    "detection_filter unique_on src_port/dst_port requires protocol tcp/udp/sctp");
             goto error;
         }
     }
@@ -428,6 +440,38 @@ static int DetectDetectionFilterTestParseUnique01(void)
     FAIL_IF_NOT(df->count == 10);
     FAIL_IF_NOT(df->seconds == 60);
     FAIL_IF_NOT(df->unique_on == DF_UNIQUE_DST_PORT);
+    DetectDetectionFilterFree(NULL, df);
+    PASS;
+}
+
+/**
+ * \test DetectDetectionFilterTestParseUniqueIP01 tests parsing unique_on src_ip
+ */
+static int DetectDetectionFilterTestParseUniqueIP01(void)
+{
+    DetectThresholdData *df =
+            DetectDetectionFilterParse("track by_dst, count 10, seconds 60, unique_on src_ip");
+    FAIL_IF_NULL(df);
+    FAIL_IF_NOT(df->track == TRACK_DST);
+    FAIL_IF_NOT(df->count == 10);
+    FAIL_IF_NOT(df->seconds == 60);
+    FAIL_IF_NOT(df->unique_on == DF_UNIQUE_SRC_IP);
+    DetectDetectionFilterFree(NULL, df);
+    PASS;
+}
+
+/**
+ * \test DetectDetectionFilterTestParseUniqueIP02 tests parsing unique_on dst_ip
+ */
+static int DetectDetectionFilterTestParseUniqueIP02(void)
+{
+    DetectThresholdData *df =
+            DetectDetectionFilterParse("track by_src, count 5, seconds 30, unique_on dst_ip");
+    FAIL_IF_NULL(df);
+    FAIL_IF_NOT(df->track == TRACK_SRC);
+    FAIL_IF_NOT(df->count == 5);
+    FAIL_IF_NOT(df->seconds == 30);
+    FAIL_IF_NOT(df->unique_on == DF_UNIQUE_DST_IP);
     DetectDetectionFilterFree(NULL, df);
     PASS;
 }
@@ -994,6 +1038,375 @@ static int DetectDetectionFilterDistinctBitmapExpiry(void)
     PASS;
 }
 
+/**
+ * \test When hash table alloc fails, unique_on falls back to classic counting (> count)
+ */
+static int DetectDetectionFilterDistinctIPAllocFailFallback(void)
+{
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    ThresholdInit();
+    memset(&th_v, 0, sizeof(th_v));
+    StatsThreadInit(&th_v.stats);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    /* Force allocation failure for distinct IP hash */
+    ThresholdForceAllocFail(1);
+
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert ip any any -> any any (msg:\"DF alloc fail fallback IP\"; "
+            "detection_filter: track by_dst, count 2, seconds 60, unique_on src_ip; sid:28;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    Packet *p1 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    Packet *p2 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    Packet *p3 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    /* For fallback (classic) counting, we need 3 packets from SAME source to trigger alert (>2)
+     * If distinct counting was working, these would count as 1 distinct IP and NOT alert.
+     * So alerting here proves we fell back to classic counting. */
+
+    /* Classic detection_filter alerts when current_count > count (i.e., 3rd packet) */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    FAIL_IF(PacketAlertCheck(p1, 28));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    FAIL_IF(PacketAlertCheck(p2, 28));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p3);
+    FAIL_IF_NOT(PacketAlertCheck(p3, 28));
+
+    /* cleanup and restore hook */
+    ThresholdForceAllocFail(0);
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    UTHFreePackets(&p3, 1);
+    ThresholdDestroy();
+    StatsThreadCleanup(&th_v.stats);
+    PASS;
+}
+
+/**
+ * \test Verify IP hash memory is tracked and pre-sized to count
+ */
+static int DetectDetectionFilterDistinctIPHashMemuseTracking(void)
+{
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    ThresholdInit();
+    memset(&th_v, 0, sizeof(th_v));
+    StatsThreadInit(&th_v.stats);
+
+    uint64_t baseline_memuse = ThresholdGetBitmapMemuse();
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert ip any any -> any any (msg:\"DF IP hash memuse\"; "
+            "detection_filter: track by_dst, count 5, seconds 60, unique_on src_ip; sid:34;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    Packet *p1 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    /* Pre-allocated flat buffer: count (5) Address slots */
+    uint64_t after_memuse = ThresholdGetBitmapMemuse();
+    FAIL_IF_NOT(after_memuse == baseline_memuse + 5 * sizeof(Address));
+
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    UTHFreePackets(&p1, 1);
+    ThresholdDestroy();
+
+    uint64_t final_memuse = ThresholdGetBitmapMemuse();
+    FAIL_IF_NOT(final_memuse == baseline_memuse);
+
+    StatsThreadCleanup(&th_v.stats);
+    PASS;
+}
+
+/**
+ * \test Test IPv6 distinct counting
+ */
+static int DetectDetectionFilterDistinctIPv6(void)
+{
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    ThresholdInit();
+    memset(&th_v, 0, sizeof(th_v));
+    StatsThreadInit(&th_v.stats);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert ip any any -> any any (msg:\"DF IPv6\"; "
+            "detection_filter: track by_dst, count 2, seconds 60, unique_on src_ip; sid:29;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    /* 3 packets from different IPv6 sources */
+    Packet *p1 =
+            UTHBuildPacketIPV6Real(NULL, 0, IPPROTO_TCP, "2001:db8::1", "2001:db8::99", 1024, 80);
+    Packet *p2 =
+            UTHBuildPacketIPV6Real(NULL, 0, IPPROTO_TCP, "2001:db8::2", "2001:db8::99", 1024, 80);
+    Packet *p3 =
+            UTHBuildPacketIPV6Real(NULL, 0, IPPROTO_TCP, "2001:db8::3", "2001:db8::99", 1024, 80);
+
+    /* 1st packet: distinct count 1 */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    FAIL_IF(PacketAlertCheck(p1, 29));
+
+    /* 2nd packet: distinct count 2 */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    FAIL_IF(PacketAlertCheck(p2, 29));
+
+    /* 3rd packet: distinct count 3 -> ALERT (>2) */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p3);
+    FAIL_IF_NOT(PacketAlertCheck(p3, 29));
+
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    UTHFreePackets(&p3, 1);
+    ThresholdDestroy();
+    StatsThreadCleanup(&th_v.stats);
+    PASS;
+}
+
+/**
+ * \test Basic IPv4 distinct src_ip counting; also a regression test for the
+ *       buffer-full boundary: the (count+1)-th distinct IP must still alert
+ *       even though the pre-allocated buffer only holds count entries.
+ */
+static int DetectDetectionFilterDistinctIPv4(void)
+{
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    ThresholdInit();
+    memset(&th_v, 0, sizeof(th_v));
+    StatsThreadInit(&th_v.stats);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert ip any any -> any any (msg:\"DF IPv4 distinct src\"; "
+            "detection_filter: track by_dst, count 2, seconds 60, unique_on src_ip; sid:35;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    Packet *p1 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "9.9.9.9", 1024, 80);
+    Packet *p2 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "2.2.2.2", "9.9.9.9", 1024, 80);
+    Packet *p3 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "3.3.3.3", "9.9.9.9", 1024, 80);
+
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    FAIL_IF(PacketAlertCheck(p1, 35));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    FAIL_IF(PacketAlertCheck(p2, 35));
+    /* 3rd distinct IP: buffer is full (count=2 slots), counter must still exceed threshold */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p3);
+    FAIL_IF_NOT(PacketAlertCheck(p3, 35));
+
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    UTHFreePackets(&p3, 1);
+    ThresholdDestroy();
+    StatsThreadCleanup(&th_v.stats);
+    PASS;
+}
+
+/**
+ * \test Repeated packets from the same IP must not increment the distinct count
+ */
+static int DetectDetectionFilterDistinctIPDuplicate(void)
+{
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    ThresholdInit();
+    memset(&th_v, 0, sizeof(th_v));
+    StatsThreadInit(&th_v.stats);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    /* count 3: 2 distinct sources repeated many times must never alert */
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert ip any any -> any any (msg:\"DF IP duplicate\"; "
+            "detection_filter: track by_dst, count 3, seconds 60, unique_on src_ip; sid:36;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    Packet *p1 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "9.9.9.9", 1024, 80);
+    Packet *p2 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "9.9.9.9", 1024, 80);
+    Packet *p3 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "2.2.2.2", "9.9.9.9", 1024, 80);
+    Packet *p4 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "9.9.9.9", 1024, 80);
+    Packet *p5 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "2.2.2.2", "9.9.9.9", 1024, 80);
+
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    FAIL_IF(PacketAlertCheck(p1, 36));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    FAIL_IF(PacketAlertCheck(p2, 36));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p3);
+    FAIL_IF(PacketAlertCheck(p3, 36));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p4);
+    FAIL_IF(PacketAlertCheck(p4, 36));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p5);
+    FAIL_IF(PacketAlertCheck(p5, 36));
+
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    UTHFreePackets(&p3, 1);
+    UTHFreePackets(&p4, 1);
+    UTHFreePackets(&p5, 1);
+    ThresholdDestroy();
+    StatsThreadCleanup(&th_v.stats);
+    PASS;
+}
+
+/**
+ * \test Window reset: after expiry the IP buffer resets and can trigger again
+ */
+static int DetectDetectionFilterDistinctIPWindowReset(void)
+{
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    ThresholdInit();
+    memset(&th_v, 0, sizeof(th_v));
+    StatsThreadInit(&th_v.stats);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert ip any any -> any any (msg:\"DF IP window reset\"; "
+            "detection_filter: track by_dst, count 2, seconds 2, unique_on src_ip; sid:37;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    Packet *p1 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "9.9.9.9", 1024, 80);
+    p1->ts = TimeGet();
+    Packet *p2 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "2.2.2.2", "9.9.9.9", 1024, 80);
+    p2->ts = TimeGet();
+    Packet *p3 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "3.3.3.3", "9.9.9.9", 1024, 80);
+    p3->ts = TimeGet();
+
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    FAIL_IF(PacketAlertCheck(p1, 37));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    FAIL_IF(PacketAlertCheck(p2, 37));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p3);
+    FAIL_IF_NOT(PacketAlertCheck(p3, 37));
+
+    /* Advance time past the window; the next packet resets the IP buffer */
+    TimeSetIncrementTime(3);
+
+    Packet *p4 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "9.9.9.9", 1024, 80);
+    p4->ts = TimeGet();
+    Packet *p5 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "2.2.2.2", "9.9.9.9", 1024, 80);
+    p5->ts = TimeGet();
+    Packet *p6 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "3.3.3.3", "9.9.9.9", 1024, 80);
+    p6->ts = TimeGet();
+
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p4);
+    FAIL_IF(PacketAlertCheck(p4, 37));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p5);
+    FAIL_IF(PacketAlertCheck(p5, 37));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p6);
+    FAIL_IF_NOT(PacketAlertCheck(p6, 37));
+
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    UTHFreePackets(&p3, 1);
+    UTHFreePackets(&p4, 1);
+    UTHFreePackets(&p5, 1);
+    UTHFreePackets(&p6, 1);
+    ThresholdDestroy();
+    StatsThreadCleanup(&th_v.stats);
+    PASS;
+}
+
+/**
+ * \test unique_on dst_ip: distinct destination IPs from one source trigger alert
+ */
+static int DetectDetectionFilterDistinctIPDstIp(void)
+{
+    ThreadVars th_v;
+    DetectEngineThreadCtx *det_ctx;
+
+    ThresholdInit();
+    memset(&th_v, 0, sizeof(th_v));
+    StatsThreadInit(&th_v.stats);
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert ip any any -> any any (msg:\"DF dst_ip distinct\"; "
+            "detection_filter: track by_src, count 2, seconds 60, unique_on dst_ip; sid:38;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    /* 3 packets from the same source to different destinations */
+    Packet *p1 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "9.9.9.1", 1024, 80);
+    Packet *p2 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "9.9.9.2", 1024, 80);
+    Packet *p3 = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "9.9.9.3", 1024, 80);
+
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+    FAIL_IF(PacketAlertCheck(p1, 38));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    FAIL_IF(PacketAlertCheck(p2, 38));
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p3);
+    FAIL_IF_NOT(PacketAlertCheck(p3, 38));
+
+    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    UTHFreePackets(&p3, 1);
+    ThresholdDestroy();
+    StatsThreadCleanup(&th_v.stats);
+    PASS;
+}
+
 static void DetectDetectionFilterRegisterTests(void)
 {
     UtRegisterTest("DetectDetectionFilterTestParse01", DetectDetectionFilterTestParse01);
@@ -1004,6 +1417,10 @@ static void DetectDetectionFilterRegisterTests(void)
     UtRegisterTest("DetectDetectionFilterTestParse06", DetectDetectionFilterTestParse06);
     UtRegisterTest(
             "DetectDetectionFilterTestParseUnique01", DetectDetectionFilterTestParseUnique01);
+    UtRegisterTest(
+            "DetectDetectionFilterTestParseUniqueIP01", DetectDetectionFilterTestParseUniqueIP01);
+    UtRegisterTest(
+            "DetectDetectionFilterTestParseUniqueIP02", DetectDetectionFilterTestParseUniqueIP02);
     UtRegisterTest("DetectDetectionFilterTestSig1", DetectDetectionFilterTestSig1);
     UtRegisterTest("DetectDetectionFilterTestSig2", DetectDetectionFilterTestSig2);
     UtRegisterTest("DetectDetectionFilterTestSig3", DetectDetectionFilterTestSig3);
@@ -1013,6 +1430,17 @@ static void DetectDetectionFilterRegisterTests(void)
             "DetectDetectionFilterDistinctWindowReset", DetectDetectionFilterDistinctWindowReset);
     UtRegisterTest("DetectDetectionFilterDistinctAllocFailFallback",
             DetectDetectionFilterDistinctAllocFailFallback);
+    UtRegisterTest("DetectDetectionFilterDistinctIPAllocFailFallback",
+            DetectDetectionFilterDistinctIPAllocFailFallback);
+    UtRegisterTest("DetectDetectionFilterDistinctIPHashMemuseTracking",
+            DetectDetectionFilterDistinctIPHashMemuseTracking);
+    UtRegisterTest("DetectDetectionFilterDistinctIPv6", DetectDetectionFilterDistinctIPv6);
+    UtRegisterTest("DetectDetectionFilterDistinctIPv4", DetectDetectionFilterDistinctIPv4);
+    UtRegisterTest(
+            "DetectDetectionFilterDistinctIPDuplicate", DetectDetectionFilterDistinctIPDuplicate);
+    UtRegisterTest("DetectDetectionFilterDistinctIPWindowReset",
+            DetectDetectionFilterDistinctIPWindowReset);
+    UtRegisterTest("DetectDetectionFilterDistinctIPDstIp", DetectDetectionFilterDistinctIPDstIp);
     UtRegisterTest("DetectDetectionFilterUniqueOnProtoValidationFail",
             DetectDetectionFilterUniqueOnProtoValidationFail);
     UtRegisterTest("DetectDetectionFilterDistinctBitmapMemuseTracking",

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -163,8 +163,12 @@ typedef struct ThresholdEntry_ {
             SCTime_t tv1;  /**< Var for time control */
             Address addr;  /* used for src/dst/either tracking */
             Address addr2; /* used for both tracking */
-            /* distinct counting state (for detection_filter unique_on ports) */
-            uint8_t *distinct_bitmap_union; /* 8192 bytes (65536 bits) */
+            /* distinct counting state (for detection_filter unique_on) */
+            uint8_t *distinct_bitmap_union; /* 8192 bytes for ports (65536 bits) */
+            /* Pre-allocated flat buffer for unique IP tracking (td->count Address slots).
+             * Avoids any runtime allocations: lookup is a linear scan, reset is free. */
+            Address *distinct_ip_buf;
+            uint32_t distinct_ip_cap; /* number of Address slots in distinct_ip_buf */
         };
     };
 
@@ -186,43 +190,75 @@ static void ThresholdDistinctInit(ThresholdEntry *te, const DetectThresholdData 
     }
     DEBUG_VALIDATE_BUG_ON(td->seconds == 0);
 
-    const uint32_t bitmap_size = DF_PORT_BITMAP_SIZE;
     te->current_count = 0;
 #ifdef UNITTESTS
     if (g_threshold_force_alloc_fail) {
         SC_ATOMIC_ADD(threshold_bitmap_alloc_fail, 1);
         te->distinct_bitmap_union = NULL;
+        te->distinct_ip_buf = NULL;
         return;
     }
 #endif
-    /* Check memcap before allocating bitmap.
-     * Bitmap memory is bounded by detect.thresholds.memcap via thash.
+
+    /* Allocate tracking structure for distinct counting (bitmap for ports, flat buffer for IPs).
+     * Memory is bounded by detect.thresholds.memcap via thash.
      * Note: if ctx.thash is NULL (e.g. init failed or unittests), we bypass
      * the memcap check but still attempt allocation unless forced to fail. */
-    if (ctx.thash != NULL && !THASH_CHECK_MEMCAP(ctx.thash, bitmap_size)) {
-        SC_ATOMIC_ADD(threshold_bitmap_alloc_fail, 1);
-        te->distinct_bitmap_union = NULL;
-        return;
-    }
 
-    te->distinct_bitmap_union = SCCalloc(1, bitmap_size);
-    if (te->distinct_bitmap_union == NULL) {
-        SC_ATOMIC_ADD(threshold_bitmap_alloc_fail, 1);
-    } else {
-        /* Track bitmap memory in thash memuse for proper accounting */
-        if (ctx.thash != NULL) {
-            (void)SC_ATOMIC_ADD(ctx.thash->memuse, bitmap_size);
+    /* Port-based distinct counting uses bitmap */
+    if (td->unique_on == DF_UNIQUE_SRC_PORT || td->unique_on == DF_UNIQUE_DST_PORT) {
+        const uint32_t bitmap_size = DF_PORT_BITMAP_SIZE;
+        if (ctx.thash != NULL && !THASH_CHECK_MEMCAP(ctx.thash, bitmap_size)) {
+            SC_ATOMIC_ADD(threshold_bitmap_alloc_fail, 1);
+            te->distinct_bitmap_union = NULL;
+            return;
         }
-        SC_ATOMIC_ADD(threshold_bitmap_memuse, bitmap_size);
+
+        te->distinct_bitmap_union = SCCalloc(1, bitmap_size);
+        if (te->distinct_bitmap_union == NULL) {
+            SC_ATOMIC_ADD(threshold_bitmap_alloc_fail, 1);
+        } else {
+            if (ctx.thash != NULL) {
+                (void)SC_ATOMIC_ADD(ctx.thash->memuse, bitmap_size);
+            }
+            SC_ATOMIC_ADD(threshold_bitmap_memuse, bitmap_size);
+        }
+    }
+    /* IP-based distinct counting uses a pre-allocated flat buffer of td->count Address slots.
+     * All memory is allocated here at init time; no per-packet allocations are needed.
+     * Lookup is a linear scan (O(count)); reset only zeroes current_count. */
+    else if (td->unique_on == DF_UNIQUE_SRC_IP || td->unique_on == DF_UNIQUE_DST_IP) {
+        const uint32_t cap = td->count;
+        const uint32_t buf_size = cap * sizeof(Address);
+        if (ctx.thash != NULL && !THASH_CHECK_MEMCAP(ctx.thash, buf_size)) {
+            SC_ATOMIC_ADD(threshold_bitmap_alloc_fail, 1);
+            te->distinct_ip_buf = NULL;
+            te->distinct_ip_cap = 0;
+            return;
+        }
+
+        te->distinct_ip_buf = SCCalloc(cap, sizeof(Address));
+        if (te->distinct_ip_buf == NULL) {
+            SC_ATOMIC_ADD(threshold_bitmap_alloc_fail, 1);
+            te->distinct_ip_cap = 0;
+        } else {
+            te->distinct_ip_cap = cap;
+            if (ctx.thash != NULL) {
+                (void)SC_ATOMIC_ADD(ctx.thash->memuse, buf_size);
+            }
+            SC_ATOMIC_ADD(threshold_bitmap_memuse, buf_size);
+        }
     }
 }
 
 static void ThresholdDistinctReset(ThresholdEntry *te)
 {
-    const uint32_t bitmap_size = DF_PORT_BITMAP_SIZE;
+    /* Reset port bitmap */
     if (te->distinct_bitmap_union) {
+        const uint32_t bitmap_size = DF_PORT_BITMAP_SIZE;
         memset(te->distinct_bitmap_union, 0x00, bitmap_size);
     }
+    /* Reset IP buffer: the pre-allocated buffer is reused; just clear the count. */
     te->current_count = 0;
 }
 
@@ -240,6 +276,64 @@ static inline void ThresholdDistinctAddPort(ThresholdEntry *te, uint16_t port)
     }
 }
 
+static inline void ThresholdDistinctAddIP(
+        ThresholdEntry *te, const Address *addr, uint32_t max_count)
+{
+    if (te->distinct_ip_buf == NULL) {
+        return;
+    }
+
+    uint16_t key_size;
+    if (addr->family == AF_INET) {
+        key_size = 4;
+    } else if (addr->family == AF_INET6) {
+        key_size = 16;
+    } else {
+        return;
+    }
+
+    /* Linear scan through valid entries. When the buffer is full, only
+     * max_count entries are stored; cap the scan range accordingly. */
+    const uint32_t scan_limit = (te->current_count < max_count) ? te->current_count : max_count;
+    for (uint32_t i = 0; i < scan_limit; i++) {
+        const Address *entry = &te->distinct_ip_buf[i];
+        if (entry->family == addr->family &&
+                memcmp(entry->addr_data32, addr->addr_data32, key_size) == 0) {
+            return; /* already present */
+        }
+    }
+
+    /* New distinct IP: store it if the buffer has space, then always count it
+     * so current_count can exceed max_count and trigger the alert. */
+    if (te->current_count < max_count) {
+        COPY_ADDRESS(addr, &te->distinct_ip_buf[te->current_count]);
+    }
+    te->current_count++;
+}
+
+/**
+ * \brief Try to add a distinct value (port or IP) based on unique_on type.
+ * \return true if distinct tracking is active (bitmap/hash allocated), false if fallback needed
+ */
+static inline bool ThresholdDistinctAdd(
+        ThresholdEntry *te, const DetectThresholdData *td, const Packet *p)
+{
+    if (td->unique_on == DF_UNIQUE_SRC_PORT || td->unique_on == DF_UNIQUE_DST_PORT) {
+        if (te->distinct_bitmap_union) {
+            uint16_t port = (td->unique_on == DF_UNIQUE_SRC_PORT) ? p->sp : p->dp;
+            ThresholdDistinctAddPort(te, port);
+            return true;
+        }
+    } else if (td->unique_on == DF_UNIQUE_SRC_IP || td->unique_on == DF_UNIQUE_DST_IP) {
+        if (te->distinct_ip_buf) {
+            const Address *addr = (td->unique_on == DF_UNIQUE_SRC_IP) ? &p->src : &p->dst;
+            ThresholdDistinctAddIP(te, addr, td->count);
+            return true;
+        }
+    }
+    return false;
+}
+
 static void ThresholdEntryFree(void *ptr)
 {
     if (ptr == NULL)
@@ -255,6 +349,16 @@ static void ThresholdEntryFree(void *ptr)
         SC_ATOMIC_SUB(threshold_bitmap_memuse, bitmap_size);
         SCFree(e->distinct_bitmap_union);
         e->distinct_bitmap_union = NULL;
+    }
+    if (e->distinct_ip_buf) {
+        const uint32_t buf_size = e->distinct_ip_cap * sizeof(Address);
+        if (ctx.thash != NULL) {
+            (void)SC_ATOMIC_SUB(ctx.thash->memuse, buf_size);
+        }
+        SC_ATOMIC_SUB(threshold_bitmap_memuse, buf_size);
+        SCFree(e->distinct_ip_buf);
+        e->distinct_ip_buf = NULL;
+        e->distinct_ip_cap = 0;
     }
 }
 
@@ -825,16 +929,12 @@ static int ThresholdSetup(const DetectThresholdData *td, ThresholdEntry *te, con
             te->tv1 = p->ts;
             te->tv_timeout = SCTIME_INITIALIZER;
             ThresholdDistinctInit(te, td);
-            /* If unique_on is enabled, we must add the current packet's port to the bitmap.
-             * ThresholdDistinctInit resets current_count to 0, so we must add the port
+            /* If unique_on is enabled, we must add the current packet's port/IP to the structure.
+             * ThresholdDistinctInit resets current_count to 0, so we must add the value
              * or restore the count if allocation failed. */
             if (td->type == TYPE_DETECTION && td->unique_on != DF_UNIQUE_NONE) {
-                if (te->distinct_bitmap_union) {
-                    uint16_t port = (td->unique_on == DF_UNIQUE_SRC_PORT) ? p->sp : p->dp;
-                    ThresholdDistinctAddPort(te, port);
-                } else {
-                    /* Allocation failed (or test mode), fallback to classic counting.
-                     * We must set current_count to 1 for this first packet. */
+                /* Try distinct tracking; if allocation failed, fallback to classic counting */
+                if (!ThresholdDistinctAdd(te, td, p)) {
                     te->current_count = 1;
                 }
             }
@@ -938,30 +1038,27 @@ static int ThresholdCheckUpdate(const DetectEngineCtx *de_ctx, const DetectThres
 
             if (SCTIME_CMP_LTE(p->ts, entry)) {
                 /* within timeout */
-                if (td->unique_on != DF_UNIQUE_NONE && te->distinct_bitmap_union) {
-                    uint16_t port = (td->unique_on == DF_UNIQUE_SRC_PORT) ? p->sp : p->dp;
-                    ThresholdDistinctAddPort(te, port);
-                    if (te->current_count > td->count) {
-                        ret = 1;
+                if (td->unique_on != DF_UNIQUE_NONE) {
+                    if (!ThresholdDistinctAdd(te, td, p)) {
+                        /* Fallback to classic counting */
+                        te->current_count++;
                     }
                 } else {
                     te->current_count++;
-                    if (te->current_count > td->count) {
-                        ret = 1;
-                    }
+                }
+                if (te->current_count > td->count) {
+                    ret = 1;
                 }
             } else {
                 /* expired, reset to new window starting now */
                 te->tv1 = p->ts;
                 ThresholdDistinctReset(te);
 
-                /* record current packet's distinct port as the first in the new window */
-                if (td->unique_on != DF_UNIQUE_NONE && te->distinct_bitmap_union) {
-                    uint16_t port = (td->unique_on == DF_UNIQUE_SRC_PORT) ? p->sp : p->dp;
-                    ThresholdDistinctAddPort(te, port);
-                } else {
-                    te->current_count = 1;
+                /* record current packet's distinct value as the first in the new window */
+                if (td->unique_on != DF_UNIQUE_NONE) {
+                    (void)ThresholdDistinctAdd(te, td, p);
                 }
+                te->current_count = 1;
             }
             break;
         }

--- a/src/detect-threshold.h
+++ b/src/detect-threshold.h
@@ -52,6 +52,8 @@ enum DetectThresholdUniqueOn {
     DF_UNIQUE_NONE = 0,
     DF_UNIQUE_SRC_PORT,
     DF_UNIQUE_DST_PORT,
+    DF_UNIQUE_SRC_IP,
+    DF_UNIQUE_DST_IP,
 };
 
 /**


### PR DESCRIPTION
Add optional unique_on {src_ip|dst_ip} to detection_filter for distinct IP address counting within the seconds window. Features:

Runtime uses a hash table per threshold entry for tracking unique IP addresses (both IPv4 and IPv6).
Follows detection_filter semantics: alerting starts after the threshold (>count), not at it.
On window expiry, the window is reset and the current packet's IP is recorded as the first distinct of the new window. Validation:
unique_on src_ip/dst_ip works with any IP protocol (unlike port-based unique_on which requires tcp/udp/sctp). Memory management:
Hash table memory is bounded by detect.thresholds.memcap.
Reuses existing counters: bitmap_memuse and bitmap_alloc_fail. Refactoring:
Added ThresholdDistinctAdd helper to consolidate port/IP tracking logic and reduce code duplication. Tests:
C unit tests for parsing unique_on src_ip and dst_ip options.

Changes:
v2:
- Update documentation
- Increase unit tests coverage
- Document use of hash table

v3:
- Cleanup unit tests

v4:
- Added validation to reject duplicate unique_on options
- Fixed memory accounting in ThresholdDistinctReset: counters are now properly decremented if hash table re-init fails
- Hash table is now pre-sized to count buckets instead of a fixed 64

v5:
- Fixed use-after-free: HashTableAdd stores pointers without copying, so ThresholdDistinctAddIP now allocates owned copies of IP address bytes. A Free callback (ThresholdDistinctIPFree) is registered with the hash table to automatically free copies on reset/free.
- Handle HashTableAdd allocation failure by freeing the IP copy
- Simplified window expiry: te->current_count = 1 is now unconditional
- Added documentation on two-phase memory allocation model (init-time bucket array vs. runtime per-entry copies)

v6:
- Replace HashTable with pre-allocated flat buffer (Address *distinct_ip_buf) for IP deduplication — eliminates all per-packet SCMalloc calls
- Add 4 new unit tests: IPv4 basic + buffer-full boundary, duplicate suppression, window reset, dst_ip with track by_src
- Restrict port-protocol validation to unique_on src_port/dst_port only (not src_ip/dst_ip)


Previous PR: https://github.com/OISF/suricata/pull/15086

Ticket: https://redmine.openinfosecfoundation.org/issues/8250
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2924