### PR TITLE
Doc rules container 8372 v1

### DIFF
--- a/doc/userguide/capture-hardware/ebpf-xdp.rst
+++ b/doc/userguide/capture-hardware/ebpf-xdp.rst
@@ -160,8 +160,13 @@ Another solution is to use a set of signatures using the ``bypass`` keyword to o
 a selective bypass. Suricata traffic ID defines flowbits that can be used in other signatures.
 For instance one could use ::
 
- alert ip any any -> any any (msg:"bypass video"; flowbits:isset,traffic/label/video; noalert; bypass; sid:1000000; rev:1;)
- alert ip any any -> any any (msg:"bypass Skype"; flowbits:isset,traffic/id/skype; noalert; bypass; sid:1000001; rev:1;)
+.. container:: example-rule
+
+  alert ip any any -> any any (msg:"bypass video"; flowbits:isset,traffic/label/video; noalert; bypass; sid:1000000; rev:1;)
+
+.. container:: example-rule
+
+  alert ip any any -> any any (msg:"bypass Skype"; flowbits:isset,traffic/id/skype; noalert; bypass; sid:1000001; rev:1;)
 
 Setup eBPF filter
 -----------------

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -795,7 +795,7 @@ The prefilter engines for other non-MPM keywords can then be enabled in specific
 
 E.g.
 
-::
+.. container:: example-rule
 
   alert ip any any -> any any (ttl:123; prefilter; sid:1;)
 

--- a/doc/userguide/quickstart.rst
+++ b/doc/userguide/quickstart.rst
@@ -120,7 +120,7 @@ Alerting
 To test the IDS functionality of Suricata it's best to test with a signature. The signature with
 ID ``2100498`` from the ET Open ruleset is written specific for such test cases.
 
-2100498::
+.. container:: example-rule
 
     alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7; metadata:created_at 2010_09_23, updated_at 2010_09_23;)
 

--- a/doc/userguide/rules/config.rst
+++ b/doc/userguide/rules/config.rst
@@ -4,7 +4,7 @@ Config Rules
 Config rules are rules that when matching, will change the configuration of
 Suricata for a flow, transaction, packet or other unit.
 
-Example::
+.. container:: example-rule
 
   config dns any any -> any any (dns.query; content:"suricata"; config: logging disable, type tx, scope tx; sid:1;)
 
@@ -12,7 +12,7 @@ This example will detect if a DNS query contains the string `suricata` and if
 so disable the DNS transaction logging. This means that `eve.json` records,
 but also Lua output, will not be generated/triggered for this DNS transaction.
 
-Example::
+.. container:: example-rule
 
   config tcp:pre_flow any any <> any 666 (config: tracking disable, type flow, scope packet; sid:1;)
 

--- a/doc/userguide/rules/differences-from-snort.rst
+++ b/doc/userguide/rules/differences-from-snort.rst
@@ -354,7 +354,7 @@ See :doc:`http-keywords` for all HTTP keywords.
    end of the URI; to do the same thing in the normalized URI buffer in
    Snort you would have to use a PCRE – ``pcre:"/\x2Eexe$/U";``
 
-   ::
+   .. container:: example-rule
 
        alert http $HOME_NET any -> $EXTERNAL_NET any (msg:".EXE File Download Request"; flow:established,to_server; content:"GET"; http_method; content:".exe"; http_uri; isdataat:!1,relative; priority:3; sid:18332111;)
 

--- a/doc/userguide/rules/dns-keywords.rst
+++ b/doc/userguide/rules/dns-keywords.rst
@@ -110,7 +110,9 @@ dns.query
 ---------
 
 ``dns.query`` is a sticky buffer that is used to inspect DNS query
-names in DNS request messages. Example::
+names in DNS request messages. 
+
+.. container:: example-rule
 
   alert dns any any -> any any (msg:"Test dns.query option"; dns.query; content:"google"; nocase; sid:1;)
 
@@ -223,7 +225,9 @@ dns.response.rrname
 ``dns.response.rrname`` is a sticky buffer that is used to look at all name
 and rdata fields of DNS response (answer) resource records that are
 represented as a resource name (hostname). It supports inspecting all
-DNS response sections. Example::
+DNS response sections.
+
+.. container:: example-rule
 
   alert dns any any -> any any (msg:"Test dns.response.rrname option"; \
       dns.response.rrname; content:"google"; nocase; sid:1;)

