### PR TITLE
Backport8 8395 8482 v4

### DIFF
--- a/doc/userguide/rules/snmp-keywords.rst
+++ b/doc/userguide/rules/snmp-keywords.rst
@@ -97,3 +97,27 @@ Signature example::
 
  alert snmp any any -> any any (msg:"SNMP response"; snmp.pdu_type:2; sid:3; rev:1;)
 
+snmp.trap_type
+--------------
+
+SNMP Trap type (integer).
+
+snmp.trap_type uses an, :ref:` unsigned 8-bits integer <rules-integer-keywords>`.
+
+You can specify the value as an integer or a string:
+
+ - 0: coldstart
+ - 1: warmstart
+ - 2: linkdown
+ - 3: linkup
+ - 4: authenticationfailure
+ - 5: egpneighborloss
+ - 6: enterprisespecific
+
+Syntax::
+
+ snmp.trap_type:(mode) <number or string>
+
+Signature example::
+
+ alert snmp any any -> any 162 (msg:"SNMP trap cold start"; snmp.pdu_type:trap_v1; snmp.trap_type:coldstart; sid:3; rev:1;)

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5572,7 +5572,12 @@
                     "type": "string"
                 },
                 "trap_type": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "snmp.trap_type"
+                        ]
+                    }
                 },
                 "usm": {
                     "type": "string"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5565,6 +5565,15 @@
                         ]
                     }
                 },
+                "trap_address": {
+                    "type": "string"
+                },
+                "trap_oid": {
+                    "type": "string"
+                },
+                "trap_type": {
+                    "type": "string"
+                },
                 "usm": {
                     "type": "string"
                 },

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -118,6 +118,7 @@ pub const SIGMATCH_NOOPT: u16 = 1; // BIT_U16(0) in detect.h
 pub(crate) const SIGMATCH_OPTIONAL_OPT: u16 = 0x10; // BIT_U16(4) in detect.h
 pub(crate) const SIGMATCH_QUOTES_MANDATORY: u16 = 0x40; // BIT_U16(6) in detect.h
 pub const SIGMATCH_INFO_STICKY_BUFFER: u16 = 0x200; // BIT_U16(9)
+pub(crate) const SIGMATCH_SUPPORT_FIREWALL: u16 = 0x1000; // BIT_U16(12)
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -20,7 +20,7 @@
 use super::snmp::{SNMPTransaction, ALPROTO_SNMP};
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{DetectUintData, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse};
-use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer};
+use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_SUPPORT_FIREWALL};
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
@@ -176,7 +176,7 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         AppLayerTxMatch: Some(snmp_detect_version_match),
         Setup: Some(snmp_detect_version_setup),
         Free: Some(snmp_detect_version_free),
-        flags: 0,
+        flags: SIGMATCH_SUPPORT_FIREWALL,
     };
     G_SNMP_VERSION_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_SNMP_VERSION_BUFFER_ID = SCDetectHelperBufferProgressRegister(
@@ -193,7 +193,7 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         AppLayerTxMatch: Some(snmp_detect_pdutype_match),
         Setup: Some(snmp_detect_pdutype_setup),
         Free: Some(snmp_detect_pdutype_free),
-        flags: 0,
+        flags: SIGMATCH_SUPPORT_FIREWALL,
     };
     G_SNMP_PDUTYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_SNMP_PDUTYPE_BUFFER_ID = SCDetectHelperBufferProgressRegister(

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -24,9 +24,9 @@ use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuf
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
-    SCDetectHelperBufferMpmRegister, SCDetectHelperBufferRegister, SCDetectHelperKeywordRegister,
-    SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx,
-    Signature,
+    SCDetectHelperBufferProgressMpmRegister, SCDetectHelperBufferProgressRegister,
+    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
+    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
 };
 
 static mut G_SNMP_VERSION_KW_ID: u16 = 0;
@@ -179,10 +179,11 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         flags: 0,
     };
     G_SNMP_VERSION_KW_ID = SCDetectHelperKeywordRegister(&kw);
-    G_SNMP_VERSION_BUFFER_ID = SCDetectHelperBufferRegister(
+    G_SNMP_VERSION_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"snmp.version\0".as_ptr() as *const libc::c_char,
         ALPROTO_SNMP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
+        1,
     );
 
     let kw = SCSigTableAppLiteElmt {
@@ -195,10 +196,11 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         flags: 0,
     };
     G_SNMP_PDUTYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
