### PR TITLE
ssl: convert memcpy to strlcpy to avoid flto issue

### DIFF
--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -268,7 +268,7 @@ static DetectSslStateData *DetectSslStateParse(const char *arg)
             goto error;
         }
 
-        memcpy(str1, str2, sizeof(str1));
+        strlcpy(str1, str2, sizeof(str1));
         pcre2_match_data_free(match2);
     }
 


### PR DESCRIPTION
When using ASAN, flto=auto and compiling on a platform that supports
AVX-512, this memcpy is optimized as its exactly 64 bytes. However, when
using ASAN, there is a fake stack that may not be 64 bytes aligned, and
this AVX write lands on an unaligned byte, causing a crash.

Use strlcpy avoids this optimization as it needs to find the NUL byte.