--- a/doc/userguide/rules/file-keywords.rst
+++ b/doc/userguide/rules/file-keywords.rst
@@ -14,25 +14,35 @@ The ``file.data`` sticky buffer matches on contents of files that are
 seen in flows that Suricata evaluates. The various payload keywords can
 be used (e.g. ``startswith``, ``nocase`` and ``bsize``) with ``file.data``.
 
-Example::
+.. container:: example-rule
 
   alert smtp any any -> any any (msg:"smtp app layer file.data example"; \
- file.data; content:"example file content"; sid:1; rev:1)
+  file.data; content:"example file content"; sid:1; rev:1;)
+
+.. container:: example-rule
 
   alert http any any -> any any (msg:"http app layer file.data example"; \
- file.data; content:"example file content"; sid:2; rev:1)
+  file.data; content:"example file content"; sid:2; rev:1;)
+
+.. container:: example-rule
 
   alert http2 any any -> any any (msg:"http2 app layer file.data example"; \
- file.data; content:"example file content"; sid:3; rev:1;)
+  file.data; content:"example file content"; sid:3; rev:1;)
+
+.. container:: example-rule
 
   alert nfs any any -> any any (msg:"nfs app layer file.data example"; \
- file.data; content:" "; sid:5; rev:1)
+  file.data; content:" "; sid:5; rev:1;)
+
+.. container:: example-rule
 
   alert ftp-data any any -> any any (msg:"ftp app layer file.data example"; \
- file.data; content:"example file content"; sid:6; rev:1;)
+  file.data; content:"example file content"; sid:6; rev:1;)
+
+.. container:: example-rule
 
   alert tcp any any -> any any (msg:"tcp file.data example"; \
- file.data; content:"example file content"; sid:4; rev:1)
+  file.data; content:"example file content"; sid:4; rev:1;)
 
 **Note** file_data is the legacy notation but can still be used.
 

--- a/doc/userguide/rules/ip-reputation-rules.rst
+++ b/doc/userguide/rules/ip-reputation-rules.rst
@@ -23,9 +23,7 @@ side to check: <any|src|dst|both>
 
 ``reputation score``: 0-127
 
-Example:
-
-::
+.. container:: example-rule
 
   alert ip $HOME_NET any -> any any (msg:"IPREP internal host talking to CnC server"; flow:to_server; iprep:dst,CnC,>,30; sid:1; rev:1;)
 
@@ -66,8 +64,7 @@ Compatibility with IP-only
 
 The "iprep" keyword is compatible with "IP-only" rules. This means that a rule like:
 
-::
-
+.. container:: example-rule
 
   alert ip any any -> any any (msg:"IPREP High Value CnC"; iprep:src,CnC,>,100; sid:1; rev:1;)
 

--- a/doc/userguide/rules/ja-keywords.rst
+++ b/doc/userguide/rules/ja-keywords.rst
@@ -19,7 +19,7 @@ ja3.hash
 
 Match on JA3 hash (md5).
 
