### PR TITLE
eve: fix pcap_filename race with --pcap-file-recursive - v6

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2750,7 +2750,8 @@
             }
         },
         "in_iface": {
-            "type": "string"
+            "type": "string",
+            "description": "Input interface for live capture; not present in pcap-file mode"
         },
         "ip_v": {
             "type": "integer",

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -417,10 +417,15 @@ static inline bool CmpFlowPacket(const Flow *f, const Packet *p)
     const uint32_t *f_dst = f->dst.address.address_un_data32;
     const uint32_t *p_src = p->src.address.address_un_data32;
     const uint32_t *p_dst = p->dst.address.address_un_data32;
+    /* In pcap-file mode p->livedev carries the PcapFileFileVars* cast to LiveDevice*;
+     * f->capture.livedev stores the same raw pointer (set from p->livedev in FlowInit),
+     * so this is a valid pointer-equality check that differentiates flows from different
+     * pcap files. */
     return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, p_src, p_dst, p->sp, p->dp) &&
            f->proto == p->proto &&
            (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, p->vlan_id) && (f->livedev == p->livedev || g_livedev_mask == 0);
+           CmpVlanIds(f->vlan_id, p->vlan_id) &&
+           (f->capture.livedev == p->livedev || g_livedev_mask == 0);
 }
 
 static inline bool CmpFlowKey(const Flow *f, const FlowKey *k)
@@ -432,7 +437,7 @@ static inline bool CmpFlowKey(const Flow *f, const FlowKey *k)
     return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, k_src, k_dst, k->sp, k->dp) &&
            f->proto == k->proto &&
            (f->recursion_level == k->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, k->vlan_id) && CmpLiveDevIds(f->livedev, k->livedev_id);
+           CmpVlanIds(f->vlan_id, k->vlan_id) && CmpLiveDevIds(f->capture.livedev, k->livedev_id);
 }
 
 static inline bool CmpAddrsAndICMPTypes(const uint32_t src1[4],
@@ -459,7 +464,8 @@ static inline bool CmpFlowICMPPacket(const Flow *f, const Packet *p)
                    p->icmp_s.type, p->icmp_d.type) &&
            f->proto == p->proto &&
            (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, p->vlan_id) && (f->livedev == p->livedev || g_livedev_mask == 0);
