### PR TITLE
rust/ffi: move conf_get helper to ffi crate - v2

### DIFF
--- a/examples/plugins/altemplate/src/template.rs
+++ b/examples/plugins/altemplate/src/template.rs
@@ -31,8 +31,8 @@ use suricata::applayer::{
     APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS, APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
 };
 use suricata::applayer::{AppLayerResultRust, StreamSliceRust};
-use suricata::conf::conf_get;
 use suricata::{export_state_data_get, export_tx_data_get};
+use suricata_ffi::conf::conf_get;
 use suricata_ffi::{build_slice, cast_pointer, SCLogError, SCLogNotice, IPPROTO_TCP};
 use suricata_sys::sys::AppProtoEnum::ALPROTO_UNKNOWN;
 use suricata_sys::sys::{

--- a/rust/ffi/src/conf.rs
+++ b/rust/ffi/src/conf.rs
@@ -1,0 +1,44 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! Conf utils.
+
+use crate::SCLogDebug;
+use std::ffi::{c_char, CStr, CString};
+use std::ptr;
+use suricata_sys::sys::SCConfGet;
+
+// Return the string value of a configuration value.
+pub fn conf_get(key: &str) -> Option<&str> {
+    let mut vptr: *const c_char = ptr::null_mut();
+
+    unsafe {
+        let s = CString::new(key).unwrap();
+        if SCConfGet(s.as_ptr(), &mut vptr) != 1 {
+            SCLogDebug!("Failed to find value for key {}", key);
+            return None;
+        }
+    }
+
+    if vptr.is_null() {
+        return None;
+    }
+
+    let value = std::str::from_utf8(unsafe { CStr::from_ptr(vptr).to_bytes() }).unwrap();
+
+    Some(value)
+}

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -15,6 +15,7 @@
  * 02110-1301, USA.
  */
 
+pub mod conf;
 pub mod debug;
 pub mod detect;
 pub mod eve;

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -29,7 +29,6 @@ use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::ptr;
 use std::str;
-use suricata_sys::sys::SCConfGet;
 use suricata_sys::sys::SCConfGetChildValue;
 use suricata_sys::sys::SCConfGetChildValueBool;
 use suricata_sys::sys::SCConfGetNode;
@@ -54,26 +53,7 @@ pub fn conf_get_node(key: &str) -> Option<ConfNode> {
     }
 }
 
-// Return the string value of a configuration value.
-pub fn conf_get(key: &str) -> Option<&str> {
-    let mut vptr: *const c_char = ptr::null_mut();
-
-    unsafe {
-        let s = CString::new(key).unwrap();
-        if SCConfGet(s.as_ptr(), &mut vptr) != 1 {
-            SCLogDebug!("Failed to find value for key {}", key);
-            return None;
-        }
-    }
-
-    if vptr.is_null() {
-        return None;
-    }
-
-    let value = str::from_utf8(unsafe { CStr::from_ptr(vptr).to_bytes() }).unwrap();
-
-    return Some(value);
-}
+pub use suricata_ffi::conf::conf_get;
 
 // Return the value of key as a boolean. A value that is not set is
 // the same as having it set to false.


### PR DESCRIPTION
#15150 with clippy issue fixed due to merges since that PR was created.
```diff
diff --git a/rust/ffi/src/conf.rs b/rust/ffi/src/conf.rs
index c8e600072a..45bc0b0ffb 100644
--- a/rust/ffi/src/conf.rs
+++ b/rust/ffi/src/conf.rs
@@ -40,5 +40,5 @@ pub fn conf_get(key: &str) -> Option<&str> {
 
     let value = std::str::from_utf8(unsafe { CStr::from_ptr(vptr).to_bytes() }).unwrap();
 
-    return Some(value);
+    Some(value)
 }
```