-Example::
+.. container:: example-rule
 
   alert tls any any -> any any (msg:"match JA3 hash"; \
       ja3.hash; content:"e7eca2baf4458d095b7f45da28c16c34"; \
@@ -38,7 +38,7 @@ ja3.string
 
 Match on JA3 string.
 
-Example::
+.. container:: example-rule
 
   alert tls any any -> any any (msg:"match JA3 string"; \
       ja3.string; content:"19-20-21-22"; \
@@ -57,7 +57,7 @@ ja3s.hash
 
 Match on JA3S hash (md5).
 
-Example::
+.. container:: example-rule
 
   alert tls any any -> any any (msg:"match JA3S hash"; \
       ja3s.hash; content:"b26c652e0a402a24b5ca2a660e84f9d5"; \
@@ -72,7 +72,7 @@ ja3s.string
 
 Match on JA3S string.
 
-Example::
+.. container:: example-rule
 
   alert tls any any -> any any (msg:"match on JA3S string"; \
       ja3s.string; content:"771,23-35"; sid:100004;)
@@ -86,7 +86,7 @@ ja4.hash
 
 Match on JA4 hash (e.g. ``q13d0310h3_55b375c5d22e_cd85d2d88918``).
 
-Example::
+.. container:: example-rule
 
   alert quic any any -> any any (msg:"match JA4 hash"; \
       ja4.hash; content:"q13d0310h3_55b375c5d22e_cd85d2d88918"; \

--- a/doc/userguide/rules/mdns-keywords.rst
+++ b/doc/userguide/rules/mdns-keywords.rst
@@ -18,7 +18,7 @@ resource name, for example "host.local".
 
 ``mdns.queries.rrname`` supports :doc:`multi-buffer-matching`.
 
-Example::
+.. container:: example-rule
 
   alert udp any any -> any 5353 (msg:"mDNS query for .local domain"; \
       mdns.queries.rrname; content:".local"; sid:1;)
@@ -34,7 +34,7 @@ resource name, for example "printer.local".
 
 ``mdns.answers.rrname`` supports :doc:`multi-buffer-matching`.
 
-Example::
+.. container:: example-rule
 
   alert udp any 5353 -> any any (msg:"mDNS answer for printer.local"; \
       mdns.answers.rrname; content:"printer.local"; sid:2;)
@@ -50,7 +50,7 @@ resource name, for example "device.local".
 
 ``mdns.authorities.rrname`` supports :doc:`multi-buffer-matching`.
 
-Example::
+.. container:: example-rule
 
   alert udp any 5353 -> any any (msg:"mDNS authority record check"; \
       mdns.authorities.rrname; content:"auth.local"; sid:3;)
@@ -66,7 +66,7 @@ resource name, for example "service.local".
 
 ``mdns.additionals.rrname`` supports :doc:`multi-buffer-matching`.
 
-Example::
+.. container:: example-rule
 
   alert udp any any -> any 5353 (msg:"mDNS additional record check"; \
       mdns.additionals.rrname; content:"_companion-link._tcp.local"; nocase; sid:4;)
@@ -87,7 +87,7 @@ fields that have the same format as an rrname (hostname).
 * NS
 * SOA
 
-Example::
+.. container:: example-rule
 
   alert udp any 5353 -> any any (msg:"mDNS answer data match"; \
       mdns.response.rrname; content:"Apple TV"; sid:5;)

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -76,10 +76,12 @@ Legend:
 
 It is possible to use the ! for exceptions in contents as well.
 
-For example::
+For example:
+
+.. container:: example-rule
 
   alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"Outdated Firefox on
-  Windows"; content:"User-Agent|3A| Mozilla/5.0 |28|Windows|3B| ";
+  Windows"; content:"User-Agent\|3A\| Mozilla/5.0 \|28\|Windows\|3B\| ";
   content:"Firefox/3."; distance:0; content:!"Firefox/3.6.13";
   distance:-10; sid:9000000; rev:1;)
 
@@ -521,30 +523,40 @@ Format::
 +----------------+------------------------------------------------------------------------------+
 
 
-Example::
+.. container:: example-rule
 
   alert tcp any any -> any any \
 	 (msg:"Byte_Test Example - Num = Value"; \
-	 content:"|00 01 00 02|"; byte_test:2,=,0x01,0;)
+	 content:"\|00 01 00 02\|"; byte_test:2,=,0x01,0;)
+
+.. container:: example-rule
 
   alert tcp any any -> any any \
 	 (msg:"Byte_Test Example - Num = Value relative to content"; \
-	 content:"|00 01 00 02|"; byte_test:2,=,0x03,2,relative;)
+	 content:"\|00 01 00 02\|"; byte_test:2,=,0x03,2,relative;)
+
+.. container:: example-rule
 
   alert tcp any any -> any any \
-	 (msg:"Byte_Test Example - Num != Value"; content:"|00 01 00 02|"; \
+	 (msg:"Byte_Test Example - Num != Value"; content:"\|00 01 00 02\|"; \
 	 byte_test:2,!=,0x06,0;)
 
+.. container:: example-rule
+
   alert tcp any any -> any any \ 
-         (msg:"Byte_Test Example - Detect Large Values"; content:"|00 01 00 02|"; \
-         byte_test:2,>,1000,1,relative;)
+         (msg:"Byte_Test Example - Detect Large Values"; content:"\|00 01 00 02\|"; \
+         byte_test:2,>,1000,1,relative; sid:1;)
+
+.. container:: example-rule
 
   alert tcp any any -> any any \
 	 (msg:"Byte_Test Example - Lowest bit is set"; \
-	 content:"|00 01 00 02|"; byte_test:2,&,0x01,12,relative;)
+	 content:"\|00 01 00 02\|"; byte_test:2,&,0x01,12,relative;)
+
+.. container:: example-rule
 
   alert tcp any any -> any any (msg:"Byte_Test Example - Compare to String"; \
- 	 content:"foobar"; byte_test:4,=,1337,1,relative,string,dec;)
+ 	 content:"foobar"; byte_test:4,=,1337,1,relative,string,dec; sid:1;)
 
 
 byte_math
