### PR TITLE
detect: opt-in more keywords for firewall mode - v2

### DIFF
--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -32,11 +32,7 @@ use crate::direction::Direction;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
-    DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
-    SCDetectHelperBufferRegister, SCDetectHelperKeywordAliasRegister,
-    SCDetectHelperKeywordRegister, SCDetectHelperMultiBufferProgressMpmRegister,
-    SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx,
-    Signature,
+    DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList, SCDetectHelperBufferRegister, SCDetectHelperKeywordAliasRegister, SCDetectHelperKeywordRegister, SCDetectHelperMultiBufferProgressMpmRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SIGMATCH_SUPPORT_FIREWALL, SigMatchCtx, Signature
 };
 
 /// Perform the DNS opcode match.
@@ -379,7 +375,7 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         AppLayerTxMatch: Some(dns_opcode_match),
         Setup: Some(dns_opcode_setup),
         Free: Some(dns_opcode_free),
-        flags: SIGMATCH_INFO_UINT8,
+        flags: SIGMATCH_INFO_UINT8 | SIGMATCH_SUPPORT_FIREWALL,
     };
     G_DNS_OPCODE_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_DNS_OPCODE_BUFFER_ID = SCDetectHelperBufferRegister(

--- a/src/detect-datarep.c
+++ b/src/detect-datarep.c
@@ -57,6 +57,7 @@ void DetectDatarepRegister (void)
     sigmatch_table[DETECT_DATAREP].url = "/rules/dataset-keywords.html#datarep";
     sigmatch_table[DETECT_DATAREP].Setup = DetectDatarepSetup;
     sigmatch_table[DETECT_DATAREP].Free  = DetectDatarepFree;
+    sigmatch_table[DETECT_DATAREP].flags = SIGMATCH_SUPPORT_FIREWALL;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -59,6 +59,7 @@ void DetectDatasetRegister (void)
     sigmatch_table[DETECT_DATASET].url = "/rules/dataset-keywords.html#dataset";
     sigmatch_table[DETECT_DATASET].Setup = DetectDatasetSetup;
     sigmatch_table[DETECT_DATASET].Free  = DetectDatasetFree;
+    sigmatch_table[DETECT_DATASET].flags = SIGMATCH_SUPPORT_FIREWALL;
 }
 
 /*

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -66,14 +66,14 @@ void DetectFlagsRegister (void)
     sigmatch_table[DETECT_FLAGS].url = "/rules/header-keywords.html#tcp-flags";
     sigmatch_table[DETECT_FLAGS].Match = DetectFlagsMatch;
     sigmatch_table[DETECT_FLAGS].Setup = DetectFlagsSetup;
-    sigmatch_table[DETECT_FLAGS].Free  = DetectFlagsFree;
-    sigmatch_table[DETECT_FLAGS].flags = SIGMATCH_SUPPORT_FIREWALL;
+    sigmatch_table[DETECT_FLAGS].Free = DetectFlagsFree;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_FLAGS].RegisterTests = FlagsRegisterTests;
 #endif
     sigmatch_table[DETECT_FLAGS].SupportsPrefilter = PrefilterTcpFlagsIsPrefilterable;
     sigmatch_table[DETECT_FLAGS].SetupPrefilter = PrefilterSetupTcpFlags;
-    sigmatch_table[DETECT_FLAGS].flags = SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_BITFLAGS_UINT;
+    sigmatch_table[DETECT_FLAGS].flags =
+            SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_BITFLAGS_UINT | SIGMATCH_SUPPORT_FIREWALL;
 }
 
 /**

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -243,7 +243,7 @@ void DetectTlsCertChainLenRegister(void)
     sigmatch_table[KEYWORD_ID].AppLayerTxMatch = DetectTLSCertChainLenMatch;
     sigmatch_table[KEYWORD_ID].Setup = DetectTLSCertChainLenSetup;
     sigmatch_table[KEYWORD_ID].Free = DetectTLSCertChainLenFree;
-    sigmatch_table[KEYWORD_ID].flags = SIGMATCH_INFO_UINT32;
+    sigmatch_table[KEYWORD_ID].flags = SIGMATCH_SUPPORT_FIREWALL | SIGMATCH_INFO_UINT32;
 
     g_tls_cert_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8387

Previous PR: https://github.com/OISF/suricata/pull/15186

Describe complete changes:

- enable `tls.cert_chain_len`
- enable `dns.opcode`
- enable `dataset`
- enable `datarep`
- `tcp.flags` firewall support flag had sort of been overwritten by other flags setting, so enabling it "again"

### Provide values to any of the below to override the defaults.

Tested with:
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3025