### PR TITLE
detect: support file* and detect* events in rules

### DIFF
--- a/rules/app-layer-events.rules
+++ b/rules/app-layer-events.rules
@@ -15,4 +15,23 @@ alert tcp any any -> any any (msg:"SURICATA Applayer No TLS after STARTTLS"; flo
 # unexpected protocol in protocol upgrade
 alert tcp any any -> any any (msg:"SURICATA Applayer Unexpected protocol"; flow:established; app-layer-event:applayer_unexpected_protocol; flowint:applayer.anomaly.count,+,1; classtype:protocol-command-decode; sid:2260005; rev:1;)
 
-#next sid is 2260006
+# File decoder events (SWF decompression failures)
+alert ip any any -> any any (msg:"SURICATA File decoder no memory"; app-layer-event:file.NO_MEMORY; classtype:protocol-command-decode; sid:2260006; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder invalid SWF length"; app-layer-event:file.INVALID_SWF_LENGTH; classtype:protocol-command-decode; sid:2260007; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder invalid SWF version"; app-layer-event:file.INVALID_SWF_VERSION; classtype:protocol-command-decode; sid:2260008; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder zlib data error"; app-layer-event:file.Z_DATA_ERROR; classtype:protocol-command-decode; sid:2260009; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder zlib stream error"; app-layer-event:file.Z_STREAM_ERROR; classtype:protocol-command-decode; sid:2260010; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder zlib buf error"; app-layer-event:file.Z_BUF_ERROR; classtype:protocol-command-decode; sid:2260011; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder zlib unknown error"; app-layer-event:file.Z_UNKNOWN_ERROR; classtype:protocol-command-decode; sid:2260012; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder LZMA IO error"; app-layer-event:file.LZMA_IO_ERROR; classtype:protocol-command-decode; sid:2260013; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder LZMA header too short"; app-layer-event:file.LZMA_HEADER_TOO_SHORT_ERROR; classtype:protocol-command-decode; sid:2260014; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder LZMA decoder error"; app-layer-event:file.LZMA_DECODER_ERROR; classtype:protocol-command-decode; sid:2260015; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder LZMA memlimit error"; app-layer-event:file.LZMA_MEMLIMIT_ERROR; classtype:protocol-command-decode; sid:2260016; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder LZMA XZ error"; app-layer-event:file.LZMA_XZ_ERROR; classtype:protocol-command-decode; sid:2260017; rev:1;)
+alert ip any any -> any any (msg:"SURICATA File decoder LZMA unknown error"; app-layer-event:file.LZMA_UNKNOWN_ERROR; classtype:protocol-command-decode; sid:2260018; rev:1;)
+
+# Detect engine events
+alert ip any any -> any any (msg:"SURICATA Detect too many buffers"; app-layer-event:detect.TOO_MANY_BUFFERS; classtype:protocol-command-decode; sid:2260019; rev:1;)
+alert ip any any -> any any (msg:"SURICATA Detect post match queue failed"; app-layer-event:detect.POST_MATCH_QUEUE_FAILED; classtype:protocol-command-decode; sid:2260020; rev:1;)
+
+#next sid is 2260021

--- a/src/app-layer-events.c
+++ b/src/app-layer-events.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014-2024 Open Information Security Foundation
+/* Copyright (C) 2014-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -43,23 +43,43 @@ int SCAppLayerGetEventIdByName(const char *event_name, SCEnumCharMap *table, uin
     return 0;
 }
 
+/* Detect engine events, defined once via X-macro. Each entry expands into:
+ * - det_ctx_event_table: { name, val }           (for rule parsing, unprefixed)
+ * - app_layer_event_pkt_table: { prefix.name, val } (for EVE logging, prefixed)
+ *
+ * To add a new event: add one DETECT_EVENT(prefix, name, enum_val) line below. */
+/* clang-format off */
+#define DETECT_ENGINE_EVENTS(DETECT_EVENT)                                                              \
+    DETECT_EVENT("file",   "NO_MEMORY",                 FILE_DECODER_EVENT_NO_MEM)                      \
+    DETECT_EVENT("file",   "INVALID_SWF_LENGTH",        FILE_DECODER_EVENT_INVALID_SWF_LENGTH)          \
+    DETECT_EVENT("file",   "INVALID_SWF_VERSION",       FILE_DECODER_EVENT_INVALID_SWF_VERSION)         \
+    DETECT_EVENT("file",   "Z_DATA_ERROR",              FILE_DECODER_EVENT_Z_DATA_ERROR)                \
+    DETECT_EVENT("file",   "Z_STREAM_ERROR",            FILE_DECODER_EVENT_Z_STREAM_ERROR)              \
+    DETECT_EVENT("file",   "Z_BUF_ERROR",               FILE_DECODER_EVENT_Z_BUF_ERROR)                \
+    DETECT_EVENT("file",   "Z_UNKNOWN_ERROR",           FILE_DECODER_EVENT_Z_UNKNOWN_ERROR)             \
+    DETECT_EVENT("file",   "LZMA_IO_ERROR",             FILE_DECODER_EVENT_LZMA_IO_ERROR)               \
+    DETECT_EVENT("file",   "LZMA_HEADER_TOO_SHORT_ERROR", FILE_DECODER_EVENT_LZMA_HEADER_TOO_SHORT_ERROR) \
+    DETECT_EVENT("file",   "LZMA_DECODER_ERROR",        FILE_DECODER_EVENT_LZMA_DECODER_ERROR)          \
+    DETECT_EVENT("file",   "LZMA_MEMLIMIT_ERROR",       FILE_DECODER_EVENT_LZMA_MEMLIMIT_ERROR)         \
+    DETECT_EVENT("file",   "LZMA_XZ_ERROR",             FILE_DECODER_EVENT_LZMA_XZ_ERROR)               \
+    DETECT_EVENT("file",   "LZMA_UNKNOWN_ERROR",        FILE_DECODER_EVENT_LZMA_UNKNOWN_ERROR)          \
+    DETECT_EVENT("detect", "TOO_MANY_BUFFERS",          DETECT_EVENT_TOO_MANY_BUFFERS)                  \
+    DETECT_EVENT("detect", "POST_MATCH_QUEUE_FAILED",   DETECT_EVENT_POST_MATCH_QUEUE_FAILED)
+/* clang-format on */
+
 /* events raised during protocol detection are stored in the
  * packets storage, not in the flow. */
-SCEnumCharMap app_layer_event_pkt_table[ ] = {
-    { "APPLAYER_MISMATCH_PROTOCOL_BOTH_DIRECTIONS",
-      APPLAYER_MISMATCH_PROTOCOL_BOTH_DIRECTIONS },
-    { "APPLAYER_WRONG_DIRECTION_FIRST_DATA",
-      APPLAYER_WRONG_DIRECTION_FIRST_DATA },
-    { "APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION",
-      APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION },
-    { "APPLAYER_PROTO_DETECTION_SKIPPED",
-      APPLAYER_PROTO_DETECTION_SKIPPED },
-    { "APPLAYER_NO_TLS_AFTER_STARTTLS",
-      APPLAYER_NO_TLS_AFTER_STARTTLS },
-    { "APPLAYER_UNEXPECTED_PROTOCOL",
-      APPLAYER_UNEXPECTED_PROTOCOL },
-    { NULL,
-      -1 },
+SCEnumCharMap app_layer_event_pkt_table[] = {
+    { "APPLAYER_MISMATCH_PROTOCOL_BOTH_DIRECTIONS", APPLAYER_MISMATCH_PROTOCOL_BOTH_DIRECTIONS },
+    { "APPLAYER_WRONG_DIRECTION_FIRST_DATA", APPLAYER_WRONG_DIRECTION_FIRST_DATA },
+    { "APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION", APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION },
+    { "APPLAYER_PROTO_DETECTION_SKIPPED", APPLAYER_PROTO_DETECTION_SKIPPED },
+    { "APPLAYER_NO_TLS_AFTER_STARTTLS", APPLAYER_NO_TLS_AFTER_STARTTLS },
+    { "APPLAYER_UNEXPECTED_PROTOCOL", APPLAYER_UNEXPECTED_PROTOCOL },
+#define EVT_TO_PREFIXED(prefix, name, val) { prefix "." name, val },
+    DETECT_ENGINE_EVENTS(EVT_TO_PREFIXED)
+#undef EVT_TO_PREFIXED
+            { NULL, -1 },
 };
 
 int AppLayerGetEventInfoById(
@@ -145,28 +165,10 @@ void SCAppLayerDecoderEventsFreeEvents(AppLayerDecoderEvents **events)
 }
 
 SCEnumCharMap det_ctx_event_table[] = {
-    { "NO_MEMORY", FILE_DECODER_EVENT_NO_MEM },
-    { "INVALID_SWF_LENGTH", FILE_DECODER_EVENT_INVALID_SWF_LENGTH },
-    { "INVALID_SWF_VERSION", FILE_DECODER_EVENT_INVALID_SWF_VERSION },
-    { "Z_DATA_ERROR", FILE_DECODER_EVENT_Z_DATA_ERROR },
-    { "Z_STREAM_ERROR", FILE_DECODER_EVENT_Z_STREAM_ERROR },
-    { "Z_BUF_ERROR", FILE_DECODER_EVENT_Z_BUF_ERROR },
-    { "Z_UNKNOWN_ERROR", FILE_DECODER_EVENT_Z_UNKNOWN_ERROR },
-    { "LZMA_IO_ERROR", FILE_DECODER_EVENT_LZMA_IO_ERROR },
-    { "LZMA_HEADER_TOO_SHORT_ERROR", FILE_DECODER_EVENT_LZMA_HEADER_TOO_SHORT_ERROR },
-    { "LZMA_DECODER_ERROR", FILE_DECODER_EVENT_LZMA_DECODER_ERROR },
-    { "LZMA_MEMLIMIT_ERROR", FILE_DECODER_EVENT_LZMA_MEMLIMIT_ERROR },
-    { "LZMA_XZ_ERROR", FILE_DECODER_EVENT_LZMA_XZ_ERROR },
-    { "LZMA_UNKNOWN_ERROR", FILE_DECODER_EVENT_LZMA_UNKNOWN_ERROR },
-    {
-            "TOO_MANY_BUFFERS",
-            DETECT_EVENT_TOO_MANY_BUFFERS,
-    },
-    {
-            "POST_MATCH_QUEUE_FAILED",
-            DETECT_EVENT_POST_MATCH_QUEUE_FAILED,
-    },
-    { NULL, -1 },
+#define EVT_TO_UNPREFIXED(_prefix, name, val) { name, val },
+    DETECT_ENGINE_EVENTS(EVT_TO_UNPREFIXED)
+#undef EVT_TO_UNPREFIXED
+            { NULL, -1 },
 };
 
 int DetectEngineGetEventInfo(

--- a/src/app-layer-events.h
+++ b/src/app-layer-events.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014-2022 Open Information Security Foundation
+/* Copyright (C) 2014-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -49,6 +49,7 @@ enum {
     APPLAYER_PROTO_DETECTION_SKIPPED,
     APPLAYER_NO_TLS_AFTER_STARTTLS,
     APPLAYER_UNEXPECTED_PROTOCOL,
+    APPLAYER_EVENT_PKT_COUNT, /**< sentinel: first usable ID for detect engine events */
 };
 
 typedef enum AppLayerEventType {

--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -53,7 +53,7 @@
 #define MAX_ALPROTO_NAME 50
 
 typedef struct DetectAppLayerEventData_ {
-    AppProto alproto;
+    AppProto alproto; /**< ALPROTO_UNKNOWN for file/detect events in det_ctx->decoder_events */
     uint8_t event_id;
 } DetectAppLayerEventData;
 
@@ -65,6 +65,9 @@ static uint8_t DetectEngineAptEventInspect(DetectEngineCtx *de_ctx, DetectEngine
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *tx, uint64_t tx_id);
 static int g_applayer_events_list_id = 0;
+#ifdef UNITTESTS
+void DetectAppLayerEventRegisterTests(void);
+#endif
 
 /**
  * \brief Registers the keyword handlers for the "app-layer-event" keyword.
@@ -78,6 +81,9 @@ void DetectAppLayerEventRegister(void)
     sigmatch_table[DETECT_APP_LAYER_EVENT].Match = DetectAppLayerEventPktMatch;
     sigmatch_table[DETECT_APP_LAYER_EVENT].Setup = DetectAppLayerEventSetup;
     sigmatch_table[DETECT_APP_LAYER_EVENT].Free = DetectAppLayerEventFree;
+#ifdef UNITTESTS
+    sigmatch_table[DETECT_APP_LAYER_EVENT].RegisterTests = DetectAppLayerEventRegisterTests;
+#endif
 
     DetectAppLayerInspectEngineRegister("app-layer-events", ALPROTO_UNKNOWN, SIG_FLAG_TOSERVER, 0,
             DetectEngineAptEventInspect, NULL);
@@ -92,18 +98,24 @@ static uint8_t DetectEngineAptEventInspect(DetectEngineCtx *de_ctx, DetectEngine
         uint8_t flags, void *alstate, void *tx, uint64_t tx_id)
 {
     int r = 0;
+    bool uses_detctx = false;
     const AppProto alproto = f->alproto;
     const AppLayerDecoderEvents *decoder_events =
             AppLayerParserGetEventsByTx(f->proto, alproto, tx);
-    if (decoder_events == NULL) {
-        goto end;
-    }
     const SigMatchData *smd = engine->smd;
     while (1) {
         const DetectAppLayerEventData *aled = (const DetectAppLayerEventData *)smd->ctx;
         KEYWORD_PROFILING_START;
 
-        if (AppLayerDecoderEventsIsEventSet(decoder_events, aled->event_id)) {
+        const AppLayerDecoderEvents *events_to_check;
+        if (aled->alproto == ALPROTO_UNKNOWN) {
+            events_to_check = det_ctx->decoder_events;
+            uses_detctx = true;
+        } else {
+            events_to_check = decoder_events;
+        }
+
+        if (AppLayerDecoderEventsIsEventSet(events_to_check, aled->event_id)) {
             KEYWORD_PROFILING_END(det_ctx, smd->type, 1);
 
             if (smd->is_last)
@@ -122,6 +134,11 @@ static uint8_t DetectEngineAptEventInspect(DetectEngineCtx *de_ctx, DetectEngine
     if (r == 1) {
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
     } else {
+        /* det_ctx events are transient (per-packet), so don't mark as CANT_MATCH
+         * which would permanently prevent future matching in this flow */
+        if (uses_detctx) {
+            return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
+        }
         if (AppLayerParserGetStateProgress(f->proto, alproto, tx, flags) ==
             AppLayerParserGetStateProgressCompletionStatus(alproto, flags))
         {
@@ -214,7 +231,7 @@ static int DetectAppLayerEventSetup(DetectEngineCtx *de_ctx, Signature *s, const
 
         const AppProto alproto = AppLayerEventGetProtoByName(alproto_name);
         if (alproto == ALPROTO_UNKNOWN) {
-            if (!strcmp(alproto_name, "file")) {
+            if (!strcmp(alproto_name, "file") || !strcmp(alproto_name, "detect")) {
                 needs_detctx = true;
             } else {
                 SCLogError("app-layer-event keyword "
@@ -233,19 +250,18 @@ static int DetectAppLayerEventSetup(DetectEngineCtx *de_ctx, Signature *s, const
             }
         }
 
-        uint8_t ipproto = 0;
-        if (DetectProtoContainsProto(&s->init_data->proto, IPPROTO_TCP)) {
-            ipproto = IPPROTO_TCP;
-        } else if (DetectProtoContainsProto(&s->init_data->proto, IPPROTO_UDP)) {
-            ipproto = IPPROTO_UDP;
-        } else {
-            SCLogError("protocol %s is disabled", alproto_name);
-            return -1;
-        }
-
         int r;
         uint8_t event_id = 0;
         if (!needs_detctx) {
+            uint8_t ipproto = 0;
+            if (DetectProtoContainsProto(&s->init_data->proto, IPPROTO_TCP)) {
+                ipproto = IPPROTO_TCP;
+            } else if (DetectProtoContainsProto(&s->init_data->proto, IPPROTO_UDP)) {
+                ipproto = IPPROTO_UDP;
+            } else {
+                SCLogError("protocol %s is disabled", alproto_name);
+                return -1;
+            }
             r = AppLayerParserGetEventInfo(ipproto, alproto, event_name, &event_id, &event_type);
         } else {
             r = DetectEngineGetEventInfo(event_name, &event_id, &event_type);
@@ -277,8 +293,11 @@ static int DetectAppLayerEventSetup(DetectEngineCtx *de_ctx, Signature *s, const
             goto error;
         }
     } else {
-        if (SCDetectSignatureSetAppProto(s, data->alproto) != 0)
-            goto error;
+        /* file/detect events are protocol-agnostic, skip alproto restriction */
+        if (data->alproto != ALPROTO_UNKNOWN) {
+            if (SCDetectSignatureSetAppProto(s, data->alproto) != 0)
+                goto error;
+        }
 
         if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_APP_LAYER_EVENT, (SigMatchCtx *)data,
                     g_applayer_events_list_id) == NULL) {
@@ -300,3 +319,100 @@ static void DetectAppLayerEventFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCFree(ptr);
 }
+
+#ifdef UNITTESTS
+
+#include "detect-engine.h"
+
+static int DetectAppLayerEventFileTest01(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+                                                 "(msg:\"test file event\"; "
+                                                 "app-layer-event:file.Z_DATA_ERROR; sid:1;)");
+    FAIL_IF_NULL(s);
+    FAIL_IF_NOT(s->flags & SIG_FLAG_APPLAYER);
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int DetectAppLayerEventFileTest02(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    const char *events[] = {
+        "file.NO_MEMORY",
+        "file.INVALID_SWF_LENGTH",
+        "file.INVALID_SWF_VERSION",
+        "file.Z_DATA_ERROR",
+        "file.Z_STREAM_ERROR",
+        "file.Z_BUF_ERROR",
+        "file.Z_UNKNOWN_ERROR",
+        "file.LZMA_IO_ERROR",
+        "file.LZMA_HEADER_TOO_SHORT_ERROR",
+        "file.LZMA_DECODER_ERROR",
+        "file.LZMA_MEMLIMIT_ERROR",
+        "file.LZMA_XZ_ERROR",
+        "file.LZMA_UNKNOWN_ERROR",
+        "detect.TOO_MANY_BUFFERS",
+        "detect.POST_MATCH_QUEUE_FAILED",
+        NULL,
+    };
+
+    for (int i = 0; events[i] != NULL; i++) {
+        char rule[256];
+        snprintf(rule, sizeof(rule),
+                "alert tcp any any -> any any "
+                "(msg:\"test\"; app-layer-event:%s; sid:%d;)",
+                events[i], i + 1);
+        Signature *s = DetectEngineAppendSig(de_ctx, rule);
+        FAIL_IF_NULL(s);
+    }
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int DetectAppLayerEventFileTest03(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    DetectEngineThreadCtx *det_ctx = NULL;
+    ThreadVars tv;
+    memset(&tv, 0, sizeof(tv));
+    int r = DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
+    FAIL_IF(r != TM_ECODE_OK);
+    FAIL_IF_NULL(det_ctx);
+
+    DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_Z_DATA_ERROR);
+    FAIL_IF_NULL(det_ctx->decoder_events);
+    FAIL_IF(det_ctx->decoder_events->cnt != 1);
+    FAIL_IF_NOT(AppLayerDecoderEventsIsEventSet(
+            det_ctx->decoder_events, FILE_DECODER_EVENT_Z_DATA_ERROR));
+    FAIL_IF(AppLayerDecoderEventsIsEventSet(det_ctx->decoder_events, FILE_DECODER_EVENT_NO_MEM));
+
+    DetectEngineSetEvent(det_ctx, DETECT_EVENT_TOO_MANY_BUFFERS);
+    FAIL_IF(det_ctx->decoder_events->cnt != 2);
+    FAIL_IF_NOT(AppLayerDecoderEventsIsEventSet(
+            det_ctx->decoder_events, DETECT_EVENT_TOO_MANY_BUFFERS));
+
+    DetectEngineThreadCtxDeinit(&tv, det_ctx);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+void DetectAppLayerEventRegisterTests(void)
+{
+    UtRegisterTest("DetectAppLayerEventFileTest01", DetectAppLayerEventFileTest01);
+    UtRegisterTest("DetectAppLayerEventFileTest02", DetectAppLayerEventFileTest02);
+    UtRegisterTest("DetectAppLayerEventFileTest03", DetectAppLayerEventFileTest03);
+}
+
+#endif /* UNITTESTS */

--- a/src/detect.c
+++ b/src/detect.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2025 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -953,6 +953,9 @@ static DetectRunScratchpad DetectRunSetup(const DetectEngineCtx *de_ctx,
     det_ctx->raw_stream_progress = 0;
     det_ctx->match_array_cnt = 0;
     det_ctx->json_content_len = 0;
+    if (det_ctx->decoder_events != NULL) {
+        AppLayerDecoderEventsResetEvents(det_ctx->decoder_events);
+    }
 
     det_ctx->alert_queue_size = 0;
     p->alerts.drop.action = 0;
@@ -1069,6 +1072,15 @@ static void DetectRunCleanup(DetectEngineThreadCtx *det_ctx,
         Packet *p, Flow * const pflow)
 {
     PACKET_PROFILING_DETECT_START(p, PROF_DETECT_CLEANUP);
+
+    /* transfer detect engine events to packet for EVE logging */
+    if (det_ctx->decoder_events != NULL && det_ctx->decoder_events->cnt > 0) {
+        for (uint8_t i = 0; i < det_ctx->decoder_events->cnt; i++) {
+            SCAppLayerDecoderEventsSetEventRaw(
+                    &p->app_layer_events, det_ctx->decoder_events->events[i]);
+        }
+    }
+
     InspectionBufferClean(det_ctx);
 
     if (pflow != NULL) {

--- a/src/detect.h
+++ b/src/detect.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2025 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -32,6 +32,7 @@
 #include "detect-metadata.h"
 #include "detect-engine-register.h"
 #include "detect-engine-inspect-buffer.h"
+#include "app-layer-events.h"
 
 #include "util-prefilter.h"
 #include "util-mpm.h"
@@ -1474,9 +1475,10 @@ typedef struct SigTableElmt_ {
     void (*Cleanup)(struct SigTableElmt_ *);
 } SigTableElmt;
 
-/* event code */
+/* event code -- starts after APPLAYER_EVENT_PKT_COUNT to avoid ID collision
+ * with app-layer packet events when transferred to p->app_layer_events */
 enum {
-    FILE_DECODER_EVENT_NO_MEM,
+    FILE_DECODER_EVENT_NO_MEM = APPLAYER_EVENT_PKT_COUNT,
     FILE_DECODER_EVENT_INVALID_SWF_LENGTH,
     FILE_DECODER_EVENT_INVALID_SWF_VERSION,
     FILE_DECODER_EVENT_Z_DATA_ERROR,


### PR DESCRIPTION
Ensure that detect* and file* events are logged and recognized properly 

Link to ticket: 
- https://redmine.openinfosecfoundation.org/issues/4482
- https://redmine.openinfosecfoundation.org/issues/4898

Describe changes:
  - Make rules like `app-layer-event:file.Z_DATA_ERROR` and `app-layer-event:detect.TOO_MANY_BUFFERS` match at runtime. The `app-layer-event` keyword now recognizes `file.` and `detect.` as event-name prefixes and looks the event up in `det_ctx->decoder_events` — where the file decoder (SWF decompression) and the detect engine set their events. The `detect.` prefix is additive; existing `file.` rules are unchanged.
  - Reset `det_ctx->decoder_events` at the start of each detection run and transfer accumulated events into `p->app_layer_events` at cleanup, so they appear in EVE alert and anomaly output.
  - Anchor detect engine event IDs after the app-layer packet event enum to prevent ID collisions in `p->app_layer_events`. Unify the rule-parsing and EVE-logging tables with a single X-macro to make adding a new event easier.
  - Add shipping rules (SIDs 2260006-2260020) in `rules/app-layer-events.rules` for all 15 events.

Here's an example showing detect and file usage:
  
### file event rule — matches when SWF decompression hits corrupt zlib data:
```
  alert ip any any -> any any (msg:"SURICATA File decoder zlib data error"; \
      app-layer-event:file.Z_DATA_ERROR; \
      classtype:protocol-command-decode; sid:2260009; rev:1;)
```
### detect engine event rule — matches when a signature exceeds the multi-buffer inspection limit:
```
  alert ip any any -> any any (msg:"SURICATA Detect too many buffers"; \
      app-layer-event:detect.TOO_MANY_BUFFERS; \
      classtype:protocol-command-decode; sid:2260019; rev:1;)
```
### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3046