@@ -608,20 +620,22 @@ Format::
 +-----------------------+-----------------------------------------------------------------------+
 
 
-Example::
+.. container:: example-rule
 
   alert tcp any any -> any any \
     (msg:"Testing bytemath_body"; \
-    content:"|00 04 93 F3|"; \
-    content:"|00 00 00 07|"; distance:4; within:4; \
+    content:"\|00 04 93 F3\|"; \
+    content:"\|00 00 00 07\|"; distance:4; within:4; \
     byte_math:bytes 4, offset 0, oper +, rvalue \
-    248, result var, relative;)
+    248, result var, relative; sid: 1;)
+
+.. container:: example-rule
 
   alert udp any any -> any any \
     (byte_extract: 1, 0, extracted_val, relative; \
     byte_math: bytes 1, offset 1, oper +, rvalue extracted_val, result var; \
     byte_test: 2, =, var, 13; \
-    msg:"Byte extract and byte math with byte test verification";)
+    msg:"Byte extract and byte math with byte test verification"; sid: 1;)
 
 
 byte_jump
@@ -675,20 +689,24 @@ Format::
 +-----------------------+-----------------------------------------------------------------------+
 
 
-Example::
+.. container:: example-rule
 
   alert tcp any any -> any any \
 	(msg:"Byte_Jump Example"; \
 	content:"Alice"; byte_jump:2,0; content:"Bob";)
 
+.. container:: example-rule
+
   alert tcp any any -> any any \
 	(msg:"Byte_Jump Multiple Jumps"; \
 	byte_jump:2,0; byte_jump:2,0,relative; content:"foobar"; distance:0; within:6;)
 
+.. container:: example-rule
+
   alert tcp any any -> any any \
 	(msg:"Byte_Jump From the End -8 Bytes"; \
 	byte_jump:0,0, from_end, post_offset -8; \
-	content:"|6c 33 33 74|"; distance:0 within:4;)
+	content:"\|6c 33 33 74\|"; distance:0 within:4;)
 
 
 byte_extract
@@ -740,18 +758,24 @@ Format::
  isdataat	offset				
 ==============	==================================
 
-Example::
+.. container:: example-rule
 
   alert tcp any any -> any any \
 	 (msg:"Byte_Extract Example Using distance"; \
 	 content:"Alice"; byte_extract:2,0,size; content:"Bob"; distance:size; within:3; sid:1;)
+
+.. container:: example-rule
+  
   alert tcp any any -> any any \
 	 (msg:"Byte_Extract Example Using within"; \
-	 flow:established,to_server; content:"|00 FF|"; \
-	 byte_extract:1,0,len,relative; content:"|5c 00|"; distance:2; within:len; sid:2;)
+	 flow:established,to_server; content:"\|00 FF\|"; \
+	 byte_extract:1,0,len,relative; content:"\|5c 00\|"; distance:2; within:len; sid:2;)
+
+.. container:: example-rule
+
   alert tcp any any -> any any \
 	 (msg:"Byte_Extract Example Comparing Bytes"; \
-	 flow:established,to_server; content:"|00 FF|"; \
+	 flow:established,to_server; content:"\|00 FF\|"; \
 	 byte_extract:2,0,cmp_ver,relative; content:"FooBar"; distance:0; byte_test:2,=,cmp_ver,0; sid:3;)
 
 .. _keyword_entropy:

--- a/doc/userguide/rules/prefilter-keywords.rst
+++ b/doc/userguide/rules/prefilter-keywords.rst
@@ -74,7 +74,7 @@ The prefilter engines for other non-MPM keywords can be enabled in specific rule
 
 In the following rule the TTL test will be used in prefiltering instead of the single byte pattern:
 
-::
+.. container:: example-rule
 
   alert ip any any -> any any (ttl:123; prefilter; content:"a"; sid:1;)
 

