### PR TITLE
Plugin crate zerodep 7666 v7

### DIFF
--- a/examples/plugins/altemplate/src/template.rs
+++ b/examples/plugins/altemplate/src/template.rs
@@ -30,7 +30,7 @@ use suricata::applayer::{
     state_get_tx_iterator, AppLayerEvent, AppLayerTxData, State, Transaction,
     APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS, APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
 };
-use suricata::applayer::{AppLayerResultRust, StreamSliceRust};
+use suricata_ffi::applayer::{AppLayerResultRust, StreamSliceRust};
 use suricata_ffi::conf::conf_get;
 use suricata_ffi::{
     build_slice, cast_pointer, export_state_data_get, export_tx_data_get, SCLogError, SCLogNotice,

--- a/examples/plugins/altemplate/src/template.rs
+++ b/examples/plugins/altemplate/src/template.rs
@@ -31,9 +31,11 @@ use suricata::applayer::{
     APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS, APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
 };
 use suricata::applayer::{AppLayerResultRust, StreamSliceRust};
-use suricata::{export_state_data_get, export_tx_data_get};
 use suricata_ffi::conf::conf_get;
-use suricata_ffi::{build_slice, cast_pointer, SCLogError, SCLogNotice, IPPROTO_TCP};
+use suricata_ffi::{
+    build_slice, cast_pointer, export_state_data_get, export_tx_data_get, SCLogError, SCLogNotice,
+    IPPROTO_TCP,
+};
 use suricata_sys::sys::AppProtoEnum::ALPROTO_UNKNOWN;
 use suricata_sys::sys::{
     AppLayerParser, AppLayerParserState, AppLayerProtocolDetect, AppLayerResult, AppLayerStateData,

--- a/rust/ffi/src/applayer.rs
+++ b/rust/ffi/src/applayer.rs
@@ -1,0 +1,42 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! App-layer utils.
+
+#[macro_export]
+macro_rules! export_tx_data_get {
+    ($name:ident, $type:ty) => {
+        unsafe extern "C" fn $name(
+            tx: *mut std::os::raw::c_void,
+        ) -> *mut suricata_sys::sys::AppLayerTxData {
+            let tx = &mut *(tx as *mut $type);
+            &mut tx.tx_data.0
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! export_state_data_get {
+    ($name:ident, $type:ty) => {
+        unsafe extern "C" fn $name(
+            state: *mut std::os::raw::c_void,
+        ) -> *mut suricata_sys::sys::AppLayerStateData {
+            let state = &mut *(state as *mut $type);
+            &mut state.state_data
+        }
+    };
+}

--- a/rust/ffi/src/applayer.rs
+++ b/rust/ffi/src/applayer.rs
@@ -17,6 +17,8 @@
 
 //! App-layer utils.
 
+use suricata_sys::sys::{AppLayerResult, StreamSlice};
+
 #[macro_export]
 macro_rules! export_tx_data_get {
     ($name:ident, $type:ty) => {
@@ -39,4 +41,101 @@ macro_rules! export_state_data_get {
             &mut state.state_data
         }
     };
+}
+
+pub trait AppLayerResultRust {
+    fn ok() -> Self;
+    fn err() -> Self;
+    fn incomplete(consumed: u32, needed: u32) -> Self;
+    fn is_ok(&self) -> bool;
+    fn is_err(&self) -> bool;
+    fn is_incomplete(&self) -> bool;
+}
+
+impl AppLayerResultRust for AppLayerResult {
+    /// parser has successfully processed in the input, and has consumed all of it
+    fn ok() -> Self {
+        Default::default()
+    }
+    /// parser has hit an unrecoverable error. Returning this to the API
+    /// leads to no further calls to the parser.
+    fn err() -> Self {
+        AppLayerResult {
+            status: -1,
+            ..Default::default()
+        }
+    }
+
+    /// parser needs more data. Through 'consumed' it will indicate how many
+    /// of the input bytes it has consumed. Through 'needed' it will indicate
+    /// how many more bytes it needs before getting called again.
+    /// Note: consumed should never be more than the input len
+    ///       needed + consumed should be more than the input len
+    fn incomplete(consumed: u32, needed: u32) -> Self {
+        Self {
+            status: 1,
+            consumed,
+            needed,
+        }
+    }
+
+    fn is_ok(&self) -> bool {
+        self.status == 0
+    }
+
+    fn is_err(&self) -> bool {
+        self.status == -1
+    }
+
+    fn is_incomplete(&self) -> bool {
+        self.status == 1
+    }
+}
+
+pub trait StreamSliceRust {
+    fn from_slice(slice: &[u8], flags: u8, offset: u64) -> Self;
+    fn is_gap(&self) -> bool;
+    fn gap_size(&self) -> u32;
+    fn as_slice(&self) -> &[u8];
+    fn is_empty(&self) -> bool;
+    fn len(&self) -> u32;
+    fn offset_from(&self, slice: &[u8]) -> u32;
+    fn flags(&self) -> u8;
+}
+
+impl StreamSliceRust for StreamSlice {
+    /// Create a StreamSlice from a Rust slice. Useful in unit tests.
+    fn from_slice(slice: &[u8], flags: u8, offset: u64) -> Self {
+        Self {
+            input: slice.as_ptr(),
+            input_len: slice.len() as u32,
+            flags,
+            offset,
+        }
+    }
+
+    fn is_gap(&self) -> bool {
+        self.input.is_null() && self.input_len > 0
+    }
+    fn gap_size(&self) -> u32 {
+        self.input_len
+    }
+    fn as_slice(&self) -> &[u8] {
+        if self.input.is_null() && self.input_len == 0 {
+            return &[];
+        }
+        unsafe { std::slice::from_raw_parts(self.input, self.input_len as usize) }
+    }
+    fn is_empty(&self) -> bool {
+        self.input_len == 0
+    }
+    fn len(&self) -> u32 {
+        self.input_len
+    }
+    fn offset_from(&self, slice: &[u8]) -> u32 {
+        self.len() - slice.len() as u32
+    }
+    fn flags(&self) -> u8 {
+        self.flags
+    }
 }

--- a/rust/ffi/src/conf.rs
+++ b/rust/ffi/src/conf.rs
@@ -42,3 +42,9 @@ pub fn conf_get(key: &str) -> Option<&str> {
 
     Some(value)
 }
+
+// Return the value of key as a boolean. A value that is not set is
+// the same as having it set to false.
+pub fn conf_get_bool(key: &str) -> bool {
+    matches!(conf_get(key), Some("1" | "yes" | "true" | "on"))
+}

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -15,6 +15,7 @@
  * 02110-1301, USA.
  */
 
+pub mod applayer;
 pub mod conf;
 pub mod debug;
 pub mod detect;

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -41,56 +41,6 @@ use suricata_sys::sys::SCAppLayerDecoderEventsSetEventRaw;
 
 pub use suricata_ffi::cast_pointer;
 
-pub trait StreamSliceRust {
-    #[cfg(test)]
-    fn from_slice(slice: &[u8], flags: u8, offset: u64) -> Self;
-    fn is_gap(&self) -> bool;
-    fn gap_size(&self) -> u32;
-    fn as_slice(&self) -> &[u8];
-    fn is_empty(&self) -> bool;
-    fn len(&self) -> u32;
-    fn offset_from(&self, slice: &[u8]) -> u32;
-    fn flags(&self) -> u8;
-}
-
-impl StreamSliceRust for StreamSlice {
-    /// Create a StreamSlice from a Rust slice. Useful in unit tests.
-    #[cfg(test)]
-    fn from_slice(slice: &[u8], flags: u8, offset: u64) -> Self {
-        Self {
-            input: slice.as_ptr(),
-            input_len: slice.len() as u32,
-            flags,
-            offset
-        }
-    }
-
-    fn is_gap(&self) -> bool {
-        self.input.is_null() && self.input_len > 0
-    }
-    fn gap_size(&self) -> u32 {
-        self.input_len
-    }
-    fn as_slice(&self) -> &[u8] {
-        if self.input.is_null() && self.input_len == 0 {
-            return &[];
-        }
-        unsafe { std::slice::from_raw_parts(self.input, self.input_len as usize) }
-    }
-    fn is_empty(&self) -> bool {
-        self.input_len == 0
-    }
-    fn len(&self) -> u32 {
-        self.input_len
-    }
-    fn offset_from(&self, slice: &[u8]) -> u32 {
-        self.len() - slice.len() as u32
-    }
-    fn flags(&self) -> u8 {
-        self.flags
-    }
-}
-
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct AppLayerTxData(pub suricata_sys::sys::AppLayerTxData);
 
@@ -184,54 +134,7 @@ pub unsafe extern "C" fn SCTxDataUpdateFileFlags(txd: &mut suricata_sys::sys::Ap
 
 pub use suricata_ffi::{export_tx_data_get, export_state_data_get};
 
-pub trait AppLayerResultRust {
-    fn ok() -> Self;
-    fn err() -> Self;
-    fn incomplete(consumed: u32, needed: u32) -> Self;
-    fn is_ok(&self) -> bool;
-    fn is_err(&self) -> bool;
-    fn is_incomplete(&self) -> bool;
-}
-
-impl AppLayerResultRust for AppLayerResult {
-    /// parser has successfully processed in the input, and has consumed all of it
-    fn ok() -> Self {
-        Default::default()
-    }
-    /// parser has hit an unrecoverable error. Returning this to the API
-    /// leads to no further calls to the parser.
-    fn err() -> Self {
-        return AppLayerResult{
-            status: -1,
-            ..Default::default()
-        };
-    }
-
-    /// parser needs more data. Through 'consumed' it will indicate how many
-    /// of the input bytes it has consumed. Through 'needed' it will indicate
-    /// how many more bytes it needs before getting called again.
-    /// Note: consumed should never be more than the input len
-    ///       needed + consumed should be more than the input len
-    fn incomplete(consumed: u32, needed: u32) -> Self {
-        return Self {
-            status: 1,
-            consumed,
-            needed,
-        };
-    }
-
-    fn is_ok(&self) -> bool {
-        self.status == 0
-    }
-
-    fn is_err(&self) -> bool {
-        self.status == -1
-    }
-
-    fn is_incomplete(&self) -> bool {
-        self.status == 1
-    }
-}
+pub use suricata_ffi::applayer::{AppLayerResultRust, StreamSliceRust};
 
 /// Rust parser declaration
 #[repr(C)]

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -182,29 +182,7 @@ pub unsafe extern "C" fn SCTxDataUpdateFileFlags(txd: &mut suricata_sys::sys::Ap
     }
 }
 
-#[macro_export]
-macro_rules!export_tx_data_get {
-    ($name:ident, $type:ty) => {
-        unsafe extern "C" fn $name(tx: *mut std::os::raw::c_void)
-            -> *mut suricata_sys::sys::AppLayerTxData
-        {
-            let tx = &mut *(tx as *mut $type);
-            &mut tx.tx_data.0
-        }
-    }
-}
-
-#[macro_export]
-macro_rules!export_state_data_get {
-    ($name:ident, $type:ty) => {
-        unsafe extern "C" fn $name(state: *mut std::os::raw::c_void)
-            -> *mut $crate::applayer::AppLayerStateData
-        {
-            let state = &mut *(state as *mut $type);
-            &mut state.state_data
-        }
-    }
-}
+pub use suricata_ffi::{export_tx_data_get, export_state_data_get};
 
 pub trait AppLayerResultRust {
     fn ok() -> Self;

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -53,13 +53,7 @@ pub fn conf_get_node(key: &str) -> Option<ConfNode> {
     }
 }
 
-pub use suricata_ffi::conf::conf_get;
-
-// Return the value of key as a boolean. A value that is not set is
-// the same as having it set to false.
-pub fn conf_get_bool(key: &str) -> bool {
-    matches!(conf_get(key), Some("1" | "yes" | "true" | "on"))
-}
+pub use suricata_ffi::conf::{conf_get, conf_get_bool};
 
 /// Wrap a Suricata ConfNode and expose some of its methods with a
 /// Rust friendly interface.


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7666

Describe changes:

reduce dependencies on suricata crate for plugins

- rust/ffi: move conf_get_bool helper to ffi crate
- rust/ffi: move export_X_data_get macros to ffi crate
- rust/ffi: move app-layer traits to ffi crate

#15150 next batch

Next PR : tackle last `src/template.rs:use suricata::applayer::` 