### PR TITLE
bypass: fix BypassManager BypassedCheckFunc check

### DIFF
--- a/src/flow-bypass.c
+++ b/src/flow-bypass.c
@@ -85,7 +85,7 @@ static TmEcode BypassedFlowManager(ThreadVars *th_v, void *thread_data)
     /* check if we have a periodic check function */
     bool found = false;
     for (i = 0; i < g_bypassed_func_max_index; i++) {
-        if (bypassedfunclist[i].FuncInit) {
+        if (bypassedfunclist[i].Func) {
             found = true;
             break;
         }


### PR DESCRIPTION
Until now, Suricata has incorrectly checked whether BypassedCheckFuncInit was registered, after already calling the function.
I believe the original intention was to check whether BypassedCheckFunc is registered.


Link to ticket: https://redmine.openinfosecfoundation.org/issues/8473

Describe changes:
- Switch check of registration of BypassedCheckFuncInit to BypassedCheckFunc