--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -4,7 +4,7 @@ Transformations
 Transformation keywords turn the data at a sticky buffer into something else. Some transformations
 support options for greater control over the transformation process
 
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (file_data; strip_whitespace; \
         content:"window.navigate("; sid:1;)
@@ -15,10 +15,10 @@ the ``navigate`` and ``(``.
 The transforms can be chained. They are processed in the order in which they
 appear in a rule. Each transform's output acts as input for the next one.
 
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (http_request_line; compress_whitespace; to_sha256; \
-        content:"|54A9 7A8A B09C 1B81 3725 2214 51D3 F997 F015 9DD7 049E E5AD CED3 945A FC79 7401|"; sid:1;)
+        content:"\|54A9 7A8A B09C 1B81 3725 2214 51D3 F997 F015 9DD7 049E E5AD CED3 945A FC79 7401\|"; sid:1;)
 
 .. note:: not all sticky buffers support transformations yet
 
@@ -29,7 +29,7 @@ Takes the buffer, and prepends a ``.`` character to help facilitate concise doma
 an input string of ``hello.google.com`` would be modified and become ``.hello.google.com``. Additionally,
 adding the dot allows ``google.com`` to match against ``content:".google.com"``
 
-Example::
+.. container:: example-rule
 
     alert dns any any -> any any (dns.query; dotprefix; \
         content:".microsoft.com"; sid:1;)
@@ -37,7 +37,9 @@ Example::
 This example will match on ``windows.update.microsoft.com`` and
 ``maps.microsoft.com.au`` but not ``windows.update.fakemicrosoft.com``.
 
-This rule can be used to match on the domain only; example::
+This rule can be used to match on the domain only; example:
+
+.. container:: example-rule
 
     alert dns any any -> any any (dns.query; dotprefix; \
         content:".microsoft.com"; endswith; sid:1;)
@@ -45,7 +47,9 @@ This rule can be used to match on the domain only; example::
 This example will match on ``windows.update.microsoft.com`` but not
 ``windows.update.microsoft.com.au``.
 
-Finally, this rule can be used to match on the TLD only; example::
+Finally, this rule can be used to match on the TLD only; example:
+
+.. container:: example-rule
 
     alert dns any any -> any any (dns.query; dotprefix; \
         content:".co.uk"; endswith; sid:1;)
@@ -94,7 +98,7 @@ strip_whitespace
 
 Strips all whitespace as considered by the ``isspace()`` call in C.
 
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (file_data; strip_whitespace; \
         content:"window.navigate("; sid:1;)
@@ -111,7 +115,7 @@ Converts the buffer to lowercase and passes the value on.
 
 This example alerts if ``http.uri`` contains ``this text has been converted to lowercase``
 
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (http.uri; to_lowercase; \
         content:"this text has been converted to lowercase"; sid:1;)
@@ -122,10 +126,10 @@ to_md5
 Takes the buffer, calculates the MD5 hash and passes the raw hash value
 on.
 
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (http_request_line; to_md5; \
-        content:"|54 A9 7A 8A B0 9C 1B 81 37 25 22 14 51 D3 F9 97|"; sid:1;)
+        content:"\|54 A9 7A 8A B0 9C 1B 81 37 25 22 14 51 D3 F9 97\|"; sid:1;)
 
 to_uppercase
 ------------
@@ -134,7 +138,7 @@ Converts the buffer to uppercase and passes the value on.
 
 This example alerts if ``http.uri`` contains ``THIS TEXT HAS BEEN CONVERTED TO UPPERCASE``
 
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (http.uri; to_uppercase; \
         content:"THIS TEXT HAS BEEN CONVERTED TO UPPERCASE"; sid:1;)
@@ -145,10 +149,10 @@ to_sha1
 Takes the buffer, calculates the SHA-1 hash and passes the raw hash value
 on.
 
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (http_request_line; to_sha1; \
-        content:"|54A9 7A8A B09C 1B81 3725 2214 51D3 F997 F015 9DD7|"; sid:1;)
+        content:"\|54A9 7A8A B09C 1B81 3725 2214 51D3 F997 F015 9DD7\|"; sid:1;)
 
 to_sha256
 ---------
