### PR TITLE
detect: enable tls.cert_chain_len in firewall mode - v1

### DIFF
--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -243,7 +243,7 @@ void DetectTlsCertChainLenRegister(void)
     sigmatch_table[KEYWORD_ID].AppLayerTxMatch = DetectTLSCertChainLenMatch;
     sigmatch_table[KEYWORD_ID].Setup = DetectTLSCertChainLenSetup;
     sigmatch_table[KEYWORD_ID].Free = DetectTLSCertChainLenFree;
-    sigmatch_table[KEYWORD_ID].flags = SIGMATCH_INFO_UINT32;
+    sigmatch_table[KEYWORD_ID].flags = SIGMATCH_SUPPORT_FIREWALL | SIGMATCH_INFO_UINT32;
 
     g_tls_cert_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 }


### PR DESCRIPTION
Part of
Ticket #8387 

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8387

Describe changes:
- enable `tls.cert_chain_len` for firewall mode

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3018