### PR TITLE
rust: suppress cargo audit for RUSTSEC-2026-0097 - v1

### DIFF
--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -89,6 +89,8 @@ jobs:
           IGNORES+=(--ignore RUSTSEC-2019-0036)
           # time crate update
           IGNORES+=(--ignore RUSTSEC-2026-0009)
+          # rand, vla tls-parser
+          IGNORES+=(--ignore RUSTSEC-2026-0097)
 
           cargo audit -D warnings "${IGNORES[@]}"
 


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8467

Per https://rustsec.org/advisories/RUSTSEC-2026-0097,
this issue it not applicable unless the "log" and "thread_rng"
features of rand are enabled.  "log" is not enabled in our
dependency chain.

Updating to the fixed version of rand requires an MSRV of 1.85.