@@ -156,10 +160,10 @@ to_sha256
 Takes the buffer, calculates the SHA-256 hash and passes the raw hash value
 on.
 
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (http_request_line; to_sha256; \
-        content:"|54A9 7A8A B09C 1B81 3725 2214 51D3 F997 F015 9DD7 049E E5AD CED3 945A FC79 7401|"; sid:1;)
+        content:"\|54A9 7A8A B09C 1B81 3725 2214 51D3 F997 F015 9DD7 049E E5AD CED3 945A FC79 7401\|"; sid:1;)
 
 pcrexform
 ---------
@@ -170,7 +174,7 @@ Takes the buffer, applies the required regular expression, and outputs the *firs
 
 
 This example alerts if ``http.request_line`` contains ``/dropper.php``
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (msg:"HTTP with pcrexform"; http.request_line; \
         pcrexform:"[a-zA-Z]+\s+(.*)\s+HTTP"; content:"/dropper.php"; sid:1;)
@@ -190,7 +194,7 @@ Takes the buffer, applies xor decoding.
 
 
 This example alerts if ``http.uri`` contains ``password=`` xored with 4-bytes key ``0d0ac8ff``
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (msg:"HTTP with xor"; http.uri; \
         xor:"0d0ac8ff"; content:"password="; sid:1;)
@@ -206,7 +210,7 @@ The implementation uses a state machine :
 - it does not change until it finds a new line and switch back to first state
 
 This example alerts for both HTTP/1 and HTTP/2 with a authorization header
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (msg:"HTTP authorization"; http.header_names; \
         header_lowercase; content:"authorization:"; sid:1;)
@@ -220,10 +224,10 @@ It strips HTTP2 pseudo-headers (names and values).
 The implementation just strips every line beginning by ``:``.
 
 This example alerts for both HTTP/1 and HTTP/2 with only a user agent
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (msg:"HTTP ua only"; http.header_names; \
-       bsize:16; content:"|0d 0a|User-Agent|0d 0a 0d 0a|"; nocase; sid:1;)
+       bsize:16; content:"\|0d 0a\|User-Agent\|0d 0a 0d 0a\|"; nocase; sid:1;)
 
 .. _from_base64:
 
