### PR TITLE
8.0.x: rust: suppress cargo audit for RUSTSEC-2026-0097

### DIFF
--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -89,5 +89,7 @@ jobs:
           IGNORES+=(--ignore RUSTSEC-2019-0036)
           # time crate update
           IGNORES+=(--ignore RUSTSEC-2026-0009)
+          # rand, vla tls-parser
+          IGNORES+=(--ignore RUSTSEC-2026-0097)
 
           cargo audit -D warnings "${IGNORES[@]}"


### PR DESCRIPTION
Backport of https://github.com/OISF/suricata/pull/15197.
