### PR TITLE
stats: log packets/bytes per second

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -57,6 +57,7 @@ enum StatsType {
     STATS_TYPE_MAXIMUM = 3,
     STATS_TYPE_FUNC = 4,
     STATS_TYPE_DERIVE_DIV = 5,
+    STATS_TYPE_TIMED = 6,
 };
 
 /**
@@ -172,6 +173,32 @@ void StatsCounterIncr(StatsThreadContext *stats, StatsCounterId id)
     BUG_ON((id.id < 1) || (id.id > pca->size));
 #endif
     pca->head[id.id].v++;
+}
+
+void StatsCounterTimedIncr(StatsThreadContext *stats, StatsCounterTimedId id)
+{
+    StatsPrivateThreadContext *pca = &stats->priv;
+#if defined(UNITTESTS) || defined(FUZZ)
+    if (pca->initialized == 0)
+        return;
+#endif
+#ifdef DEBUG
+    BUG_ON((id.id < 1) || (id.id > pca->size));
+#endif
+    pca->head[id.id].v++;
+}
+
+void StatsCounterTimedAddI64(StatsThreadContext *stats, StatsCounterTimedId id, int64_t x)
+{
+    StatsPrivateThreadContext *pca = &stats->priv;
+#if defined(UNITTESTS) || defined(FUZZ)
+    if (pca->initialized == 0)
+        return;
+#endif
+#ifdef DEBUG
+    BUG_ON((id.id < 1) || (id.id > pca->size));
+#endif
+    pca->head[id.id].v += x;
 }
 
 /**
@@ -831,6 +858,7 @@ static int StatsOutput(ThreadVars *tv)
                     merge_table[c].value = e->value;
                     break;
                 case STATS_TYPE_AVERAGE:
+                case STATS_TYPE_TIMED:
                 default:
                     merge_table[c].value += e->value;
                     break;
@@ -863,6 +891,13 @@ static int StatsOutput(ThreadVars *tv)
                         r->value = (uint64_t)(e->value / e->updates);
                     }
                     break;
+                case STATS_TYPE_TIMED:
+                    r->counter_pvalue = r->counter_value;
+                    r->counter_value = e->value;
+                    if (stats_tts > 0) {
+                        r->value = (r->counter_value - r->counter_pvalue) / stats_tts;
+                    }
+                    break;
                 default:
                     r->value = e->value;
                     break;
@@ -891,6 +926,13 @@ static int StatsOutput(ThreadVars *tv)
             case STATS_TYPE_DERIVE_DIV:
                 if (m->value > 0 && m->updates > 0) {
                     table[x].value = (uint64_t)(m->value / m->updates);
+                }
+                break;
+            case STATS_TYPE_TIMED:
+                table[x].counter_pvalue = table[x].counter_value;
+                table[x].counter_value = m->value;
+                if (stats_tts > 0) {
+                    table[x].value = (table[x].counter_value - table[x].counter_pvalue) / stats_tts;
                 }
                 break;
             default:
@@ -1077,6 +1119,24 @@ StatsCounterMaxId StatsRegisterMaxCounter(const char *name, StatsThreadContext *
     uint16_t id =
             StatsRegisterQualifiedCounter(name, &stats->pub, STATS_TYPE_MAXIMUM, NULL, NULL, NULL);
     StatsCounterMaxId s = { .id = id };
+    return s;
+}
+
+/**
+ * \brief Registers a counter whose display value is the rate of change per
+ *        second, computed as (current_raw - previous_raw) / stats_interval.
+ *
+ * \param name  Name of the counter, to be registered
+ * \param stats Pointer to the StatsThreadContext for this thread
+ *
+ * \retval id Counter id for the newly registered counter, or the already
+ *            present counter
+ */
+StatsCounterTimedId StatsRegisterTimedCounter(const char *name, StatsThreadContext *stats)
+{
+    uint16_t id =
+            StatsRegisterQualifiedCounter(name, &stats->pub, STATS_TYPE_TIMED, NULL, NULL, NULL);
+    StatsCounterTimedId s = { .id = id };
     return s;
 }
 