@@ -409,7 +413,7 @@ the transform will decompress data up to max-size.
 Value 0 is forbidden for max-size (there is no unlimited value).
 
 This example alerts if ``http.uri`` contains base64-encoded gzipped value
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (msg:"from_base64 + gunzip";
             http.uri; content:"/gzb64?value="; fast_pattern;
@@ -431,7 +435,7 @@ the transform will decompress data up to max-size.
 Value 0 is forbidden for max-size (there is no unlimited value).
 
 This example alerts if ``http.uri`` contains base64-encoded zlib-compressed value
-Example::
+.. container:: example-rule
 
     alert http any any -> any any (msg:"from_base64 + gunzip";
             http.uri; content:"/zb64?value="; fast_pattern;

--- a/doc/userguide/rules/xbits.rst
+++ b/doc/userguide/rules/xbits.rst
@@ -103,15 +103,22 @@ The first 2 rules match on a SSH software version often used in bots.
 They drop the traffic and create an 'xbit' 'badssh' for the source ip.
 It expires in an hour::
 
+.. container:: example-rule
+
     drop ssh any any -> $MYSERVER 22 (msg:"DROP libssh incoming";   \
       flow:to_server,established; ssh.software; content:"libssh";     \
       xbits:set, badssh, track ip_src, expire 3600; sid:4000000005;)
+
+.. container:: example-rule
+
     drop ssh any any -> $MYSERVER 22 (msg:"DROP PUTTY incoming";    \
       flow:to_server,established; ssh.software; content:"PUTTY";      \
       xbits:set, badssh, track ip_src, expire 3600; sid:4000000007;)
 
 Then the following rule simply drops any incoming traffic to that server
 that is on that 'badssh' list::
+
+.. container:: example-rule
 
     drop ssh any any -> $MYSERVER 22 (msg:"DROP BLACKLISTED";       \
       xbits:isset, badssh, track ip_src; sid:4000000006;)

--- a/scripts/check-doc-rules.py
+++ b/scripts/check-doc-rules.py
@@ -19,10 +19,6 @@ from typing import Iterable, Iterator, List, Optional, Tuple
 ROLE_RE = re.compile(
     r"`?:example-rule-(?:action|header|options|emphasis):`([^`]*)`"
 )
-RULE_START_RE = re.compile(
-    r"^(alert|drop|pass|reject|rejectsrc|rejectdst|rejectboth)\b", re.IGNORECASE
-)
-
 
 RuleWithOrigin = Tuple[str, Path, int]
 
@@ -124,7 +120,6 @@ def check_rule_with_suricata(
             str(suricata_bin),
             "-T",
             "-c", str(suricata_yaml),
-            "--set", "app-layer.protocols.pgsql.enabled=true",
             "--data-dir="+tmpdir,
             "-S", str(rule_file),
             "-l", tmpdir,

--- a/scripts/docrules/docrules.yaml
+++ b/scripts/docrules/docrules.yaml
@@ -8,6 +8,7 @@ vars:
   address-groups:
     HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
     EXTERNAL_NET: "!$HOME_NET"
+    MYSERVER: "192.168.12.34"
 
 
 datasets:

--- a/scripts/docrules/docrulesrep.lst
+++ b/scripts/docrules/docrulesrep.lst
@@ -1,2 +1,3 @@
 10,trusted-hosts,comment
 21,known-bad-hosts,another comment
+22,CnC,another comment

--- a/src/detect-dns-name.c
+++ b/src/detect-dns-name.c
@@ -51,12 +51,24 @@ static int mdns_answer_buffer_id = 0;
 static int mdns_authority_buffer_id = 0;
 static int mdns_additional_buffer_id = 0;
 
-static int DetectSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str, int id)
+static int DetectSetupDNS(DetectEngineCtx *de_ctx, Signature *s, const char *str, int id)
 {
     if (SCDetectBufferSetActiveList(de_ctx, s, id) < 0) {
         return -1;
     }
-    if (SCDetectSignatureSetAppProto(s, s->alproto) < 0) {
+    if (SCDetectSignatureSetAppProto(s, ALPROTO_DNS) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int DetectSetupMDNS(DetectEngineCtx *de_ctx, Signature *s, const char *str, int id)
+{
+    if (SCDetectBufferSetActiveList(de_ctx, s, id) < 0) {
+        return -1;
+    }
+    if (SCDetectSignatureSetAppProto(s, ALPROTO_MDNS) < 0) {
         return -1;
     }
 
@@ -65,42 +77,42 @@ static int DetectSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str, i
 
 static int SetupQueryBuffer(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    return DetectSetup(de_ctx, s, str, query_buffer_id);
+    return DetectSetupDNS(de_ctx, s, str, query_buffer_id);
 }
 
 static int SetupAnswerBuffer(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    return DetectSetup(de_ctx, s, str, answer_buffer_id);
+    return DetectSetupDNS(de_ctx, s, str, answer_buffer_id);
 }
 
 static int SetupAdditionalsBuffer(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    return DetectSetup(de_ctx, s, str, additional_buffer_id);
+    return DetectSetupDNS(de_ctx, s, str, additional_buffer_id);
 }
 
 static int SetupAuthoritiesBuffer(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    return DetectSetup(de_ctx, s, str, authority_buffer_id);
+    return DetectSetupDNS(de_ctx, s, str, authority_buffer_id);
 }
 
 static int SetupQueryBufferMdns(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    return DetectSetup(de_ctx, s, str, mdns_query_buffer_id);
+    return DetectSetupMDNS(de_ctx, s, str, mdns_query_buffer_id);
 }
 
 static int SetupAnswerBufferMdns(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    return DetectSetup(de_ctx, s, str, mdns_answer_buffer_id);
+    return DetectSetupMDNS(de_ctx, s, str, mdns_answer_buffer_id);
 }
 
 static int SetupAdditionalsBufferMdns(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    return DetectSetup(de_ctx, s, str, mdns_additional_buffer_id);
+    return DetectSetupMDNS(de_ctx, s, str, mdns_additional_buffer_id);
 }
 
 static int SetupAuthoritiesBufferMdns(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    return DetectSetup(de_ctx, s, str, mdns_authority_buffer_id);
+    return DetectSetupMDNS(de_ctx, s, str, mdns_authority_buffer_id);
 }
 
 static int Register(const char *keyword, const char *desc, const char *doc,


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8372

Describe changes:
- doc: move more rules to css container
- detect/dns: fix loading of rules like `alert udp any any -> any 5353 (mdns.additionals.rrname; content:"_companion-link._tcp.local"; nocase; sid:4;)`

cc @jasonish what do you think about the (M)DNS stuff ? Does it deserve its ticket+SV test + backport ?