+           CmpVlanIds(f->vlan_id, p->vlan_id) &&
+           (f->capture.livedev == p->livedev || g_livedev_mask == 0);
 }
 
 /**
@@ -484,7 +490,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                 f->proto == ICMPV4_GET_EMB_PROTO(p) &&
                 (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
                 CmpVlanIds(f->vlan_id, p->vlan_id) &&
-                (f->livedev == p->livedev || g_livedev_mask == 0)) {
+                (f->capture.livedev == p->livedev || g_livedev_mask == 0)) {
             return 1;
 
         /* check the less likely case where the ICMP error was a response to
@@ -495,7 +501,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                    f->proto == ICMPV4_GET_EMB_PROTO(p) &&
                    (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
                    CmpVlanIds(f->vlan_id, p->vlan_id) &&
-                   (f->livedev == p->livedev || g_livedev_mask == 0)) {
+                   (f->capture.livedev == p->livedev || g_livedev_mask == 0)) {
             return 1;
         }
 
@@ -527,7 +533,7 @@ static inline int FlowCompareESP(Flow *f, const Packet *p)
     return CmpAddrs(f_src, p_src) && CmpAddrs(f_dst, p_dst) && f->proto == p->proto &&
            (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
            CmpVlanIds(f->vlan_id, p->vlan_id) && f->esp.spi == ESP_GET_SPI(PacketGetESP(p)) &&
-           (f->livedev == p->livedev || g_livedev_mask == 0);
+           (f->capture.livedev == p->livedev || g_livedev_mask == 0);
 }
 
 void FlowSetupPacket(Packet *p)
@@ -1127,7 +1133,7 @@ Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t ha
     f->sp = key->sp;
     f->dp = key->dp;
     f->recursion_level = 0;
-    // f->livedev is set by caller EBPFCreateFlowForKey
+    // f->capture.livedev is set by caller EBPFCreateFlowForKey
     f->flow_hash = hash;
     if (key->src.family == AF_INET) {
         f->flags |= FLOW_IPV4;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -252,20 +252,21 @@ static inline bool FlowBypassedTimeout(Flow *f, SCTime_t ts, FlowTimeoutCounters
             bytes_tosrc = fc->tosrcbytecnt - bytes_tosrc;
             pkts_todst = fc->todstpktcnt - pkts_todst;
             bytes_todst = fc->todstbytecnt - bytes_todst;
-            if (f->capture.livedev) {
-                SC_ATOMIC_ADD(f->capture.livedev->bypassed,
-                        pkts_tosrc + pkts_todst);
+            struct LiveDevice_ *ldev = FlowGetLiveDev(f);
+            if (ldev) {
+                SC_ATOMIC_ADD(ldev->bypassed, pkts_tosrc + pkts_todst);
             }
             counters->bypassed_pkts += pkts_tosrc + pkts_todst;
             counters->bypassed_bytes += bytes_tosrc + bytes_todst;
             return false;
         }
         SCLogDebug("No new packet, dead flow %" PRIu64 "", FlowGetId(f));
-        if (f->capture.livedev) {
+        struct LiveDevice_ *ldev = FlowGetLiveDev(f);
+        if (ldev) {
             if (FLOW_IS_IPV4(f)) {
-                LiveDevSubBypassStats(f->capture.livedev, 1, AF_INET);
+                LiveDevSubBypassStats(ldev, 1, AF_INET);
             } else if (FLOW_IS_IPV6(f)) {
-                LiveDevSubBypassStats(f->capture.livedev, 1, AF_INET6);
+                LiveDevSubBypassStats(ldev, 1, AF_INET6);
             }
         }
         counters->bypassed_count++;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -252,8 +252,8 @@ static inline bool FlowBypassedTimeout(Flow *f, SCTime_t ts, FlowTimeoutCounters
             bytes_tosrc = fc->tosrcbytecnt - bytes_tosrc;
             pkts_todst = fc->todstpktcnt - pkts_todst;
             bytes_todst = fc->todstbytecnt - bytes_todst;
-            if (f->livedev) {
-                SC_ATOMIC_ADD(f->livedev->bypassed,
+            if (f->capture.livedev) {
+                SC_ATOMIC_ADD(f->capture.livedev->bypassed,
                         pkts_tosrc + pkts_todst);
             }
             counters->bypassed_pkts += pkts_tosrc + pkts_todst;
@@ -261,11 +261,11 @@ static inline bool FlowBypassedTimeout(Flow *f, SCTime_t ts, FlowTimeoutCounters
             return false;
         }
         SCLogDebug("No new packet, dead flow %" PRIu64 "", FlowGetId(f));
-        if (f->livedev) {
+        if (f->capture.livedev) {
             if (FLOW_IS_IPV4(f)) {
-                LiveDevSubBypassStats(f->livedev, 1, AF_INET);
+                LiveDevSubBypassStats(f->capture.livedev, 1, AF_INET);
             } else if (FLOW_IS_IPV6(f)) {
-                LiveDevSubBypassStats(f->livedev, 1, AF_INET6);
+                LiveDevSubBypassStats(f->capture.livedev, 1, AF_INET6);
             }
         }
         counters->bypassed_count++;

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -42,6 +42,8 @@
 #include "flow-timeout.h"
 #include "pkt-var.h"
 #include "host.h"
+#include "source-pcap-file-helper.h"
+
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
 #include "stream-tcp.h"
@@ -91,10 +93,21 @@ static inline Packet *FlowPseudoPacketSetup(
     p->flags |= PKT_PSEUDO_STREAM_END;
     memcpy(&p->vlan_id[0], &f->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = f->vlan_idx;
-    p->livedev = (struct LiveDevice_ *)f->capture.livedev;
+    p->livedev = FlowGetLiveDev(f);
 
     if (f->flags & FLOW_NOPAYLOAD_INSPECTION) {
         DecodeSetNoPayloadInspectionFlag(p);
+    }
+
+    PcapFileFileVars *pfv = FlowGetPcapFileVars(f);
+    if (pfv != NULL) {
+        /* Assign pfv for filename tracking. No extra PcapFileRef here: the
+         * flow already holds a reference (from FlowInit) that keeps pfv alive
+         * for the entire duration of FlowFinish, which completes before
+         * FlowClearMemory releases the flow's reference.  Using
+         * PacketPoolReturnPacket directly (as FlowFinish does) would skip
+         * p->ReleasePacket anyway, so adding a ref here just leaks ref_cnt. */
+        p->pcap_v.pfv = pfv;
     }
 
     if (direction == 0)

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -42,7 +42,6 @@
 #include "flow-timeout.h"
 #include "pkt-var.h"
 #include "host.h"
-
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
 #include "stream-tcp.h"
