### PR TITLE
dpdk: add initial unittests for DPDK codebase v12.1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -956,6 +956,7 @@ jobs:
                 ccache \
                 clang \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -981,6 +982,7 @@ jobs:
                 lz4-devel \
                 make \
                 parallel \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python \
@@ -1000,7 +1002,7 @@ jobs:
       - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow" ./configure --disable-shared
       - run: make check
       - run: make distclean
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-qa-simulation --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-qa-simulation --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         env:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -469,7 +469,7 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
         SCReturnInt(-EINVAL);
     }
 
-    if (iconf->threads <= 0) {
+    if (iconf->threads == 0) {
         SCLogError("%s: positive number of threads required", iconf->iface);
         SCReturnInt(-ERANGE);
     }

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -52,6 +52,7 @@
 #include "util-conf.h"
 #include "suricata.h"
 #include "util-affinity.h"
+#include "conf-yaml-loader.h"
 
 #ifdef HAVE_DPDK
 
@@ -388,11 +389,11 @@ static int32_t remaining_auto_cpus = -1; // -1 means not initialized
 static void AutoRemainingThreadsInit(void)
 {
     if (remaining_auto_cpus == -1) {
-        ThreadsAffinityType *wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", NULL);
+        ThreadsAffinityType *wtaf = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", NULL);
         if (wtaf == NULL)
             FatalError("Worker-cpu-set not listed in the threading section");
 
-        int32_t total_cpus = UtilAffinityGetAffinedCPUNum(wtaf);
+        int32_t total_cpus = AffinityGetAffinedCPUNum(wtaf);
         if (total_cpus == 0)
             FatalError("No worker CPU cores with affinity were configured");
 
@@ -2007,6 +2008,349 @@ int RunModeIdsDpdkWorkers(void)
 #endif /* HAVE_DPDK */
     SCReturnInt(0);
 }
+
+#if defined(HAVE_DPDK) && defined(UNITTESTS)
+
+/**
+ * \brief Reset the remaining auto-assigned threads count so next call of
+ * AutoRemainingThreadsInit() will recalculate the number of remaining
+ * auto-assigned threads.
+ */
+static void AutoRemainingThreadsReset(void)
+{
+    remaining_auto_cpus = -1;
+}
+
+static void DPDKRunmodeSetThreadsInit(const char *input, size_t input_len)
+{
+    SCConfCreateContextBackup();
+    SCConfInit();
+    AffinityReset();
+    LiveDeviceListClean();
+    AutoRemainingThreadsReset();
+    int ret = SCConfYamlLoadString(input, input_len);
+    if (ret != 0) {
+        FatalError("Unable to load configuration");
+    }
+    RunModeInitializeThreadSettings();
+    LiveBuildDeviceListCustom("unittest-ifaces", "iface");
+    LiveDeviceFinalize();
+    AutoRemainingThreadsInit();
+}
+
+static void DPDKRunmodeSetThreadsDeinit(void)
+{
+    LiveDeviceListClean();
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+}
+
+static void (*cleanup_cbs[])(void) = { DPDKRunmodeSetThreadsDeinit };
+static size_t cleanup_cbs_len = sizeof(cleanup_cbs) / sizeof(cleanup_cbs[0]);
+
+/**
+ * \brief Management CPU set excludes all available CPUs from the Worker CPU set
+ */
+static int DPDKRunmodeSetThreads01(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ \"all\" ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"all\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "1");
+    FAIL_IF_NOT(r == -EINVAL);
+
+    DPDKRunmodeSetThreadsDeinit();
+
+    PASS;
+}
+
+/**
+ * \brief Management/Worker CPU set exclusion leaves 2 CPUs available
+ */
+static int DPDKRunmodeSetThreads02(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"all\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "auto");
+    FAIL_IF_NOT(iconf.threads == UtilCpuGetNumProcessorsOnline() - 1);
+    FAIL_IF_NOT(r == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Management/Worker CPU set exclusion leaves 2 CPUs available
+ */
+static int DPDKRunmodeSetThreads03(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-2\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "auto");
+    FAIL_IF_NOT(iconf.threads == 2);
+    FAIL_IF_NOT(r == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Auto assignment of 1 CPU per interface
+ */
+static int DPDKRunmodeSetThreads04(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev1\n\
+    - iface: test_dev2\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-2\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
+
+    DPDKIfaceConfig iconf1 = { 0 };
+    int r1 = ConfigSetThreads(&iconf1, "auto");
+    DPDKIfaceConfig iconf2 = { 0 };
+    int r2 = ConfigSetThreads(&iconf2, "auto");
+    FAIL_IF_NOT(iconf1.threads == 1);
+    FAIL_IF_NOT(r1 == 0);
+    FAIL_IF_NOT(iconf2.threads == 1);
+    FAIL_IF_NOT(r2 == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Auto assignment test with 2 CPUs available for the first interface
+ */
+static int DPDKRunmodeSetThreads05(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev1\n\
+    - iface: test_dev2\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-3\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
+
+    DPDKIfaceConfig iconf1 = { 0 }; // test_dev1
+    int r1 = ConfigSetThreads(&iconf1, "auto");
+    DPDKIfaceConfig iconf2 = { 0 }; // test_dev2
+    int r2 = ConfigSetThreads(&iconf2, "auto");
+    FAIL_IF_NOT(iconf1.threads == 2);
+    FAIL_IF_NOT(r1 == 0);
+    FAIL_IF_NOT(iconf2.threads == 1);
+    FAIL_IF_NOT(r2 == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Sanity test for the ConfigSetThreads function
+ */
+static int DPDKRunmodeSetThreads06(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-2\" ]\n\
+";
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "-2");
+    FAIL_IF_NOT(r == -EINVAL);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "0");
+    FAIL_IF_NOT(r == -ERANGE);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "abc");
+    FAIL_IF_NOT(r == -EINVAL);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "99999999999999");
+    FAIL_IF(r == 0);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "1");
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.threads == 1);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "2");
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.threads == 2);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize01(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    const char *entry_str;
+
+    entry_str = NULL;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    entry_str = "";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    entry_str = "-1";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    entry_str = "999999999999999999";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize02(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "auto");
+    iconf.mempool_size = 1023;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.mempool_cache_size_auto);
+    iconf.mempool_cache_size = MempoolCacheSizeCalculate(iconf.mempool_size);
+    FAIL_IF(iconf.mempool_cache_size >= RTE_MEMPOOL_CACHE_MAX_SIZE);
+    FAIL_IF(iconf.mempool_cache_size >= iconf.mempool_size / 1.5);
+    FAIL_IF_NOT(iconf.mempool_size % iconf.mempool_cache_size == 0);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize03(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "%d", 1);
+    iconf.mempool_size = 1023;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.mempool_cache_size == 1);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize04(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "%d", RTE_MEMPOOL_CACHE_MAX_SIZE + 1);
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -ERANGE);
+
+    PASS;
+}
+
+/**
+ * \brief This function registers unit tests for AlertFastLog API.
+ */
+void RunmodeDpdkRegisterTests(void)
+{
+
+    UtRegisterTest("DPDKRunmodeSetThreads01", DPDKRunmodeSetThreads01);
+    UtRegisterTest("DPDKRunmodeSetThreads02", DPDKRunmodeSetThreads02);
+    UtRegisterTest("DPDKRunmodeSetThreads03", DPDKRunmodeSetThreads03);
+    UtRegisterTest("DPDKRunmodeSetThreads04", DPDKRunmodeSetThreads04);
+    UtRegisterTest("DPDKRunmodeSetThreads05", DPDKRunmodeSetThreads05);
+    UtRegisterTest("DPDKRunmodeSetThreads06", DPDKRunmodeSetThreads06);
+
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize01", DPDKRunmodeSetMempoolCacheSize01);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize02", DPDKRunmodeSetMempoolCacheSize02);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize03", DPDKRunmodeSetMempoolCacheSize03);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize04", DPDKRunmodeSetMempoolCacheSize04);
+}
+#endif /* UNITTESTS and HAVE_DPDK */
 
 /**
  * @}

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -35,6 +35,7 @@
 #include "runmode-dpdk.h"
 #include "decode.h"
 #include "source-dpdk.h"
+#include "util-affinity.h"
 #include "util-runmodes.h"
 #include "util-byte.h"
 #include "util-cpu.h"
@@ -389,32 +390,32 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
     }
 
     bool wtaf_periface = true;
-    ThreadsAffinityType *wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", iconf->iface);
+    ThreadsAffinityType *wtaf = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", iconf->iface);
     if (wtaf == NULL) {
         wtaf_periface = false;
-        wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", NULL); // mandatory
+        wtaf = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", NULL); // mandatory
         if (wtaf == NULL) {
             SCLogError("Specify worker-cpu-set list in the threading section");
             SCReturnInt(-EINVAL);
         }
     }
-    ThreadsAffinityType *mtaf = GetAffinityTypeForNameAndIface("management-cpu-set", NULL);
+    ThreadsAffinityType *mtaf = AffinityTypeGetByIfaceOrCpuset("management-cpu-set", NULL);
     if (mtaf == NULL) {
         SCLogError("Specify management-cpu-set list in the threading section");
         SCReturnInt(-EINVAL);
     }
-    uint16_t sched_cpus = UtilAffinityGetAffinedCPUNum(wtaf);
+    uint16_t sched_cpus = AffinityGetAffinedCPUNum(wtaf);
     if (sched_cpus == UtilCpuGetNumProcessorsOnline()) {
         SCLogWarning(
                 "\"all\" specified in worker CPU cores affinity, excluding management threads");
-        UtilAffinityCpusExclude(wtaf, mtaf);
-        sched_cpus = UtilAffinityGetAffinedCPUNum(wtaf);
+        AffinityCpusSubtract(wtaf, mtaf);
+        sched_cpus = AffinityGetAffinedCPUNum(wtaf);
     }
 
     if (sched_cpus == 0) {
         SCLogError("No worker CPU cores with configured affinity were configured");
         SCReturnInt(-EINVAL);
-    } else if (UtilAffinityCpusOverlap(wtaf, mtaf) != 0) {
+    } else if (AffinityCpusOverlap(wtaf, mtaf)) {
         SCLogWarning("Worker threads should not overlap with management threads in the CPU core "
                      "affinity configuration");
     }
@@ -1044,10 +1045,10 @@ static bool ConfigThreadsGenericIsValid(uint16_t iface_threads, ThreadsAffinityT
         SCLogError("Specify worker-cpu-set list in the threading section");
         return false;
     }
-    if (total_cpus > UtilAffinityGetAffinedCPUNum(wtaf)) {
+    if (total_cpus > AffinityGetAffinedCPUNum(wtaf)) {
         SCLogError("Interfaces requested more cores than configured in the worker-cpu-set "
                    "threading section (requested %d configured %d",
-                total_cpus, UtilAffinityGetAffinedCPUNum(wtaf));
+                total_cpus, AffinityGetAffinedCPUNum(wtaf));
         return false;
     }
 
@@ -1056,10 +1057,10 @@ static bool ConfigThreadsGenericIsValid(uint16_t iface_threads, ThreadsAffinityT
 
 static bool ConfigThreadsInterfaceIsValid(uint16_t iface_threads, ThreadsAffinityType *itaf)
 {
-    if (iface_threads > UtilAffinityGetAffinedCPUNum(itaf)) {
+    if (iface_threads > AffinityGetAffinedCPUNum(itaf)) {
         SCLogError("Interface requested more cores than configured in the interface-specific "
                    "threading section (requested %d configured %d",
-                iface_threads, UtilAffinityGetAffinedCPUNum(itaf));
+                iface_threads, AffinityGetAffinedCPUNum(itaf));
         return false;
     }
 
@@ -1068,8 +1069,8 @@ static bool ConfigThreadsInterfaceIsValid(uint16_t iface_threads, ThreadsAffinit
 
 static bool ConfigIsThreadingValid(uint16_t iface_threads, const char *iface)
 {
-    ThreadsAffinityType *itaf = GetAffinityTypeForNameAndIface("worker-cpu-set", iface);
-    ThreadsAffinityType *wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", NULL);
+    ThreadsAffinityType *itaf = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", iface);
+    ThreadsAffinityType *wtaf = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", NULL);
     if (itaf && !ConfigThreadsInterfaceIsValid(iface_threads, itaf)) {
         return false;
     } else if (itaf == NULL && !ConfigThreadsGenericIsValid(iface_threads, wtaf)) {

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -380,10 +380,50 @@ static void ConfigSetIface(DPDKIfaceConfig *iconf, const char *entry_str)
     SCReturn;
 }
 
+static int32_t remaining_auto_cpus = -1; // -1 means not initialized
+
+/**
+ * \brief Initialize the number of remaining auto-assigned threads
+ */
+static void AutoRemainingThreadsInit(void)
+{
+    if (remaining_auto_cpus == -1) {
+        ThreadsAffinityType *wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", NULL);
+        if (wtaf == NULL)
+            FatalError("Worker-cpu-set not listed in the threading section");
+
+        int32_t total_cpus = UtilAffinityGetAffinedCPUNum(wtaf);
+        if (total_cpus == 0)
+            FatalError("No worker CPU cores with affinity were configured");
+
+        int32_t ldevs = LiveGetDeviceCount();
+        if (ldevs == 0)
+            FatalError("No devices configured");
+        remaining_auto_cpus = total_cpus % ldevs;
+    }
+}
+
+/**
+ * \brief Decrease the number of remaining auto-assigned threads by one
+ * \return Remaining number of the auto-assigned leftover threads
+ */
+static bool AutoRemainingThreadsUsedOne(void)
+{
+    if (remaining_auto_cpus == -1) {
+        FatalError("Not yet initialized");
+    }
+
+    if (remaining_auto_cpus > 0) {
+        remaining_auto_cpus--;
+        return true;
+    }
+
+    return false;
+}
+
 static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
 {
     SCEnter();
-    static uint16_t remaining_auto_cpus = UINT16_MAX; // uninitialized
     if (!threading_set_cpu_affinity) {
         SCLogError("DPDK runmode requires configured thread affinity");
         SCReturnInt(-EINVAL);
@@ -449,16 +489,9 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
             SCReturnInt(-ERANGE);
         }
 
-        if (remaining_auto_cpus == UINT16_MAX) {
-            // first time auto-assignment
-            remaining_auto_cpus = sched_cpus % live_dev_count;
-            if (remaining_auto_cpus > 0) {
-                iconf->threads++;
-                remaining_auto_cpus--;
-            }
-        } else if (remaining_auto_cpus > 0) {
+        AutoRemainingThreadsInit();
+        if (AutoRemainingThreadsUsedOne()) {
             iconf->threads++;
-            remaining_auto_cpus--;
         }
         SCLogConfig("%s: auto-assigned %u threads", iconf->iface, iconf->threads);
         SCReturnInt(0);

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -46,4 +46,8 @@ int RunModeIdsDpdkWorkers(void);
 void RunModeDpdkRegister(void);
 const char *RunModeDpdkGetDefaultMode(void);
 
+#if defined(HAVE_DPDK) && defined(UNITTESTS)
+void RunmodeDpdkRegisterTests(void);
+#endif /* HAVE_DPDK and UNITTESTS */
+
 #endif /* SURICATA_RUNMODE_DPDK_H */

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -128,6 +128,8 @@
 #include "source-windivert.h"
 #endif
 
+#include "runmode-dpdk.h"
+
 #endif /* UNITTESTS */
 
 void TmqhSetup (void);
@@ -224,6 +226,9 @@ static void RegisterUnittests(void)
     UtilCIDRTests();
     OutputJsonStatsRegisterTests();
     CoredumpConfigRegisterTests();
+#ifdef HAVE_DPDK
+    RunmodeDpdkRegisterTests();
+#endif
 }
 #endif
 

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -202,7 +202,7 @@ static void RegisterUnittests(void)
     SCLogRegisterTests();
     MagicRegisterTests();
     UtilMiscRegisterTests();
-    ThreadingAffinityRegisterTests();
+    AffinityRegisterTests();
     DetectAddressTests();
     DetectProtoTests();
     DetectPortTests();

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -962,6 +962,10 @@ void RunModeInitializeThreadSettings(void)
     /* try to get custom cpu mask value if needed */
     if (threading_set_cpu_affinity) {
         AffinityLoadFromConfig();
+        if (!AffinityCPUConfigIsCompatible()) {
+            FatalError("CPU affinity configuration validation failed. Please check your "
+                       "threading.cpu-affinity configuration.");
+        }
     }
     if ((SCConfGetFloat("threading.detect-thread-ratio", &threading_detect_ratio)) != 1) {
         if (SCConfGetNode("threading.detect-thread-ratio") != NULL)

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -961,7 +961,7 @@ void RunModeInitializeThreadSettings(void)
 
     /* try to get custom cpu mask value if needed */
     if (threading_set_cpu_affinity) {
-        AffinitySetupLoadFromConfig();
+        AffinityLoadFromConfig();
     }
     if ((SCConfGetFloat("threading.detect-thread-ratio", &threading_detect_ratio)) != 1) {
         if (SCConfGetNode("threading.detect-thread-ratio") != NULL)

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -877,15 +877,15 @@ TmEcode TmThreadSetupOptions(ThreadVars *tv)
     if (tv->thread_setup_flags & THREAD_SET_AFFTYPE) {
         ThreadsAffinityType *taf = &thread_affinity[tv->cpu_affinity];
         bool use_iface_affinity = RunmodeIsAutofp() && tv->cpu_affinity == RECEIVE_CPU_SET &&
-                                  FindAffinityByInterface(taf, tv->iface_name) != NULL;
+                                  AffinityTypeGetChildTypeByIface(taf, tv->iface_name) != NULL;
         use_iface_affinity |= RunmodeIsWorkers() && tv->cpu_affinity == WORKER_CPU_SET &&
-                              FindAffinityByInterface(taf, tv->iface_name) != NULL;
+                              AffinityTypeGetChildTypeByIface(taf, tv->iface_name) != NULL;
 
         if (use_iface_affinity) {
-            taf = FindAffinityByInterface(taf, tv->iface_name);
+            taf = AffinityTypeGetChildTypeByIface(taf, tv->iface_name);
         }
 
-        if (UtilAffinityGetAffinedCPUNum(taf) == 0) {
+        if (AffinityGetAffinedCPUNum(taf) == 0) {
             if (!taf->nocpu_warned) {
                 SCLogWarning("No CPU affinity set for %s", AffinityGetYamlPath(taf));
                 taf->nocpu_warned = true;

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -1348,19 +1348,17 @@ static int ThreadingAffinityTest04(void)
                          "threading:\n"
                          "  cpu-affinity:\n"
                          "    worker-cpu-set:\n"
-                         "      cpu: [ 1, 3, 5 ]\n";
+                         "      cpu: [ 0, 1, 3 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
     SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
+    FAIL_IF_NOT(CPU_ISSET(0, &worker_taf->cpu_set));
     FAIL_IF_NOT(CPU_ISSET(1, &worker_taf->cpu_set));
     FAIL_IF_NOT(CPU_ISSET(3, &worker_taf->cpu_set));
-    FAIL_IF_NOT(CPU_ISSET(5, &worker_taf->cpu_set));
-    FAIL_IF(CPU_ISSET(0, &worker_taf->cpu_set));
     FAIL_IF(CPU_ISSET(2, &worker_taf->cpu_set));
-    FAIL_IF(CPU_ISSET(4, &worker_taf->cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == 3);
 
     SCConfDeInit();
@@ -1549,7 +1547,7 @@ static int ThreadingAffinityTest10(void)
                          "        - interface: \"eth0\"\n"
                          "          cpu: [ 1, 2 ]\n"
                          "        - interface: \"eth1\"\n"
-                         "          cpu: [ 3, 4 ]\n";
+                         "          cpu: [ 3 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
@@ -1568,8 +1566,7 @@ static int ThreadingAffinityTest10(void)
                 eth0_found = true;
             }
         } else if (strcmp(iface_taf->name, "eth1") == 0) {
-            if (CPU_ISSET(3, &iface_taf->cpu_set) && CPU_ISSET(4, &iface_taf->cpu_set) &&
-                    CPU_COUNT(&iface_taf->cpu_set) == 2) {
+            if (CPU_ISSET(3, &iface_taf->cpu_set) && CPU_COUNT(&iface_taf->cpu_set) == 1) {
                 eth1_found = true;
             }
         }
@@ -1644,12 +1641,12 @@ static int ThreadingAffinityTest12(void)
                          "      cpu: [ 2, 3 ]\n"
                          "      interface-specific-cpu-set:\n"
                          "        - interface: \"eth0\"\n"
-                         "          cpu: [ \"5-7\" ]\n"
+                         "          cpu: [ \"1-3\" ]\n"
                          "          prio:\n"
                          "            high: [ \"all\" ]\n"
                          "            default: \"high\"\n"
                          "    verdict-cpu-set:\n"
-                         "      cpu: [ 4 ]\n";
+                         "      cpu: [ 1 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
@@ -1659,19 +1656,20 @@ static int ThreadingAffinityTest12(void)
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[MANAGEMENT_CPU_SET].cpu_set) == 1);
     FAIL_IF_NOT(CPU_ISSET(1, &thread_affinity[RECEIVE_CPU_SET].cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[RECEIVE_CPU_SET].cpu_set) == 1);
-    FAIL_IF_NOT(CPU_ISSET(4, &thread_affinity[VERDICT_CPU_SET].cpu_set));
+    FAIL_IF_NOT(CPU_ISSET(1, &thread_affinity[VERDICT_CPU_SET].cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[VERDICT_CPU_SET].cpu_set) == 1);
     FAIL_IF_NOT(CPU_ISSET(2, &thread_affinity[WORKER_CPU_SET].cpu_set));
     FAIL_IF_NOT(CPU_ISSET(3, &thread_affinity[WORKER_CPU_SET].cpu_set));
+    FAIL_IF_NOT(CPU_COUNT(&thread_affinity[WORKER_CPU_SET].cpu_set) == 2);
 
     FAIL_IF_NOT(thread_affinity[WORKER_CPU_SET].nb_children == 1);
     ThreadsAffinityType *iface_taf = thread_affinity[WORKER_CPU_SET].children[0];
     FAIL_IF_NOT(strcmp(iface_taf->name, "eth0") == 0);
-    FAIL_IF_NOT(CPU_ISSET(1, &iface_taf->hiprio_cpu));
-    FAIL_IF_NOT(CPU_ISSET(2, &iface_taf->hiprio_cpu));
-    FAIL_IF_NOT(CPU_ISSET(3, &iface_taf->hiprio_cpu));
+    FAIL_IF_NOT(CPU_ISSET(1, &iface_taf->cpu_set));
+    FAIL_IF_NOT(CPU_ISSET(2, &iface_taf->cpu_set));
+    FAIL_IF_NOT(CPU_ISSET(3, &iface_taf->cpu_set));
+    FAIL_IF_NOT(CPU_COUNT(&iface_taf->cpu_set) == 3);
     FAIL_IF_NOT(iface_taf->prio == PRIO_HIGH);
-    FAIL_IF_NOT(CPU_COUNT(&thread_affinity[WORKER_CPU_SET].cpu_set) == 2);
 
     SCConfDeInit();
     SCConfRestoreContextBackup();

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -256,17 +256,15 @@ int AffinityBuildCpusetWithCallback(
                 SCLogError("%s: invalid cpu range (bad order): \"%s\"", name, lnode->val);
                 return -1;
             }
-            if (b > max) {
-                SCLogError("%s: upper bound (%d) of cpu set is too high, only %d cpu(s)", name, b,
-                        max + 1);
-                return -1;
-            }
         } else {
             if (StringParseUint32(&a, 10, strlen(lnode->val), lnode->val) <= 0) {
                 SCLogError("%s: invalid cpu range (not an integer): \"%s\"", name, lnode->val);
                 return -1;
             }
             b = a;
+        }
+        if (b > max) {
+            b = max;
         }
         for (i = a; i<= b; i++) {
             Callback(i, data);
@@ -1056,6 +1054,68 @@ uint16_t AffinityGetAffinedCPUNum(ThreadsAffinityType *taf)
     return ncpu;
 }
 
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__)
+/**
+ * \brief Validate that a CPU affinity set only references valid CPU IDs
+ * \param taf ThreadsAffinityType to validate
+ * \retval true if the CPU set only uses CPUs within the available range, false otherwise
+ */
+static bool AffinityCpuSetIsValid(ThreadsAffinityType *taf)
+{
+    bool valid = true;
+    if (taf == NULL) {
+        return false;
+    }
+
+    cpu_set_t test_set;
+    CPU_ZERO(&test_set);
+    SCMutexLock(&taf->taf_mutex);
+    uint16_t max_cpus = UtilCpuGetNumProcessorsOnline();
+    for (int cpu = 0; cpu < max_cpus; cpu++) {
+        if (CPU_ISSET(cpu, &taf->cpu_set)) {
+            CPU_SET(cpu, &test_set);
+        }
+    }
+
+    if (!CPU_EQUAL(&test_set, &taf->cpu_set)) {
+        SCLogWarning("CPU affinity set '%s' references CPU IDs beyond available %d CPUs (0-%d)",
+                taf->name ? taf->name : "unknown", max_cpus, max_cpus - 1);
+        valid = false;
+    }
+
+    SCMutexUnlock(&taf->taf_mutex);
+    return valid;
+}
+#endif /* defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) */
+
+/**
+ * \brief Verify that all CPU sets contain CPU up to the max available CPUs
+ * \retval true on success, false if any CPU set is incompatible
+ */
+bool AffinityCPUConfigIsCompatible(void)
+{
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__)
+    for (int i = 0; i < MAX_CPU_SET; i++) {
+        ThreadsAffinityType *taf = &thread_affinity[i];
+        if (!AffinityCpuSetIsValid(taf)) {
+            return false;
+        }
+
+        if (taf->children != NULL) {
+            for (uint32_t j = 0; j < taf->nb_children; j++) {
+                ThreadsAffinityType *child = taf->children[j];
+                if (child != NULL) {
+                    if (!AffinityCpuSetIsValid(child)) {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+#endif /* defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) */
+    return true;
+}
+
 #ifdef HAVE_DPDK
 /**
  * Find if CPU sets overlap
@@ -1106,6 +1166,9 @@ void AffinityCpusSubtract(ThreadsAffinityType *mod_taf, ThreadsAffinityType *sta
 #ifdef UNITTESTS
 // avoiding Darwin/MacOS as it does not support bitwise CPU affinity
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__)
+
+static void (*cleanup_cbs[])(void) = { SCConfDeInit, SCConfRestoreContextBackup };
+static size_t cleanup_cbs_len = sizeof(cleanup_cbs) / sizeof(cleanup_cbs[0]);
 
 /**
  * \brief Helper function to reset affinity state for unit tests
@@ -1158,6 +1221,20 @@ void AffinityReset(void)
 }
 
 /**
+ * \brief Verify that the test's CPU requirement is met
+ * \retval 0 if the requirement is met, 2 if the test is skipped
+ */
+int AffinityVerifyCPURequirement(void)
+{
+    if (AffinityCPUConfigIsCompatible() == false) {
+        char err_msg[256];
+        snprintf(err_msg, sizeof(err_msg), "not enough cpus in the system");
+        SKIP(err_msg);
+    }
+    return 0;
+}
+
+/**
  * \brief Test basic CPU affinity parsing in new format
  */
 static int ThreadingAffinityTest01(void)
@@ -1175,8 +1252,8 @@ static int ThreadingAffinityTest01(void)
                          "      cpu: [ 1, 2, 3 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
     FAIL_IF_NOT(AffinityConfigIsLegacy() == false);
 
     ThreadsAffinityType *mgmt_taf = &thread_affinity[MANAGEMENT_CPU_SET];
@@ -1212,6 +1289,7 @@ static int ThreadingAffinityTest02(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
     FAIL_IF_NOT(AffinityConfigIsLegacy() == true);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
@@ -1242,6 +1320,7 @@ static int ThreadingAffinityTest03(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_ISSET(0, &worker_taf->cpu_set));
@@ -1273,6 +1352,7 @@ static int ThreadingAffinityTest04(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_ISSET(1, &worker_taf->cpu_set));
@@ -1306,6 +1386,7 @@ static int ThreadingAffinityTest05(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == UtilCpuGetNumProcessorsOnline());
@@ -1338,6 +1419,7 @@ static int ThreadingAffinityTest06(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_ISSET(0, &worker_taf->lowprio_cpu));
@@ -1370,6 +1452,7 @@ static int ThreadingAffinityTest07(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->mode_flag == EXCLUSIVE_AFFINITY);
@@ -1398,6 +1481,7 @@ static int ThreadingAffinityTest08(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_threads == 4);
@@ -1429,6 +1513,7 @@ static int ThreadingAffinityTest09(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 1);
@@ -1468,6 +1553,7 @@ static int ThreadingAffinityTest10(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *receive_taf = &thread_affinity[RECEIVE_CPU_SET];
     FAIL_IF_NOT(receive_taf->nb_children == 2);
@@ -1520,6 +1606,7 @@ static int ThreadingAffinityTest11(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 1);
@@ -1566,6 +1653,7 @@ static int ThreadingAffinityTest12(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     FAIL_IF_NOT(CPU_ISSET(0, &thread_affinity[MANAGEMENT_CPU_SET].cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[MANAGEMENT_CPU_SET].cpu_set) == 1);
@@ -1608,6 +1696,7 @@ static int ThreadingAffinityTest13(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == 0);
@@ -1633,6 +1722,7 @@ static int ThreadingAffinityTest14(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     FAIL_IF_NOT(
             CPU_COUNT(&thread_affinity[WORKER_CPU_SET].cpu_set) == UtilCpuGetNumProcessorsOnline());
@@ -1661,6 +1751,7 @@ static int ThreadingAffinityTest15(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[MANAGEMENT_CPU_SET].cpu_set) == 0);
 
@@ -1689,6 +1780,7 @@ static int ThreadingAffinityTest16(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1714,6 +1806,7 @@ static int ThreadingAffinityTest17(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1739,6 +1832,7 @@ static int ThreadingAffinityTest18(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1764,6 +1858,7 @@ static int ThreadingAffinityTest19(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1789,6 +1884,7 @@ static int ThreadingAffinityTest20(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1844,6 +1940,7 @@ static int ThreadingAffinityTest22(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 1);
@@ -1876,6 +1973,7 @@ static int ThreadingAffinityTest23(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *result = AffinityTypeGetByIfaceOrCpuset(NULL, "eth0");
     FAIL_IF_NOT(result == NULL);
@@ -1918,6 +2016,7 @@ static int ThreadingAffinityTest24(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 0);
@@ -2005,6 +2104,7 @@ static int ThreadingAffinityTest27(void)
 
     SCConfYamlLoadString(config, strlen(config));
     AffinityLoadFromConfig();
+    SKIP_INCOMPATIBLE_ENVIRONMENT(cleanup_cbs, cleanup_cbs_len);
 
     ThreadsAffinityType *mgmt_taf = &thread_affinity[MANAGEMENT_CPU_SET];
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -110,6 +110,7 @@ ThreadsAffinityType *AffinityTypeGetChildTypeByIface(
 
 uint16_t AffinityGetNextCPU(ThreadVars *tv, ThreadsAffinityType *taf);
 uint16_t AffinityGetAffinedCPUNum(ThreadsAffinityType *taf);
+bool AffinityCPUConfigIsCompatible(void);
 #ifdef HAVE_DPDK
 bool AffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2);
 void AffinityCpusSubtract(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf);
@@ -120,7 +121,22 @@ int AffinityBuildCpusetWithCallback(
 
 #ifdef UNITTESTS
 void AffinityRegisterTests(void);
+int AffinityVerifyCPURequirement(void);
 void AffinityReset(void);
+
+#define SKIP_INCOMPATIBLE_ENVIRONMENT(callbacks, len)                                              \
+    do {                                                                                           \
+        int ret = AffinityVerifyCPURequirement();                                                  \
+        FAIL_IF(ret < 0);                                                                          \
+        if (ret != 0) {                                                                            \
+            for (size_t i = 0; i < (len); i++) {                                                   \
+                if ((callbacks)[i] != NULL) {                                                      \
+                    (callbacks)[i]();                                                              \
+                }                                                                                  \
+            }                                                                                      \
+            return ret;                                                                            \
+        }                                                                                          \
+    } while (0)
 #endif
 
 #endif /* SURICATA_UTIL_AFFINITY_H */

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -96,27 +96,31 @@ typedef struct ThreadsAffinityType_ {
 extern ThreadsAffinityType thread_affinity[MAX_CPU_SET];
 #endif
 
+void TopologyDestroy(void);
+
 char *AffinityGetYamlPath(ThreadsAffinityType *taf);
-void AffinitySetupLoadFromConfig(void);
-ThreadsAffinityType *GetOrAllocAffinityTypeForIfaceOfName(
-        const char *name, const char *interface_name);
-ThreadsAffinityType *GetAffinityTypeForNameAndIface(const char *name, const char *interface_name);
-ThreadsAffinityType *FindAffinityByInterface(
+void AffinityLoadFromConfig(void);
+
+ThreadsAffinityType *AffinityTypeGetOrCreateByIfaceOrCpuset(
+        const char *affinity_set_name, const char *interface_name);
+ThreadsAffinityType *AffinityTypeGetByIfaceOrCpuset(
+        const char *affinity_set_name, const char *interface_name);
+ThreadsAffinityType *AffinityTypeGetChildTypeByIface(
         ThreadsAffinityType *parent, const char *interface_name);
 
-void TopologyDestroy(void);
 uint16_t AffinityGetNextCPU(ThreadVars *tv, ThreadsAffinityType *taf);
-uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf);
+uint16_t AffinityGetAffinedCPUNum(ThreadsAffinityType *taf);
 #ifdef HAVE_DPDK
-uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2);
-void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf);
+bool AffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2);
+void AffinityCpusSubtract(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf);
 #endif /* HAVE_DPDK */
 
-int BuildCpusetWithCallback(
+int AffinityBuildCpusetWithCallback(
         const char *name, SCConfNode *node, void (*Callback)(int i, void *data), void *data);
 
 #ifdef UNITTESTS
-void ThreadingAffinityRegisterTests(void);
+void AffinityRegisterTests(void);
+void AffinityReset(void);
 #endif
 
 #endif /* SURICATA_UTIL_AFFINITY_H */

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -360,6 +360,8 @@ int LiveDeviceListClean(void)
         SCFree(pd);
     }
 
+    // set the list to NULL
+    TAILQ_INIT(&live_devices);
     SCReturnInt(TM_ECODE_OK);
 }
 
@@ -471,6 +473,9 @@ void LiveDeviceFinalize(void)
         }
         SCFree(ld);
     }
+
+    // set the list to NULL
+    TAILQ_INIT(&pre_live_devices);
 }
 
 static void LiveDevExtensionFree(void *x)

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -185,7 +185,7 @@ int LiveGetDeviceCountWithoutAssignedThreading(void)
     LiveDevice *pd;
 
     TAILQ_FOREACH (pd, &live_devices, next) {
-        if (GetAffinityTypeForNameAndIface("worker-cpu-set", pd->dev) == NULL) {
+        if (AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", pd->dev) == NULL) {
             i++;
         }
     }

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -990,7 +990,8 @@ void EBPFBuildCPUSet(SCConfNode *node, char *iface)
                         BPF_ANY);
         return;
     }
-    if (BuildCpusetWithCallback("xdp-cpu-redirect", node, EBPFRedirectMapAddCPU, iface) < 0) {
+    if (AffinityBuildCpusetWithCallback("xdp-cpu-redirect", node, EBPFRedirectMapAddCPU, iface) <
+            0) {
         SCLogWarning("Failed to parse XDP CPU redirect configuration");
         return;
     }

--- a/src/util-unittest.c
+++ b/src/util-unittest.c
@@ -188,7 +188,7 @@ void UtListTests(const char *regex_arg)
 uint32_t UtRunTests(const char *regex_arg)
 {
     UtTest *ut;
-    uint32_t good = 0, bad = 0, matchcnt = 0;
+    uint32_t good = 0, skip = 0, bad = 0, matchcnt = 0;
     int ret = 0, rcomp = 0;
 
     StreamTcpInitMemuse();
@@ -225,22 +225,28 @@ uint32_t UtRunTests(const char *regex_arg)
                     ret = 0;
                 }
 
-                printf("%s\n", ret ? "pass" : "FAILED");
-
                 if (!ret) {
                     if (unittests_fatal == 1) {
                         fprintf(stderr, "ERROR: unittest failed.\n");
                         exit(EXIT_FAILURE);
                     }
                     bad++;
+                    printf("FAILED\n");
+                } else if (ret == 2) {
+                    skip++;
+                    printf("skip\n");
                 } else {
                     good++;
+                    printf("pass\n");
                 }
             }
         }
         if(matchcnt > 0){
             printf("==== TEST RESULTS ====\n");
             printf("PASSED: %" PRIu32 "\n", good);
+            if (skip > 0) {
+                printf("SKIPPED: %" PRIu32 "\n", skip);
+            }
             printf("FAILED: %" PRIu32 "\n", bad);
             printf("======================\n");
         } else {

--- a/src/util-unittest.h
+++ b/src/util-unittest.h
@@ -106,6 +106,18 @@ extern int unittests_fatal;
         return 1; \
     } while (0)
 
+/**
+ * \brief Skip the test.
+ *
+ * Used to skip the tests that cannot be run in the current environment.
+ * The aim is to keep this at 0.
+ */
+#define SKIP(reason)                                                                               \
+    do {                                                                                           \
+        SCLogInfo("Test skipped: %s", reason);                                                     \
+        return 2;                                                                                  \
+    } while (0)
+
 #endif
 
 #endif /* SURICATA_UTIL_UNITTEST_H */


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata/pull/14589

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6927

The PR is adding unit tests tailored to verify CPU threading logic and the automatic calculation of the mempool cache of the interface. Tests are skipped if the minimal CPU requirements (CPU count) on the executing machine are not met.

Describe changes:
v12.1 (Victor-greened in v11.4):
- Copilot review comments addressed
- limited the addition of the number of Github CI builds to 1, to one Fedora build only
- the triage of not firing the function warning (unused function) in https://github.com/OISF/suricata/pull/14589#issuecomment-3940995485
- rebased

v11.4:
- reword "skip affinity" commit - explains there is no real behavior change, just the check was moved elsewhere - explain in https://github.com/OISF/suricata/pull/14150#discussion_r2680231654
- added have_dpdk guard where reminded
- rebased

v11.3:
- limit AffinityCPUConfigIsCompatible to Linux only (to exclude Darwin) as it does not contain CPU_EQUAL API
- Change SKIP_INCOMPATIBLE_ENVIRONMENT macro to accept an array of deinit callbacks to not leak memory when skipping tests
- rebased

v11.2:
- rebased
- util-affinity tests are now skipped
- minor follow-up adjustments in the dpdk unittests, cleaning LiveDevList on the Init as it crashed tests when the previous test failed.

v10.1:
- rebased

v2 (v10):

- rebased

v1 - PR splitted to sub-PRs:

- new unit tests
- skip directive for unit tests for incompatible environments
