### PR TITLE
Add missing value keyword to entropy's documentation examples

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -754,7 +754,7 @@ This results in the calculated entropy value being compared with
 
 Example::
 
-  entropy: 7.01
+  entropy: value 7.01
 
 A match occurs when the calculated entropy and specified entropy values agree.
 This is determined by calculating the entropy value and comparing it with the
@@ -762,7 +762,7 @@ value from the rule using the specified operator.
 
 Example::
 
-  entropy: <7.01
+  entropy: value <7.01
 
 Options have default values:
 - bytes is equal to the current content length


### PR DESCRIPTION
Two "value" keywords were missing in the examples provided for the entropy keyword's documentation

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [X] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Describe changes:
- The documentation for the entropy keyword contained two examples missing a mandatory keyword (value) resulting in the examples not being matching the expected format. This commit fixes those two examples.


### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
