### PR TITLE
rust: clippy fix, and fix clippy checks

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -357,7 +357,7 @@ jobs:
               echo "::error ::Bindgen bindings appear to be out of date"
               exit 1
           fi
-      - run: cargo clippy --all-features --fix --allow-no-vcs
+      - run: cargo clippy --workspace --all-features --fix --allow-no-vcs
         working-directory: rust
       - run: |
           diff=$(git diff)

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -366,7 +366,7 @@ jobs:
               echo "::error ::Clippy --fix made changes, please fix"
               exit 1
           fi
-      - run: cargo clippy --all-features --all-targets
+      - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
         working-directory: rust
       # especially without debug feature
       - run: cargo clippy

--- a/rust/ffi/src/detect.rs
+++ b/rust/ffi/src/detect.rs
@@ -56,17 +56,17 @@ fn helper_keyword_register_buffer_flags(kw: &SigTableElmtStickyBuffer, flags: u3
     unsafe {
         let r = SCDetectHelperKeywordRegister(&st);
         SCDetectHelperKeywordSetCleanCString(r);
-        return r;
+        r
     }
 }
 
 pub fn helper_keyword_register_multi_buffer(kw: &SigTableElmtStickyBuffer) -> u16 {
-    return helper_keyword_register_buffer_flags(
+    helper_keyword_register_buffer_flags(
         kw,
         SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER,
-    );
+    )
 }
 
 pub fn helper_keyword_register_sticky_buffer(kw: &SigTableElmtStickyBuffer) -> u16 {
-    return helper_keyword_register_buffer_flags(kw, SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER);
+    helper_keyword_register_buffer_flags(kw, SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER)
 }


### PR DESCRIPTION
- The ffi crate was throwing a clippy warning, but not caught as an error, fix the lint
- To ci, make warnings an error