--- a/src/counters.h
+++ b/src/counters.h
@@ -49,6 +49,10 @@ typedef struct StatsCounterDeriveId {
     uint16_t id;
 } StatsCounterDeriveId;
 
+typedef struct StatsCounterTimedId {
+    uint16_t id;
+} StatsCounterTimedId;
+
 /**
  * \brief Container to hold the counter variable
  */
@@ -152,6 +156,11 @@ StatsCounterGlobalId StatsRegisterGlobalCounter(const char *cname, uint64_t (*Fu
 
 StatsCounterDeriveId StatsRegisterDeriveDivCounter(
         const char *cname, const char *dname1, const char *dname2, StatsThreadContext *);
+StatsCounterTimedId StatsRegisterTimedCounter(const char *, StatsThreadContext *);
+
+/* functions used to update timed counter values */
+void StatsCounterTimedIncr(StatsThreadContext *, StatsCounterTimedId);
+void StatsCounterTimedAddI64(StatsThreadContext *, StatsCounterTimedId, int64_t);
 
 /* functions used to update local counter values */
 void StatsCounterAddI64(StatsThreadContext *, StatsCounterId, int64_t);

--- a/src/decode.c
+++ b/src/decode.c
@@ -636,6 +636,8 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     /* register counters */
     dtv->counter_pkts = StatsRegisterCounter("decoder.pkts", &tv->stats);
     dtv->counter_bytes = StatsRegisterCounter("decoder.bytes", &tv->stats);
+    dtv->counter_pkts_per_sec = StatsRegisterTimedCounter("decoder.pkts_per_sec", &tv->stats);
+    dtv->counter_bytes_per_sec = StatsRegisterTimedCounter("decoder.bytes_per_sec", &tv->stats);
     dtv->counter_invalid = StatsRegisterCounter("decoder.invalid", &tv->stats);
     dtv->counter_ipv4 = StatsRegisterCounter("decoder.ipv4", &tv->stats);
     dtv->counter_ipv6 = StatsRegisterCounter("decoder.ipv6", &tv->stats);
@@ -795,6 +797,8 @@ void DecodeUpdatePacketCounters(ThreadVars *tv,
 {
     StatsCounterIncr(&tv->stats, dtv->counter_pkts);
     StatsCounterAddI64(&tv->stats, dtv->counter_bytes, GET_PKT_LEN(p));
+    StatsCounterTimedIncr(&tv->stats, dtv->counter_pkts_per_sec);
+    StatsCounterTimedAddI64(&tv->stats, dtv->counter_bytes_per_sec, GET_PKT_LEN(p));
     StatsCounterMaxUpdateI64(&tv->stats, dtv->counter_max_pkt_size, GET_PKT_LEN(p));
 }
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -986,6 +986,8 @@ typedef struct DecodeThreadVars_
     /** stats/counters */
     StatsCounterId counter_pkts;
     StatsCounterId counter_bytes;
+    StatsCounterTimedId counter_pkts_per_sec;
+    StatsCounterTimedId counter_bytes_per_sec;
     StatsCounterDeriveId counter_avg_pkt_size;
     StatsCounterMaxId counter_max_pkt_size;
     StatsCounterMaxId counter_max_mac_addrs_src;

--- a/src/output-stats.h
+++ b/src/output-stats.h
@@ -32,8 +32,10 @@ typedef struct StatsRecord_ {
     const char *name;
     const char *short_name;
     const char *tm_name;
-    int64_t value;  /**< total value */
-    int64_t pvalue; /**< prev value (may be higher for memuse counters) */
+    int64_t value;          /**< total value */
+    int64_t pvalue;         /**< prev value (may be higher for memuse counters) */
+    int64_t counter_value;  /**< raw accumulated counter value this window (STATS_TYPE_TIMED) */
+    int64_t counter_pvalue; /**< raw accumulated counter value previous window (STATS_TYPE_TIMED) */
 } StatsRecord;
 
 typedef struct StatsTable_ {


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
   - Add new STATS_TYPE_TIMED counter type that calculates per-second rates
     by dividing the delta between stats windows by the stats interval
   - Guard against division by zero when stats_tts is 0
   - Register decoder.pkts_per_sec and decoder.bytes_per_sec using the new type
   - Add corresponding fields to the eve.json schema

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
