### PR TITLE
firewall/stats: add dedicated counters - v1

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2812,6 +2812,8 @@ It is possible to run Suricata as a firewall.
 Please read :ref:`Firewall Mode Design <firewall mode design>` before using this.
 The existing yaml configuration options are listed below. If the engine is run as a firewall, dedicated stats counters will be added to the stats logs.
 
+To see the stats reported for the firewall mode, refer to :ref:`firewall mode stats`.
+
    firewall:
      # toggle to enable firewall mode
      #enabled: no

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2805,6 +2805,26 @@ use of.
     vista: []
     windows2k3: []
 
+Suricata as a Firewall options (experimental)
+---------------------------------------------
+
+It is possible to run Suricata as a firewall.
+Please read :ref:`Firewall Mode Design <firewall mode design>` before using this.
+The existing yaml configuration options are listed below. If the engine is run as a firewall, dedicated stats counters will be added to the stats logs.
+
+   firewall:
+     # toggle to enable firewall mode
+     #enabled: no
+     # Firewall rule file are in their own path and are not managed
+     # by Suricata-Update.
+     #rule-path: /etc/suricata/firewall/
+
+     # List of files with firewall rules. Order matters, files are loaded
+     # in order and rules are applied in that order (per state, see docs)
+     #rule-files:
+     #  - firewall.rules
+
+
 Engine analysis and profiling
 -----------------------------
 

--- a/doc/userguide/firewall/firewall-stats.rst
+++ b/doc/userguide/firewall/firewall-stats.rst
@@ -1,0 +1,25 @@
+.. _firewall mode stats:
+
+Firewall Mode Stats
+*******************
+
+Statistics counters for the firewall mode cover:
+
+    - drop reasons: ``stats.ips.drop_reason.firewall``
+    - discarded alerts: ``stats.detect.firewall.discarded_alerts``
+
+Drop reasons
+============
+
+If a drop was caused by the firewall, the corresponding counter will be incremented. The existing ones are:
+
+    - ``rules``: a firewall rule triggered the drop
+    - ``default_packet_policy``: drop caused by the default fail closed firewall behavior, on the packet hook level
+    - ``default_app_policy``: drop caused by the default fail close firewall behavior, on the app-layer hook level
+    - ``pre_flow_hook``: drop caused by the pre-flow hook
+    - ``pre_stream_hook``: drop caused by the pre-stream hook
+
+Discarded alerts
+================
+
+In Firewall mode, alerts generated *after* a drop are discarded these are reported with the counter ``stats.detect.firewall.discarded_alerts``.

--- a/doc/userguide/firewall/index.rst
+++ b/doc/userguide/firewall/index.rst
@@ -5,3 +5,4 @@ Firewall Mode
 
    firewall-design
    firewall-example
+   firewall-stats

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -7246,7 +7246,7 @@
                         },
                         "alert_queue_overflow": {
                             "type": "integer",
-                            "description": "Count of alerts discarded due to alert queue overflow or a drop in firewall mode"
+                            "description": "Count of alerts discarded due to alert queue overflow"
                         },
                         "alerts_suppressed": {
                             "type": "integer",
@@ -7279,6 +7279,16 @@
                                         "type": "integer",
                                         "description": "Count of rules that were skipped due to missing requirements"
                                     }
+                                }
+                            }
+                        },
+                        "firewall": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "discarded_alerts": {
+                                    "type": "integer",
+                                    "description": "Count of alerts discarded due to a drop while in firewall mode"
                                 }
                             }
                         },
