### PR TITLE
Ftp max tx config and rule

### DIFF
--- a/rules/ftp-events.rules
+++ b/rules/ftp-events.rules
@@ -4,3 +4,4 @@
 
 alert ftp any any -> any any (msg:"SURICATA FTP Request command too long"; flow:to_server; app-layer-event:ftp.request_command_too_long; classtype:protocol-command-decode; sid:2232000; rev:1;)
 alert ftp any any -> any any (msg:"SURICATA FTP Response command too long"; flow:to_client; app-layer-event:ftp.response_command_too_long; classtype:protocol-command-decode; sid:2232001; rev:1;)
+alert ftp any any -> any any (msg:"SURICATA FTP too many transactions"; app-layer-event:ftp.too_many_transactions; classtype:protocol-command-decode; sid:2232002; rev:1;)

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -997,6 +997,7 @@ app-layer:
 
     ftp:
       enabled: yes
+      # max-tx: 1024
       # memcap: 64 MiB
     websocket:
       #enabled: yes


### PR DESCRIPTION
Background: 
- max tx for ftp is documented [here](https://docs.suricata.io/en/latest/configuration/suricata-yaml.html#maximum-transactions)
- its also implemented in the ftp parser (see https://github.com/OISF/suricata/blob/main/rust/src/ftp/ftp.rs#L204 ) and a default of `1024` is configured (see: https://github.com/OISF/suricata/blob/main/src/app-layer-ftp.c#L53 )
- a rule which generates a `ftp.too_many_transactions` event is currently missing
- there is also missing a comment in `suricata.yaml` indicating the config option exists whereas for other protocols with a configurable max-tx there is a comment in `suricata.yaml`


Describe changes:
- added max-tx to ftp section in app layer of suricata.yaml.in
- added rule to generate 'ftp.too_many_transactions` event

SV_BRANCH: ftp-max-tx-config-and-rule
SU_BRANCH: main