@@ -92,7 +91,7 @@ static inline Packet *FlowPseudoPacketSetup(
     p->flags |= PKT_PSEUDO_STREAM_END;
     memcpy(&p->vlan_id[0], &f->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = f->vlan_idx;
-    p->livedev = (struct LiveDevice_ *)f->livedev;
+    p->livedev = (struct LiveDevice_ *)f->capture.livedev;
 
     if (f->flags & FLOW_NOPAYLOAD_INSPECTION) {
         DecodeSetNoPayloadInspectionFlag(p);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -156,7 +156,7 @@ void FlowInit(ThreadVars *tv, Flow *f, const Packet *p)
 
     f->thread_id[0] = (FlowThreadId)tv->id;
 
-    f->livedev = p->livedev;
+    f->capture.livedev = p->livedev;
 
     if (PacketIsIPv4(p)) {
         const IPV4Hdr *ip4h = PacketGetIPv4(p);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -24,6 +24,7 @@
  */
 
 #include "suricata-common.h"
+#include "suricata.h"
 #include "threads.h"
 
 #include "flow.h"
@@ -45,6 +46,8 @@
 #include "decode-icmpv4.h"
 
 #include "util-validate.h"
+#include "source-pcap-file-helper.h"
+#include "runmodes.h"
 
 /** \brief allocate a flow
  *
@@ -214,7 +217,26 @@ void FlowInit(ThreadVars *tv, Flow *f, const Packet *p)
 
     SCFlowRunInitCallbacks(tv, f, p);
 
+    PcapFileFileVars *pfv = FlowGetPcapFileVars(f);
+    if (pfv != NULL) {
+        PcapFileRef(pfv);
+    }
+
     SCReturn;
+}
+
+struct PcapFileFileVars_ *FlowGetPcapFileVars(const Flow *f)
+{
+    if (IsRunModeOffline(SCRunmodeGet()))
+        return f->capture.pcap_file_vars;
+    return NULL;
+}
+
+struct LiveDevice_ *FlowGetLiveDev(const Flow *f)
+{
+    if (!IsRunModeOffline(SCRunmodeGet()))
+        return f->capture.livedev;
+    return NULL;
 }
 
 SCFlowStorageId g_bypass_info_id = { .id = -1 };

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -141,6 +141,24 @@ uint8_t FlowGetProtoMapping(uint8_t);
 void FlowInit(ThreadVars *, Flow *, const Packet *);
 uint8_t FlowGetReverseProtoMapping(uint8_t rproto);
 
+/**
+ * \brief Return the pcap file vars for a flow, or NULL.
+ *
+ * Returns f->capture.pcap_file_vars only when running in an offline (pcap-file) run
+ * mode.  In live-capture modes the union slot holds a LiveDevice pointer, so
+ * callers must never interpret it as a PcapFileFileVars without this guard.
+ */
+struct PcapFileFileVars_ *FlowGetPcapFileVars(const Flow *f);
+
+/**
+ * \brief Return the live device for a flow, or NULL.
+ *
+ * Returns f->capture.livedev only in live-capture run modes.  In offline (pcap-file)
+ * mode the same union slot holds a PcapFileFileVars pointer, so callers must
+ * never interpret it as a LiveDevice without this guard.
+ */
+struct LiveDevice_ *FlowGetLiveDev(const Flow *f);
+
 /* flow end counter logic */
 
 typedef struct FlowEndCounters_ {

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -40,7 +40,7 @@
         (f)->sp = 0;                                                                               \
         (f)->dp = 0;                                                                               \
         (f)->proto = 0;                                                                            \
-        (f)->livedev = NULL;                                                                       \
+        (f)->capture.livedev = NULL;                                                               \
         (f)->timeout_policy = 0;                                                                   \
         (f)->vlan_idx = 0;                                                                         \
         (f)->next = NULL;                                                                          \
@@ -83,7 +83,7 @@
         (f)->sp = 0;                                                                               \
         (f)->dp = 0;                                                                               \
         (f)->proto = 0;                                                                            \
-        (f)->livedev = NULL;                                                                       \
+        (f)->capture.livedev = NULL;                                                               \
         (f)->vlan_idx = 0;                                                                         \
         (f)->ffr = 0;                                                                              \
         (f)->next = NULL;                                                                          \

--- a/src/flow.c
+++ b/src/flow.c
@@ -46,6 +46,9 @@
 #include "flow-bypass.h"
 #include "flow-spare-pool.h"
 #include "flow-callbacks.h"
+#include "source-pcap-file-helper.h"
+#include "flow-timeout.h"
+#include "tmqh-packetpool.h"
 
 #include "stream-tcp-private.h"
 
@@ -1131,6 +1134,12 @@ int FlowClearMemory(Flow* f, uint8_t proto_map)
         flow_freefuncs[proto_map].Freefunc(f->protoctx);
     }
 
+    PcapFileFileVars *pfv = FlowGetPcapFileVars(f);
+    if (pfv != NULL) {
+        PcapFileUnref(pfv);
+        /* f->capture.livedev (union) is cleared by FLOW_RECYCLE below */
+    }
+
     SCFlowFreeStorage(f);
 
     FLOW_RECYCLE(f);
@@ -1461,6 +1470,201 @@ static int FlowTest09 (void)
     return result;
 }
 
+/**
+ * \test Verify that pcap_file_vars remains NULL when a non-pcap
+ *       packet creates a flow (no pfv on the packet).
+ */
+static int FlowTest10(void)
+{
+    FlowInitConfig(FLOW_QUIET);
+
+    Packet *p = UTHBuildPacket((uint8_t *)"a", 1, IPPROTO_TCP);
+    FAIL_IF_NULL(p);
+
+    Flow *f = FlowAlloc();
+    FAIL_IF_NULL(f);
+
+    ThreadVars tv;
+    memset(&tv, 0, sizeof(tv));
+    FlowInit(&tv, f, p);
+
+    /* pfv must stay NULL for non-pcap packets */
+    FAIL_IF(FlowGetPcapFileVars(f) != NULL);
+
+    FlowClearMemory(f, f->protomap);
+    FlowFree(f);
+    UTHFreePacket(p);
+    FlowShutdown();
+    PASS;
+}
+
+/**
+ * \test Verify that FlowInit increments the pfv ref_cnt and
+ *       FlowClearMemory decrements it correctly.
+ */
+static int FlowTest11(void)
+{
+    FlowInitConfig(FLOW_QUIET);
+
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    SC_ATOMIC_INIT(pfv.ref_cnt);
+    SC_ATOMIC_SET(pfv.ref_cnt, 1);
+    pfv.cleanup_requested = false;
+
+    Packet *p = UTHBuildPacket((uint8_t *)"a", 1, IPPROTO_TCP);
+    FAIL_IF_NULL(p);
+    p->pcap_v.pfv = &pfv;
+    /* livedev carries pfv so FlowInit sets f->capture.pcap_file_vars via the union */
+    p->livedev = (struct LiveDevice_ *)&pfv;
+
+    Flow *f = FlowAlloc();
+    FAIL_IF_NULL(f);
+
+    /* offline mode so FlowInit and FlowClearMemory use the pcap_file_vars path */
+    SCRunMode saved_mode = SCRunmodeGet();
+    SCRunmodeSet(RUNMODE_PCAP_FILE);
+
+    ThreadVars tv;
+    memset(&tv, 0, sizeof(tv));
+    FlowInit(&tv, f, p);
+
+    /* FlowInit should have incremented ref_cnt from 1 to 2 */
+    FAIL_IF_NOT(SC_ATOMIC_GET(pfv.ref_cnt) == 2);
+    FAIL_IF_NOT(FlowGetPcapFileVars(f) == &pfv);
+
+    /* FlowClearMemory should decrement ref_cnt from 2 to 1 */
+    FlowClearMemory(f, f->protomap);
+    FlowFree(f);
+
+    FAIL_IF_NOT(SC_ATOMIC_GET(pfv.ref_cnt) == 1);
+
+    SCRunmodeSet(saved_mode);
+    p->pcap_v.pfv = NULL;
+    p->livedev = NULL;
+    UTHFreePacket(p);
+    FlowShutdown();
+    PASS;
+}
+
+/**
+ * \test Verify that FlowPseudoPacketGet assigns pfv to the pseudo-packet
+ *       without adding an extra ref_cnt (the flow's existing reference is
+ *       sufficient to keep pfv alive for the packet's inline lifetime).
+ */
+static int FlowTest12(void)
+{
+    FlowInitConfig(FLOW_QUIET);
+    PacketPoolInit();
+
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    SC_ATOMIC_INIT(pfv.ref_cnt);
+    SC_ATOMIC_SET(pfv.ref_cnt, 1);
+    pfv.cleanup_requested = false;
+
+    Flow *f = FlowAlloc();
+    FAIL_IF_NULL(f);
+    f->flags |= FLOW_IPV4; // Ensure flow is IPv4 to avoid crash in FlowPseudoPacketSetup
+    f->src.addr_data32[0] = 0x01020304;
+    f->dst.addr_data32[0] = 0x05060708;
+
+    f->capture.pcap_file_vars = &pfv;
+    PcapFileRef(&pfv); /* simulate flow's own ref; ref_cnt now 2 */
+
+    /* offline mode so FlowPseudoPacketSetup sets p->pcap_v.pfv and
+     * FlowClearMemory calls PcapFileUnref */
+    SCRunMode saved_mode = SCRunmodeGet();
+    SCRunmodeSet(RUNMODE_PCAP_FILE);
+
+    TcpSession ssn;
+    memset(&ssn, 0, sizeof(ssn));
+
+    Packet *p = FlowPseudoPacketGet(0, f, &ssn);
+    FAIL_IF_NULL(p);
+
+    /* FlowPseudoPacketGet must set pfv but must NOT add an extra ref:
+     * the flow already holds one, and FlowFinish uses PacketPoolReturnPacket
+     * which never calls p->ReleasePacket, so adding a ref here would leak. */
+    FAIL_IF_NOT(SC_ATOMIC_GET(pfv.ref_cnt) == 2);
+    FAIL_IF_NOT(p->pcap_v.pfv == &pfv);
+
+    /* Return packet to pool (as FlowFinish does); ref_cnt must stay at 2. */
+    PacketPoolReturnPacket(p);
+
+    FAIL_IF_NOT(SC_ATOMIC_GET(pfv.ref_cnt) == 2);
+
+    FlowClearMemory(f, f->protomap);
+    FlowFree(f);
+
+    SCRunmodeSet(saved_mode);
+    PacketPoolDestroy();
+    FlowShutdown();
+    PASS;
+}
+
+/**
+ * \test FlowGetPcapFileVars returns NULL in live mode even when the union
+ *       field is non-NULL, and returns the real pointer in offline mode.
+ */
+static int FlowTest13(void)
+{
+    FlowInitConfig(FLOW_QUIET);
+
+    PcapFileFileVars pfv;
+    memset(&pfv, 0, sizeof(pfv));
+    SC_ATOMIC_INIT(pfv.ref_cnt);
+
+    Flow *f = FlowAlloc();
+    FAIL_IF_NULL(f);
+    f->capture.pcap_file_vars = &pfv;
+
+    /* RUNMODE_UNITTEST is not offline: accessor must hide the union value */
+    FAIL_IF_NOT(FlowGetPcapFileVars(f) == NULL);
+
+    /* Switch to offline: accessor must expose it */
+    SCRunMode saved = SCRunmodeGet();
+    SCRunmodeSet(RUNMODE_PCAP_FILE);
+    FAIL_IF_NOT(FlowGetPcapFileVars(f) == &pfv);
+    SCRunmodeSet(saved);
+
+    f->capture.pcap_file_vars = NULL;
+    FlowFree(f);
+    FlowShutdown();
+    PASS;
+}
+
+/**
+ * \test FlowGetLiveDev returns the livedev in live mode and NULL in offline
+ *       mode, even when the union field is non-NULL.
+ */
+static int FlowTest14(void)
+{
+    FlowInitConfig(FLOW_QUIET);
+
+    /* Use a PcapFileFileVars as a stand-in to avoid needing a real LiveDevice */
+    PcapFileFileVars dummy;
+    memset(&dummy, 0, sizeof(dummy));
+
+    Flow *f = FlowAlloc();
+    FAIL_IF_NULL(f);
+    f->capture.livedev = (struct LiveDevice_ *)&dummy;
+
+    /* RUNMODE_UNITTEST is not offline: accessor must return livedev */
+    FAIL_IF_NOT(FlowGetLiveDev(f) == (struct LiveDevice_ *)&dummy);
+
+    /* Switch to offline: accessor must hide livedev (it's actually a pfv) */
+    SCRunMode saved = SCRunmodeGet();
+    SCRunmodeSet(RUNMODE_PCAP_FILE);
+    FAIL_IF_NOT(FlowGetLiveDev(f) == NULL);
+    SCRunmodeSet(saved);
+
+    f->capture.livedev = NULL;
+    FlowFree(f);
+    FlowShutdown();
+    PASS;
+}
+
 #endif /* UNITTESTS */
 
 /**
@@ -1478,6 +1682,11 @@ void FlowRegisterTests (void)
                    FlowTest08);
     UtRegisterTest("FlowTest09 -- Test flow Allocations when it reach memcap",
                    FlowTest09);
+    UtRegisterTest("FlowTest10 -- pcap_file_vars NULL on non-pcap packet", FlowTest10);
+    UtRegisterTest("FlowTest11 -- pcap_file_vars refcounting", FlowTest11);
+    UtRegisterTest("FlowTest12 -- pcap_file_vars pseudo packet refcounting", FlowTest12);
+    UtRegisterTest("FlowTest13 -- FlowGetPcapFileVars run-mode guard", FlowTest13);
+    UtRegisterTest("FlowTest14 -- FlowGetLiveDev run-mode guard", FlowTest14);
 
     SCRegisterFlowStorageTests();
 #endif /* UNITTESTS */

--- a/src/flow.h
+++ b/src/flow.h
@@ -343,6 +343,8 @@ typedef uint16_t FlowThreadId;
  *  of a flow. This is why we can access those without protection of the lock.
  */
 
+struct PcapFileFileVars_;
+
 typedef struct Flow_
 {
     /* flow "header", used for hashing and flow lookup. Static after init,
@@ -388,8 +390,13 @@ typedef struct Flow_
      *  the flow_id. */
     uint32_t flow_hash;
 
-    /** Incoming interface */
-    struct LiveDevice_ *livedev;
+    /** Incoming interface (live) or source pcap file vars (pcap-file-recursive).
+     *  These run modes are mutually exclusive; use FlowGetLiveDev() /
+     *  FlowGetPcapFileVars() rather than accessing the union directly. */
+    union {
+        struct LiveDevice_ *livedev;
+        struct PcapFileFileVars_ *pcap_file_vars;
+    } capture;
 
     struct Flow_ *next; /* (hash) list next */
 

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -52,6 +52,7 @@
 #include "stream-tcp-private.h"
 #include "flow-storage.h"
 #include "util-exception-policy.h"
+#include "flow-util.h"
 
 static SCJsonBuilder *CreateEveHeaderFromFlow(const Flow *f, OutputJsonCommonSettings *cfg)
 {
@@ -106,8 +107,9 @@ static SCJsonBuilder *CreateEveHeaderFromFlow(const Flow *f, OutputJsonCommonSet
 #endif
 
     /* input interface */
-    if (f->capture.livedev) {
-        SCJbSetString(jb, "in_iface", f->capture.livedev->dev);
+    struct LiveDevice_ *ldev = FlowGetLiveDev(f);
+    if (ldev != NULL) {
+        SCJbSetString(jb, "in_iface", ldev->dev);
     }
 
     JB_SET_STRING(jb, "event_type", "flow");

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -106,8 +106,8 @@ static SCJsonBuilder *CreateEveHeaderFromFlow(const Flow *f, OutputJsonCommonSet
 #endif
 
     /* input interface */
-    if (f->livedev) {
-        SCJbSetString(jb, "in_iface", f->livedev->dev);
+    if (f->capture.livedev) {
+        SCJbSetString(jb, "in_iface", f->capture.livedev->dev);
     }
 
     JB_SET_STRING(jb, "event_type", "flow");

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -49,6 +49,7 @@
 #include "output-json-netflow.h"
 
 #include "stream-tcp-private.h"
+#include "flow-util.h"
 
 static SCJsonBuilder *CreateEveHeaderFromNetFlow(
         const Flow *f, int dir, OutputJsonCommonSettings *cfg)
@@ -110,8 +111,9 @@ static SCJsonBuilder *CreateEveHeaderFromNetFlow(
 #endif
 
     /* input interface */
-    if (f->capture.livedev) {
-        SCJbSetString(js, "in_iface", f->capture.livedev->dev);
+    struct LiveDevice_ *ldev = FlowGetLiveDev(f);
+    if (ldev != NULL) {
+        SCJbSetString(js, "in_iface", ldev->dev);
     }
 
     JB_SET_STRING(js, "event_type", "netflow");

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -110,8 +110,8 @@ static SCJsonBuilder *CreateEveHeaderFromNetFlow(
 #endif
 
     /* input interface */
-    if (f->livedev) {
-        SCJbSetString(js, "in_iface", f->livedev->dev);
+    if (f->capture.livedev) {
+        SCJbSetString(js, "in_iface", f->capture.livedev->dev);
     }
 
     JB_SET_STRING(js, "event_type", "netflow");

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -60,6 +60,7 @@
 #include "flow-var.h"
 #include "flow-bit.h"
 #include "flow-storage.h"
+#include "flow-util.h"
 
 #include "source-pcap-file-helper.h"
 
@@ -970,6 +971,8 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
     }
 
     if (file_ctx->is_pcap_offline) {
+        /* Only stats events use this legacy path (OutputStatsLog);
+         * all other EVE events go through OutputJsonBuilderBuffer. */
         json_object_set_new(js, "pcap_filename", json_string(PcapFileGetFilename()));
     }
 
@@ -1001,7 +1004,23 @@ void OutputJsonBuilderBuffer(
     }
 
     if (file_ctx->is_pcap_offline) {
-        SCJbSetString(js, "pcap_filename", PcapFileGetFilename());
+        /* Use the per-packet filename to avoid a race where the RX thread
+         * has already moved to the next pcap file while workers still
+         * process packets from the previous one.
+         * Flow/netflow events pass p == NULL; use the pfv stored in the flow
+         * so they report the correct file even after the RX thread has moved
+         * on to the next file.  Fall back to the global only when both p and
+         * f are NULL, which happens for stats events (OutputStatsLog) that
+         * carry neither a packet nor a flow. */
+        const char *filename;
+        if (p != NULL) {
+            BUG_ON(p->pcap_v.pfv == NULL);
+            filename = p->pcap_v.pfv->filename;
+        } else {
+            PcapFileFileVars *pfv = (f != NULL) ? FlowGetPcapFileVars(f) : NULL;
+            filename = pfv ? pfv->filename : PcapFileGetFilename();
+        }
+        SCJbSetString(js, "pcap_filename", filename);
     }
 
     SCEveRunCallbacks(tv, p, f, js);

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -1049,6 +1049,63 @@ static int SourcePcapFileHelperTest15(void)
 }
 
 /**
+ * \test Verify that per-packet pfv->filename is independent of the global
+ *       pcap_filename -- simulates the race condition from ticket #5255.
+ */
+static int SourcePcapFileHelperTest16(void)
+{
+    /* Set global to "file_B.pcap" (as if RX thread moved on) */
+    extern char pcap_filename[PATH_MAX];
+    strlcpy(pcap_filename, "file_B.pcap", sizeof(pcap_filename));
+
+    /* Create a pfv for "file_A.pcap" (the file this packet actually belongs to) */
+    PcapFileFileVars *pfv = SCCalloc(1, sizeof(*pfv));
+    FAIL_IF_NULL(pfv);
+    pfv->filename = SCStrdup("file_A.pcap");
+    FAIL_IF_NULL(pfv->filename);
+    SC_ATOMIC_INIT(pfv->ref_cnt);
+    SC_ATOMIC_SET(pfv->ref_cnt, 0);
+    SC_ATOMIC_INIT(pfv->alerts_count);
+    SC_ATOMIC_SET(pfv->alerts_count, 0);
+
+    Packet *p = PacketGetFromAlloc();
+    FAIL_IF_NULL(p);
+    p->pcap_v.pfv = pfv;
+
+    /* Per-packet filename must be "file_A.pcap" even though global says B */
+    FAIL_IF_NOT(strcmp(p->pcap_v.pfv->filename, "file_A.pcap") == 0);
+    FAIL_IF_NOT(strcmp(PcapFileGetFilename(), "file_B.pcap") == 0);
+
+    /* Cleanup */
+    PacketFreeOrRelease(p);
+    CleanupPcapFileFileVars(pfv);
+    strlcpy(pcap_filename, "unknown", sizeof(pcap_filename));
+    PASS;
+}
+
+/**
+ * \test Verify the global fallback: when both p == NULL and f == NULL
+ *       (e.g. stats events), PcapFileGetFilename() is used.
+ */
+static int SourcePcapFileHelperTest17(void)
+{
+    extern char pcap_filename[PATH_MAX];
+    strlcpy(pcap_filename, "current_file.pcap", sizeof(pcap_filename));
+
+    /* With no packet and no flow (stats events), the global is the
+     * correct source of truth. */
+    FAIL_IF_NOT(strcmp(PcapFileGetFilename(), "current_file.pcap") == 0);
+
+    /* Verify the global tracks file changes correctly */
+    strlcpy(pcap_filename, "next_file.pcap", sizeof(pcap_filename));
+    FAIL_IF_NOT(strcmp(PcapFileGetFilename(), "next_file.pcap") == 0);
+
+    /* Cleanup */
+    strlcpy(pcap_filename, "unknown", sizeof(pcap_filename));
+    PASS;
+}
+
+/**
  * \test Verify that PcapFileShouldDeletePcapFile uses the cached pfv->delete_mode
  *       and does not touch pfv->shared, which may be NULL (freed) in the deferred
  *       cleanup path (Bug 2 regression test).
@@ -1159,6 +1216,8 @@ void SourcePcapFileHelperRegisterTests(void)
     UtRegisterTest("SourcePcapFileHelperTest13", SourcePcapFileHelperTest13);
     UtRegisterTest("SourcePcapFileHelperTest14", SourcePcapFileHelperTest14);
     UtRegisterTest("SourcePcapFileHelperTest15", SourcePcapFileHelperTest15);
+    UtRegisterTest("SourcePcapFileHelperTest16", SourcePcapFileHelperTest16);
+    UtRegisterTest("SourcePcapFileHelperTest17", SourcePcapFileHelperTest17);
     UtRegisterTest("SourcePcapFileHelperTest18", SourcePcapFileHelperTest18);
     UtRegisterTest("SourcePcapFileHelperTest19", SourcePcapFileHelperTest19);
 }

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -82,6 +82,9 @@ typedef struct PcapFileFileVars_
     struct bpf_program filter;
 
     PcapFileSharedVars *shared;
+    /** Cached copy of shared->delete_mode, valid even after shared is freed
+     *  (deferred cleanup path). Set in InitPcapFile. */
+    PcapFileDeleteMode delete_mode;
 
     SC_ATOMIC_DECLARE(uint64_t, alerts_count);
     /* Reference count for outstanding users (e.g., pseudo packets created
@@ -150,6 +153,9 @@ void PcapFileSetCurrentPfv(PcapFileFileVars *pfv);
 PcapFileFileVars *PcapFileGetCurrentPfv(void);
 
 void PcapFileInstallCaptureHooks(void);
+
+void PcapFileRef(PcapFileFileVars *pfv);
+void PcapFileUnref(PcapFileFileVars *pfv);
 
 #ifdef UNITTESTS
 void SourcePcapFileHelperRegisterTests(void);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6935,7 +6935,7 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->flags |= PKT_PSEUDO_DETECTLOG_FLUSH;
     memcpy(&np->vlan_id[0], &f->vlan_id[0], sizeof(np->vlan_id));
     np->vlan_idx = f->vlan_idx;
-    np->livedev = (struct LiveDevice_ *)f->livedev;
+    np->livedev = (struct LiveDevice_ *)f->capture.livedev;
 
     if (parent->flags & PKT_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(np);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6935,7 +6935,10 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->flags |= PKT_PSEUDO_DETECTLOG_FLUSH;
     memcpy(&np->vlan_id[0], &f->vlan_id[0], sizeof(np->vlan_id));
     np->vlan_idx = f->vlan_idx;
-    np->livedev = (struct LiveDevice_ *)f->capture.livedev;
+    /* Unlike Flow (which uses a union), Packet keeps livedev and
+     * pcap_v as separate fields; set both — exactly one is non-NULL. */
+    np->livedev = FlowGetLiveDev(f);
+    np->pcap_v.pfv = FlowGetPcapFileVars(f);
 
     if (parent->flags & PKT_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(np);

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -537,7 +537,7 @@ static bool EBPFCreateFlowForKey(struct flows_stats *flowstats, LiveDevice *dev,
             fc->BypassFree = EBPFBypassFree;
             fc->todstpktcnt = pkts_cnt;
             fc->todstbytecnt = bytes_cnt;
-            f->livedev = dev;
+            f->capture.livedev = dev;
             EBPFBypassData *eb = SCCalloc(1, sizeof(EBPFBypassData));
             if (eb == NULL) {
                 SCFree(fc);
@@ -583,7 +583,7 @@ static bool EBPFCreateFlowForKey(struct flows_stats *flowstats, LiveDevice *dev,
         memcpy(mkey, key, skey);
         eb->key[1] = mkey;
     }
-    f->livedev = dev;
+    f->capture.livedev = dev;
     FLOWLOCK_UNLOCK(f);
     return false;
 }


### PR DESCRIPTION
When processing multiple pcap files with --pcap-file-recursive, the pcap_filename field in EVE JSON events could show the wrong filename. The RX thread updates a global variable as it moves to the next file, but worker threads logging events from the previous file would read the already-updated global.

Use the per-packet PcapFileFileVars reference (p->pcap_v.pfv->filename) that is set at capture time, making the filename immutable for the packet's lifetime. For flow/netflow events where no packet is available (p == NULL), the global fallback is correct as these events are emitted synchronously on the RX thread.

BUGFIX: We also fix in the first commit a bug that we did not increase the ref count in all needed cases. This raised now that we have to have it in this scenario. The first commit handles it.

Previous PR: https://github.com/OISF/suricata/pull/15116

v2:
- Avoid extending the flow struct.

v3:
- Update schema.

v4:
- Name the union (capture) so direct access requires f->capture.livedev, preventing future code from accidentally misinterpreting the union value.
- Update flow-hash.c, flow-manager.c, and util-ebpf.c for the named union.
- Use FlowGetLiveDev() accessor in flow-manager.c (bypassed-flow stats).
- Clarify PcapFileGetFilename() fallback comment (stats events only).

v5:
- Split commit 1 into two: flow: introduce capture union (pure mechanical rename) and flow: fix ref_cnt leak and use-after-free (accessors, ref counting, tests)
- Replace raw (LiveDevice_*) cast with FlowGetLiveDev(f) on pseudo-packet creation in stream-tcp.c and flow-timeout.c
- Add comment in CmpFlowPacket() explaining the pointer-equality trick for pcap-file mode
- Drop invalid "optional" JSON Schema keyword from in_iface in schema.json; keep description only

v6:
- Squash "eve: guard in_iface field" into the ref_cnt commit so no intermediate state has the union misread bug (3 commits instead of 4)
- Add clarifying comment in stream-tcp.c that Packet keeps livedev and pcap_v as separate fields (not a union), so both assignments are needed
- Add comment in output-json.c that the PcapFileGetFilename() legacy path is only used for stats events


Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5255
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3013