@@ -7834,13 +7844,11 @@
                                 },
                                 "default_app_policy": {
                                     "type": "integer",
-                                    "description":
-                                            "Number of packets dropped due to default app policy"
+                                    "description": "count of packets dropped due to firewall's default app-layer drop policy"
                                 },
                                 "default_packet_policy": {
                                     "type": "integer",
-                                    "description":
-                                            "Number of packets dropped due to default packet policy"
+                                    "description": "count of packets dropped due to firewall's default packet drop policy"
                                 },
                                 "defrag_error": {
                                     "type": "integer",
@@ -7851,6 +7859,34 @@
                                     "type": "integer",
                                     "description":
                                             "Number of packets dropped due to defrag memcap exception policy"
+                                },
+                                "firewall": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "default_app_policy": {
+                                            "type": "integer",
+                                            "description":
+                                                    "Number of packets dropped due to firewall's mode default app policy"
+                                        },
+                                        "default_packet_policy": {
+                                            "type": "integer",
+                                            "description":
+                                                    "Number of packets dropped due to firewall's mode default packet policy"
+                                        },
+                                        "pre_flow_hook": {
+                                            "type": "integer",
+                                            "description": "Number of packets dropped due to pre-flow hook"
+                                        },
+                                        "pre_stream_hook": {
+                                            "type": "integer",
+                                            "description": "Number of packets dropped due to pre-stream hook"
+                                        },
+                                        "rules": {
+                                            "type": "integer",
+                                            "description": "Number of packets dropped due to firewall rules"
+                                        }
+                                    }
                                 },
                                 "flow_drop": {
                                     "type": "integer",

--- a/src/decode.c
+++ b/src/decode.c
@@ -923,6 +923,10 @@ const char *PktSrcToString(enum PktSrcEnum pkt_src)
 
 const char *PacketDropReasonToString(enum PacketDropReason r)
 {
+    // TODOs
+    // Declare the a char[] first
+    // add the drop reason to it, based on case
+    // add prefix "ips.drop_reason" or "ips.drop_reason.firewall" accordingly
     switch (r) {
         case PKT_DROP_REASON_DECODE_ERROR:
             return "decode error";
@@ -950,20 +954,26 @@ const char *PacketDropReasonToString(enum PacketDropReason r)
             return "applayer memcap";
         case PKT_DROP_REASON_RULES:
             return "rules";
+        case PKT_DROP_REASON_FW_RULES:
+            return "firewall rules";
         case PKT_DROP_REASON_RULES_THRESHOLD:
             return "threshold detection_filter";
         case PKT_DROP_REASON_NFQ_ERROR:
             return "nfq error";
         case PKT_DROP_REASON_INNER_PACKET:
             return "tunnel packet drop";
-        case PKT_DROP_REASON_DEFAULT_PACKET_POLICY:
-            return "default packet policy";
-        case PKT_DROP_REASON_DEFAULT_APP_POLICY:
-            return "default app policy";
+        case PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY:
+            return "firewall default packet policy";
+        case PKT_DROP_REASON_FW_DEFAULT_APP_POLICY:
+            return "firewall default app policy";
         case PKT_DROP_REASON_STREAM_PRE_HOOK:
             return "pre stream hook";
+        case PKT_DROP_REASON_FW_STREAM_PRE_HOOK:
+            return "firewall pre stream hook";
         case PKT_DROP_REASON_FLOW_PRE_HOOK:
             return "pre flow hook";
+        case PKT_DROP_REASON_FW_FLOW_PRE_HOOK:
+            return "firewall pre flow hook";
         case PKT_DROP_REASON_NOT_SET:
         case PKT_DROP_REASON_MAX:
             return NULL;
@@ -973,6 +983,10 @@ const char *PacketDropReasonToString(enum PacketDropReason r)
 
 static const char *PacketDropReasonToJsonString(enum PacketDropReason r)
 {
+    // TODOs
+    // Declare the a char[] first
+    // add the drop reason to it, based on case
+    // add prefix "ips.drop_reason" or "ips.drop_reason.firewall" accordingly
     switch (r) {
         case PKT_DROP_REASON_DECODE_ERROR:
             return "ips.drop_reason.decode_error";
@@ -1000,20 +1014,26 @@ static const char *PacketDropReasonToJsonString(enum PacketDropReason r)
             return "ips.drop_reason.applayer_memcap";
         case PKT_DROP_REASON_RULES:
             return "ips.drop_reason.rules";
+        case PKT_DROP_REASON_FW_RULES:
+            return "ips.drop_reason.firewall.rules";
         case PKT_DROP_REASON_RULES_THRESHOLD:
             return "ips.drop_reason.threshold_detection_filter";
         case PKT_DROP_REASON_NFQ_ERROR:
             return "ips.drop_reason.nfq_error";
         case PKT_DROP_REASON_INNER_PACKET:
             return "ips.drop_reason.tunnel_packet_drop";
-        case PKT_DROP_REASON_DEFAULT_PACKET_POLICY:
-            return "ips.drop_reason.default_packet_policy";
-        case PKT_DROP_REASON_DEFAULT_APP_POLICY:
-            return "ips.drop_reason.default_app_policy";
+        case PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY:
+            return "ips.drop_reason.firewall.default_packet_policy";
+        case PKT_DROP_REASON_FW_DEFAULT_APP_POLICY:
+            return "ips.drop_reason.firewall.default_app_policy";
         case PKT_DROP_REASON_STREAM_PRE_HOOK:
             return "ips.drop_reason.pre_stream_hook";
+        case PKT_DROP_REASON_FW_STREAM_PRE_HOOK:
+            return "ips.drop_reason.firewall.pre_stream_hook";
         case PKT_DROP_REASON_FLOW_PRE_HOOK:
             return "ips.drop_reason.pre_flow_hook";
+        case PKT_DROP_REASON_FW_FLOW_PRE_HOOK:
+            return "ips.drop_reason.firewall.pre_flow_hook";
         case PKT_DROP_REASON_NOT_SET:
         case PKT_DROP_REASON_MAX:
             return NULL;

--- a/src/decode.h
+++ b/src/decode.h
@@ -396,13 +396,13 @@ enum PacketDropReason {
     PKT_DROP_REASON_STREAM_MIDSTREAM,
     PKT_DROP_REASON_STREAM_REASSEMBLY,
     PKT_DROP_REASON_STREAM_URG,
-    PKT_DROP_REASON_NFQ_ERROR,             /**< no nfq verdict, must be error */
-    PKT_DROP_REASON_INNER_PACKET,          /**< drop issued by inner (tunnel) packet */
+    PKT_DROP_REASON_NFQ_ERROR,                /**< no nfq verdict, must be error */
+    PKT_DROP_REASON_INNER_PACKET,             /**< drop issued by inner (tunnel) packet */
     PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY, /**< drop issued by default packet policy */
     PKT_DROP_REASON_FW_DEFAULT_APP_POLICY,    /**< drop issued by default app policy */
-    PKT_DROP_REASON_STREAM_PRE_HOOK,        /**< drop issued in the pre_stream hook */
+    PKT_DROP_REASON_STREAM_PRE_HOOK,          /**< drop issued in the pre_stream hook */
     PKT_DROP_REASON_FW_STREAM_PRE_HOOK,       /**< drop issued in the pre_stream hook */
-    PKT_DROP_REASON_FLOW_PRE_HOOK,          /**< drop issued in the pre_flow hook */
+    PKT_DROP_REASON_FLOW_PRE_HOOK,            /**< drop issued in the pre_flow hook */
     PKT_DROP_REASON_FW_FLOW_PRE_HOOK,         /**< drop issued in the pre_flow hook */
     PKT_DROP_REASON_MAX,
 };

--- a/src/decode.h
+++ b/src/decode.h
@@ -287,6 +287,7 @@ extern uint16_t packet_alert_max;
 typedef struct PacketAlerts_ {
     uint16_t cnt;
     uint16_t discarded;
+    uint16_t firewall_discarded;
     uint16_t suppressed;
     PacketAlert *alerts;
     /* single pa used when we're dropping,
@@ -388,6 +389,7 @@ enum PacketDropReason {
     PKT_DROP_REASON_APPLAYER_ERROR,
     PKT_DROP_REASON_APPLAYER_MEMCAP,
     PKT_DROP_REASON_RULES,
+    PKT_DROP_REASON_FW_RULES,
     PKT_DROP_REASON_RULES_THRESHOLD, /**< detection_filter in action */
     PKT_DROP_REASON_STREAM_ERROR,
     PKT_DROP_REASON_STREAM_MEMCAP,
@@ -396,10 +398,12 @@ enum PacketDropReason {
     PKT_DROP_REASON_STREAM_URG,
     PKT_DROP_REASON_NFQ_ERROR,             /**< no nfq verdict, must be error */
     PKT_DROP_REASON_INNER_PACKET,          /**< drop issued by inner (tunnel) packet */
-    PKT_DROP_REASON_DEFAULT_PACKET_POLICY, /**< drop issued by default packet policy */
-    PKT_DROP_REASON_DEFAULT_APP_POLICY,    /**< drop issued by default app policy */
-    PKT_DROP_REASON_STREAM_PRE_HOOK,       /**< drop issued in the pre_stream hook */
-    PKT_DROP_REASON_FLOW_PRE_HOOK,         /**< drop issued in the pre_flow hook */
+    PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY, /**< drop issued by default packet policy */
+    PKT_DROP_REASON_FW_DEFAULT_APP_POLICY,    /**< drop issued by default app policy */
+    PKT_DROP_REASON_STREAM_PRE_HOOK,        /**< drop issued in the pre_stream hook */
+    PKT_DROP_REASON_FW_STREAM_PRE_HOOK,       /**< drop issued in the pre_stream hook */
+    PKT_DROP_REASON_FLOW_PRE_HOOK,          /**< drop issued in the pre_flow hook */
+    PKT_DROP_REASON_FW_FLOW_PRE_HOOK,         /**< drop issued in the pre_flow hook */
     PKT_DROP_REASON_MAX,
 };
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -191,13 +191,22 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const Pac
     SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x", PcapPacketCntGet(p), s->id,
             pa->action, pa->flags);
 
+    bool is_fw_rule = s->flags & SIG_FLAG_FIREWALL ? true : false;
     /* REJECT also sets ACTION_DROP, just make it more visible with this check */
     if (pa->action & ACTION_DROP_REJECT) {
-        uint8_t drop_reason = PKT_DROP_REASON_RULES;
-        if (s->detect_table == DETECT_TABLE_PACKET_PRE_STREAM) {
-            drop_reason = PKT_DROP_REASON_STREAM_PRE_HOOK;
-        } else if (s->detect_table == DETECT_TABLE_PACKET_PRE_FLOW) {
-            drop_reason = PKT_DROP_REASON_FLOW_PRE_HOOK;
+        uint8_t drop_reason = is_fw_rule ? PKT_DROP_REASON_FW_RULES : PKT_DROP_REASON_RULES;
+        if (is_fw_rule) {
+            if (s->detect_table == DETECT_TABLE_PACKET_PRE_STREAM) {
+                drop_reason = PKT_DROP_REASON_FW_STREAM_PRE_HOOK;
+            } else if (s->detect_table == DETECT_TABLE_PACKET_PRE_FLOW) {
+                drop_reason = PKT_DROP_REASON_FW_FLOW_PRE_HOOK;
+            }
+        } else {
+            if (s->detect_table == DETECT_TABLE_PACKET_PRE_STREAM) {
+                drop_reason = PKT_DROP_REASON_STREAM_PRE_HOOK;
+            } else if (s->detect_table == DETECT_TABLE_PACKET_PRE_FLOW) {
+                drop_reason = PKT_DROP_REASON_FLOW_PRE_HOOK;
+            }
         }
 
         /* PacketDrop will update the packet action, too */
@@ -540,7 +549,7 @@ static inline void PacketAlertFinalizeProcessQueue(
 
         /* skip firewall sigs following a drop: IDS mode still shows alerts after an alert. */
         if ((s->flags & SIG_FLAG_FIREWALL) && dropped) {
-            p->alerts.discarded++;
+            p->alerts.firewall_discarded++;
 
             /* Thresholding removes this alert */
         } else if (res == 0 || res == 2 || (s->action & (ACTION_ALERT | ACTION_PASS)) == 0) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3418,6 +3418,8 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
     det_ctx->counter_alerts = StatsRegisterCounter("detect.alert", &tv->stats);
     det_ctx->counter_alerts_overflow =
             StatsRegisterCounter("detect.alert_queue_overflow", &tv->stats);
+    det_ctx->counter_firewall_discarded_alerts =
+            StatsRegisterCounter("detect.firewall.discarded_alerts", &tv->stats);
     det_ctx->counter_alerts_suppressed =
             StatsRegisterCounter("detect.alerts_suppressed", &tv->stats);
 
@@ -3501,6 +3503,8 @@ DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
     det_ctx->counter_alerts = StatsRegisterCounter("detect.alert", &tv->stats);
     det_ctx->counter_alerts_overflow =
             StatsRegisterCounter("detect.alert_queue_overflow", &tv->stats);
+    det_ctx->counter_firewall_discarded_alerts =
+            StatsRegisterCounter("detect.firewall.discarded_alerts", &tv->stats);
     det_ctx->counter_alerts_suppressed =
             StatsRegisterCounter("detect.alerts_suppressed", &tv->stats);
 #ifdef PROFILING

--- a/src/detect.c
+++ b/src/detect.c
@@ -915,7 +915,7 @@ next:
     if (have_fw_rules && scratch->default_action == ACTION_DROP) {
         if (!fw_verdict) {
             DEBUG_VALIDATE_BUG_ON(action & ACTION_DROP);
-            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_PACKET_POLICY);
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY);
             action |= ACTION_DROP;
         } else {
             /* apply fw action */
@@ -945,6 +945,7 @@ static DetectRunScratchpad DetectRunSetup(const DetectEngineCtx *de_ctx,
     if (RunmodeIsUnittests()) {
         p->alerts.cnt = 0;
         p->alerts.discarded = 0;
+        p->alerts.firewall_discarded = 0;
         p->alerts.suppressed = 0;
     }
 #endif
@@ -1048,6 +1049,10 @@ static inline void DetectRunPostRules(ThreadVars *tv, const DetectEngineCtx *de_
         StatsCounterAddI64(
                 &tv->stats, det_ctx->counter_alerts_overflow, (uint64_t)p->alerts.discarded);
     }
+    if (p->alerts.firewall_discarded > 0) {
+        StatsCounterAddI64(&tv->stats, det_ctx->counter_firewall_discarded_alerts,
+                (uint64_t)p->alerts.firewall_discarded);
+    }
     if (p->alerts.suppressed > 0) {
         StatsCounterAddI64(
                 &tv->stats, det_ctx->counter_alerts_suppressed, (uint64_t)p->alerts.suppressed);
@@ -1061,7 +1066,7 @@ static inline void DetectRunPostRules(ThreadVars *tv, const DetectEngineCtx *de_
             scratch->default_action == ACTION_DROP) {
         SCLogDebug("packet %" PRIu64 ": droppit as no ACCEPT set %02x (pkt %s)",
                 PcapPacketCntGet(p), p->action, PktSrcToString(p->pkt_src));
-        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_PACKET_POLICY);
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY);
     }
 }
 
@@ -1696,7 +1701,7 @@ static bool ApplyAccept(Packet *p, const uint8_t flow_flags, const Signature *s,
         if (fw_next_progress_missing) {
             SCLogDebug("%" PRIu64 ": %s default drop for progress", PcapPacketCntGet(p),
                     flow_flags & STREAM_TOSERVER ? "toserver" : "toclient");
-            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_APP_POLICY);
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FW_DEFAULT_APP_POLICY);
             p->flow->flags |= FLOW_ACTION_DROP;
             return true;
         }
@@ -2015,7 +2020,7 @@ static void DetectRunTx(ThreadVars *tv,
                             flow_flags & STREAM_TOSERVER ? "toserver" : "toclient");
                     /* if this rule was the last for our progress state, and it didn't match,
                      * we have to invoke the default drop policy. */
-                    PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_APP_POLICY);
+                    PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FW_DEFAULT_APP_POLICY);
                     p->flow->flags |= FLOW_ACTION_DROP;
                     break_out_of_app_filter = true;
                     tx_fw_verdict = true;
@@ -2105,7 +2110,7 @@ static void DetectRunTx(ThreadVars *tv,
     if (tx_inspected && have_fw_rules && tx_inspected != fw_verdicted) {
         SCLogDebug("%" PRIu64 ": %s default drop", PcapPacketCntGet(p),
                 flow_flags & STREAM_TOSERVER ? "toserver" : "toclient");
-        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_APP_POLICY);
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FW_DEFAULT_APP_POLICY);
         p->flow->flags |= FLOW_ACTION_DROP;
         return;
     }

--- a/src/detect.h
+++ b/src/detect.h
@@ -1297,6 +1297,8 @@ typedef struct DetectEngineThreadCtx_ {
     StatsCounterId counter_alerts;
     /** id for discarded alerts counter */
     StatsCounterId counter_alerts_overflow;
+    /** id for firewall discarded alerts counter */
+    StatsCounterId counter_firewall_discarded_alerts;
     /** id for suppressed alerts counter */
     StatsCounterId counter_alerts_suppressed;
 #ifdef PROFILING

--- a/src/packet.c
+++ b/src/packet.c
@@ -135,6 +135,7 @@ void PacketReinit(Packet *p)
 #define RESET_PKT_LEN(p) ((p)->pktlen = 0)
     RESET_PKT_LEN(p);
     p->alerts.discarded = 0;
+    p->alerts.firewall_discarded = 0;
     p->alerts.suppressed = 0;
     p->alerts.drop.action = 0;
     if (p->alerts.cnt > 0) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7699

This is marked as a draft because:
- counters name and structure must be agreed upon
- there are place with great potential for changes/ optimization (marked with TODO)
- we must decide whether firewall stats counters should only appear in firewall mode (I think that's the best, but will require more thinking, so decided to share something first, so we can discuss other aspects already)

Describe changes:
- add dedicated stats counters for `firewall` mode, mainly related to `stats.ips.drop_reason`
- make `stats.detect.alerts_queue_overflow`  be only about alert queue overflow again (add a `stats.detect.firewall.discarded_alerts`)
- update docs to include Firewall stats counters and firewall configuration (TODO - adjust the docs to remove -- or not -- the info about firewall counters only being recorded when in firewall mode)

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3010
