### PR TITLE
decode/tcp: fix unaligned access in TCP option parsing

### DIFF
--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -39,6 +39,11 @@
 #include "util-optimize.h"
 #include "flow.h"
 
+static inline uint16_t DecodeTCPGetU16(const uint8_t *d)
+{
+    return (uint16_t)(((uint16_t)d[0] << 8) | (uint16_t)d[1]);
+}
+
 static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
 {
     uint8_t tcp_opt_cnt = 0;
@@ -106,7 +111,7 @@ static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
                             ENGINE_SET_EVENT(p,TCP_OPT_DUPLICATE);
                         } else {
                             p->l4.vars.tcp.mss_set = true;
-                            p->l4.vars.tcp.mss = SCNtohs(*(uint16_t *)(tcp_opts[tcp_opt_cnt].data));
+                            p->l4.vars.tcp.mss = DecodeTCPGetU16(tcp_opts[tcp_opt_cnt].data);
                         }
                     }
                     break;
@@ -173,7 +178,7 @@ static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
                 case TCP_OPT_EXP2:
                     SCLogDebug("TCP EXP option, len %u", olen);
                     if (olen == 4 || olen == 12) {
-                        uint16_t magic = SCNtohs(*(uint16_t *)tcp_opts[tcp_opt_cnt].data);
+                        uint16_t magic = DecodeTCPGetU16(tcp_opts[tcp_opt_cnt].data);
                         if (magic == 0xf989) {
                             if (p->l4.vars.tcp.tfo_set) {
                                 ENGINE_SET_EVENT(p,TCP_OPT_DUPLICATE);


### PR DESCRIPTION
## Summary
Fix unaligned memory access in TCP option parsing.

## Details
DecodeTCPOptions reads MSS and EXP/TFO option values using direct
uint16_t* casts on packet buffers.

Since TCP options are byte-packed, these pointers are not guaranteed
to be aligned. On strict-alignment architectures (e.g., MIPS, SPARC,
and some ARM configurations), this can lead to faults. Additionally,
casting to uint16_t* without guaranteed alignment is undefined behavior in C.

## Fix
Replace unaligned reads with byte-wise 16-bit extraction from the buffer,
avoiding unaligned casts while keeping parsing logic unchanged.

## Notes
- Avoids alignment and strict-aliasing issues in a portable way
- No change in logic or behavior
- Length checks already ensure sufficient data before reads
- Uses a simple and explicit idiom for extracting network-order values

Tested with local build and runtime execution.

---

## Contribution style:
- [x] I have read the contributing guide lines at
  https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
  https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide
- [ ] I have updated the JSON schema
- [x] I have created a ticket