-    G_SNMP_PDUTYPE_BUFFER_ID = SCDetectHelperBufferRegister(
+    G_SNMP_PDUTYPE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"snmp.pdu_type\0".as_ptr() as *const libc::c_char,
         ALPROTO_SNMP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
+        1,
     );
 
     let kw = SigTableElmtStickyBuffer {
@@ -208,12 +210,13 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         setup: snmp_detect_usm_setup,
     };
     let _g_snmp_usm_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_SNMP_USM_BUFFER_ID = SCDetectHelperBufferMpmRegister(
+    G_SNMP_USM_BUFFER_ID = SCDetectHelperBufferProgressMpmRegister(
         b"snmp.usm\0".as_ptr() as *const libc::c_char,
         b"SNMP USM\0".as_ptr() as *const libc::c_char,
         ALPROTO_SNMP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
         Some(snmp_detect_usm_get_data),
+        1,
     );
 
     let kw = SigTableElmtStickyBuffer {
@@ -223,11 +226,12 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         setup: snmp_detect_community_setup,
     };
     let _g_snmp_community_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_SNMP_COMMUNITY_BUFFER_ID = SCDetectHelperBufferMpmRegister(
+    G_SNMP_COMMUNITY_BUFFER_ID = SCDetectHelperBufferProgressMpmRegister(
         b"snmp.community\0".as_ptr() as *const libc::c_char,
         b"SNMP Community identifier\0".as_ptr() as *const libc::c_char,
         ALPROTO_SNMP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
         Some(snmp_detect_community_get_data),
+        1,
     );
 }

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2019 Open Information Security Foundation
+/* Copyright (C) 2017-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -19,8 +19,14 @@
 
 use super::snmp::{SNMPTransaction, ALPROTO_SNMP};
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
-use crate::detect::uint::{DetectUintData, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse};
-use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_SUPPORT_FIREWALL};
+use crate::detect::uint::{
+    detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse,
+    SCDetectU8Free, SCDetectU8Match,
+};
+use crate::detect::{
+    helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_SUPPORT_FIREWALL,
+};
+use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
@@ -35,6 +41,8 @@ static mut G_SNMP_PDUTYPE_KW_ID: u16 = 0;
 static mut G_SNMP_PDUTYPE_BUFFER_ID: c_int = 0;
 static mut G_SNMP_USM_BUFFER_ID: c_int = 0;
 static mut G_SNMP_COMMUNITY_BUFFER_ID: c_int = 0;
+static mut G_SNMP_TRAPTYPE_KW_ID: u16 = 0;
+static mut G_SNMP_TRAPTYPE_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn snmp_detect_version_setup(
     de: *mut DetectEngineCtx, s: *mut Signature, raw: *const libc::c_char,
@@ -74,6 +82,77 @@ unsafe extern "C" fn snmp_detect_version_free(_de: *mut DetectEngineCtx, ctx: *m
     // Just unbox...
     let ctx = cast_pointer!(ctx, DetectUintData<u32>);
     SCDetectU32Free(ctx);
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, FromPrimitive, EnumStringU8)]
+#[allow(non_camel_case_types)]
+pub enum SnmpTrapType {
+    COLDSTART = 0,
+    WARMSTART = 1,
+    LINKDOWN = 2,
+    LINKUP = 3,
+    AUTHENTICATIONFAILURE = 4,
+    EGPNEIGHBORLOSS = 5,
+    ENTERPRISESPECIFIC = 6,
+}
+
+unsafe extern "C" fn snmp_detect_traptype_parse(
+    ustr: *const std::os::raw::c_char,
+) -> *mut DetectUintData<u8> {
+    let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
+    if let Ok(s) = ft_name.to_str() {
+        if let Some(ctx) = detect_parse_uint_enum::<u8, SnmpTrapType>(s) {
+            let boxed = Box::new(ctx);
+            return Box::into_raw(boxed);
+        }
+    }
+    return std::ptr::null_mut();
+}
+
+unsafe extern "C" fn snmp_detect_traptype_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const libc::c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_SNMP) != 0 {
+        return -1;
+    }
+    let ctx = snmp_detect_traptype_parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_SNMP_TRAPTYPE_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_SNMP_TRAPTYPE_BUFFER_ID,
+    )
+    .is_null()
+    {
+        snmp_detect_traptype_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn snmp_detect_traptype_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, _flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, SNMPTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    if let Some(ref info) = tx.info {
+        if let Some((trap_type, _, _)) = info.trap_type {
+            return SCDetectU8Match(trap_type.0, ctx);
+        }
+    }
+    return 0;
+}
+
+unsafe extern "C" fn snmp_detect_traptype_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    SCDetectU8Free(ctx);
 }
 
 unsafe extern "C" fn snmp_detect_pdutype_setup(
@@ -232,6 +311,23 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         ALPROTO_SNMP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
         Some(snmp_detect_community_get_data),
+        1,
+    );
+
+    let kw = SCSigTableAppLiteElmt {
+        name: b"snmp.trap_type\0".as_ptr() as *const libc::c_char,
+        desc: b"match SNMP Trap type\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/snmp-keywords.html#snmp-trap-type\0".as_ptr() as *const libc::c_char,
+        AppLayerTxMatch: Some(snmp_detect_traptype_match),
+        Setup: Some(snmp_detect_traptype_setup),
+        Free: Some(snmp_detect_traptype_free),
+        flags: SIGMATCH_SUPPORT_FIREWALL,
+    };
+    G_SNMP_TRAPTYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_SNMP_TRAPTYPE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"snmp.trap_type\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SNMP,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         1,
     );
 }

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -36,13 +36,11 @@ use suricata_sys::sys::{
 };
 
 static mut G_SNMP_VERSION_KW_ID: u16 = 0;
-static mut G_SNMP_VERSION_BUFFER_ID: c_int = 0;
 static mut G_SNMP_PDUTYPE_KW_ID: u16 = 0;
-static mut G_SNMP_PDUTYPE_BUFFER_ID: c_int = 0;
 static mut G_SNMP_USM_BUFFER_ID: c_int = 0;
 static mut G_SNMP_COMMUNITY_BUFFER_ID: c_int = 0;
 static mut G_SNMP_TRAPTYPE_KW_ID: u16 = 0;
-static mut G_SNMP_TRAPTYPE_BUFFER_ID: c_int = 0;
+static mut G_SNMP_GENERIC_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn snmp_detect_version_setup(
     de: *mut DetectEngineCtx, s: *mut Signature, raw: *const libc::c_char,
@@ -59,7 +57,7 @@ unsafe extern "C" fn snmp_detect_version_setup(
         s,
         G_SNMP_VERSION_KW_ID,
         ctx as *mut SigMatchCtx,
-        G_SNMP_VERSION_BUFFER_ID,
+        G_SNMP_GENERIC_BUFFER_ID,
     )
     .is_null()
     {
@@ -125,7 +123,7 @@ unsafe extern "C" fn snmp_detect_traptype_setup(
         s,
         G_SNMP_TRAPTYPE_KW_ID,
         ctx as *mut SigMatchCtx,
-        G_SNMP_TRAPTYPE_BUFFER_ID,
+        G_SNMP_GENERIC_BUFFER_ID,
     )
     .is_null()
     {
@@ -170,7 +168,7 @@ unsafe extern "C" fn snmp_detect_pdutype_setup(
         s,
         G_SNMP_PDUTYPE_KW_ID,
         ctx as *mut SigMatchCtx,
-        G_SNMP_PDUTYPE_BUFFER_ID,
+        G_SNMP_GENERIC_BUFFER_ID,
     )
     .is_null()
     {
@@ -248,6 +246,12 @@ unsafe extern "C" fn snmp_detect_community_get_data(
 }
 
 pub(super) unsafe extern "C" fn detect_snmp_register() {
+    G_SNMP_GENERIC_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"snmp.generic\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SNMP,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        1,
+    );
     let kw = SCSigTableAppLiteElmt {
         name: b"snmp.version\0".as_ptr() as *const libc::c_char,
         desc: b"match SNMP version\0".as_ptr() as *const libc::c_char,
@@ -258,12 +262,6 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         flags: SIGMATCH_SUPPORT_FIREWALL,
     };
     G_SNMP_VERSION_KW_ID = SCDetectHelperKeywordRegister(&kw);
-    G_SNMP_VERSION_BUFFER_ID = SCDetectHelperBufferProgressRegister(
-        b"snmp.version\0".as_ptr() as *const libc::c_char,
-        ALPROTO_SNMP,
-        STREAM_TOSERVER | STREAM_TOCLIENT,
-        1,
-    );
 
     let kw = SCSigTableAppLiteElmt {
         name: b"snmp.pdu_type\0".as_ptr() as *const libc::c_char,
@@ -275,12 +273,6 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         flags: SIGMATCH_SUPPORT_FIREWALL,
     };
     G_SNMP_PDUTYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
-    G_SNMP_PDUTYPE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
-        b"snmp.pdu_type\0".as_ptr() as *const libc::c_char,
-        ALPROTO_SNMP,
-        STREAM_TOSERVER | STREAM_TOCLIENT,
-        1,
-    );
 
     let kw = SigTableElmtStickyBuffer {
         name: String::from("snmp.usm"),
@@ -324,10 +316,4 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         flags: SIGMATCH_SUPPORT_FIREWALL,
     };
     G_SNMP_TRAPTYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
-    G_SNMP_TRAPTYPE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
-        b"snmp.trap_type\0".as_ptr() as *const libc::c_char,
-        ALPROTO_SNMP,
-        STREAM_TOSERVER | STREAM_TOCLIENT,
-        1,
-    );
 }

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -375,6 +375,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn SCDetectHelperBufferProgressMpmRegister(
+        name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
+        alproto: AppProto, direction: u8, GetData: InspectionSingleBufferGetDataPtr,
+        progress: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn SCDetectHelperMultiBufferMpmRegister(
         name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
         alproto: AppProto, direction: u8, GetData: InspectionMultiBufferGetDataPtr,

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -363,6 +363,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn SCDetectHelperBufferProgressRegister(
+        name: *const ::std::os::raw::c_char, alproto: AppProto, direction: u8,
+        progress: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn SCDetectHelperBufferMpmRegister(
         name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
         alproto: AppProto, direction: u8, GetData: InspectionSingleBufferGetDataPtr,

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -77,6 +77,25 @@ int SCDetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto
     return DetectBufferTypeGetByName(name);
 }
 
+int SCDetectHelperBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
+        uint8_t direction, InspectionSingleBufferGetDataPtr GetData, int progress)
+{
+    if (direction & STREAM_TOSERVER) {
+        DetectAppLayerInspectEngineRegisterSingle(name, alproto, SIG_FLAG_TOSERVER, progress,
+                DetectEngineInspectBufferSingle, GetData);
+        DetectAppLayerMpmRegisterSingle(
+                name, SIG_FLAG_TOSERVER, 2, PrefilterSingleMpmRegister, GetData, alproto, progress);
+    }
+    if (direction & STREAM_TOCLIENT) {
+        DetectAppLayerInspectEngineRegisterSingle(name, alproto, SIG_FLAG_TOCLIENT, progress,
+                DetectEngineInspectBufferSingle, GetData);
+        DetectAppLayerMpmRegisterSingle(
+                name, SIG_FLAG_TOCLIENT, 2, PrefilterSingleMpmRegister, GetData, alproto, progress);
+    }
+    DetectBufferTypeSetDescriptionByName(name, desc);
+    return DetectBufferTypeGetByName(name);
+}
+
 int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc,
         AppProto alproto, uint8_t direction, InspectionMultiBufferGetDataPtr GetData, int progress)
 {

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -44,6 +44,20 @@ int SCDetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t dir
     return DetectBufferTypeRegister(name);
 }
 
+int SCDetectHelperBufferProgressRegister(
+        const char *name, AppProto alproto, uint8_t direction, int progress)
+{
+    if (direction & STREAM_TOSERVER) {
+        DetectAppLayerInspectEngineRegister(
+                name, alproto, SIG_FLAG_TOSERVER, progress, DetectEngineInspectGenericList, NULL);
+    }
+    if (direction & STREAM_TOCLIENT) {
+        DetectAppLayerInspectEngineRegister(
+                name, alproto, SIG_FLAG_TOCLIENT, progress, DetectEngineInspectGenericList, NULL);
+    }
+    return DetectBufferTypeRegister(name);
+}
+
 int SCDetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionSingleBufferGetDataPtr GetData)
 {

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -81,6 +81,8 @@ int SCDetectHelperNewKeywordId(void);
 uint16_t SCDetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw);
 void SCDetectHelperKeywordAliasRegister(uint16_t kwid, const char *alias);
 int SCDetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direction);
+int SCDetectHelperBufferProgressRegister(
+        const char *name, AppProto alproto, uint8_t direction, int progress);
 
 int SCDetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionSingleBufferGetDataPtr GetData);

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -86,6 +86,8 @@ int SCDetectHelperBufferProgressRegister(
 
 int SCDetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionSingleBufferGetDataPtr GetData);
+int SCDetectHelperBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
+        uint8_t direction, InspectionSingleBufferGetDataPtr GetData, int progress);
 int SCDetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData);
 int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc,

--- a/src/detect.c
+++ b/src/detect.c
@@ -1591,6 +1591,7 @@ static int DetectRunTxCheckFirewallPolicy(DetectEngineThreadCtx *det_ctx, Packet
                 SCLogDebug("peek: there are no rules to allow the state after this rule");
                 *fw_next_progress_missing = true;
             }
+            *last_for_progress = true;
         }
 
         if ((*skip_fw_hook) == true) {

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -296,8 +296,12 @@ static OutputInitResult JsonDropLogInitCtxSub(SCConfNode *conf, OutputCtx *paren
                              "'flow' are 'start' and 'all'");
             }
         }
+
         extended = SCConfNodeLookupChildValue(conf, "verdict");
-        if (extended != NULL) {
+
+        if (EngineModeIsFirewall()) {
+            drop_ctx->flags |= LOG_DROP_VERDICT;
+        } else if (extended != NULL) {
             if (SCConfValIsTrue(extended)) {
                 drop_ctx->flags |= LOG_DROP_VERDICT;
             }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/8432
https://redmine.openinfosecfoundation.org/issues/8483

Describe changes:
- backport of #15210, unclean cherry-picks

I left out the final minor code cleanups commits

And I added the new helpers while keeping the old one so as not to break compatibility

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3040
