### PR TITLE
src/reputation: remove unused code

### DIFF
--- a/src/reputation.c
+++ b/src/reputation.c
@@ -354,6 +354,17 @@ static int SRepLoadCatFile(const char *filename)
     return r;
 }
 
+static inline size_t GetEffectiveLineLen(const char *line)
+{
+    size_t len = strlen(line);
+    /* ignore comments and empty lines */
+    if (len == 0 || line[0] == '\n' || line[0] == '\r' || line[0] == ' ' || line[0] == '#' ||
+            line[0] == '\t')
+        return 0;
+
+    return len;
+}
+
 int SRepLoadCatFileFromFD(FILE *fp)
 {
     char line[8192] = "";
@@ -365,19 +376,11 @@ int SRepLoadCatFileFromFD(FILE *fp)
     BUG_ON(SRepGetVersion() > 0);
 
     while(fgets(line, (int)sizeof(line), fp) != NULL) {
-        size_t len = strlen(line);
+        size_t len = GetEffectiveLineLen(line);
         if (len == 0)
-            continue;
-
-        /* ignore comments and empty lines */
-        if (line[0] == '\n' || line [0] == '\r' || line[0] == ' ' || line[0] == '#' || line[0] == '\t')
             continue;
 
         /* Check if we have a trailing newline, and remove it */
-        len = strlen(line);
-        if (len == 0)
-            continue;
-
         if (line[len - 1] == '\n' || line[len - 1] == '\r') {
             line[len - 1] = '\0';
         }
@@ -423,19 +426,11 @@ int SRepLoadFileFromFD(SRepCIDRTree *cidr_ctx, FILE *fp)
     char line[8192] = "";
 
     while(fgets(line, (int)sizeof(line), fp) != NULL) {
-        size_t len = strlen(line);
+        size_t len = GetEffectiveLineLen(line);
         if (len == 0)
-            continue;
-
-        /* ignore comments and empty lines */
-        if (line[0] == '\n' || line [0] == '\r' || line[0] == ' ' || line[0] == '#' || line[0] == '\t')
             continue;
 
         /* Check if we have a trailing newline, and remove it */
-        len = strlen(line);
-        if (len == 0)
-            continue;
-
         if (line[len - 1] == '\n' || line[len - 1] == '\r') {
             line[len - 1] = '\0';
         }

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -373,8 +373,6 @@ int SRepLoadCatFileFromFD(FILE *fp)
         if (line[0] == '\n' || line [0] == '\r' || line[0] == ' ' || line[0] == '#' || line[0] == '\t')
             continue;
 
-        while (isspace((unsigned char)line[--len]));
-
         /* Check if we have a trailing newline, and remove it */
         len = strlen(line);
         if (len == 0)
@@ -432,8 +430,6 @@ int SRepLoadFileFromFD(SRepCIDRTree *cidr_ctx, FILE *fp)
         /* ignore comments and empty lines */
         if (line[0] == '\n' || line [0] == '\r' || line[0] == ' ' || line[0] == '#' || line[0] == '\t')
             continue;
-
-        while (isspace((unsigned char)line[--len]));
 
         /* Check if we have a trailing newline, and remove it */
         len = strlen(line);


### PR DESCRIPTION
Remove useless while() and simplify skiping empty lines/comments

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [X] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8500

Removed useless while() and simplified skiping empty lines/comments

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3059
SU_REPO=
SU_BRANCH=
