### PR TITLE
Plugin crate zerodep 7666 v8

### DIFF
--- a/examples/plugins/altemplate/src/template.rs
+++ b/examples/plugins/altemplate/src/template.rs
@@ -26,12 +26,10 @@ use std;
 use std::collections::VecDeque;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
-use suricata::applayer::{
-    state_get_tx_iterator, AppLayerEvent, AppLayerTxData, State, Transaction,
-};
+use suricata::applayer::{AppLayerEvent, AppLayerTxData};
 use suricata_ffi::applayer::{
-    AppLayerResultRust, StreamSliceRust, APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS,
-    APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+    state_get_tx_iterator, AppLayerResultRust, State, StreamSliceRust, Transaction,
+    APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS, APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
 };
 use suricata_ffi::conf::conf_get;
 use suricata_ffi::{

--- a/examples/plugins/altemplate/src/template.rs
+++ b/examples/plugins/altemplate/src/template.rs
@@ -28,9 +28,11 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 use suricata::applayer::{
     state_get_tx_iterator, AppLayerEvent, AppLayerTxData, State, Transaction,
-    APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS, APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+    APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS,
 };
-use suricata_ffi::applayer::{AppLayerResultRust, StreamSliceRust};
+use suricata_ffi::applayer::{
+    AppLayerResultRust, StreamSliceRust, APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+};
 use suricata_ffi::conf::conf_get;
 use suricata_ffi::{
     build_slice, cast_pointer, export_state_data_get, export_tx_data_get, SCLogError, SCLogNotice,

--- a/examples/plugins/altemplate/src/template.rs
+++ b/examples/plugins/altemplate/src/template.rs
@@ -28,10 +28,10 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 use suricata::applayer::{
     state_get_tx_iterator, AppLayerEvent, AppLayerTxData, State, Transaction,
-    APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS,
 };
 use suricata_ffi::applayer::{
-    AppLayerResultRust, StreamSliceRust, APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+    AppLayerResultRust, StreamSliceRust, APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS,
+    APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
 };
 use suricata_ffi::conf::conf_get;
 use suricata_ffi::{

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -86,16 +86,6 @@ include = [
 # default: []
 exclude = [
     "CLuaState",
-    "SIGMATCH_NOOPT",
-    "SIGMATCH_INFO_STICKY_BUFFER",
-    "SIGMATCH_INFO_MULTI_BUFFER",
-    "SIGMATCH_INFO_UINT8",
-    "SIGMATCH_INFO_UINT16",
-    "SIGMATCH_INFO_UINT32",
-    "SIGMATCH_INFO_UINT64",
-    "SIGMATCH_INFO_MULTI_UINT",
-    "SIGMATCH_INFO_ENUM_UINT",
-    "SIGMATCH_INFO_BITFLAGS_UINT",
 ]
 
 # Types of items that we'll generate. If empty, then all types of item are emitted.

--- a/rust/ffi/src/applayer.rs
+++ b/rust/ffi/src/applayer.rs
@@ -43,6 +43,9 @@ macro_rules! export_state_data_get {
     };
 }
 
+/* Flags for AppLayerParserProtoCtx. */
+pub const APP_LAYER_PARSER_OPT_ACCEPT_GAPS: u32 = 1 << 0;
+
 pub trait AppLayerResultRust {
     fn ok() -> Self;
     fn err() -> Self;

--- a/rust/ffi/src/applayer.rs
+++ b/rust/ffi/src/applayer.rs
@@ -43,6 +43,18 @@ macro_rules! export_state_data_get {
     };
 }
 
+/* Flags for AppLayerParserState. */
+// flag available                               BIT_U16(0)
+pub const APP_LAYER_PARSER_NO_INSPECTION: u16 = 1 << 1;
+pub const APP_LAYER_PARSER_NO_REASSEMBLY: u16 = 1 << 2;
+pub const APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD: u16 = 1 << 3;
+pub const APP_LAYER_PARSER_BYPASS_READY: u16 = 1 << 4;
+pub const APP_LAYER_PARSER_EOF_TS: u16 = 1 << 5;
+pub const APP_LAYER_PARSER_EOF_TC: u16 = 1 << 6;
+/* 2x vacancy */
+pub const APP_LAYER_PARSER_SFRAME_TS: u16 = 1 << 9;
+pub const APP_LAYER_PARSER_SFRAME_TC: u16 = 1 << 10;
+
 /* Flags for AppLayerParserProtoCtx. */
 pub const APP_LAYER_PARSER_OPT_ACCEPT_GAPS: u32 = 1 << 0;
 

--- a/rust/ffi/src/applayer.rs
+++ b/rust/ffi/src/applayer.rs
@@ -17,7 +17,10 @@
 
 //! App-layer utils.
 
-use suricata_sys::sys::{AppLayerResult, StreamSlice};
+use crate::cast_pointer;
+use suricata_sys::sys::{
+    AppLayerGetTxIterState, AppLayerGetTxIterTuple, AppLayerResult, AppProto, StreamSlice,
+};
 
 #[macro_export]
 macro_rules! export_tx_data_get {
@@ -153,4 +156,74 @@ impl StreamSliceRust for StreamSlice {
     fn flags(&self) -> u8 {
         self.flags
     }
+}
+
+trait AppLayerGetTxIterTupleRust {
+    fn with_values(tx_ptr: *mut std::os::raw::c_void, tx_id: u64, has_next: bool) -> Self;
+    fn not_found() -> Self;
+}
+
+impl AppLayerGetTxIterTupleRust for AppLayerGetTxIterTuple {
+    fn with_values(
+        tx_ptr: *mut std::os::raw::c_void, tx_id: u64, has_next: bool,
+    ) -> AppLayerGetTxIterTuple {
+        AppLayerGetTxIterTuple {
+            tx_ptr,
+            tx_id,
+            has_next,
+        }
+    }
+    fn not_found() -> AppLayerGetTxIterTuple {
+        AppLayerGetTxIterTuple {
+            tx_ptr: std::ptr::null_mut(),
+            tx_id: 0,
+            has_next: false,
+        }
+    }
+}
+
+/// Transaction trait.
+///
+/// This trait defines methods that a Transaction struct must implement
+/// in order to define some generic helper functions.
+pub trait Transaction {
+    fn id(&self) -> u64;
+}
+
+pub trait State<Tx: Transaction> {
+    /// Return the number of transactions in the state's transaction collection.
+    fn get_transaction_count(&self) -> usize;
+
+    /// Return a transaction by its index in the container.
+    fn get_transaction_by_index(&self, index: usize) -> Option<&Tx>;
+
+    fn get_transaction_iterator(&self, min_tx_id: u64, state: &mut u64) -> AppLayerGetTxIterTuple {
+        let mut index = *state as usize;
+        let len = self.get_transaction_count();
+        while index < len {
+            let tx = self.get_transaction_by_index(index).unwrap();
+            if tx.id() < min_tx_id + 1 {
+                index += 1;
+                continue;
+            }
+            *state = index as u64;
+            return AppLayerGetTxIterTuple::with_values(
+                tx as *const _ as *mut _,
+                tx.id() - 1,
+                len - index > 1,
+            );
+        }
+        AppLayerGetTxIterTuple::not_found()
+    }
+}
+
+/// # Safety
+///
+/// state variable must be a valid state pointer from Suricata.
+pub unsafe extern "C" fn state_get_tx_iterator<S: State<Tx>, Tx: Transaction>(
+    _ipproto: u8, _alproto: AppProto, state: *mut std::os::raw::c_void, min_tx_id: u64,
+    _max_tx_id: u64, istate: *mut AppLayerGetTxIterState,
+) -> AppLayerGetTxIterTuple {
+    let state = cast_pointer!(state, S);
+    state.get_transaction_iterator(min_tx_id, &mut (*istate).un.u64_)
 }

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -317,16 +317,11 @@ pub fn applayer_register_protocol_detection(parser: &RustParser, enable_default:
     unsafe {SCAppLayerRegisterProtocolDetection(&det, enable_default) }
 }
 
-
-// Defined in app-layer-parser.h
-pub const APP_LAYER_PARSER_NO_INSPECTION : u16 = BIT_U16!(1);
-pub const APP_LAYER_PARSER_NO_REASSEMBLY : u16 = BIT_U16!(2);
-pub const APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD : u16 = BIT_U16!(3);
-pub const APP_LAYER_PARSER_BYPASS_READY : u16 = BIT_U16!(4);
-pub const APP_LAYER_PARSER_EOF_TS : u16 = BIT_U16!(5);
-pub const APP_LAYER_PARSER_EOF_TC : u16 = BIT_U16!(6);
-
-pub use suricata_ffi::applayer::APP_LAYER_PARSER_OPT_ACCEPT_GAPS;
+pub use suricata_ffi::applayer::{
+    APP_LAYER_PARSER_BYPASS_READY, APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS,
+    APP_LAYER_PARSER_NO_INSPECTION, APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD,
+    APP_LAYER_PARSER_NO_REASSEMBLY, APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+};
 
 pub const APP_LAYER_TX_SKIP_INSPECT_TS: u8 = BIT_U8!(0);
 pub const APP_LAYER_TX_SKIP_INSPECT_TC: u8 = BIT_U8!(1);

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -329,24 +329,6 @@ pub const _APP_LAYER_TX_INSPECTED_TS: u8 = BIT_U8!(2);
 pub const _APP_LAYER_TX_INSPECTED_TC: u8 = BIT_U8!(3);
 pub const APP_LAYER_TX_ACCEPT: u8 = BIT_U8!(4);
 
-pub trait AppLayerGetTxIterTupleRust {
-    fn with_values(tx_ptr: *mut std::os::raw::c_void, tx_id: u64, has_next: bool) -> Self;
-    fn not_found() -> Self;
-}
-
-impl AppLayerGetTxIterTupleRust for AppLayerGetTxIterTuple {
-    fn with_values(tx_ptr: *mut std::os::raw::c_void, tx_id: u64, has_next: bool) -> AppLayerGetTxIterTuple {
-        AppLayerGetTxIterTuple {
-            tx_ptr, tx_id, has_next,
-        }
-    }
-    fn not_found() -> AppLayerGetTxIterTuple {
-        AppLayerGetTxIterTuple {
-            tx_ptr: std::ptr::null_mut(), tx_id: 0, has_next: false,
-        }
-    }
-}
-
 /// AppLayerEvent trait that will be implemented on enums that
 /// derive AppLayerEvent.
 pub trait AppLayerEvent {
@@ -427,48 +409,7 @@ pub unsafe fn get_event_info_by_id<T: AppLayerEvent>(
     return -1;
 }
 
-/// Transaction trait.
-///
-/// This trait defines methods that a Transaction struct must implement
-/// in order to define some generic helper functions.
-pub trait Transaction {
-    fn id(&self) -> u64;
-}
-
-pub trait State<Tx: Transaction> {
-    /// Return the number of transactions in the state's transaction collection.
-    fn get_transaction_count(&self) -> usize;
-
-    /// Return a transaction by its index in the container.
-    fn get_transaction_by_index(&self, index: usize) -> Option<&Tx>;
-
-    fn get_transaction_iterator(&self, min_tx_id: u64, state: &mut u64) -> AppLayerGetTxIterTuple {
-        let mut index = *state as usize;
-        let len = self.get_transaction_count();
-        while index < len {
-            let tx = self.get_transaction_by_index(index).unwrap();
-            if tx.id() < min_tx_id + 1 {
-                index += 1;
-                continue;
-            }
-            *state = index as u64;
-            return AppLayerGetTxIterTuple::with_values(
-                tx as *const _ as *mut _,
-                tx.id() - 1,
-                len - index > 1,
-            );
-        }
-        return AppLayerGetTxIterTuple::not_found();
-    }
-}
-
-pub unsafe extern "C" fn state_get_tx_iterator<S: State<Tx>, Tx: Transaction>(
-    _ipproto: u8, _alproto: AppProto, state: *mut std::os::raw::c_void, min_tx_id: u64,
-    _max_tx_id: u64, istate: *mut AppLayerGetTxIterState,
-) -> AppLayerGetTxIterTuple {
-    let state = cast_pointer!(state, S);
-    state.get_transaction_iterator(min_tx_id, &mut (*istate).un.u64_)
-}
+pub use suricata_ffi::applayer::{state_get_tx_iterator, State, Transaction};
 
 /// AppLayerFrameType trait.
 ///

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -326,7 +326,7 @@ pub const APP_LAYER_PARSER_BYPASS_READY : u16 = BIT_U16!(4);
 pub const APP_LAYER_PARSER_EOF_TS : u16 = BIT_U16!(5);
 pub const APP_LAYER_PARSER_EOF_TC : u16 = BIT_U16!(6);
 
-pub const APP_LAYER_PARSER_OPT_ACCEPT_GAPS: u32 = BIT_U32!(0);
+pub use suricata_ffi::applayer::APP_LAYER_PARSER_OPT_ACCEPT_GAPS;
 
 pub const APP_LAYER_TX_SKIP_INSPECT_TS: u8 = BIT_U8!(0);
 pub const APP_LAYER_TX_SKIP_INSPECT_TC: u8 = BIT_U8!(1);

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -39,18 +39,6 @@ typedef enum LoggerId LoggerId;
 // Forward declarations from util-file.h
 typedef struct AppLayerGetFileState AppLayerGetFileState;
 
-/* Flags for AppLayerParserState. */
-// flag available                               BIT_U16(0)
-#define APP_LAYER_PARSER_NO_INSPECTION         BIT_U16(1)
-#define APP_LAYER_PARSER_NO_REASSEMBLY         BIT_U16(2)
-#define APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD BIT_U16(3)
-#define APP_LAYER_PARSER_BYPASS_READY          BIT_U16(4)
-#define APP_LAYER_PARSER_EOF_TS                BIT_U16(5)
-#define APP_LAYER_PARSER_EOF_TC                BIT_U16(6)
-/* 2x vacancy */
-#define APP_LAYER_PARSER_SFRAME_TS             BIT_U16(9)
-#define APP_LAYER_PARSER_SFRAME_TC             BIT_U16(10)
-
 #define APP_LAYER_PARSER_INT_STREAM_DEPTH_SET   BIT_U32(0)
 
 /* for use with the detect_progress_ts|detect_progress_tc fields */

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -51,9 +51,6 @@ typedef struct AppLayerGetFileState AppLayerGetFileState;
 #define APP_LAYER_PARSER_SFRAME_TS             BIT_U16(9)
 #define APP_LAYER_PARSER_SFRAME_TC             BIT_U16(10)
 
-/* Flags for AppLayerParserProtoCtx. */
-#define APP_LAYER_PARSER_OPT_ACCEPT_GAPS BIT_U32(0)
-
 #define APP_LAYER_PARSER_INT_STREAM_DEPTH_SET   BIT_U32(0)
 
 /* for use with the detect_progress_ts|detect_progress_tc fields */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7666

Describe changes:

reduce dependencies on suricata crate for plugins

- rust/ffi: move some consts and helper traits to ffi

#15235 next batch

Next PR : tackle 2 last imports `src/template.rs:use suricata::applayer::{AppLayerEvent, AppLayerTxData};` 