### PR TITLE
detect/transforms: constify some callbacks arguments

### DIFF
--- a/rust/src/detect/transforms/base64.rs
+++ b/rust/src/detect/transforms/base64.rs
@@ -224,7 +224,7 @@ unsafe extern "C" fn base64_setup(
     return r;
 }
 
-unsafe extern "C" fn base64_id(data: *mut *const u8, length: *mut u32, ctx: *mut c_void) {
+unsafe extern "C" fn base64_id(data: *mut *const u8, length: *mut u32, ctx: *const c_void) {
     if data.is_null() || length.is_null() || ctx.is_null() {
         return;
     }
@@ -237,7 +237,7 @@ unsafe extern "C" fn base64_id(data: *mut *const u8, length: *mut u32, ctx: *mut
 }
 
 unsafe extern "C" fn base64_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;

--- a/rust/src/detect/transforms/casechange.rs
+++ b/rust/src/detect/transforms/casechange.rs
@@ -41,7 +41,7 @@ fn tolower_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 unsafe extern "C" fn tolower_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -62,7 +62,7 @@ unsafe extern "C" fn tolower_transform(
     SCInspectionBufferTruncate(buffer, input_len);
 }
 
-unsafe extern "C" fn tolower_validate(content: *const u8, len: u16, _ctx: *mut c_void) -> bool {
+unsafe extern "C" fn tolower_validate(content: *const u8, len: u16, _ctx: *const c_void) -> bool {
     let input = build_slice!(content, len as usize);
     for &c in input {
         if c.is_ascii_uppercase() {
@@ -104,7 +104,7 @@ fn toupper_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 unsafe extern "C" fn toupper_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -125,7 +125,7 @@ unsafe extern "C" fn toupper_transform(
     SCInspectionBufferTruncate(buffer, input_len);
 }
 
-unsafe extern "C" fn toupper_validate(content: *const u8, len: u16, _ctx: *mut c_void) -> bool {
+unsafe extern "C" fn toupper_validate(content: *const u8, len: u16, _ctx: *const c_void) -> bool {
     let input = build_slice!(content, len as usize);
     for &c in input {
         if c.is_ascii_lowercase() {

--- a/rust/src/detect/transforms/compress_whitespace.rs
+++ b/rust/src/detect/transforms/compress_whitespace.rs
@@ -51,7 +51,7 @@ fn compress_whitespace_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 unsafe extern "C" fn compress_whitespace_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -88,7 +88,7 @@ fn compress_whitespace_validate_do(input: &[u8]) -> bool {
 }
 
 unsafe extern "C" fn compress_whitespace_validate(
-    content: *const u8, len: u16, _ctx: *mut c_void,
+    content: *const u8, len: u16, _ctx: *const c_void,
 ) -> bool {
     let input = build_slice!(content, len as usize);
     return compress_whitespace_validate_do(input);

--- a/rust/src/detect/transforms/decompress.rs
+++ b/rust/src/detect/transforms/decompress.rs
@@ -160,7 +160,7 @@ unsafe fn decompress_transform(
 }
 
 unsafe extern "C" fn gunzip_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *const c_void,
 ) {
     let ctx = cast_pointer!(ctx, DetectTransformDecompressData);
     decompress_transform(buffer, ctx, gunzip_transform_do);
@@ -170,7 +170,7 @@ unsafe extern "C" fn decompress_free(_de: *mut DetectEngineCtx, ctx: *mut c_void
     std::mem::drop(Box::from_raw(ctx as *mut DetectTransformDecompressData));
 }
 
-unsafe extern "C" fn decompress_id(data: *mut *const u8, length: *mut u32, ctx: *mut c_void) {
+unsafe extern "C" fn decompress_id(data: *mut *const u8, length: *mut u32, ctx: *const c_void) {
     if data.is_null() || length.is_null() || ctx.is_null() {
         return;
     }
@@ -202,7 +202,7 @@ fn zlib_deflate_transform_do(input: &[u8], output: &mut [u8]) -> Option<u32> {
 }
 
 unsafe extern "C" fn zlib_deflate_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *const c_void,
 ) {
     let ctx = cast_pointer!(ctx, DetectTransformDecompressData);
     decompress_transform(buffer, ctx, zlib_deflate_transform_do);

--- a/rust/src/detect/transforms/domain.rs
+++ b/rust/src/detect/transforms/domain.rs
@@ -45,7 +45,7 @@ fn get_domain(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 unsafe extern "C" fn domain_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -84,7 +84,7 @@ fn get_tld(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 unsafe extern "C" fn tld_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;

--- a/rust/src/detect/transforms/dotprefix.rs
+++ b/rust/src/detect/transforms/dotprefix.rs
@@ -43,7 +43,7 @@ fn dot_prefix_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 unsafe extern "C" fn dot_prefix_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input_len = (*buffer).inspect_len;
     if input_len == 0 {

--- a/rust/src/detect/transforms/hash.rs
+++ b/rust/src/detect/transforms/hash.rs
@@ -52,7 +52,7 @@ fn md5_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 unsafe extern "C" fn md5_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -107,7 +107,7 @@ fn sha1_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 unsafe extern "C" fn sha1_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -162,7 +162,7 @@ fn sha256_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 unsafe extern "C" fn sha256_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;

--- a/rust/src/detect/transforms/http_headers.rs
+++ b/rust/src/detect/transforms/http_headers.rs
@@ -54,7 +54,7 @@ fn header_lowertransform_do(input: &[u8], output: &mut [u8]) {
 }
 
 unsafe extern "C" fn header_lowertransform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -119,7 +119,7 @@ fn strip_pseudo_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 unsafe extern "C" fn strip_pseudo_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;

--- a/rust/src/detect/transforms/strip_whitespace.rs
+++ b/rust/src/detect/transforms/strip_whitespace.rs
@@ -48,7 +48,7 @@ fn strip_whitespace_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 unsafe extern "C" fn strip_whitespace_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -70,7 +70,7 @@ unsafe extern "C" fn strip_whitespace_transform(
 }
 
 unsafe extern "C" fn strip_whitespace_validate(
-    content: *const u8, len: u16, _ctx: *mut c_void,
+    content: *const u8, len: u16, _ctx: *const c_void,
 ) -> bool {
     let input = build_slice!(content, len as usize);
     for &c in input {

--- a/rust/src/detect/transforms/urldecode.rs
+++ b/rust/src/detect/transforms/urldecode.rs
@@ -88,7 +88,7 @@ fn url_decode_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 unsafe extern "C" fn url_decode_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;

--- a/rust/src/detect/transforms/xor.rs
+++ b/rust/src/detect/transforms/xor.rs
@@ -82,7 +82,7 @@ fn xor_transform_do(input: &[u8], output: &mut [u8], ctx: &DetectTransformXorDat
 }
 
 unsafe extern "C" fn xor_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *mut c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -108,7 +108,7 @@ unsafe extern "C" fn xor_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     std::mem::drop(Box::from_raw(ctx as *mut DetectTransformXorData));
 }
 
-unsafe extern "C" fn xor_id(data: *mut *const u8, length: *mut u32, ctx: *mut c_void) {
+unsafe extern "C" fn xor_id(data: *mut *const u8, length: *mut u32, ctx: *const c_void,) {
     if data.is_null() || length.is_null() || ctx.is_null() {
         return;
     }

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -794,21 +794,21 @@ pub struct SCTransformTableElmt {
         unsafe extern "C" fn(
             arg1: *mut DetectEngineThreadCtx,
             arg2: *mut InspectionBuffer,
-            context: *mut ::std::os::raw::c_void,
+            context: *const ::std::os::raw::c_void,
         ),
     >,
     pub TransformValidate: ::std::option::Option<
         unsafe extern "C" fn(
             content: *const u8,
             content_len: u16,
-            context: *mut ::std::os::raw::c_void,
+            context: *const ::std::os::raw::c_void,
         ) -> bool,
     >,
     pub TransformId: ::std::option::Option<
         unsafe extern "C" fn(
             id_data: *mut *const u8,
             id_length: *mut u32,
-            context: *mut ::std::os::raw::c_void,
+            context: *const ::std::os::raw::c_void,
         ),
     >,
 }

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -156,16 +156,13 @@ int SCDetectHelperTransformRegister(const SCTransformTableElmt *kw)
     sigmatch_table[transform_id].desc = kw->desc;
     sigmatch_table[transform_id].url = kw->url;
     sigmatch_table[transform_id].flags = kw->flags;
-    sigmatch_table[transform_id].Transform =
-            (void (*)(DetectEngineThreadCtx * det_ctx, InspectionBuffer * buffer, void *options))
-                    kw->Transform;
-    sigmatch_table[transform_id].TransformValidate = (bool (*)(
-            const uint8_t *content, uint16_t content_len, void *context))kw->TransformValidate;
+    sigmatch_table[transform_id].Transform = (void (*)(DetectEngineThreadCtx * det_ctx,
+            InspectionBuffer * buffer, const void *options)) kw->Transform;
+    sigmatch_table[transform_id].TransformValidate = kw->TransformValidate;
     sigmatch_table[transform_id].Setup =
             (int (*)(DetectEngineCtx * de, Signature * s, const char *raw)) kw->Setup;
     sigmatch_table[transform_id].Free = (void (*)(DetectEngineCtx * de, void *ptr)) kw->Free;
-    sigmatch_table[transform_id].TransformId =
-            (void (*)(const uint8_t **id_data, uint32_t *length, void *context))kw->TransformId;
+    sigmatch_table[transform_id].TransformId = kw->TransformId;
 
     return transform_id;
 }

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -71,9 +71,9 @@ typedef struct SCTransformTableElmt {
     uint32_t flags;
     int (*Setup)(DetectEngineCtx *, Signature *, const char *);
     void (*Free)(DetectEngineCtx *, void *);
-    void (*Transform)(DetectEngineThreadCtx *, InspectionBuffer *, void *context);
-    bool (*TransformValidate)(const uint8_t *content, uint16_t content_len, void *context);
-    void (*TransformId)(const uint8_t **id_data, uint32_t *id_length, void *context);
+    void (*Transform)(DetectEngineThreadCtx *, InspectionBuffer *, const void *context);
+    bool (*TransformValidate)(const uint8_t *content, uint16_t content_len, const void *context);
+    void (*TransformId)(const uint8_t **id_data, uint32_t *id_length, const void *context);
 } SCTransformTableElmt;
 
 int SCDetectHelperNewKeywordId(void);

--- a/src/detect-transform-luaxform.c
+++ b/src/detect-transform-luaxform.c
@@ -40,7 +40,7 @@
 static int DetectTransformLuaxformSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectTransformLuaxformFree(DetectEngineCtx *de_ctx, void *ptr);
 static void TransformLuaxform(
-        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options);
+        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, const void *options);
 
 #define LUAXFORM_MAX_ARGS 10
 
@@ -61,7 +61,7 @@ typedef struct DetectLuaxformThreadData {
     lua_State *luastate;
 } DetectLuaxformThreadData;
 
-static void DetectTransformLuaxformId(const uint8_t **data, uint32_t *length, void *context)
+static void DetectTransformLuaxformId(const uint8_t **data, uint32_t *length, const void *context)
 {
     if (context) {
         DetectLuaxformData *lua = (DetectLuaxformData *)context;
@@ -302,13 +302,13 @@ error:
 }
 
 static void TransformLuaxform(
-        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options)
+        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, const void *options)
 {
     if (buffer->inspect_len == 0) {
         return;
     }
 
-    DetectLuaxformData *lua = options;
+    const DetectLuaxformData *lua = options;
     DetectLuaThreadData *tlua =
             (DetectLuaThreadData *)DetectThreadCtxGetKeywordThreadCtx(det_ctx, lua->thread_ctx_id);
     if (tlua == NULL) {

--- a/src/detect-transform-pcrexform.c
+++ b/src/detect-transform-pcrexform.c
@@ -41,12 +41,12 @@ typedef struct DetectTransformPcrexformData {
 static int DetectTransformPcrexformSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectTransformPcrexformFree(DetectEngineCtx *, void *);
 static void DetectTransformPcrexform(
-        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options);
+        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, const void *options);
 #ifdef UNITTESTS
 void DetectTransformPcrexformRegisterTests (void);
 #endif
 
-static void DetectTransformPcrexformId(const uint8_t **data, uint32_t *length, void *context)
+static void DetectTransformPcrexformId(const uint8_t **data, uint32_t *length, const void *context)
 {
     if (context) {
         DetectTransformPcrexformData *pxd = (DetectTransformPcrexformData *)context;
@@ -157,11 +157,11 @@ static int DetectTransformPcrexformSetup (DetectEngineCtx *de_ctx, Signature *s,
 }
 
 static void DetectTransformPcrexform(
-        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options)
+        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, const void *options)
 {
     const char *input = (const char *)buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
-    DetectTransformPcrexformData *pxd = options;
+    const DetectTransformPcrexformData *pxd = options;
 
     pcre2_match_data *match = pcre2_match_data_create_from_pattern(pxd->regex, NULL);
     int ret = pcre2_match(pxd->regex, (PCRE2_SPTR8)input, input_len, 0, 0, match, pxd->context);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1440,11 +1440,11 @@ typedef struct SigTableElmt_ {
         uint8_t flags, File *, const Signature *, const SigMatchCtx *);
 
     /** InspectionBuffer transformation callback */
-    void (*Transform)(DetectEngineThreadCtx *, InspectionBuffer *, void *context);
-    bool (*TransformValidate)(const uint8_t *content, uint16_t content_len, void *context);
+    void (*Transform)(DetectEngineThreadCtx *, InspectionBuffer *, const void *context);
+    bool (*TransformValidate)(const uint8_t *content, uint16_t content_len, const void *context);
 
     /** Transform identity callback */
-    void (*TransformId)(const uint8_t **data, uint32_t *length, void *context);
+    void (*TransformId)(const uint8_t **data, uint32_t *length, const void *context);
 
     /** keyword setup function pointer */
     int (*Setup)(DetectEngineCtx *, Signature *, const char *);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8298

Describe changes:
- detect/transforms: constify some callbacks arguments

#15173 with clean PR history after using clang-format 14 instead of my local clang-format 22