### PR TITLE
conf: avoid use-after-free when processing include sequences - v1

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -82,7 +82,7 @@ Mangle(char *string)
 static void
 ConfYamlSetConfDirname(const char *filename)
 {
-    char *ep;
+    const char *ep;
 
     ep = strrchr(filename, '\\');
     if (ep == NULL)

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -387,7 +387,8 @@ static int ConfYamlParse(
             if (ConfYamlParse(parser, state == CONF_INCLUDE ? parent : node, 1, rlevel,
                         state == CONF_INCLUDE ? CONF_INCLUDE : 0) != 0)
                 goto fail;
-            node->is_seq = 1;
+            if (state != CONF_INCLUDE)
+                node->is_seq = 1;
             state = CONF_KEY;
         }
         else if (event.type == YAML_SEQUENCE_END_EVENT) {


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8465

Additionally fix a const compiler warning in the same file.
