### PR TITLE
Dpdk rte flow dynamic bypass draft v3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2454,10 +2454,10 @@ return 0;
 # get MAJOR_MINOR version for embedding in configuration file.
     MAJOR_MINOR=`expr "${PACKAGE_VERSION}" : "\([[0-9]]\+\.[[0-9]]\+\).*"`
 
-if test "${enable_ebpf}" = "yes" || test "${enable_unittests}" = "yes"; then
+if test "${enable_ebpf}" = "yes" || test "${enable_unittests}" = "yes" ||  test "${enable_dpdk}" = "yes"; then
   AC_DEFINE([CAPTURE_OFFLOAD_MANAGER], [1],[Building flow bypass manager code])
 fi
-if test "${enable_ebpf}" = "yes" || test "${enable_nfqueue}" = "yes" || test "${enable_pfring}" = "yes" || test "${enable_napatech}" = "yes"  || test "${enable_unittests}" = "yes"; then
+if test "${enable_ebpf}" = "yes" || test "${enable_nfqueue}" = "yes" || test "${enable_pfring}" = "yes" || test "${enable_napatech}" = "yes"  || test "${enable_unittests}" = "yes" || test "${enable_dpdk}" = "yes"; then
   AC_DEFINE([CAPTURE_OFFLOAD], [1],[Building flow capture bypass code])
 fi
 

--- a/doc/userguide/capture-hardware/dpdk.rst
+++ b/doc/userguide/capture-hardware/dpdk.rst
@@ -239,3 +239,56 @@ Encapsulation stripping
 Suricata supports stripping the hardware-offloaded encapsulation stripping on
 the supported NICs. Currently, VLAN encapsulation stripping is supported.
 VLAN encapsulation stripping can be enabled with `vlan-strip-offload`.
+
+Drop filter
+-----------------------------
+
+Drop filter can improve the performance of Suricata by filtering 
+used-predefined flows directly in the Network interface card. The user can 
+specify unwanted flows before the start of Suricata. These flows are not going to be 
+inspected by Suricata and will be ignored for the whole run of the program.
+
+The syntax for drop filter in Suricata is similar to the dpdk-testpmd application
+rule syntax, although in Suricata, only the "pattern" section is applicable. 
+The user can define multiple rules, either to match specific flow 
+or a range of flows (e.g. using ip or port masks).
+
+Patterns currently supported by this feature are listed in 
+"src/util-dpdk-rte-flow-pattern.c" in "enum index next_item[]" 
+and their corresponding attributes in "enum index item_<pattern>[]".
+
+This feature is supported and tested only on NICs wih mlx5, ice and i40e 
+drivers. The level of functionality varies between these cards, 
+the most versatile are cards with mlx5 drivers.
+
+ice does not support broad patterns; some pattern item has to have
+specification, e.g., "pattern eth / ipv4 / end" raises an error but
+"pattern eth / ipv4 src is x / end" or "eth / ipv4 / tcp src is x" works fine.
+
+i40e does not support different item sets on the same pattern item type,
+e.g., if the first rule is in the form "pattern eth / ipv4 src is x / end",
+then if any other rule contains an ipv4 pattern type, it needs to have
+exclusively attribute src.
+
+The configuration for the drop filter can be found and modified in the 
+DPDK section of the suricata.yaml file.
+
+Additionally, mlx5 and ice drivers are able to gather statistics about filtered flows.
+The number of filtered packets is stored in dpdk.rte_flow_filtered field in eve.json.
+ice driver gathers statistics only in the case when all of the rules match one specific flow
+(e.g. mask can not be used).
+
+Below is a sample configuration that demonstrates how to filter specific flow and a range of flows:
+
+::
+
+  ...
+  dpdk:
+      eal-params:
+        proc-type: primary
+
+      interfaces:
+        - interface: 0000:3b:00.0
+          drop-filter:
+            - rule: "pattern eth / ipv4 src is 192.11.120.50 / tcp / end"
+            - rule: "pattern eth / ipv4 src is 170.22.40.0 src mask 255.255.255.0 / tcp / end"

--- a/doc/userguide/capture-hardware/dpdk.rst
+++ b/doc/userguide/capture-hardware/dpdk.rst
@@ -307,3 +307,46 @@ Below is a sample configuration that demonstrates how to filter a specific flow 
           drop-filter:
             - rule: "pattern eth / ipv4 src is 192.11.120.50 / tcp / end"
             - rule: "pattern eth / ipv4 src is 170.22.40.0 src mask 255.255.255.0 / tcp / end"
+
+Dynamic bypass
+--------------
+
+Suricata in IDS mode supports hardware accelerated flow bypass directly in the NIC.
+The capabilities of the bypass, such as how many flows can be bypassed in the hardware before 
+switching to software bypass, depend on the underlying hardware and the Poll Mode Driver.
+
+The DPDK hardware bypass can be enabled/disabled in the suricata.yaml file, via the ``capture-bypass`` option.
+The ``dpdk.bypass-info-mp-size`` option sets the number of flows that can be bypassed at once. 
+By default, this number is set to the maximum capabilities of the NIC in use, which can be in order of millions of flows.
+The ``auto`` option also sets this value to maximum.
+As the memory for bypassed flows is preallocated, in the case the expected number of bypassed flows is not high,
+it is possible to save memory by lowering this value, although it is recommended to set 
+the number to a power of 2 for efficiency reasons.
+
+The global bypass statistics are gathered in eve.json (in the flow section) and stats.log (flow_bypassed.*).
+
+Limitations:
+
+* Mellanox NICs with the mlx5_core PMD are currently the only supported NICs for this feature.
+
+* Mellanox NICs support offload of around 2 million flows at once, after the limit is reached, 
+  Suricata switches to software bypass. Although the NIC can handle more than 4 million hardware rules,
+  we need 2 rules for each direction of the flow.
+
+* The underlying hardware rules are taken from the same resources as the rules for `drop-filter`, meaning
+  defining more rules in the `drop-filter` decreases the capacity of rules for hardware bypass.
+
+* The feature can be used on multiple interfaces at the same time, but only if the interfaces are on the same NIC.
+  The capacity of the bypassed flows is shared across the interfaces.
+
+
+Below is an example configuration with bypass enabled and the capacity of bypassed flows set to maximum: 
+::
+
+  ...
+  dpdk:
+      eal-params:
+        proc-type: primary
+
+      capture-bypass: yes
+      bypass-info-mp-size: auto 

--- a/doc/userguide/capture-hardware/dpdk.rst
+++ b/doc/userguide/capture-hardware/dpdk.rst
@@ -241,44 +241,59 @@ the supported NICs. Currently, VLAN encapsulation stripping is supported.
 VLAN encapsulation stripping can be enabled with `vlan-strip-offload`.
 
 Drop filter
------------------------------
+-----------
 
-Drop filter can improve the performance of Suricata by filtering 
-used-predefined flows directly in the Network interface card. The user can 
-specify unwanted flows before the start of Suricata. These flows are not going to be 
-inspected by Suricata and will be ignored for the whole run of the program.
+The drop filter can improve Suricata's performance by filtering
+user-predefined traffic patterns directly in the NIC. The user can
+specify unwanted traffic patterns before starting Suricata. The specified 
+traffic is not going to be inspected by Suricata and will be ignored for the whole run of the program.
+On some PMDs, the statistics of matched rules are gathered and stored in eve.json 
+in the field ``stats.capture.dpdk.rte_flow_filtered``.
 
-The syntax for drop filter in Suricata is similar to the dpdk-testpmd application
-rule syntax, although in Suricata, only the "pattern" section is applicable. 
-The user can define multiple rules, either to match specific flow 
-or a range of flows (e.g. using ip or port masks).
+The syntax for the drop filter in Suricata is similar to the dpdk-testpmd application
+rule syntax, although only the "pattern" section is applicable in Suricata.
+The user can define multiple rules, either to match a specific flow
+or a broad section of incoming network traffic (e.g., using ip and port masks, matching on specific protocols ...).
 
-Patterns currently supported by this feature are listed in 
-"src/util-dpdk-rte-flow-pattern.c" in "enum index next_item[]" 
-and their corresponding attributes in "enum index item_<pattern>[]".
+Patterns currently supported by this feature are listed in
+"src/util-dpdk-rte-flow-pattern.c" in ``enum index next_item[]``
+and their corresponding attributes in ``enum index item_<pattern>[]``.
 
-This feature is supported and tested only on NICs wih mlx5, ice and i40e 
-drivers. The level of functionality varies between these cards, 
-the most versatile are cards with mlx5 drivers.
+.. literalinclude:: ../../../src/util-dpdk-rte-flow-pattern.c
+    :language: c
+    :start-at: /* --- start pattern enum --- */
+    :end-at: /* --- end pattern enum --- */
 
-ice does not support broad patterns; some pattern item has to have
-specification, e.g., "pattern eth / ipv4 / end" raises an error but
-"pattern eth / ipv4 src is x / end" or "eth / ipv4 / tcp src is x" works fine.
 
-i40e does not support different item sets on the same pattern item type,
-e.g., if the first rule is in the form "pattern eth / ipv4 src is x / end",
-then if any other rule contains an ipv4 pattern type, it needs to have
-exclusively attribute src.
+This feature is supported and tested only on NICs with mlx5, ice, and i40e drivers.
+Some of the drivers also support collecting statistics about dropped traffic.
+The level of functionality varies between these cards, as specified below:
 
-The configuration for the drop filter can be found and modified in the 
-DPDK section of the suricata.yaml file.
+* ice:
 
-Additionally, mlx5 and ice drivers are able to gather statistics about filtered flows.
-The number of filtered packets is stored in dpdk.rte_flow_filtered field in eve.json.
-ice driver gathers statistics only in the case when all of the rules match one specific flow
-(e.g. mask can not be used).
+  The driver does not support broad (wildcard) patterns; some pattern item must 
+  be specified, e.g., ``pattern eth / ipv4 / end`` raises an error but
+  ``pattern eth / ipv4 src is x / end`` or ``pattern eth / ipv4 / tcp src is x`` works fine.
+  It also supports gathering statistics of the filtered packets, but only
+  when none of the rules use wildcard patterns (e.g., mask cannot be used).
 
-Below is a sample configuration that demonstrates how to filter specific flow and a range of flows:
+* i40e:
+
+  The driver does not support different item sets on the same pattern item type,
+  e.g., if the first rule is in the form ``pattern eth / ipv4 src is x / end``,
+  then any other rule containing an ipv4 pattern type must exclusively use the src attribute.
+  Statistics of the filtered packets are not supported.
+
+* mlx5:
+
+  The driver is the most versatile PMD, supporting a wide range of patterns.
+  It also supports gathering statistics of the filtered packets without any other constraints.
+
+
+The configuration for the drop filter can be found and modified in the
+DPDK section of suricata.yaml file.
+
+Below is a sample configuration that demonstrates how to filter a specific flow and a range of flows:
 
 ::
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -484,6 +484,8 @@ noinst_HEADERS = \
 	util-dpdk-mlx5.h \
 	util-dpdk-rss.h \
 	util-dpdk.h \
+	util-dpdk-rte-flow.h \
+	util-dpdk-rte-flow-pattern.h \
 	util-ebpf.h \
 	util-enum.h \
 	util-error.h \
@@ -1043,6 +1045,8 @@ libsuricata_c_a_SOURCES = \
 	util-dpdk-mlx5.c \
 	util-dpdk-rss.c \
 	util-dpdk.c \
+	util-dpdk-rte-flow.c \
+	util-dpdk-rte-flow-pattern.c \
 	util-ebpf.c \
 	util-enum.c \
 	util-error.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -486,6 +486,7 @@ noinst_HEADERS = \
 	util-dpdk.h \
 	util-dpdk-rte-flow.h \
 	util-dpdk-rte-flow-pattern.h \
+	util-dpdk-rte-flow-structs.h \
 	util-ebpf.h \
 	util-enum.h \
 	util-error.h \

--- a/src/flow-bypass.c
+++ b/src/flow-bypass.c
@@ -31,7 +31,13 @@
 
 #ifdef CAPTURE_OFFLOAD_MANAGER
 
+#ifdef HAVE_DPDK
+#define FLOW_BYPASS_DELAY 0.01f
+#define FLOW_BYPASS_SLEEP 0.01f
+#else
 #define FLOW_BYPASS_DELAY       10
+#define FLOW_BYPASS_SLEEP       10
+#endif /* HAVE_DPDK */
 
 #ifndef TIMEVAL_TO_TIMESPEC
 #define TIMEVAL_TO_TIMESPEC(tv, ts) {                               \
@@ -125,7 +131,7 @@ static TmEcode BypassedFlowManager(ThreadVars *th_v, void *thread_data)
                 return TM_ECODE_OK;
             }
             StatsSyncCountersIfSignalled(&th_v->stats);
-            SleepMsec(10);
+            SleepMsec(FLOW_BYPASS_SLEEP);
         }
     }
     return TM_ECODE_OK;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -951,7 +951,10 @@ Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *fls, Packet *p, Flow
         const bool our_flow = FlowCompare(f, p) != 0;
         if (our_flow || timeout_check) {
             FLOWLOCK_WRLOCK(f);
-            const bool timedout = (timeout_check && FlowIsTimedOut(tv_id, f, p->ts, emerg));
+            bool timedout = (timeout_check && FlowIsTimedOut(tv_id, f, p->ts, emerg));
+#ifdef CAPTURE_OFFLOAD
+            timedout &= (f->flow_state != FLOW_STATE_CAPTURE_BYPASSED);
+#endif /* CAPTURE_OFFLOAD */
             if (timedout) {
                 next_f = f->next;
                 MoveToWorkQueue(tv, fls, fb, f, prev_f);

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -1067,7 +1067,7 @@ Flow *FlowGetExistingFlowFromFlowId(uint64_t flow_id)
  *  \param hash Value of the flow hash
  *  \retval f *LOCKED* flow or NULL
  */
-static Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash)
+Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash)
 {
     /* get our hash bucket and lock it */
     FlowBucket *fb = &flow_hash[hash % flow_config.hash_size];

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -80,7 +80,7 @@ typedef struct FlowBucket_ {
 /* prototypes */
 
 Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *tctx, Packet *, Flow **);
-
+Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash);
 Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t hash);
 Flow *FlowGetExistingFlowFromFlowId(uint64_t flow_id);
 uint32_t FlowKeyGetHash(FlowKey *flow_key);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -357,7 +357,12 @@ static void FlowManagerHashRowTimeout(FlowManagerTimeoutThread *td, Flow *f, SCT
          * be modified when we have both the flow and hash row lock */
 
         /* timeout logic goes here */
-        if (!FlowManagerFlowTimeout(f, ts, next_ts, emergency)) {
+        bool bypass_shutdown = false;
+#ifdef CAPTURE_OFFLOAD
+        bypass_shutdown = (f->flow_state == FLOW_STATE_CAPTURE_BYPASSED) &&
+                          (SC_ATOMIC_GET(flow_flags) & FLOW_SHUTDOWN);
+#endif
+        if (!bypass_shutdown && !FlowManagerFlowTimeout(f, ts, next_ts, emergency)) {
             FLOWLOCK_UNLOCK(f);
             counters->flows_notimeout++;
 
@@ -448,21 +453,25 @@ static uint32_t FlowTimeoutHash(FlowManagerTimeoutThread *td, SCTime_t ts, const
 #endif
 
     const uint32_t ts_secs = (uint32_t)SCTIME_SECS(ts);
+    const bool shutdown = (SC_ATOMIC_GET(flow_flags) & FLOW_SHUTDOWN);
     for (uint32_t idx = hash_min; idx < hash_max; idx+=BITS) {
         TYPE check_bits = 0;
         const uint32_t check = MIN(BITS, (hash_max - idx));
-        for (uint32_t i = 0; i < check; i++) {
-            FlowBucket *fb = &flow_hash[idx+i];
-            check_bits |= (TYPE)(SC_ATOMIC_LOAD_EXPLICIT(
-                                         fb->next_ts, SC_ATOMIC_MEMORY_ORDER_RELAXED) <= ts_secs)
-                          << (TYPE)i;
+        if (!shutdown) {
+            for (uint32_t i = 0; i < check; i++) {
+                FlowBucket *fb = &flow_hash[idx + i];
+                check_bits |= (TYPE)(SC_ATOMIC_LOAD_EXPLICIT(fb->next_ts,
+                                             SC_ATOMIC_MEMORY_ORDER_RELAXED) <= ts_secs)
+                              << (TYPE)i;
+            }
+            if (check_bits == 0)
+                continue;
         }
-        if (check_bits == 0)
-            continue;
-
         for (uint32_t i = 0; i < check; i++) {
             FlowBucket *fb = &flow_hash[idx+i];
-            if ((check_bits & ((TYPE)1 << (TYPE)i)) != 0 && SC_ATOMIC_GET(fb->next_ts) <= ts_secs) {
+            if (((check_bits & ((TYPE)1 << (TYPE)i)) != 0 &&
+                        SC_ATOMIC_GET(fb->next_ts) <= ts_secs) ||
+                    shutdown) {
                 FBLOCK_LOCK(fb);
                 Flow *evicted = NULL;
                 if (fb->evicted != NULL || fb->head != NULL) {
@@ -970,6 +979,13 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         }
 
         if (TmThreadsCheckFlag(th_v, THV_KILL)) {
+            SC_ATOMIC_OR(flow_flags, FLOW_SHUTDOWN);
+#ifdef CAPTURE_OFFLOAD
+            /* Pass through all flows to gather counters from bypassed flows */
+            FlowTimeoutCounters counters = { 0 };
+            FlowTimeoutHash(&ftd->timeout, ts, ftd->min, ftd->max, &counters);
+            FlowCountersUpdate(th_v, ftd, &counters);
+#endif /* CAPTURE_OFFLOAD */
             StatsSyncCounters(&th_v->stats);
             break;
         }

--- a/src/flow-private.h
+++ b/src/flow-private.h
@@ -35,6 +35,7 @@
  *  flows for new flows and/or it's memcap limit it reached. In this state the
  *  flow engine with evaluate flows with lower timeout settings. */
 #define FLOW_EMERGENCY   0x01
+#define FLOW_SHUTDOWN    0x02
 
 /* Flow Time out values */
 #define FLOW_DEFAULT_NEW_TIMEOUT 30

--- a/src/flow.h
+++ b/src/flow.h
@@ -303,6 +303,7 @@ typedef struct FlowKey_
     uint8_t proto;
     uint8_t recursion_level;
     uint16_t livedev_id;
+    struct LiveDevice_ *livedev;
     uint16_t vlan_id[VLAN_MAX_LAYERS];
 } FlowKey;
 

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -106,6 +106,8 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
         const struct rte_eth_conf *port_conf);
 static int DeviceValidateOutIfaceConfig(DPDKIfaceConfig *iconf);
 static int DeviceConfigureIPS(DPDKIfaceConfig *iconf);
+static int DeviceConfigureDynamicBypass(
+        DPDKIfaceConfig *iconf, const struct rte_eth_dev_info *dev_info);
 static int DeviceConfigure(DPDKIfaceConfig *iconf);
 static void *ParseDpdkConfigAndConfigureDevice(const char *iface);
 static void DPDKDerefConfig(void *conf);
@@ -145,6 +147,7 @@ DPDKIfaceConfigAttributes dpdk_yaml = {
     .copy_mode = "copy-mode",
     .copy_iface = "copy-iface",
     .drop_filter = "drop-filter",
+    .capture_bypass = "capture-bypass",
 };
 
 /**
@@ -327,6 +330,13 @@ static void DPDKDerefConfig(void *conf)
     DPDKIfaceConfig *iconf = (DPDKIfaceConfig *)conf;
 
     if (SC_ATOMIC_SUB(iconf->ref, 1) == 1) {
+        if (iconf->dpdk_dev_resources != NULL &&
+                iconf->dpdk_dev_resources->rte_flow_bypass_data != NULL) {
+            if (iconf->dpdk_dev_resources->rte_flow_bypass_data->bypass_mp != NULL) {
+                rte_mempool_free(iconf->dpdk_dev_resources->rte_flow_bypass_data->bypass_mp);
+                iconf->dpdk_dev_resources->rte_flow_bypass_data->bypass_mp = NULL;
+            }
+        }
         DPDKDeviceResourcesDeinit(&iconf->dpdk_dev_resources);
         iconf->RteRulesFree(&iconf->drop_filter);
         SCFree(iconf);
@@ -1054,6 +1064,11 @@ static int ConfigLoad(DPDKIfaceConfig *iconf, const char *iface)
     if (retval < 0)
         SCReturnInt(retval);
 
+    /* Global flag dpdk.capture-bypass is set to each interface */
+    retval = ConfigSetCaptureBypass(iconf);
+    if (retval < 0)
+        SCReturnInt(retval);
+
     SCReturnInt(0);
 }
 
@@ -1476,7 +1491,7 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
     if (retval < 0) {
         goto cleanup;
     }
-
+    iconf->dpdk_dev_resources->port_id = iconf->port_id;
     // +4 for VLAN header
     uint16_t mtu_size = iconf->mtu + RTE_ETHER_CRC_LEN + RTE_ETHER_HDR_LEN + 4;
     uint16_t mbuf_size = ROUNDUP(mtu_size, 1024) + RTE_PKTMBUF_HEADROOM;
@@ -1637,6 +1652,23 @@ static int DeviceConfigureIPS(DPDKIfaceConfig *iconf)
     SCReturnInt(0);
 }
 
+static int DeviceConfigureDynamicBypass(
+        DPDKIfaceConfig *iconf, const struct rte_eth_dev_info *dev_info)
+{
+    SCEnter();
+    int retval = 0;
+    if (!(iconf->capture_bypass_enabled)) {
+        SCReturnInt(retval);
+    }
+    const char *driver_name = dev_info->driver_name;
+    if (strcmp(driver_name, "mlx5_pci") == 0) {
+        retval = RteBypassInit(iconf, driver_name);
+    }
+
+    if (retval == 0)
+        SCLogConfig("%s rte_flow capture bypass enabled", iconf->iface);
+    SCReturnInt(retval);
+}
 /**
  * Function verifies changes in e.g. device info after configuration has
  * happened. Sometimes (e.g. DPDK Bond PMD with Intel NICs i40e/ixgbe) change
@@ -1814,6 +1846,10 @@ static int DeviceConfigure(DPDKIfaceConfig *iconf)
         SCReturnInt(retval);
     }
 
+    retval = DeviceConfigureDynamicBypass(iconf, &dev_info);
+    if (retval < 0) {
+        SCReturnInt(retval);
+    }
     SCReturnInt(0);
 }
 

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -148,20 +148,6 @@ DPDKIfaceConfigAttributes dpdk_yaml = {
 };
 
 /**
- * \brief Input is a number of which we want to find the greatest divisor up to max_num (inclusive).
- * The divisor is returned.
- */
-static uint32_t GreatestDivisorUpTo(uint32_t num, uint32_t max_num)
-{
-    for (uint32_t i = max_num; i >= 2; i--) {
-        if (num % i == 0) {
-            return i;
-        }
-    }
-    return 1;
-}
-
-/**
  * \brief Input is a number of which we want to find the greatest power of 2 up to num. The power of
  * 2 is returned or 0 if no valid power of 2 is found.
  */
@@ -637,15 +623,6 @@ static int ConfigSetMempoolSize(
     }
 
     SCReturnInt(0);
-}
-
-static uint32_t MempoolCacheSizeCalculate(uint32_t mp_sz)
-{
-    // It is advised to have mempool cache size lower or equal to:
-    //   RTE_MEMPOOL_CACHE_MAX_SIZE (by default 512) and "mempool-size / 1.5"
-    // and at the same time "mempool-size modulo cache_size == 0".
-    uint32_t max_cache_size = MIN(RTE_MEMPOOL_CACHE_MAX_SIZE, (uint32_t)(mp_sz / 1.5));
-    return GreatestDivisorUpTo(mp_sz, max_cache_size);
 }
 
 static int ConfigSetMempoolCacheSize(DPDKIfaceConfig *iconf, const char *entry_str)

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -47,6 +47,7 @@
 #include "util-dpdk-ice.h"
 #include "util-dpdk-ixgbe.h"
 #include "util-dpdk-rss.h"
+#include "util-dpdk-rte-flow.h"
 #include "util-time.h"
 #include "util-conf.h"
 #include "suricata.h"
@@ -143,6 +144,7 @@ DPDKIfaceConfigAttributes dpdk_yaml = {
     .tx_descriptors = "tx-descriptors",
     .copy_mode = "copy-mode",
     .copy_iface = "copy-iface",
+    .drop_filter = "drop-filter",
 };
 
 /**
@@ -340,6 +342,7 @@ static void DPDKDerefConfig(void *conf)
 
     if (SC_ATOMIC_SUB(iconf->ref, 1) == 1) {
         DPDKDeviceResourcesDeinit(&iconf->pkt_mempools);
+        iconf->RteRulesFree(&iconf->drop_filter);
         SCFree(iconf);
     }
     SCReturn;
@@ -357,6 +360,7 @@ static void ConfigInit(DPDKIfaceConfig **iconf)
     SC_ATOMIC_INIT(ptr->ref);
     (void)SC_ATOMIC_ADD(ptr->ref, 1);
     ptr->DerefFunc = DPDKDerefConfig;
+    ptr->RteRulesFree = RteFlowRuleStorageFree;
     ptr->flags = 0;
 
     *iconf = ptr;
@@ -1066,6 +1070,10 @@ static int ConfigLoad(DPDKIfaceConfig *iconf, const char *iface)
     }
 
     retval = ConfigSetCopyIfaceSettings(iconf, copy_iface_str, copy_mode_str);
+    if (retval < 0)
+        SCReturnInt(retval);
+
+    retval = ConfigLoadRteFlowRules(if_root, dpdk_yaml.drop_filter, &iconf->drop_filter);
     if (retval < 0)
         SCReturnInt(retval);
 

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -341,7 +341,7 @@ static void DPDKDerefConfig(void *conf)
     DPDKIfaceConfig *iconf = (DPDKIfaceConfig *)conf;
 
     if (SC_ATOMIC_SUB(iconf->ref, 1) == 1) {
-        DPDKDeviceResourcesDeinit(&iconf->pkt_mempools);
+        DPDKDeviceResourcesDeinit(&iconf->dpdk_dev_resources);
         iconf->RteRulesFree(&iconf->drop_filter);
         SCFree(iconf);
     }
@@ -1495,7 +1495,7 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
     struct rte_eth_rxconf rxq_conf;
     struct rte_eth_txconf txq_conf;
 
-    retval = DPDKDeviceResourcesInit(&(iconf->pkt_mempools), iconf->nb_rx_queues);
+    retval = DPDKDeviceResourcesInit(&(iconf->dpdk_dev_resources), iconf->nb_rx_queues);
     if (retval < 0) {
         goto cleanup;
     }
@@ -1511,9 +1511,9 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
     for (int i = 0; i < iconf->nb_rx_queues; i++) {
         char mempool_name[64];
         snprintf(mempool_name, sizeof(mempool_name), "mp_%d_%.20s", i, iconf->iface);
-        iconf->pkt_mempools->pkt_mp[i] = rte_pktmbuf_pool_create(mempool_name,
+        iconf->dpdk_dev_resources->pkt_mp[i] = rte_pktmbuf_pool_create(mempool_name,
                 iconf->queue_mempool_size, q_mp_cache_sz, 0, mbuf_size, (int)iconf->socket_id);
-        if (iconf->pkt_mempools->pkt_mp[i] == NULL) {
+        if (iconf->dpdk_dev_resources->pkt_mp[i] == NULL) {
             retval = -rte_errno;
             SCLogError("%s: rte_pktmbuf_pool_create failed with code %d (mempool: %s) - %s",
                     iconf->iface, rte_errno, mempool_name, rte_strerror(rte_errno));
@@ -1537,7 +1537,8 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
                 rxq_conf.rx_free_thresh, rxq_conf.rx_drop_en);
 
         retval = rte_eth_rx_queue_setup(iconf->port_id, queue_id, iconf->nb_rx_desc,
-                (unsigned int)iconf->socket_id, &rxq_conf, iconf->pkt_mempools->pkt_mp[queue_id]);
+                (unsigned int)iconf->socket_id, &rxq_conf,
+                iconf->dpdk_dev_resources->pkt_mp[queue_id]);
         if (retval < 0) {
             SCLogError("%s: failed to setup RX queue %u: %s", iconf->iface, queue_id,
                     rte_strerror(-retval));
@@ -1568,7 +1569,7 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
     SCReturnInt(0);
 
 cleanup:
-    DPDKDeviceResourcesDeinit(&iconf->pkt_mempools);
+    DPDKDeviceResourcesDeinit(&iconf->dpdk_dev_resources);
     SCReturnInt(retval);
 }
 
@@ -1885,8 +1886,8 @@ static void *ParseDpdkConfigAndConfigureDevice(const char *iface)
     if (ldev_instance == NULL) {
         FatalError("Device %s is not registered as a live device", iface);
     }
-    ldev_instance->dpdk_vars = iconf->pkt_mempools;
-    iconf->pkt_mempools = NULL;
+    ldev_instance->dpdk_vars = iconf->dpdk_dev_resources;
+    iconf->dpdk_dev_resources = NULL;
     return iconf;
 }
 

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2021-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -40,6 +40,7 @@ typedef struct DPDKIfaceConfigAttributes_ {
     const char *tx_descriptors;
     const char *copy_mode;
     const char *copy_iface;
+    const char *drop_filter;
 } DPDKIfaceConfigAttributes;
 
 int RunModeIdsDpdkWorkers(void);

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -41,6 +41,7 @@ typedef struct DPDKIfaceConfigAttributes_ {
     const char *copy_mode;
     const char *copy_iface;
     const char *drop_filter;
+    const char *capture_bypass;
 } DPDKIfaceConfigAttributes;
 
 int RunModeIdsDpdkWorkers(void);

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -116,6 +116,7 @@ typedef struct DPDKThreadVars_ {
     LiveDevice *livedev;
     ChecksumValidationMode checksum_mode;
     bool intr_enabled;
+    bool port_stopped;
     /* references to packet and drop counters */
     StatsCounterId capture_dpdk_packets;
     StatsCounterId capture_dpdk_rx_errs;
@@ -123,6 +124,7 @@ typedef struct DPDKThreadVars_ {
     StatsCounterId capture_dpdk_rx_no_mbufs;
     StatsCounterId capture_dpdk_ierrors;
     StatsCounterId capture_dpdk_tx_errs;
+    StatsCounterId capture_dpdk_rte_flow_filtered;
     unsigned int flags;
     uint16_t threads;
     /* for IPS */
@@ -211,6 +213,7 @@ static int DevicePostStartPMDSpecificActions(
                 RteFlowRulesCreate(dpdk_config->port_id, &dpdk_config->drop_filter, driver_name);
         if (retval != 0)
             SCReturnInt(retval);
+        ptv->livedev->dpdk_vars->drop_filter = &dpdk_config->drop_filter;
     }
     SCReturnInt(0);
 }
@@ -299,6 +302,18 @@ static inline void DPDKDumpCounters(DPDKThreadVars *ptv)
         if (unlikely(retval != 0)) {
             SCLogError("%s: failed to get stats: %s", ptv->livedev->dev, rte_strerror(-retval));
             return;
+        }
+
+        if (!ptv->port_stopped) {
+            RteFlowRuleStorage *drop_filter = ptv->livedev->dpdk_vars->drop_filter;
+            if (drop_filter != NULL) {
+                uint64_t filtered_packets = 0;
+                filtered_packets = RteFlowFilteredPacketsQuery(drop_filter->rule_handlers,
+                        drop_filter->rule_cnt, ptv->livedev->dev, ptv->port_id);
+                if (filtered_packets > 0)
+                    StatsCounterSetI64(
+                            &ptv->tv->stats, ptv->capture_dpdk_rte_flow_filtered, filtered_packets);
+            }
         }
 
         StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_packets,
@@ -560,6 +575,7 @@ static void HandleShutdown(DPDKThreadVars *ptv)
             // in IDS we stop our port - no peer threads are running
             rte_eth_dev_stop(ptv->port_id);
         }
+        ptv->port_stopped = true;
     }
 }
 
@@ -662,12 +678,15 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
     ptv->capture_dpdk_imissed = StatsRegisterCounter("capture.dpdk.imissed", &ptv->tv->stats);
     ptv->capture_dpdk_rx_no_mbufs = StatsRegisterCounter("capture.dpdk.no_mbufs", &ptv->tv->stats);
     ptv->capture_dpdk_ierrors = StatsRegisterCounter("capture.dpdk.ierrors", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_flow_filtered =
+            StatsRegisterCounter("capture.dpdk.rte_flow_filtered", &ptv->tv);
 
     ptv->copy_mode = dpdk_config->copy_mode;
     ptv->checksum_mode = dpdk_config->checksum_mode;
 
     ptv->threads = dpdk_config->threads;
     ptv->intr_enabled = (dpdk_config->flags & DPDK_IRQ_MODE) != 0;
+    ptv->port_stopped = false;
     ptv->port_id = dpdk_config->port_id;
     ptv->out_port_id = dpdk_config->out_port_id;
     ptv->port_socket_id = dpdk_config->socket_id;

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -679,7 +679,7 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
     ptv->capture_dpdk_rx_no_mbufs = StatsRegisterCounter("capture.dpdk.no_mbufs", &ptv->tv->stats);
     ptv->capture_dpdk_ierrors = StatsRegisterCounter("capture.dpdk.ierrors", &ptv->tv->stats);
     ptv->capture_dpdk_rte_flow_filtered =
-            StatsRegisterCounter("capture.dpdk.rte_flow_filtered", &ptv->tv);
+            StatsRegisterCounter("capture.dpdk.rte_flow_filtered", &ptv->tv->stats);
 
     ptv->copy_mode = dpdk_config->copy_mode;
     ptv->checksum_mode = dpdk_config->checksum_mode;

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -125,6 +125,14 @@ typedef struct DPDKThreadVars_ {
     StatsCounterId capture_dpdk_ierrors;
     StatsCounterId capture_dpdk_tx_errs;
     StatsCounterId capture_dpdk_rte_flow_filtered;
+    StatsCounterId capture_dpdk_rtee_flow_rules_created;
+    StatsCounterId capture_dpdk_rte_bypass_rules_error;
+    StatsCounterId capture_dpdk_rte_bypass_enqueue_error;
+    StatsCounterId capture_dpdk_rte_bypass_mempool_get_error;
+    StatsCounterId capture_dpdk_rte_bypass_info_mempool_get_error;
+    StatsCounterId capture_dpdk_rte_bypass_flow_error;
+    StatsCounterId capture_dpdk_rte_bypass_query_error;
+    bool capture_bypass_enabled;
     unsigned int flags;
     uint16_t threads;
     /* for IPS */
@@ -328,6 +336,24 @@ static inline void DPDKDumpCounters(DPDKThreadVars *ptv)
         StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_tx_errs, eth_stats.oerrors);
         SC_ATOMIC_SET(
                 ptv->livedev->drop, eth_stats.imissed + eth_stats.ierrors + eth_stats.rx_nombuf);
+        if (ptv->capture_bypass_enabled) {
+            RteFlowBypassData *rte_flow_bypass_data = ptv->livedev->dpdk_vars->rte_flow_bypass_data;
+
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_rules_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_rules_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_enqueue_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_enqueue_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_info_mempool_get_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_info_mempool_get_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_mempool_get_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_mempool_get_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_flow_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_flow_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_query_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_query_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rtee_flow_rules_created,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_rules_created));
+        }
     } else {
         StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_packets, ptv->pkts);
     }
@@ -454,6 +480,8 @@ static inline Packet *PacketInitFromMbuf(DPDKThreadVars *ptv, struct rte_mbuf *m
     p->ts = TimeGet();
     p->dpdk_v.mbuf = mbuf;
     p->ReleasePacket = DPDKReleasePacket;
+    if (ptv->capture_bypass_enabled)
+        p->BypassPacketsFlow = RteFlowBypassCallback;
     p->dpdk_v.copy_mode = ptv->copy_mode;
     p->dpdk_v.out_port_id = ptv->out_port_id;
     p->dpdk_v.out_queue_id = ptv->queue_id;
@@ -569,6 +597,21 @@ static void HandleShutdown(DPDKThreadVars *ptv)
         // If Suricata runs in peered mode, the peer threads might still want to send
         // packets to our port. Instead, we know, that we are done with the peered port, so
         // we stop it. The peered threads will stop our port.
+        if (ptv->capture_bypass_enabled) {
+            if (SC_ATOMIC_GET(
+                        ptv->livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_rules_active) !=
+                    0) {
+                SCLogInfo("Waiting for all bypass rte_flow rules to be removed");
+                while (SC_ATOMIC_GET(ptv->livedev->dpdk_vars->rte_flow_bypass_data
+                                             ->rte_bypass_rules_active) != 0) {
+                    rte_delay_us(10000);
+                }
+            }
+        }
+
+        DPDKDumpCounters(ptv);
+        struct rte_flow_error err = { 0 };
+        rte_flow_flush(0, &err);
         if (ptv->copy_mode == DPDK_COPY_MODE_TAP || ptv->copy_mode == DPDK_COPY_MODE_IPS) {
             rte_eth_dev_stop(ptv->out_port_id);
         } else {
@@ -680,7 +723,21 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
     ptv->capture_dpdk_ierrors = StatsRegisterCounter("capture.dpdk.ierrors", &ptv->tv->stats);
     ptv->capture_dpdk_rte_flow_filtered =
             StatsRegisterCounter("capture.dpdk.rte_flow_filtered", &ptv->tv->stats);
-
+    ptv->capture_dpdk_rtee_flow_rules_created =
+            StatsRegisterCounter("capture.dpdk.rte_rules_created", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_rules_error =
+            StatsRegisterCounter("capture.dpdk.bypass_rte_rules_error", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_enqueue_error =
+            StatsRegisterCounter("capture.dpdk.bypass_rte_ring_enqueue_error", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_mempool_get_error =
+            StatsRegisterCounter("capture.dpdk.bypass_mempool_get_error", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_info_mempool_get_error =
+            StatsRegisterCounter("capture.dpdk.bypass_mempool_info_get_error", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_flow_error =
+            StatsRegisterCounter("capture.dpdk.bypass_flow_error", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_query_error =
+            StatsRegisterCounter("capture.dpdk.bypass_stat_query_errors", &ptv->tv->stats);
+    ptv->capture_bypass_enabled = dpdk_config->capture_bypass_enabled;
     ptv->copy_mode = dpdk_config->copy_mode;
     ptv->checksum_mode = dpdk_config->checksum_mode;
 

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -42,6 +42,7 @@
 #include "tmqh-packetpool.h"
 #include "util-privs.h"
 #include "util-device-private.h"
+#include "util-dpdk-rte-flow.h"
 #include "action-globals.h"
 
 #ifndef HAVE_DPDK
@@ -190,7 +191,8 @@ static inline void DPDKFreeMbufArray(
     }
 }
 
-static void DevicePostStartPMDSpecificActions(DPDKThreadVars *ptv, const char *driver_name)
+static int DevicePostStartPMDSpecificActions(
+        DPDKThreadVars *ptv, DPDKIfaceConfig *dpdk_config, const char *driver_name)
 {
     if (strcmp(driver_name, "net_bonding") == 0)
         driver_name = BondingDeviceDriverGet(ptv->port_id);
@@ -202,6 +204,15 @@ static void DevicePostStartPMDSpecificActions(DPDKThreadVars *ptv, const char *d
         iceDeviceSetRSS(ptv->port_id, ptv->threads, ptv->livedev->dev);
     else if (strcmp(driver_name, "mlx5_pci") == 0)
         mlx5DeviceSetRSS(ptv->port_id, ptv->threads, ptv->livedev->dev);
+
+    if ((strcmp(driver_name, "mlx5_pci") == 0 || strcmp(driver_name, "net_ice") == 0 ||
+                strcmp(driver_name, "net_i40e") == 0)) {
+        int retval =
+                RteFlowRulesCreate(dpdk_config->port_id, &dpdk_config->drop_filter, driver_name);
+        if (retval != 0)
+            SCReturnInt(retval);
+    }
+    SCReturnInt(0);
 }
 
 static void DevicePreClosePMDSpecificActions(DPDKThreadVars *ptv, const char *driver_name)
@@ -729,8 +740,11 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
             SCLogWarning("%s: link is down, trying to continue anyway", dpdk_config->iface);
         }
 
-        // some PMDs requires additional actions only after the device has started
-        DevicePostStartPMDSpecificActions(ptv, dev_info.driver_name);
+        /* some PMDs requires additional actions only after the device has started */
+        retval = DevicePostStartPMDSpecificActions(ptv, dpdk_config, dev_info.driver_name);
+        if (retval != 0) {
+            goto fail;
+        }
 
         uint16_t inconsistent_numa_cnt = SC_ATOMIC_GET(dpdk_config->inconsistent_numa_cnt);
         if (inconsistent_numa_cnt > 0 && ptv->port_socket_id != SOCKET_ID_ANY) {

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -26,7 +26,6 @@
 
 #include "suricata-common.h"
 #include "util-dpdk.h"
-#include "util-dpdk-rte-flow.h"
 
 #ifdef HAVE_DPDK
 #include <rte_ethdev.h>
@@ -78,6 +77,7 @@ typedef struct DPDKIfaceConfig_ {
     DPDKDeviceResources *dpdk_dev_resources;
     uint16_t linkup_timeout; // in seconds how long to wait for link to come up
     RteFlowRuleStorage drop_filter;
+    bool capture_bypass_enabled;
     SC_ATOMIC_DECLARE(uint16_t, ref);
     /* threads bind queue id one by one */
     SC_ATOMIC_DECLARE(uint16_t, queue_id);

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2021-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -26,6 +26,7 @@
 
 #include "suricata-common.h"
 #include "util-dpdk.h"
+#include "util-dpdk-rte-flow.h"
 
 #ifdef HAVE_DPDK
 #include <rte_ethdev.h>
@@ -76,12 +77,14 @@ typedef struct DPDKIfaceConfig_ {
     bool mempool_cache_size_auto; // auto cache size based on mempool size
     DPDKDeviceResources *pkt_mempools;
     uint16_t linkup_timeout; // in seconds how long to wait for link to come up
+    RteFlowRuleStorage drop_filter;
     SC_ATOMIC_DECLARE(uint16_t, ref);
     /* threads bind queue id one by one */
     SC_ATOMIC_DECLARE(uint16_t, queue_id);
     SC_ATOMIC_DECLARE(uint16_t, inconsistent_numa_cnt);
     DPDKWorkerSync *workers_sync;
     void (*DerefFunc)(void *);
+    void (*RteRulesFree)(RteFlowRuleStorage *);
 
     struct rte_flow *flow[100];
 #endif

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -75,7 +75,7 @@ typedef struct DPDKIfaceConfig_ {
     uint32_t queue_mempool_size;
     uint32_t mempool_cache_size;
     bool mempool_cache_size_auto; // auto cache size based on mempool size
-    DPDKDeviceResources *pkt_mempools;
+    DPDKDeviceResources *dpdk_dev_resources;
     uint16_t linkup_timeout; // in seconds how long to wait for link to come up
     RteFlowRuleStorage drop_filter;
     SC_ATOMIC_DECLARE(uint16_t, ref);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2832,6 +2832,11 @@ int PostConfLoadedSetup(SCInstance *suri)
         LiveDevRegisterExtension();
     }
 #endif
+#ifdef HAVE_DPDK
+    if (suri->run_mode == RUNMODE_DPDK) {
+        LiveDevRegisterExtension();
+    }
+#endif
     RegisterFlowBypassInfo();
 
     MacSetRegisterFlowStorage();

--- a/src/util-device-private.h
+++ b/src/util-device-private.h
@@ -24,7 +24,7 @@
 #include "util-device.h"
 #include "queue.h"
 #include "util-storage.h"
-#include "util-dpdk-common.h"
+#include "util-dpdk.h"
 
 #define MAX_DEVNAME 10
 

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -258,11 +258,11 @@ static int LiveSafeDeviceName(const char *devname, char *newdevname, size_t dest
 }
 
 /**
- *  \brief Get a pointer to the device at idx
+ *  \brief Get a pointer to the device by name
  *
- *  \param number idx of the device in our list
+ *  \param str name of the device in our list
  *
- *  \retval ptr pointer to the string containing the device
+ *  \retval ptr pointer to the device instance
  *  \retval NULL on error
  */
 LiveDevice *LiveGetDevice(const char *name)
@@ -278,6 +278,30 @@ LiveDevice *LiveGetDevice(const char *name)
         if (!strcmp(name, pd->dev)) {
             return pd;
         }
+    }
+
+    return NULL;
+}
+
+/**
+ *  \brief Get a pointer to the device at idx
+ *
+ *  \param number idx of the device in our list
+ *
+ *  \retval ptr pointer to the device instance
+ *  \retval NULL on error
+ */
+LiveDevice *LiveGetDeviceByIdx(int number)
+{
+    int i = 0;
+    LiveDevice *pd;
+
+    TAILQ_FOREACH (pd, &live_devices, next) {
+        if (i == number) {
+            return pd;
+        }
+
+        i++;
     }
 
     return NULL;

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -366,6 +366,18 @@ int LiveDeviceListClean(void)
     }
     TAILQ_FOREACH_SAFE(pd, &live_devices, next, tpd) {
         if (live_devices_stats) {
+#ifdef CAPTURE_OFFLOAD
+            SCLogNotice("%s: packets: %" PRIu64 ", bypassed: %" PRIu64 ", drops: %" PRIu64
+                        " (%.2f%%), invalid chksum: %" PRIu64,
+                    pd->dev, SC_ATOMIC_GET(pd->pkts), SC_ATOMIC_GET(pd->bypassed),
+                    SC_ATOMIC_GET(pd->drop),
+                    SC_ATOMIC_GET(pd->pkts) > 0
+                            ? 100 * ((double)SC_ATOMIC_GET(pd->drop)) /
+                                      ((double)SC_ATOMIC_GET(pd->pkts) +
+                                              (double)SC_ATOMIC_GET(pd->bypassed))
+                            : 0,
+                    SC_ATOMIC_GET(pd->invalid_checksums));
+#else
             SCLogNotice("%s: packets: %" PRIu64 ", drops: %" PRIu64
                         " (%.2f%%), invalid chksum: %" PRIu64,
                     pd->dev, SC_ATOMIC_GET(pd->pkts), SC_ATOMIC_GET(pd->drop),
@@ -373,6 +385,7 @@ int LiveDeviceListClean(void)
                                                           (double)SC_ATOMIC_GET(pd->pkts)
                                                 : 0,
                     SC_ATOMIC_GET(pd->invalid_checksums));
+#endif
         }
 
         RestoreIfaceOffloading(pd);

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -56,6 +56,7 @@ int LiveGetDeviceCountWithoutAssignedThreading(void);
 int LiveGetDeviceCount(void);
 const char *LiveGetDeviceName(int number);
 LiveDevice *LiveGetDevice(const char *dev);
+LiveDevice *LiveGetDeviceByIdx(int number);
 const char *LiveGetShortName(const char *dev);
 int LiveBuildDeviceList(const char *base);
 void LiveDeviceHasNoStats(void);

--- a/src/util-dpdk-common.c
+++ b/src/util-dpdk-common.c
@@ -27,43 +27,27 @@
 
 #ifdef HAVE_DPDK
 
-int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt)
+/**
+ * \brief Input is a number of which we want to find the greatest divisor up to max_num (inclusive).
+ * The divisor is returned.
+ */
+static int GreatestDivisorUpTo(uint32_t num, uint32_t max_num)
 {
-    SCEnter();
-    *dpdk_vars = SCCalloc(1, sizeof(*dpdk_vars[0]));
-    if (*dpdk_vars == NULL) {
-        SCLogError("failed to allocate memory for packet mempools structure");
-        SCReturnInt(-ENOMEM);
+    for (int i = max_num; i >= 2; i--) {
+        if (num % i == 0) {
+            return i;
+        }
     }
-
-    (*dpdk_vars)->pkt_mp = SCCalloc(mp_cnt, sizeof((*dpdk_vars)->pkt_mp[0]));
-    if ((*dpdk_vars)->pkt_mp == NULL) {
-        SCLogError("failed to allocate memory for packet mempools");
-        SCReturnInt(-ENOMEM);
-    }
-    (*dpdk_vars)->pkt_mp_capa = mp_cnt;
-    (*dpdk_vars)->pkt_mp_cnt = 0;
-
-    SCReturnInt(0);
+    return 1;
 }
 
-void DPDKDeviceResourcesDeinit(DPDKDeviceResources **dpdk_vars)
+uint32_t MempoolCacheSizeCalculate(uint32_t mp_sz)
 {
-    if ((*dpdk_vars) != NULL) {
-        if ((*dpdk_vars)->pkt_mp != NULL) {
-            for (int j = 0; j < (*dpdk_vars)->pkt_mp_capa; j++) {
-                if ((*dpdk_vars)->pkt_mp[j] != NULL) {
-                    rte_mempool_free((*dpdk_vars)->pkt_mp[j]);
-                }
-            }
-            SCFree((*dpdk_vars)->pkt_mp);
-            (*dpdk_vars)->pkt_mp_capa = 0;
-            (*dpdk_vars)->pkt_mp_cnt = 0;
-            (*dpdk_vars)->pkt_mp = NULL;
-        }
-        SCFree(*dpdk_vars);
-        *dpdk_vars = NULL;
-    }
+    // It is advised to have mempool cache size lower or equal to:
+    //   RTE_MEMPOOL_CACHE_MAX_SIZE (by default 512) and "mempool-size / 1.5"
+    // and at the same time "mempool-size modulo cache_size == 0".
+    uint32_t max_cache_size = MIN(RTE_MEMPOOL_CACHE_MAX_SIZE, mp_sz / 1.5);
+    return GreatestDivisorUpTo(mp_sz, max_cache_size);
 }
 
 #endif /* HAVE_DPDK */

--- a/src/util-dpdk-common.h
+++ b/src/util-dpdk-common.h
@@ -26,7 +26,6 @@
 
 #ifdef HAVE_DPDK
 
-#include "util-dpdk-rte-flow.h"
 #include <rte_eal.h>
 #include <rte_ethdev.h>
 #ifdef HAVE_DPDK_BOND

--- a/src/util-dpdk-common.h
+++ b/src/util-dpdk-common.h
@@ -26,6 +26,7 @@
 
 #ifdef HAVE_DPDK
 
+#include "util-dpdk-rte-flow.h"
 #include <rte_eal.h>
 #include <rte_ethdev.h>
 #ifdef HAVE_DPDK_BOND
@@ -122,6 +123,7 @@ typedef struct {
     struct rte_mempool **pkt_mp;
     uint16_t pkt_mp_cnt;
     uint16_t pkt_mp_capa;
+    RteFlowRuleStorage *drop_filter;
 } DPDKDeviceResources;
 
 int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt);

--- a/src/util-dpdk-common.h
+++ b/src/util-dpdk-common.h
@@ -119,15 +119,7 @@
 #define RTE_ETH_LINK_MAX_STR_LEN 40
 #endif
 
-typedef struct {
-    struct rte_mempool **pkt_mp;
-    uint16_t pkt_mp_cnt;
-    uint16_t pkt_mp_capa;
-    RteFlowRuleStorage *drop_filter;
-} DPDKDeviceResources;
-
-int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt);
-void DPDKDeviceResourcesDeinit(DPDKDeviceResources **dpdk_vars);
+uint32_t MempoolCacheSizeCalculate(uint32_t mp_sz);
 
 #endif /* HAVE_DPDK */
 

--- a/src/util-dpdk-ice.c
+++ b/src/util-dpdk-ice.c
@@ -124,6 +124,26 @@ void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf)
     rss_conf->rss_key_len = 52;
 }
 
+/**
+ * \brief Check and log whether pattern is broad / not-specific
+ *        as ice does not support these patterns with counter
+ *        enabled
+ * \param items array of pattern items
+ * \return true if pattern is broad / wildcard, false otherwise
+ */
+bool iceDeviceRteFlowPatternError(struct rte_flow_item *items)
+{
+    SCEnter();
+    int i = 0;
+    while (items[i].type != RTE_FLOW_ITEM_TYPE_END) {
+        if (items[i].spec != NULL) {
+            SCReturnBool(false);
+        }
+        ++i;
+    }
+    SCReturnBool(true);
+}
+
 #endif /* HAVE_DPDK */
 /**
  * @}

--- a/src/util-dpdk-ice.c
+++ b/src/util-dpdk-ice.c
@@ -35,8 +35,10 @@
 #include "util-dpdk-rss.h"
 #include "util-debug.h"
 #include "util-dpdk-bonding.h"
+#include "util-dpdk-rte-flow.h"
 
 #ifdef HAVE_DPDK
+static bool RteFlowRulesContainPatternWildcard(RteFlowRuleStorage *);
 
 static void iceDeviceSetRSSHashFunction(uint64_t *rss_hf)
 {
@@ -142,6 +144,42 @@ bool iceDeviceRteFlowPatternError(struct rte_flow_item *items)
         ++i;
     }
     SCReturnBool(true);
+}
+
+/**
+ * \brief Checks whether at least one pattern contains wildcard matching
+ *
+ * \param rule_storage struct contaning number of rules, their string instances and rte_flow
+ *        handlers
+ * \return true if any pattern contains wildcard matching, false otherwise
+ */
+static bool RteFlowRulesContainPatternWildcard(RteFlowRuleStorage *rule_storage)
+{
+    for (size_t i = 0; i < rule_storage->rule_cnt; i++) {
+        char *pattern = rule_storage->rules[i];
+        if (strstr(pattern, " mask ") != NULL || (strstr(pattern, " last ") != NULL))
+            return true;
+    }
+    return false;
+}
+
+/**
+ * \brief Decide based on the pattern whether rte_flow rules should
+ *        support gathering statistic or not
+ * \param rule_storage struct contaning number of rules and their string instances
+ * \param port_name name of the port
+ * \return true if any pattern contains wildcard, false otherwise
+ */
+bool iceDeviceDecideRteFlowActionType(RteFlowRuleStorage *rule_storage, const char *port_name)
+{
+    if (RteFlowRulesContainPatternWildcard(rule_storage)) {
+        SCLogWarning(
+                "%s: gathering statistic for the rte_flow rule is disabled because of wildcard "
+                "pattern (ice PMD specific)",
+                port_name);
+        return false;
+    }
+    return true;
 }
 
 #endif /* HAVE_DPDK */

--- a/src/util-dpdk-ice.h
+++ b/src/util-dpdk-ice.h
@@ -32,6 +32,7 @@
 
 int iceDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
 void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf);
+bool iceDeviceRteFlowPatternError(struct rte_flow_item *items);
 
 #endif /* HAVE_DPDK */
 

--- a/src/util-dpdk-ice.h
+++ b/src/util-dpdk-ice.h
@@ -29,10 +29,12 @@
 #ifdef HAVE_DPDK
 
 #include "util-dpdk.h"
+#include "util-dpdk-rte-flow.h"
 
 int iceDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
 void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf);
 bool iceDeviceRteFlowPatternError(struct rte_flow_item *items);
+bool iceDeviceDecideRteFlowActionType(RteFlowRuleStorage *rule_storage, const char *port_name);
 
 #endif /* HAVE_DPDK */
 

--- a/src/util-dpdk-mlx5.c
+++ b/src/util-dpdk-mlx5.c
@@ -39,6 +39,9 @@
 #ifdef HAVE_DPDK
 
 #define MLX5_RSS_HKEY_LEN 40
+/* Although 2^16 rules are supported on mlx5 in rte_flow group 0,
+   rules in approximately top 10% of the capacity do not support counters */
+#define MLX5_MAX_RTE_FLOW_RULES 57000
 
 int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
 {
@@ -67,6 +70,19 @@ int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
         return retval;
     }
 
+    return 0;
+}
+
+int mlx5DeviceCheckDropFilterLimits(uint32_t rte_flow_rule_count, char **err_msg)
+{
+    if (rte_flow_rule_count > MLX5_MAX_RTE_FLOW_RULES) {
+        static char msg_buffer[1024];
+        snprintf(msg_buffer, sizeof(msg_buffer),
+                "Maximum number of rte_flow rules reached, curr: %i, max %i", rte_flow_rule_count,
+                MLX5_MAX_RTE_FLOW_RULES);
+        *err_msg = msg_buffer;
+        return -ENOSPC;
+    }
     return 0;
 }
 

--- a/src/util-dpdk-mlx5.c
+++ b/src/util-dpdk-mlx5.c
@@ -39,9 +39,6 @@
 #ifdef HAVE_DPDK
 
 #define MLX5_RSS_HKEY_LEN 40
-/* Although 2^16 rules are supported on mlx5 in rte_flow group 0,
-   rules in approximately top 10% of the capacity do not support counters */
-#define MLX5_MAX_RTE_FLOW_RULES 57000
 
 int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
 {
@@ -75,11 +72,11 @@ int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
 
 int mlx5DeviceCheckDropFilterLimits(uint32_t rte_flow_rule_count, char **err_msg)
 {
-    if (rte_flow_rule_count > MLX5_MAX_RTE_FLOW_RULES) {
+    if (rte_flow_rule_count > MLX5_RTE_FLOW_RULES_CAPACITY) {
         static char msg_buffer[1024];
         snprintf(msg_buffer, sizeof(msg_buffer),
                 "Maximum number of rte_flow rules reached, curr: %i, max %i", rte_flow_rule_count,
-                MLX5_MAX_RTE_FLOW_RULES);
+                MLX5_RTE_FLOW_RULES_CAPACITY);
         *err_msg = msg_buffer;
         return -ENOSPC;
     }

--- a/src/util-dpdk-mlx5.h
+++ b/src/util-dpdk-mlx5.h
@@ -28,6 +28,8 @@
 
 #ifdef HAVE_DPDK
 
+#define MLX5_RTE_FLOW_RULES_CAPACITY 4194304
+
 int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
 int mlx5DeviceCheckDropFilterLimits(uint32_t rte_flow_rule_count, char **err_msg);
 

--- a/src/util-dpdk-rss.c
+++ b/src/util-dpdk-rss.c
@@ -104,6 +104,7 @@ int DPDKCreateRSSFlowGeneric(
     rss_conf.types = RTE_ETH_RSS_IPV4 | RTE_ETH_RSS_IPV6;
 
     attr.ingress = 1;
+    attr.priority = 1;
     action[0].type = RTE_FLOW_ACTION_TYPE_RSS;
     action[0].conf = &rss_conf;
     action[1].type = RTE_FLOW_ACTION_TYPE_END;

--- a/src/util-dpdk-rss.c
+++ b/src/util-dpdk-rss.c
@@ -35,6 +35,7 @@
 #include "util-debug.h"
 
 #ifdef HAVE_DPDK
+#define RTE_JUMP_GROUP 1
 
 uint8_t RSS_HKEY[] = {
     0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A,
@@ -105,6 +106,8 @@ int DPDKCreateRSSFlowGeneric(
 
     attr.ingress = 1;
     attr.priority = 1;
+    attr.group = RTE_JUMP_GROUP;
+
     action[0].type = RTE_FLOW_ACTION_TYPE_RSS;
     action[0].conf = &rss_conf;
     action[1].type = RTE_FLOW_ACTION_TYPE_END;

--- a/src/util-dpdk-rte-flow-pattern.c
+++ b/src/util-dpdk-rte-flow-pattern.c
@@ -143,6 +143,7 @@ static const enum index item_param[] = {
     ZERO,
 };
 
+/* --- start pattern enum --- */
 static const enum index next_item[] = {
     ITEM_END,
     ITEM_VOID,
@@ -171,6 +172,7 @@ static const enum index next_item[] = {
     ITEM_VXLAN_GPE,
     ZERO,
 };
+/* --- end pattern enum --- */
 
 static const enum index item_any[] = {
     ITEM_NEXT,

--- a/src/util-dpdk-rte-flow-pattern.c
+++ b/src/util-dpdk-rte-flow-pattern.c
@@ -1,0 +1,1382 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2016 6WIND S.A.
+ * Copyright 2016 Mellanox Technologies, Ltd
+ *
+ *
+ * Modifications by Adam Kiripolsky:
+ * - The code is a modification of the parser for dpdk-testpmd application
+ *   located in DPDK 25.11 source code at  dpdk/app/testpmd/cmdline_flow.c
+ * - Simplified the parser and it's corresponding parts to parse only
+ *   pattern instead of the whole test-pmd commands
+ * - Add ParsePattern function to utilize the parser from outside
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+
+ * - Neither the name of the Qualys, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ *  \defgroup dpdk pattern parser
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK parser for pattern
+ *
+ */
+
+#include "util-debug.h"
+#include "util-dpdk.h"
+#include "util-dpdk-rte-flow-pattern.h"
+
+#ifdef HAVE_DPDK
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+
+#include <cmdline_parse_etheraddr.h>
+
+#define DATA_BUFFER_SIZE 1024
+
+enum index {
+    /* Special tokens. */
+    ZERO = 0,
+    END,
+
+    /* Create tokens */
+    CREATE,
+
+    /* Common tokens. */
+    COMMON_UNSIGNED,
+    COMMON_MAC_ADDR,
+    COMMON_IPV4_ADDR,
+    COMMON_IPV6_ADDR,
+
+    /* Validate/create pattern. */
+    ITEM_PATTERN,
+    ITEM_PARAM_IS,
+    ITEM_PARAM_SPEC,
+    ITEM_PARAM_LAST,
+    ITEM_PARAM_MASK,
+    ITEM_NEXT,
+    ITEM_END,
+    ITEM_VOID,
+    ITEM_ANY,
+    ITEM_PORT_ID,
+    ITEM_ETH,
+    ITEM_ETH_DST,
+    ITEM_ETH_SRC,
+    ITEM_ETH_TYPE,
+    ITEM_ETH_HAS_VLAN,
+    ITEM_RAW,
+    ITEM_VLAN,
+    ITEM_IPV4,
+    ITEM_IPV4_SRC,
+    ITEM_IPV4_DST,
+    ITEM_IPV6,
+    ITEM_IPV6_SRC,
+    ITEM_IPV6_DST,
+    ITEM_ICMP,
+    ITEM_ICMP_TYPE,
+    ITEM_ICMP_CODE,
+    ITEM_ICMP_IDENT,
+    ITEM_ICMP_SEQ,
+    ITEM_ICMP6,
+    ITEM_ICMP6_TYPE,
+    ITEM_ICMP6_CODE,
+    ITEM_UDP,
+    ITEM_UDP_SRC,
+    ITEM_UDP_DST,
+    ITEM_TCP,
+    ITEM_TCP_SRC,
+    ITEM_TCP_DST,
+    ITEM_TCP_FLAGS,
+    ITEM_SCTP,
+    ITEM_SCTP_SRC,
+    ITEM_SCTP_DST,
+    ITEM_SCTP_TAG,
+    ITEM_SCTP_CKSUM,
+    ITEM_VXLAN,
+    ITEM_E_TAG,
+    ITEM_NVGRE,
+    ITEM_MPLS,
+    ITEM_GRE,
+    ITEM_FUZZY,
+    ITEM_GTP,
+    ITEM_GTPC,
+    ITEM_GTPU,
+    ITEM_GENEVE,
+    ITEM_VXLAN_GPE,
+};
+
+static const enum index item_param[] = {
+    ITEM_PARAM_IS,
+    ITEM_PARAM_SPEC,
+    ITEM_PARAM_LAST,
+    ITEM_PARAM_MASK,
+    ZERO,
+};
+
+static const enum index next_item[] = {
+    ITEM_END,
+    ITEM_VOID,
+    ITEM_ANY,
+    ITEM_PORT_ID,
+    ITEM_ETH,
+    ITEM_RAW,
+    ITEM_VLAN,
+    ITEM_IPV4,
+    ITEM_IPV6,
+    ITEM_ICMP,
+    ITEM_ICMP6,
+    ITEM_UDP,
+    ITEM_TCP,
+    ITEM_SCTP,
+    ITEM_VXLAN,
+    ITEM_E_TAG,
+    ITEM_NVGRE,
+    ITEM_MPLS,
+    ITEM_GRE,
+    ITEM_FUZZY,
+    ITEM_GTP,
+    ITEM_GTPC,
+    ITEM_GTPU,
+    ITEM_GENEVE,
+    ITEM_VXLAN_GPE,
+    ZERO,
+};
+
+static const enum index item_any[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_port_id[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_eth[] = {
+    ITEM_ETH_DST,
+    ITEM_ETH_SRC,
+    ITEM_ETH_TYPE,
+    ITEM_ETH_HAS_VLAN,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_raw[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_vlan[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_ipv4[] = {
+    ITEM_IPV4_SRC,
+    ITEM_IPV4_DST,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_ipv6[] = {
+    ITEM_IPV6_SRC,
+    ITEM_IPV6_DST,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_icmp[] = {
+    ITEM_ICMP_TYPE,
+    ITEM_ICMP_CODE,
+    ITEM_ICMP_IDENT,
+    ITEM_ICMP_SEQ,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_icmp6[] = {
+    ITEM_ICMP6_TYPE,
+    ITEM_ICMP6_CODE,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_udp[] = {
+    ITEM_UDP_SRC,
+    ITEM_UDP_DST,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_tcp[] = {
+    ITEM_TCP_SRC,
+    ITEM_TCP_DST,
+    ITEM_TCP_FLAGS,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_sctp[] = {
+    ITEM_SCTP_SRC,
+    ITEM_SCTP_DST,
+    ITEM_SCTP_TAG,
+    ITEM_SCTP_CKSUM,
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_vxlan[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_e_tag[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_nvgre[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_mpls[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gre[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gtp[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gtpc[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_gtpu[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_geneve[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_fuzzy[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index item_vxlan_gpe[] = {
+    ITEM_NEXT,
+    ZERO,
+};
+
+static const enum index next_vc_attr[] = {
+    ITEM_PATTERN,
+    ZERO,
+};
+
+/** Maximum number of subsequent tokens and arguments on the stack. */
+#define CTX_STACK_SIZE 16
+
+/** Maximum size for pattern in struct rte_flow_item_raw. */
+#define ITEM_RAW_PATTERN_SIZE 512
+
+/** Static initializer for the args field. */
+#define ARGS(...)                                                                                  \
+    (const struct arg *const[])                                                                    \
+    {                                                                                              \
+        __VA_ARGS__, NULL,                                                                         \
+    }
+
+#define ARGS_ENTRY_HTON(s, f)                                                                      \
+    (&(const struct arg){                                                                          \
+            .hton = 1,                                                                             \
+            .offset = offsetof(s, f),                                                              \
+            .size = sizeof(((s *)0)->f),                                                           \
+    })
+
+#define PRIV_ITEM(t, s)                                                                            \
+    (&(const struct parse_item_priv){                                                              \
+            .type = RTE_FLOW_ITEM_TYPE_##t,                                                        \
+            .size = s,                                                                             \
+    })
+
+/** Static initializer for ARGS() to target a bit-field. */
+#define ARGS_ENTRY_BF(s, f, b)                                                                     \
+    (&(const struct arg){                                                                          \
+            .size = sizeof(s),                                                                     \
+            .mask = (const void *)&(const s){ .f = (1 << (b)) - 1 },                               \
+    })
+
+/** Static initializer for the next field. */
+#define NEXT(...)                                                                                  \
+    (const enum index *const[])                                                                    \
+    {                                                                                              \
+        __VA_ARGS__, NULL,                                                                         \
+    }
+
+/** Static initializer for a NEXT() entry. */
+#define NEXT_ENTRY(...)                                                                            \
+    (const enum index[])                                                                           \
+    {                                                                                              \
+        __VA_ARGS__, ZERO,                                                                         \
+    }
+
+/** Storage size for struct rte_flow_item_raw including pattern. */
+#define ITEM_RAW_SIZE (sizeof(struct rte_flow_item_raw) + ITEM_RAW_PATTERN_SIZE)
+
+/** Token argument. */
+struct arg {
+    uint32_t hton : 1;    /**< Use network byte ordering. */
+    uint32_t sign : 1;    /**< Value is signed. */
+    uint32_t bounded : 1; /**< Value is bounded. */
+    uintmax_t min;        /**< Minimum value if bounded. */
+    uintmax_t max;        /**< Maximum value if bounded. */
+    uint32_t offset;      /**< Relative offset from ctx->object. */
+    uint32_t size;        /**< Field size. */
+    const uint8_t *mask;  /**< Bit-mask to use instead of offset/size. */
+};
+
+struct buffer {
+    enum index command; /**< Flow command. */
+    union {
+        struct {
+            struct rte_flow_attr attr;
+            struct rte_flow_item *pattern;
+            uint32_t pattern_n;
+            uint8_t *data;
+        } vc; /**< Validate/create arguments. */
+
+    } args; /**< Command arguments. */
+};
+
+/** Parser context. */
+struct context {
+    /** Stack of subsequent token lists to process. */
+    const enum index *next[CTX_STACK_SIZE];
+    /** Arguments for stacked tokens. */
+    const void *args[CTX_STACK_SIZE];
+    enum index curr;   /**< Current token index. */
+    enum index prev;   /**< Index of the last token seen. */
+    int next_num;      /**< Number of entries in next[]. */
+    int args_num;      /**< Number of entries in args[]. */
+    uint32_t eol : 1;  /**< EOL has been detected. */
+    uint32_t last : 1; /**< No more arguments. */
+    uint16_t port;     /**< Current port ID (for completions). */
+    uint32_t objdata;  /**< Object-specific data. */
+    void *object;      /**< Address of current object for relative offsets. */
+    void *objmask;     /**< Object a full mask must be written to. */
+};
+
+static struct context cmd_flow_context;
+
+/** Initialize context. */
+static void cmd_flow_context_init(struct context *ctx)
+{
+    /* A full memset() is not necessary. */
+    ctx->curr = ZERO;
+    ctx->prev = ZERO;
+    ctx->next_num = 0;
+    ctx->args_num = 0;
+    ctx->eol = 0;
+    ctx->last = 0;
+    ctx->objdata = 0;
+    ctx->object = NULL;
+    ctx->objmask = NULL;
+}
+
+struct token {
+    /** Type displayed during completion (defaults to "TOKEN"). */
+    const char *type;
+    /** Private data used by parser functions. */
+    const void *priv;
+    /**
+     * Lists of subsequent tokens to push on the stack. Each call to the
+     * parser consumes the last entry of that stack.
+     */
+    const enum index *const *next;
+    /** Arguments stack for subsequent tokens that need them. */
+    const struct arg *const *args;
+    /**
+     * Token-processing callback, returns -1 in case of error, the
+     * length of the matched string otherwise. If NULL, attempts to
+     * match the token name.
+     *
+     * If buf is not NULL, the result should be stored in it according
+     * to context. An error is returned if not large enough.
+     */
+    int (*call)(struct context *ctx, const struct token *token, const char *str, unsigned int len,
+            void *buf, unsigned int size);
+    /** Mandatory token name, no default value. */
+    const char *name;
+};
+
+#if RTE_VERSION < RTE_VERSION_NUM(24, 0, 0, 0)
+/**
+ * Maximum IPv6 address size in bytes.
+ */
+#define RTE_IPV6_ADDR_SIZE 16
+
+/**
+ * IPv6 Address
+ */
+struct rte_ipv6_addr {
+    uint8_t a[RTE_IPV6_ADDR_SIZE];
+};
+#endif /* RTE_VERSION < RTE_VERSION_NUM(24, 0, 0, 0) */
+
+struct parse_item_priv {
+    enum rte_flow_item_type type; /**< Item type. */
+    uint32_t size;                /**< Size of item specification structure. */
+};
+
+static int parse_vc(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_vc_spec(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_init(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_int(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_mac_addr(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_ipv4_addr(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+static int parse_ipv6_addr(
+        struct context *, const struct token *, const char *, unsigned int, void *, unsigned int);
+
+static int parse_default(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size);
+
+static const struct token token_list[] = {
+
+    /* Starts parsing from ITEM_PATTERN */
+	[ZERO] = {
+		.name = "ZERO",
+		.next = NEXT(NEXT_ENTRY(ITEM_PATTERN)),
+	},
+	/* Create Token, not used directly */
+	[CREATE] = {
+		.name = "create",
+		.next = NEXT(next_vc_attr),
+		.call = parse_vc,
+	},
+    /* Common tokens. */
+	[COMMON_UNSIGNED] = {
+		.name = "{unsigned}",
+		.type = "UNSIGNED",
+		.call = parse_int,
+	},
+	[COMMON_MAC_ADDR] = {
+		.name = "{MAC address}",
+		.type = "MAC-48",
+		.call = parse_mac_addr,
+	},
+	[COMMON_IPV4_ADDR] = {
+		.name = "{IPv4 address}",
+		.type = "IPV4 ADDRESS",
+		.call = parse_ipv4_addr,
+	},
+	[COMMON_IPV6_ADDR] = {
+		.name = "{IPv6 address}",
+		.type = "IPV6 ADDRESS",
+		.call = parse_ipv6_addr,
+	},
+	/* Validate/create pattern. */
+	[ITEM_PATTERN] = {
+		.name = "pattern",
+		.next = NEXT(next_item),
+		.call = parse_init,
+	},
+	[ITEM_PARAM_IS] = {
+		.name = "is",
+		.call = parse_vc_spec,
+	},
+	[ITEM_PARAM_SPEC] = {
+		.name = "spec",
+		.call = parse_vc_spec,
+	},
+	[ITEM_PARAM_LAST] = {
+		.name = "last",
+		.call = parse_vc_spec,
+	},
+	[ITEM_PARAM_MASK] = {
+		.name = "mask",
+		.call = parse_vc_spec,
+	},
+	[ITEM_NEXT] = {
+		.name = "/",
+		.next = NEXT(next_item),
+	},
+    [ITEM_END] = {
+		.name = "end",
+		.priv = PRIV_ITEM(END, 0),
+		.next = NEXT(NEXT_ENTRY(END)),
+		.call = parse_vc,
+	},
+	[ITEM_VOID] = {
+		.name = "void",
+		.priv = PRIV_ITEM(VOID, 0),
+		.next = NEXT(NEXT_ENTRY(ITEM_NEXT)),
+		.call = parse_vc,
+	},
+	[ITEM_ANY] = {
+		.name = "any",
+		.priv = PRIV_ITEM(ANY, sizeof(struct rte_flow_item_any)),
+		.next = NEXT(item_any),
+		.call = parse_vc,
+	},
+	[ITEM_PORT_ID] = {
+		.name = "port_id",
+		.priv = PRIV_ITEM(PORT_ID,
+				  sizeof(struct rte_flow_item_port_id)),
+		.next = NEXT(item_port_id),
+		.call = parse_vc,
+	},
+	[ITEM_RAW] = {
+		.name = "raw",
+		.priv = PRIV_ITEM(RAW, ITEM_RAW_SIZE),
+		.next = NEXT(item_raw),
+		.call = parse_vc,
+	},
+	[ITEM_ETH] = {
+		.name = "eth",
+		.priv = PRIV_ITEM(ETH, sizeof(struct rte_flow_item_eth)),
+		.next = NEXT(item_eth),
+		.call = parse_vc,
+	},
+	[ITEM_ETH_SRC] = {
+		.name = "src",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_MAC_ADDR), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_eth, hdr.src_addr)),
+	},
+	[ITEM_ETH_DST] = {
+		.name = "dst",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_MAC_ADDR), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_eth, hdr.dst_addr)),
+	},
+	[ITEM_ETH_TYPE] = {
+		.name = "type",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_eth, hdr.ether_type)),
+	},
+	[ITEM_ETH_HAS_VLAN] = {
+		.name = "has_vlan",
+		.next = NEXT(item_eth, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_BF(struct rte_flow_item_eth,
+					   has_vlan, 1)),
+	},
+	[ITEM_VLAN] = {
+		.name = "vlan",
+		.priv = PRIV_ITEM(VLAN, sizeof(struct rte_flow_item_vlan)),
+		.next = NEXT(item_vlan),
+		.call = parse_vc,
+	},
+	[ITEM_IPV4] = {
+		.name = "ipv4",
+		.priv = PRIV_ITEM(IPV4, sizeof(struct rte_flow_item_ipv4)),
+		.next = NEXT(item_ipv4),
+		.call = parse_vc,
+	},
+	[ITEM_IPV4_SRC] = {
+		.name = "src",
+		.next = NEXT(item_ipv4, NEXT_ENTRY(COMMON_IPV4_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv4,
+					     hdr.src_addr)),
+	},
+	[ITEM_IPV4_DST] = {
+		.name = "dst",
+		.next = NEXT(item_ipv4, NEXT_ENTRY(COMMON_IPV4_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv4,
+					     hdr.dst_addr)),
+	},
+	[ITEM_IPV6] = {
+		.name = "ipv6",
+		.priv = PRIV_ITEM(IPV6, sizeof(struct rte_flow_item_ipv6)),
+		.next = NEXT(item_ipv6),
+		.call = parse_vc,
+	},
+	[ITEM_IPV6_SRC] = {
+		.name = "src",
+		.next = NEXT(item_ipv6, NEXT_ENTRY(COMMON_IPV6_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv6,
+					     hdr.src_addr)),
+	},
+	[ITEM_IPV6_DST] = {
+		.name = "dst",
+		.next = NEXT(item_ipv6, NEXT_ENTRY(COMMON_IPV6_ADDR),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_ipv6,
+					     hdr.dst_addr)),
+	},
+	[ITEM_ICMP] = {
+		.name = "icmp",
+		.priv = PRIV_ITEM(ICMP, sizeof(struct rte_flow_item_icmp)),
+		.next = NEXT(item_icmp),
+		.call = parse_vc,
+	},
+	[ITEM_ICMP_TYPE] = {
+		.name = "type",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_type)),
+	},
+	[ITEM_ICMP_CODE] = {
+		.name = "code",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_code)),
+	},
+	[ITEM_ICMP_IDENT] = {
+		.name = "ident",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_ident)),
+	},
+	[ITEM_ICMP_SEQ] = {
+		.name = "seq",
+		.next = NEXT(item_icmp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_icmp,
+					     hdr.icmp_seq_nb)),
+	},
+	[ITEM_UDP] = {
+		.name = "udp",
+		.priv = PRIV_ITEM(UDP, sizeof(struct rte_flow_item_udp)),
+		.next = NEXT(item_udp),
+		.call = parse_vc,
+	},
+	[ITEM_UDP_SRC] = {
+		.name = "src",
+		.next = NEXT(item_udp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_udp,
+					     hdr.src_port)),
+	},
+	[ITEM_UDP_DST] = {
+		.name = "dst",
+		.next = NEXT(item_udp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_udp,
+					     hdr.dst_port)),
+	},
+	[ITEM_TCP] = {
+		.name = "tcp",
+		.priv = PRIV_ITEM(TCP, sizeof(struct rte_flow_item_tcp)),
+		.next = NEXT(item_tcp),
+		.call = parse_vc,
+	},
+	[ITEM_TCP_SRC] = {
+		.name = "src",
+		.next = NEXT(item_tcp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_tcp,
+					     hdr.src_port)),
+	},
+	[ITEM_TCP_DST] = {
+		.name = "dst",
+		.next = NEXT(item_tcp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_tcp,
+					     hdr.dst_port)),
+	},
+	[ITEM_TCP_FLAGS] = {
+		.name = "flags",
+		.next = NEXT(item_tcp, NEXT_ENTRY(COMMON_UNSIGNED), item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_tcp,
+					     hdr.tcp_flags)),
+	},
+	[ITEM_SCTP] = {
+		.name = "sctp",
+		.priv = PRIV_ITEM(SCTP, sizeof(struct rte_flow_item_sctp)),
+		.next = NEXT(item_sctp),
+		.call = parse_vc,
+	},
+	[ITEM_SCTP_SRC] = {
+		.name = "src",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.src_port)),
+	},
+	[ITEM_SCTP_DST] = {
+		.name = "dst",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.dst_port)),
+	},
+	[ITEM_SCTP_TAG] = {
+		.name = "tag",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.tag)),
+	},
+	[ITEM_SCTP_CKSUM] = {
+		.name = "cksum",
+		.next = NEXT(item_sctp, NEXT_ENTRY(COMMON_UNSIGNED),
+			     item_param),
+		.args = ARGS(ARGS_ENTRY_HTON(struct rte_flow_item_sctp,
+					     hdr.cksum)),
+	},
+	[ITEM_VXLAN] = {
+		.name = "vxlan",
+		.priv = PRIV_ITEM(VXLAN, sizeof(struct rte_flow_item_vxlan)),
+		.next = NEXT(item_vxlan),
+		.call = parse_vc,
+	},
+	[ITEM_E_TAG] = {
+		.name = "e_tag",
+		.priv = PRIV_ITEM(E_TAG, sizeof(struct rte_flow_item_e_tag)),
+		.next = NEXT(item_e_tag),
+		.call = parse_vc,
+	},
+	[ITEM_NVGRE] = {
+		.name = "nvgre",
+		.priv = PRIV_ITEM(NVGRE, sizeof(struct rte_flow_item_nvgre)),
+		.next = NEXT(item_nvgre),
+		.call = parse_vc,
+	},
+	[ITEM_MPLS] = {
+		.name = "mpls",
+		.priv = PRIV_ITEM(MPLS, sizeof(struct rte_flow_item_mpls)),
+		.next = NEXT(item_mpls),
+		.call = parse_vc,
+	},
+	[ITEM_GRE] = {
+		.name = "gre",
+		.priv = PRIV_ITEM(GRE, sizeof(struct rte_flow_item_gre)),
+		.next = NEXT(item_gre),
+		.call = parse_vc,
+	},
+	[ITEM_FUZZY] = {
+		.name = "fuzzy",
+		.priv = PRIV_ITEM(FUZZY,
+				sizeof(struct rte_flow_item_fuzzy)),
+		.next = NEXT(item_fuzzy),
+		.call = parse_vc,
+	},
+
+	[ITEM_GTP] = {
+		.name = "gtp",
+		.priv = PRIV_ITEM(GTP, sizeof(struct rte_flow_item_gtp)),
+		.next = NEXT(item_gtp),
+		.call = parse_vc,
+	},
+
+	[ITEM_GTPC] = {
+		.name = "gtpc",
+		.priv = PRIV_ITEM(GTPC, sizeof(struct rte_flow_item_gtp)),
+		.next = NEXT(item_gtpc),
+		.call = parse_vc,
+	},
+	[ITEM_GTPU] = {
+		.name = "gtpu",
+		.priv = PRIV_ITEM(GTPU, sizeof(struct rte_flow_item_gtp)),
+		.next = NEXT(item_gtpu),
+		.call = parse_vc,
+	},
+	[ITEM_GENEVE] = {
+		.name = "geneve",
+		.priv = PRIV_ITEM(GENEVE, sizeof(struct rte_flow_item_geneve)),
+		.next = NEXT(item_geneve),
+		.call = parse_vc,
+	},
+	[ITEM_VXLAN_GPE] = {
+		.name = "vxlan-gpe",
+		.priv = PRIV_ITEM(VXLAN_GPE,
+				  sizeof(struct rte_flow_item_vxlan_gpe)),
+		.next = NEXT(item_vxlan_gpe),
+		.call = parse_vc,
+	},
+
+	[ITEM_ICMP6] = {
+		.name = "icmp6",
+		.priv = PRIV_ITEM(ICMP6, sizeof(struct rte_flow_item_icmp6)),
+		.next = NEXT(item_icmp6),
+		.call = parse_vc,
+	},
+
+};
+
+/** Remove and return last entry from argument stack. */
+static const struct arg *pop_args(struct context *ctx)
+{
+    return ctx->args_num ? ctx->args[--ctx->args_num] : NULL;
+}
+
+/** Add entry on top of the argument stack. */
+static int push_args(struct context *ctx, const struct arg *arg)
+{
+    if (ctx->args_num == CTX_STACK_SIZE)
+        return -1;
+    ctx->args[ctx->args_num++] = arg;
+    return 0;
+}
+
+/** Spread value into buffer according to bit-mask. */
+static size_t arg_entry_bf_fill(void *dst, uintmax_t val, const struct arg *arg)
+{
+    uint32_t i = arg->size;
+    uint32_t end = 0;
+    int sub = 1;
+    int add = 0;
+    size_t len = 0;
+
+    if (!arg->mask)
+        return 0;
+#if RTE_BYTE_ORDER == RTE_LITTLE_ENDIAN
+    if (!arg->hton) {
+        i = 0;
+        end = arg->size;
+        sub = 0;
+        add = 1;
+    }
+#endif
+    while (i != end) {
+        unsigned int shift = 0;
+        uint8_t *buf = (uint8_t *)dst + arg->offset + (i -= sub);
+
+        for (shift = 0; arg->mask[i] >> shift; ++shift) {
+            if (!(arg->mask[i] & (1 << shift)))
+                continue;
+            ++len;
+            if (!dst)
+                continue;
+            *buf &= ~(1 << shift);
+            *buf |= (val & 1) << shift;
+            val >>= 1;
+        }
+        i += add;
+    }
+    return len;
+}
+
+/** Compare a string with a partial one of a given length. */
+static int strcmp_partial(const char *full, const char *partial, size_t partial_len)
+{
+    int r = strncmp(full, partial, partial_len);
+
+    if (r)
+        return r;
+    if (strlen(full) <= partial_len)
+        return 0;
+    return full[partial_len];
+}
+
+/** Parse flow command, initialize output buffer for subsequent tokens. */
+static int parse_init(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    struct buffer *out = buf;
+
+    /* Token name must match. */
+    if (parse_default(ctx, token, str, len, NULL, 0) < 0)
+        return -1;
+    /* Nothing else to do if there is no buffer. */
+    if (!out)
+        return len;
+    /* Make sure buffer is large enough. */
+    if (size < sizeof(*out))
+        return -1;
+    /* Initialize buffer. */
+    memset(out, 0x00, sizeof(*out));
+    memset((uint8_t *)out + sizeof(*out), 0x22, size - sizeof(*out));
+    ctx->objdata = 0;
+    ctx->object = out;
+    ctx->objmask = NULL;
+    parse_vc(ctx, token, str, len, buf, size);
+    return len;
+}
+
+/**
+ * Parse a MAC address.
+ *
+ * Last argument (ctx->args) is retrieved to determine storage size and
+ * location.
+ */
+static int parse_mac_addr(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    struct rte_ether_addr tmp;
+    int ret;
+
+    (void)token;
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    size = arg->size;
+    /* Bit-mask fill is not supported. */
+    if (arg->mask || size != sizeof(tmp))
+        goto error;
+    /* Only network endian is supported. */
+    if (!arg->hton)
+        goto error;
+    ret = cmdline_parse_etheraddr(NULL, str, &tmp, size);
+    if (ret < 0 || (unsigned int)ret != len)
+        goto error;
+    if (!ctx->object)
+        return len;
+    buf = (uint8_t *)ctx->object + arg->offset;
+    memcpy(buf, &tmp, size);
+    if (ctx->objmask)
+        memset((uint8_t *)ctx->objmask + arg->offset, 0xff, size);
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/**
+ * Parse an IPv4 address.
+ *
+ * Last argument (ctx->args) is retrieved to determine storage size and
+ * location.
+ */
+static int parse_ipv4_addr(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    char str2[len + 1];
+    struct in_addr tmp;
+    int ret;
+
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    size = arg->size;
+    /* Bit-mask fill is not supported. */
+    if (arg->mask || size != sizeof(tmp))
+        goto error;
+    /* Only network endian is supported. */
+    if (!arg->hton)
+        goto error;
+    memcpy(str2, str, len);
+    str2[len] = '\0';
+    ret = inet_pton(AF_INET, str2, &tmp);
+    if (ret != 1) {
+        /* Attempt integer parsing. */
+        push_args(ctx, arg);
+        return parse_int(ctx, token, str, len, buf, size);
+    }
+    if (!ctx->object)
+        return len;
+    buf = (uint8_t *)ctx->object + arg->offset;
+    memcpy(buf, &tmp, size);
+    if (ctx->objmask)
+        memset((uint8_t *)ctx->objmask + arg->offset, 0xff, size);
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/**
+ * Parse an IPv6 address.
+ *
+ * Last argument (ctx->args) is retrieved to determine storage size and
+ * location.
+ */
+static int parse_ipv6_addr(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    char str2[len + 1];
+    struct rte_ipv6_addr tmp;
+    int ret;
+
+    (void)token;
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    size = arg->size;
+    /* Bit-mask fill is not supported. */
+    if (arg->mask || size != sizeof(tmp))
+        goto error;
+    /* Only network endian is supported. */
+    if (!arg->hton)
+        goto error;
+    memcpy(str2, str, len);
+    str2[len] = '\0';
+    ret = inet_pton(AF_INET6, str2, &tmp);
+    if (ret != 1)
+        goto error;
+    if (!ctx->object)
+        return len;
+    buf = (uint8_t *)ctx->object + arg->offset;
+    memcpy(buf, &tmp, size);
+    if (ctx->objmask)
+        memset((uint8_t *)ctx->objmask + arg->offset, 0xff, size);
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/**
+ * Parse signed/unsigned integers 8 to 64-bit long.
+ *
+ * Last argument (ctx->args) is retrieved to determine integer type and
+ * storage location.
+ */
+static int parse_int(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    const struct arg *arg = pop_args(ctx);
+    uintmax_t u;
+    char *end;
+
+    (void)token;
+    /* Argument is expected. */
+    if (!arg)
+        return -1;
+    errno = 0;
+    u = arg->sign ? (uintmax_t)strtoimax(str, &end, 0) : strtoumax(str, &end, 0);
+    if (errno || (size_t)(end - str) != len)
+        goto error;
+    if (arg->bounded && ((arg->sign && ((intmax_t)u < (intmax_t)arg->min ||
+                                               (intmax_t)u > (intmax_t)arg->max)) ||
+                                (!arg->sign && (u < arg->min || u > arg->max))))
+        goto error;
+    if (!ctx->object)
+        return len;
+    if (arg->mask) {
+        if (!arg_entry_bf_fill(ctx->object, u, arg) || !arg_entry_bf_fill(ctx->objmask, -1, arg))
+            goto error;
+        return len;
+    }
+    buf = (uint8_t *)ctx->object + arg->offset;
+    size = arg->size;
+    if (u > RTE_LEN2MASK(size * CHAR_BIT, uint64_t))
+        return -1;
+objmask:
+    switch (size) {
+        case sizeof(uint8_t):
+            *(uint8_t *)buf = u;
+            break;
+        case sizeof(uint16_t):
+            *(uint16_t *)buf = arg->hton ? rte_cpu_to_be_16(u) : u;
+            break;
+        case sizeof(uint8_t[3]):
+#if RTE_BYTE_ORDER == RTE_LITTLE_ENDIAN
+            if (!arg->hton) {
+                ((uint8_t *)buf)[0] = u;
+                ((uint8_t *)buf)[1] = u >> 8;
+                ((uint8_t *)buf)[2] = u >> 16;
+                break;
+            }
+#endif
+            ((uint8_t *)buf)[0] = u >> 16;
+            ((uint8_t *)buf)[1] = u >> 8;
+            ((uint8_t *)buf)[2] = u;
+            break;
+        case sizeof(uint32_t):
+            *(uint32_t *)buf = arg->hton ? rte_cpu_to_be_32(u) : u;
+            break;
+        case sizeof(uint64_t):
+            *(uint64_t *)buf = arg->hton ? rte_cpu_to_be_64(u) : u;
+            break;
+        default:
+            goto error;
+    }
+    if (ctx->objmask && buf != (uint8_t *)ctx->objmask + arg->offset) {
+        u = -1;
+        buf = (uint8_t *)ctx->objmask + arg->offset;
+        goto objmask;
+    }
+    return len;
+error:
+    push_args(ctx, arg);
+    return -1;
+}
+
+/** Default parsing function for token name matching. */
+static int parse_default(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    (void)ctx;
+    (void)buf;
+    (void)size;
+    if (strcmp_partial(token->name, str, len))
+        return -1;
+    return len;
+}
+
+/** Parse tokens for validate/create commands. */
+static int parse_vc(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    struct buffer *out = buf;
+    uint8_t *data;
+    uint32_t data_size;
+
+    /* Token name must match. */
+    if (parse_default(ctx, token, str, len, NULL, 0) < 0)
+        return -1;
+    /* Nothing else to do if there is no buffer. */
+    if (!out)
+        return len;
+    if (!out->command) {
+        if (sizeof(*out) > size)
+            return -1;
+        out->command = CREATE;
+        ctx->objdata = 0;
+        ctx->object = out;
+        ctx->objmask = NULL;
+        out->args.vc.data = (uint8_t *)out + size;
+    }
+    ctx->objdata = 0;
+    ctx->object = &out->args.vc.attr;
+    ctx->objmask = NULL;
+    switch (ctx->curr) {
+        case ITEM_PATTERN:
+            out->args.vc.pattern = (void *)RTE_ALIGN_CEIL((uintptr_t)(out + 1), sizeof(double));
+            ctx->object = out->args.vc.pattern;
+            ctx->objmask = NULL;
+            return len;
+        default:
+            if (!token->priv)
+                return -1;
+            break;
+    }
+    const struct parse_item_priv *priv = token->priv;
+    struct rte_flow_item *item = out->args.vc.pattern + out->args.vc.pattern_n;
+
+    data_size = priv->size * 3; /* spec, last, mask */
+    data = (void *)RTE_ALIGN_FLOOR((uintptr_t)(out->args.vc.data - data_size), sizeof(double));
+    if ((uint8_t *)item + sizeof(*item) > data)
+        return -1;
+    *item = (struct rte_flow_item){
+        .type = priv->type,
+    };
+    ++out->args.vc.pattern_n;
+    ctx->object = item;
+    ctx->objmask = NULL;
+
+    memset(data, 0, data_size);
+    out->args.vc.data = data;
+    ctx->objdata = data_size;
+    return len;
+}
+
+/** Parse pattern item parameter type. */
+static int parse_vc_spec(struct context *ctx, const struct token *token, const char *str,
+        unsigned int len, void *buf, unsigned int size)
+{
+    struct buffer *out = buf;
+    struct rte_flow_item *item;
+    uint32_t data_size;
+    int index;
+    int objmask = 0;
+
+    (void)size;
+    /* Token name must match. */
+    if (parse_default(ctx, token, str, len, NULL, 0) < 0)
+        return -1;
+    /* Parse parameter types. */
+    switch (ctx->curr) {
+
+        case ITEM_PARAM_IS:
+            index = 0;
+            objmask = 1;
+            break;
+        case ITEM_PARAM_SPEC:
+            index = 0;
+            break;
+        case ITEM_PARAM_LAST:
+            index = 1;
+            break;
+        case ITEM_PARAM_MASK:
+            index = 2;
+            break;
+        default:
+            return -1;
+    }
+    /* Nothing else to do if there is no buffer. */
+    if (!out)
+        return len;
+    if (!out->args.vc.pattern_n)
+        return -1;
+    item = &out->args.vc.pattern[out->args.vc.pattern_n - 1];
+    data_size = ctx->objdata / 3; /* spec, last, mask */
+    /* Point to selected object. */
+    ctx->object = out->args.vc.data + (data_size * index);
+    if (objmask) {
+        ctx->objmask = out->args.vc.data + (data_size * 2); /* mask */
+        item->mask = ctx->objmask;
+    } else
+        ctx->objmask = NULL;
+    /* Update relevant item pointer. */
+    *((const void **[]){ &item->spec, &item->last, &item->mask })[index] = ctx->object;
+    return len;
+}
+
+/** Parse a token (cmdline API). */
+static int cmd_flow_parse(const char *src, void *result, unsigned int size)
+{
+    struct context *ctx = &cmd_flow_context;
+    const struct token *token;
+    const enum index *list;
+    int len;
+    int i;
+
+    token = &token_list[ctx->curr];
+    /* Check argument length. */
+    ctx->eol = 0;
+    ctx->last = 1;
+    for (len = 0; src[len]; ++len)
+        if (src[len] == '#' || isspace(src[len]))
+            break;
+    if (!len)
+        return -1;
+    /* Last argument and EOL detection. */
+    for (i = len; src[i]; ++i)
+        if (src[i] == '#' || src[i] == '\r' || src[i] == '\n')
+            break;
+        else if (!isspace(src[i])) {
+            ctx->last = 0;
+            break;
+        }
+    for (; src[i]; ++i)
+        if (src[i] == '\r' || src[i] == '\n') {
+            ctx->eol = 1;
+            break;
+        }
+    /* Initialize context if necessary. */
+    if (!ctx->next_num) {
+        if (!token->next)
+            return 0;
+        ctx->next[ctx->next_num++] = token->next[0];
+    }
+    /* Process argument through candidates. */
+    ctx->prev = ctx->curr;
+    list = ctx->next[ctx->next_num - 1];
+    for (i = 0; list[i]; ++i) {
+        const struct token *next = &token_list[list[i]];
+        int tmp;
+
+        ctx->curr = list[i];
+        if (next->call)
+            tmp = next->call(ctx, next, src, len, result, size);
+        else
+            tmp = parse_default(ctx, next, src, len, result, size);
+        if (tmp == -1 || tmp != len)
+            continue;
+        token = next;
+        break;
+    }
+    if (!list[i])
+        return -1;
+    --ctx->next_num;
+    /* Push subsequent tokens if any. */
+    if (token->next)
+        for (i = 0; token->next[i]; ++i) {
+            if (ctx->next_num == RTE_DIM(ctx->next))
+                return -1;
+            ctx->next[ctx->next_num++] = token->next[i];
+        }
+    /* Push arguments if any. */
+    if (token->args)
+        for (i = 0; token->args[i]; ++i) {
+            if (ctx->args_num == RTE_DIM(ctx->args))
+                return -1;
+            ctx->args[ctx->args_num++] = token->args[i];
+        }
+    return len;
+}
+
+static int flow_parse(
+        const char *src, void *result, unsigned int size, struct rte_flow_item **pattern)
+{
+    int ret;
+    struct context saved_flow_ctx = cmd_flow_context;
+
+    memset(result, 0x00, sizeof(*result));
+    memset((uint8_t *)result + sizeof(*result), 0x22, size - sizeof(*result));
+
+    cmd_flow_context_init(&cmd_flow_context);
+    do {
+        ret = cmd_flow_parse(src, result, size);
+        if (ret > 0) {
+            src += ret;
+            while (isspace(*src))
+                src++;
+        }
+    } while (ret > 0 && strlen(src));
+    cmd_flow_context = saved_flow_ctx;
+    *pattern = ((struct buffer *)result)->args.vc.pattern;
+
+    return (ret >= 0 && !strlen(src)) ? 0 : -1;
+}
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)*/
+
+/**
+ * \brief Parse rte_flow rule pattern and store individual pattern items in items and their
+ *        attributes in buffer data
+ *
+ * \param pattern rte_flow rule pattern to be parsed
+ * \param data buffer to store parsed pattern
+ * \param size size of buffer
+ * \param items parsed items used when creating rte_flow rules
+ * \return 0 on success, -1 on error
+ */
+int ParsePattern(char *pattern, struct rte_flow_item **items)
+{
+    SCEnter();
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+    static uint8_t items_data_buffer[DATA_BUFFER_SIZE] = { 0 };
+    SCReturnInt(flow_parse(pattern, (void *)items_data_buffer, sizeof(items_data_buffer), items));
+#else
+    SCReturnInt(0);
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)*/
+}
+
+#endif /* HAVE_DPDK */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow-pattern.h
+++ b/src/util-dpdk-rte-flow-pattern.h
@@ -16,21 +16,31 @@
  */
 
 /**
+ *  \defgroup dpdk DPDK rte_flow rules util functions
+ *
+ *  @{
+ */
+
+/**
  * \file
  *
  * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
  */
 
-#ifndef UTIL_DPDK_MLX5_H
-#define UTIL_DPDK_MLX5_H
-
-#include "suricata-common.h"
+#ifndef SURICATA_RTE_FLOW_RULES_PATTERN_H
+#define SURICATA_RTE_FLOW_RULES_PATTERN_H
 
 #ifdef HAVE_DPDK
 
-int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
-int mlx5DeviceCheckDropFilterLimits(uint32_t rte_flow_rule_count, char **err_msg);
+#include "util-dpdk.h"
+
+int ParsePattern(char *pattern, struct rte_flow_item **items);
 
 #endif /* HAVE_DPDK */
-
-#endif /* UTIL_DPDK_MLX5_H */
+#endif /* SURICATA_RTE_FLOW_RULES_PATTERN_H */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow-structs.h
+++ b/src/util-dpdk-rte-flow-structs.h
@@ -1,0 +1,67 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  \defgroup dpdk DPDK rte_flow rules util functions
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util structures
+ *
+ */
+
+#ifndef SURICATA_RTE_FLOW_STRUCTS_H
+#define SURICATA_RTE_FLOW_STRUCTS_H
+
+#ifdef HAVE_DPDK
+#include "suricata-common.h"
+#include "util-dpdk-common.h"
+
+typedef struct RteFlowRuleStorage_ {
+    uint32_t rule_cnt;
+    uint32_t rule_size;
+    char **rules;
+    struct rte_flow **rule_handlers;
+} RteFlowRuleStorage;
+
+typedef struct RteFlowBypassData_ {
+    struct rte_mempool *bypass_info_mp;
+    struct rte_mempool *bypass_mp;
+    struct rte_ring *bypass_ring;
+    uint32_t rte_bypass_rule_capacity;
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_rules_error);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_rules_created);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_rules_active);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_mempool_get_error);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_info_mempool_get_error);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_flow_error);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_query_error);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_enqueue_error);
+
+} RteFlowBypassData;
+
+#endif /* HAVE_DPDK */
+#endif /* SURICATA_RTE_FLOW_STRUCTS_H */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.c
+++ b/src/util-dpdk-rte-flow.c
@@ -1,0 +1,306 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  \defgroup dpdk DPDK rte_flow rules util functions
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
+ */
+
+#include "decode.h"
+#include "runmode-dpdk.h"
+#include "util-debug.h"
+#include "util-dpdk.h"
+#include "util-dpdk-ice.h"
+#include "util-dpdk-mlx5.h"
+#include "util-dpdk-rte-flow.h"
+#include "util-dpdk-rte-flow-pattern.h"
+
+#ifdef HAVE_DPDK
+
+#define RULE_STORAGE_INIT_SIZE 8
+#define RULE_STORAGE_SIZE_INC  16
+
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+
+static int RteFlowRuleStorageInit(RteFlowRuleStorage *);
+static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *, const char *);
+static int RteFlowRuleStorageExtendCapacity(RteFlowRuleStorage *, int);
+static char *DriverSpecificErrorMessage(const char *, struct rte_flow_item *);
+static int DeviceCheckDropFilterLimits(RteFlowRuleStorage *, const char *, char **);
+
+/**
+ * \brief Specify ambiguous error messages as some drivers have specific
+ *        behaviour when creating rte_flow rules.
+ *
+ * \param driver_name name of a driver
+ * \param items array of pattern items
+ * \return error message if error present, NULL otherwise
+ */
+static char *DriverSpecificErrorMessage(const char *driver_name, struct rte_flow_item *items)
+{
+    if (strcmp(driver_name, "net_ice") == 0) {
+        if (iceDeviceRteFlowPatternError(items) == true) {
+            char msg[] = "Driver specific errmsg: ice driver does not support broad patterns";
+            char *ret = SCCalloc((strlen(msg) + 1), sizeof(msg[0]));
+            strlcpy(ret, msg, sizeof(msg[0]) * (strlen(msg) + 1));
+            return ret;
+        }
+    }
+
+    return NULL;
+}
+
+static int DeviceCheckDropFilterLimits(
+        RteFlowRuleStorage *rule_storage, const char *driver_name, char **err_msg)
+{
+    if (strcmp(driver_name, "mlx5_pci") == 0)
+        return mlx5DeviceCheckDropFilterLimits(rule_storage->rule_cnt, err_msg);
+    return 0;
+}
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
+
+static int RteFlowRuleStorageInit(RteFlowRuleStorage *rule_storage)
+{
+    SCEnter();
+    rule_storage->rule_cnt = 0;
+    rule_storage->rule_size = RULE_STORAGE_INIT_SIZE;
+    rule_storage->rules = SCCalloc(rule_storage->rule_size, sizeof(char *));
+
+    if (rule_storage->rules == NULL) {
+        SCLogError("Setup memory allocation for rte_flow rule storage failed");
+        SCReturnInt(-ENOMEM);
+    }
+    SCReturnInt(0);
+}
+
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *rule_storage, const char *rule)
+{
+    SCEnter();
+    if (rule_storage->rule_cnt == rule_storage->rule_size) {
+        int retval = RteFlowRuleStorageExtendCapacity(rule_storage, RULE_STORAGE_SIZE_INC);
+        if (retval != 0)
+            SCReturnInt(retval);
+    }
+
+    rule_storage->rules[rule_storage->rule_cnt] = SCCalloc(strlen(rule) + 1, sizeof(rule[0]));
+    if (rule_storage->rules[rule_storage->rule_cnt] == NULL) {
+        SCLogError("Memory allocation for rte_flow rule string failed");
+        SCReturnInt(-ENOMEM);
+    }
+
+    strlcpy(rule_storage->rules[rule_storage->rule_cnt], rule,
+            (strlen(rule) + 1) * sizeof(rule[0]));
+    rule_storage->rule_cnt++;
+    SCReturnInt(0);
+}
+
+static int RteFlowRuleStorageExtendCapacity(RteFlowRuleStorage *rule_storage, int inc)
+{
+    SCEnter();
+    char **tmp_rules;
+
+    rule_storage->rule_size += inc;
+    tmp_rules = SCRealloc(rule_storage->rules, rule_storage->rule_size * sizeof(char *));
+
+    if (tmp_rules == NULL) {
+        SCLogError("Memory reallocation for rte_flow rule storage failed");
+        SCReturnInt(-ENOMEM);
+    }
+
+    rule_storage->rules = tmp_rules;
+    SCReturnInt(0);
+}
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
+
+/**
+ * \brief Deallocation of memory containing user set rte_flow rules
+ *
+ * \param rule_storage rules loaded from suricata.yaml
+ */
+void RteFlowRuleStorageFree(RteFlowRuleStorage *rule_storage)
+{
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+
+    if (rule_storage->rules == NULL) {
+        SCReturn;
+    }
+    for (uint32_t i = 0; i < rule_storage->rule_cnt; i++) {
+        SCFree(rule_storage->rules[i]);
+    }
+    SCFree(rule_storage->rules);
+    rule_storage->rules = NULL;
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
+}
+
+/**
+ * \brief Load rte_flow rules patterns from suricata.yaml
+ *
+ * \param if_root root node in suricata.yaml
+ * \param drop_filter_str value to look for in suricata.yaml
+ * \param rule_storage pointer to structure to load rte_flow rules into
+ * \return 0 on success, -1 on error
+ */
+int ConfigLoadRteFlowRules(
+        SCConfNode *if_root, const char *drop_filter_str, RteFlowRuleStorage *rule_storage)
+{
+    SCEnter();
+    SCConfNode *node = SCConfNodeLookupChild(if_root, drop_filter_str);
+    if (node == NULL) {
+        SCLogInfo("No configuration node found for %s", drop_filter_str);
+    } else {
+        SCConfNode *rule_node;
+        const char *rule = NULL;
+        /* Suppress unused variable warning in case of DPDK version < 21.11  */
+        (void)rule;
+        int retval = RteFlowRuleStorageInit(rule_storage);
+        if (retval != 0) {
+            SCReturnInt(retval);
+        }
+
+        TAILQ_FOREACH (rule_node, &node->head, next) {
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+            if (strcmp(rule_node->val, "rule") == 0) {
+                SCConfGetChildValue(rule_node, "rule", &rule);
+                retval = RteFlowRuleStorageAddRule(rule_storage, rule);
+                if (retval != 0) {
+                    RteFlowRuleStorageFree(rule_storage);
+                    SCReturnInt(retval);
+                }
+            } else {
+                SCLogError("DPDK .%s contains unrecognized key, only \"rule\" is supported",
+                        drop_filter_str);
+                SCReturnInt(-1);
+            }
+#else
+            if (strcmp(rule_node->val, "rule") == 0) {
+                SCLogError("DPDK .%s is supported from DPDK version 21.11 and higher, "
+                           "filter not applied",
+                        drop_filter_str);
+                RteFlowRuleStorageFree(rule_storage);
+                SCReturnInt(0);
+            }
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
+        }
+    }
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Create rte_flow drop rules with patterns stored in rule_storage on a port with id
+ *        port_id
+ *
+ * \param port_id identificator of a port
+ * \param rule_storage pointer to structure containing rte_flow rule patterns
+ * \param driver_name name of a driver
+ * \return 0 on success, -1 on error
+ */
+int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name)
+{
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+    SCEnter();
+    uint32_t failed_rule_count = 0;
+    struct rte_flow_error flush_error = { 0 };
+    struct rte_flow_attr attr = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+    const char *port_name = DPDKGetPortNameByPortID(port_id);
+
+    char *err_msg;
+    int retval = DeviceCheckDropFilterLimits(rule_storage, driver_name, &err_msg);
+    if (retval != 0) {
+        SCLogError("%s: Can't configure drop-filter: %s", port_name, err_msg);
+        SCReturnInt(-ENOSPC);
+    }
+
+    attr.ingress = 1;
+    action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+    rule_storage->rule_handlers = SCCalloc(rule_storage->rule_size, sizeof(struct rte_flow *));
+    if (rule_storage->rule_handlers == NULL) {
+        SCLogError("%s: Memory allocation for rte_flow rule string failed", port_name);
+        RteFlowRuleStorageFree(rule_storage);
+        SCReturnInt(-ENOMEM);
+    }
+
+    SCLogInfo("%s: loading %i rte_flow drop-filter rules into hardware", port_name,
+            rule_storage->rule_cnt);
+    for (uint32_t i = 0; i < rule_storage->rule_cnt; i++) {
+        struct rte_flow_item *items = { 0 };
+        struct rte_flow_error flow_error = { 0 };
+
+        int retval = ParsePattern(rule_storage->rules[i], &items);
+        if (retval != 0) {
+            failed_rule_count++;
+            SCLogError("%s: Error when parsing rte_flow rule \"%s\"", port_name,
+                    rule_storage->rules[i]);
+            continue;
+        }
+
+        retval = rte_flow_validate(port_id, &attr, items, action, &flow_error);
+        if (retval != 0) {
+            failed_rule_count++;
+            char *driver_specific_err = DriverSpecificErrorMessage(driver_name, items);
+            SCLogError("%s: Error when validating rte_flow rule \"%s\": %s, errmsg: "
+                       "%s. %s",
+                    port_name, rule_storage->rules[i], rte_strerror(-retval), flow_error.message,
+                    driver_specific_err != NULL ? driver_specific_err : "");
+            if (driver_specific_err != NULL) {
+                SCFree(driver_specific_err);
+            }
+            continue;
+        }
+
+        struct rte_flow *flow_handler = rte_flow_create(port_id, &attr, items, action, &flow_error);
+        if (flow_handler == NULL) {
+            failed_rule_count++;
+            SCLogError("%s: Error when creating rte_flow rule \"%s\": %s", port_name,
+                    rule_storage->rules[i], flow_error.message);
+            continue;
+        }
+        rule_storage->rule_handlers[i] = flow_handler;
+    }
+
+    if (failed_rule_count) {
+        SCLogError("%s: Error parsing/creating %i rte_flow rule(s), flushing rules", port_name,
+                failed_rule_count);
+        int retval = rte_flow_flush(port_id, &flush_error);
+        if (retval != 0) {
+            SCLogError("%s Unable to flush rte_flow rules: %s Flush error msg: %s", port_name,
+                    rte_strerror(-retval), flush_error.message);
+        }
+        SCReturnInt(-ENOTSUP);
+    }
+    SCLogInfo("%s: %i rte_flow rules created for drop-filter", port_name, rule_storage->rule_cnt);
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)*/
+    SCReturnInt(0);
+}
+
+#endif /* HAVE_DPDK */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.c
+++ b/src/util-dpdk-rte-flow.c
@@ -31,13 +31,24 @@
  */
 
 #include "decode.h"
+#include "flow-bypass.h"
+#include "flow-hash.h"
+#include "flow-storage.h"
+#include "flow-callbacks.h"
 #include "runmode-dpdk.h"
+#include "util-byte.h"
 #include "util-debug.h"
 #include "util-dpdk.h"
 #include "util-dpdk-ice.h"
 #include "util-dpdk-mlx5.h"
 #include "util-dpdk-rte-flow.h"
 #include "util-dpdk-rte-flow-pattern.h"
+#include "util-device-private.h"
+#include "flow-private.h"
+#include "flow.h"
+#include "runmodes.h"
+#include "tm-threads.h"
+#include "suricata.h"
 
 #ifdef HAVE_DPDK
 
@@ -46,6 +57,11 @@
 #define COUNT_ACTION_ID        1
 
 #if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+#define RTE_JUMP_GROUP               1
+#define RTE_BYPASS_RING_NAME         "rte_bypass_ring"
+#define RTE_BYPASS_MEMPOOL_NAME      "rte_bypass_mempool"
+#define RTE_BYPASS_INFO_MEMPOOL_NAME "rte_bypass_info_mempool"
+#define RTE_BYPASS_RING_SIZE         65536
 
 static int RteFlowRuleStorageInit(RteFlowRuleStorage *);
 static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *, const char *);
@@ -56,6 +72,22 @@ static void RteFlowDropFilterInitAttr(const char *, struct rte_flow_attr *);
 static void RteFlowDropFilterInitAction(
         RteFlowRuleStorage *, const char *, const char *, struct rte_flow_action *);
 static bool RteFlowShouldGatherStats(RteFlowRuleStorage *, const char *, const char *);
+static uint32_t RteFlowBypassGetBypassInfoMPSize(const char *, uint32_t *);
+static int RteFlowBypassRuleCreate(
+        RteFlowBypassData *, struct rte_flow_item *, int, struct rte_flow **);
+static void RteFlowHandleEmergency(ThreadVars *, Flow *, void *);
+static void RteFlowBiRuleDestroy(uint16_t, struct rte_flow *, struct rte_flow *);
+static int RteFlowUpdateStats(FlowBypassInfo *, uint16_t, struct rte_flow *, struct rte_flow *);
+static int RteFlowSetFlowBypassInfo(Flow *, struct rte_flow *, struct rte_flow *, int);
+static uint32_t DeviceDecideRteFlowRulesCapacity(const char *, uint32_t);
+
+typedef struct RteFlowHandlerToFlow_ {
+    Flow *flow;
+    struct rte_flow *src_handler;
+    struct rte_flow *dst_handler;
+    RteFlowBypassData *rte_flow_bypass_data;
+    LiveDevice *livedev;
+} RteFlowHandlerToFlow;
 
 /**
  * \brief Specify ambiguous error messages as some drivers have specific
@@ -86,6 +118,33 @@ static int DeviceCheckDropFilterLimits(
     return 0;
 }
 
+static void RteFlowDropFilterInitJumpRule(uint16_t port_id)
+{
+    struct rte_flow_error flow_error = { 0 };
+    struct rte_flow_attr attr = { 0 };
+    struct rte_flow_item pattern[] = { { 0 } };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+
+    uint32_t jump_group = RTE_JUMP_GROUP;
+
+    attr.ingress = 1;
+    attr.priority = 0;
+    attr.group = 0;
+
+    pattern[0].type = RTE_FLOW_ITEM_TYPE_END;
+
+    struct rte_flow_action_jump jump = {
+        .group = jump_group,
+    };
+    action[0].type = RTE_FLOW_ACTION_TYPE_JUMP;
+    action[0].conf = &jump;
+
+    struct rte_flow *flow_handler = rte_flow_create(port_id, &attr, pattern, action, &flow_error);
+    if (flow_handler == NULL) {
+        SCLogError("Error when creating rte_flow jump rule  %s", flow_error.message);
+    }
+}
+
 /**
  * \brief Initializes the attributes of rte_flow rules
  *
@@ -96,7 +155,7 @@ static void RteFlowDropFilterInitAttr(const char *driver_name, struct rte_flow_a
 {
     attr->ingress = 1;
     attr->priority = 0;
-    attr->group = 0;
+    attr->group = RTE_JUMP_GROUP;
 
     /* ICE PMD has to have attribute group set to 2 on DPDK 23.11 and higher for the count action to
      * work properly */
@@ -352,6 +411,7 @@ int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const
         SCReturnInt(-ENOSPC);
     }
 
+    RteFlowDropFilterInitJumpRule(port_id);
     RteFlowDropFilterInitAttr(driver_name, &attr);
     RteFlowDropFilterInitAction(rule_storage, port_name, driver_name, action);
 
@@ -420,7 +480,677 @@ int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const
     SCReturnInt(0);
 }
 
-#endif /* HAVE_DPDK */
+/**
+ * \brief Decide what is the maximal capacity of dynamic bypass rte_flow rules the device can
+ * handle.
+ *
+ * \param driver_name name of the driver
+ * \param current_rule_cnt count of currently loaded rte_flow rules in device
+ * \return uint32_t count of rte_flow bypass rules the device can utilize
+ */
+static uint32_t DeviceDecideRteFlowRulesCapacity(const char *driver_name, uint32_t current_rule_cnt)
+{
+    uint32_t retval = 0;
+    if (strcmp(driver_name, "mlx5_pci") == 0)
+        retval = MLX5_RTE_FLOW_RULES_CAPACITY - current_rule_cnt;
+    return retval;
+}
+
+/**
+ * \brief Retrieve dpdk.capture-bypass and set it to all interfaces.
+ *
+ * Get dpdk.capture-bypass flag for enabling rte_flow bypass.
+ * Set this global flag to each interface.
+ * Default setting is disabled.
+ *
+ * \param capture_bypass_str value to look for in suricata.yaml
+ * \param capture_bypass_enabled pointer to save gathered value
+ * \return 1 if bypass enabled, 0 if disabled
+ */
+int ConfigSetCaptureBypass(DPDKIfaceConfig *iconf)
+{
+    SCEnter();
+    int entry_bool = 0;
+    int retval = SCConfGetBool("dpdk.capture-bypass", &entry_bool);
+    if (retval != 1) {
+        iconf->capture_bypass_enabled = false;
+    } else {
+        iconf->capture_bypass_enabled = entry_bool;
+        retval = entry_bool;
+    }
+    SCReturnInt(retval);
+}
+
+/**
+ * \brief Get bypass-info mempool size from config.
+ *
+ * \param driver_name name of the driver
+ * \param[out] bypass_info_mp_size size of the mempool
+ * \return 0 on success, negative value on error
+ */
+static uint32_t RteFlowBypassGetBypassInfoMPSize(
+        const char *driver_name, uint32_t *bypass_info_mp_size)
+{
+    SCEnter();
+    SCConfNode *dpdk_root = SCConfGetNode("dpdk");
+
+    /* We are not taking into consideration the number of drop-filter rules here,
+       because we want to have a mempool of size (2^n)-1 */
+    uint32_t max_sz = DeviceDecideRteFlowRulesCapacity(driver_name, 0) - 1;
+    uint32_t sz = 0;
+
+    const char *entry_str = NULL;
+    int ret = SCConfGetChildValue(dpdk_root, "bypass-info-mp-size", &entry_str);
+    /* Set to maximum if value is "auto" or missing */
+    if (ret != 1 || strcmp(entry_str, "auto") == 0) {
+        sz = max_sz;
+    } else {
+        if (StringParseUint32(&sz, 10, 0, entry_str) < 0) {
+            SCLogError("bypass-info-mp-size contains non-numerical characters - \"%s\"", entry_str);
+            SCReturnInt(-EINVAL);
+        }
+    }
+
+    if (sz > max_sz) {
+        SCLogConfig("bypass-info-mp-size too big (%d), setting it to driver (%s) maximum: %d", sz,
+                driver_name, max_sz);
+        sz = max_sz;
+    } else {
+        SCLogConfig("bypass-info-mp-size set to %d", sz);
+    }
+    *bypass_info_mp_size = sz;
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Enable and register functions for BypassManager,
+ *        initialize rte_ring data structure and store in global
+ *        variable
+ *
+ * \param iconf configuration of the interface
+ * \return int 0 on success, negative value on error
+ */
+int RteBypassInit(DPDKIfaceConfig *iconf, const char *driver_name)
+{
+    SCEnter();
+    static RteFlowBypassData *rte_flow_bypass_data = NULL;
+    char *port_name = iconf->iface;
+    LiveDevice *livedev = LiveGetDevice(port_name);
+    LiveDevUseBypass(livedev);
+    int retval = 0;
+
+    /* If the bypass data is already allocated,
+       the bypass is ready and we need only to decrease the rte_flow rules capacity
+       by number of drop-filter rules present on this interface */
+    if (rte_flow_bypass_data != NULL) {
+        iconf->dpdk_dev_resources->rte_flow_bypass_data = rte_flow_bypass_data;
+        rte_flow_bypass_data->rte_bypass_rule_capacity -= iconf->drop_filter.rule_cnt;
+        SCReturnInt(retval);
+    }
+
+    RunModeEnablesBypassManager();
+    rte_flow_bypass_data = SCCalloc(1, sizeof(RteFlowBypassData));
+    if (rte_flow_bypass_data == NULL) {
+        SCLogError("%s: Memory allocation for RteFlowBypassData failed", port_name);
+        SCReturnInt(-ENOMEM);
+    }
+
+    struct rte_ring *bypass_ring = rte_ring_create(
+            RTE_BYPASS_RING_NAME, RTE_BYPASS_RING_SIZE, rte_socket_id(), RING_F_SC_DEQ);
+    if (bypass_ring == NULL) {
+        SCLogError("%s: rte_ring_create failed with (ring: %s): %s", port_name,
+                RTE_BYPASS_RING_NAME, rte_strerror(rte_errno));
+        goto cleanup;
+    }
+    rte_flow_bypass_data->bypass_ring = bypass_ring;
+
+    uint32_t bypass_mempool_size = (RTE_BYPASS_RING_SIZE * 2) - 1;
+    struct rte_mempool *bypass_mp = rte_mempool_create(RTE_BYPASS_MEMPOOL_NAME, bypass_mempool_size,
+            sizeof(FlowKey), MempoolCacheSizeCalculate(bypass_mempool_size), 0, NULL, NULL, NULL,
+            NULL, rte_socket_id(), 0);
+    if (bypass_mp == NULL) {
+        SCLogError("%s: rte_mempool_create failed (mempool: %s): %s", port_name,
+                RTE_BYPASS_MEMPOOL_NAME, rte_strerror(rte_errno));
+        goto cleanup;
+    }
+    rte_flow_bypass_data->bypass_mp = bypass_mp;
+
+    /* We set the bypass_info_mp size to the capacity of the underlying hardware */
+    uint32_t bypass_info_mempool_size;
+    retval = RteFlowBypassGetBypassInfoMPSize(driver_name, &bypass_info_mempool_size);
+    if (retval < 0) {
+        goto cleanup;
+    }
+    struct rte_mempool *bypass_info_mp = rte_mempool_create(RTE_BYPASS_INFO_MEMPOOL_NAME,
+            bypass_info_mempool_size, sizeof(RteFlowHandlerToFlow),
+            MempoolCacheSizeCalculate(bypass_info_mempool_size), 0, NULL, NULL, NULL, NULL,
+            rte_socket_id(), 0);
+    if (bypass_info_mp == NULL) {
+        SCLogError("%s: rte_mempool_create failed (mempool: %s): %s", port_name,
+                RTE_BYPASS_INFO_MEMPOOL_NAME, rte_strerror(rte_errno));
+        retval = -1;
+        goto cleanup;
+    }
+    rte_flow_bypass_data->bypass_info_mp = bypass_info_mp;
+
+    BypassedFlowManagerRegisterCheckFunc(RteFlowBypassRuleLoad, NULL, (void *)rte_flow_bypass_data);
+
+    rte_flow_bypass_data->rte_bypass_rule_capacity =
+            DeviceDecideRteFlowRulesCapacity(driver_name, iconf->drop_filter.rule_cnt);
+
+    /* Destroys rte_flow rules of bypassed flows evicted during emergency mode */
+    SCFlowRegisterFinishCallback(RteFlowHandleEmergency, NULL);
+
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_rules_active);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_rules_created);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_rules_error);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_enqueue_error);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_mempool_get_error);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_info_mempool_get_error);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_query_error);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_flow_error);
+
+    iconf->dpdk_dev_resources->rte_flow_bypass_data = rte_flow_bypass_data;
+
+    SCReturnInt(retval);
+
+cleanup:
+    SCFree(rte_flow_bypass_data);
+    SCReturnInt(retval);
+}
+
+/**
+ * \brief Decides whether the rte_flow rule should be removed from the table
+ *
+ * \param port_id identificator of a port
+ * \param src_rule_handler rte_flow rule handler for specific flow in one direction
+ * \param dst_rule_handler rte_flow rule handler for specific flow in other direction
+ * \param flow flow to be possibly removed from the table
+ * \return int 1 if the rte_flow rule is active, 0 if it should be removed
+ */
+static int RteFlowUpdateStats(FlowBypassInfo *fc, uint16_t port_id,
+        struct rte_flow *src_rule_handler, struct rte_flow *dst_rule_handler)
+{
+    SCEnter();
+    struct rte_flow_query_count query_count = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+    struct rte_flow_error flow_error = { 0 };
+    uint32_t counter_id = COUNT_ACTION_ID;
+    RteFlowHandlerToFlow *flow_handler_info = (RteFlowHandlerToFlow *)fc->bypass_data;
+    int retval = 0;
+
+    query_count.reset = 1;
+    action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+    action[0].conf = &counter_id;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+    retval = rte_flow_query(
+            port_id, src_rule_handler, &(action[0]), (void *)&query_count, &flow_error);
+    if (retval != 0) {
+        SCLogError("rte_flow dynamic bypass: count query error %s errmsg: %s",
+                rte_strerror(-retval), flow_error.message);
+        SC_ATOMIC_ADD(flow_handler_info->rte_flow_bypass_data->rte_bypass_query_error, 1);
+    };
+
+    uint64_t src_packets = query_count.hits;
+    uint64_t src_bytes = query_count.bytes;
+
+    memset(&query_count, 0, sizeof(struct rte_flow_query_count));
+    query_count.reset = 1;
+    retval = rte_flow_query(
+            port_id, dst_rule_handler, &(action[0]), (void *)&query_count, &flow_error);
+    if (retval != 0) {
+        SCLogError("rte_flow dynamic bypass: count query error %s errmsg: %s",
+                rte_strerror(-retval), flow_error.message);
+        SC_ATOMIC_ADD(
+                flow_handler_info->livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_query_error,
+                1);
+    };
+
+    uint64_t dst_packets = query_count.hits;
+    uint64_t dst_bytes = query_count.bytes;
+
+    /* Proceed only if there are new filtered packets in the flow */
+    if (src_packets || dst_packets) {
+        fc->tosrcpktcnt += src_packets;
+        fc->tosrcbytecnt += src_bytes;
+        fc->todstpktcnt += dst_packets;
+        fc->todstbytecnt += dst_bytes;
+        SCReturnInt(1);
+    }
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Create rte_flow drop rule for dynamic bypass
+ *
+ * \param items array of pattern items
+ * \param port_id identificator of a port
+ * \param flow_handler rte_flow rule handler
+ * \return int 0 on success, negative value on error
+ */
+static int RteFlowBypassRuleCreate(RteFlowBypassData *rte_flow_bypass_data,
+        struct rte_flow_item *items, int port_id, struct rte_flow **flow_handler)
+{
+    struct rte_flow_error flow_error = { 0 };
+    struct rte_flow_attr attr = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+
+    attr.ingress = 1;
+    attr.priority = 0;
+    attr.group = RTE_JUMP_GROUP;
+
+    uint32_t counter_id = COUNT_ACTION_ID;
+
+    action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+    action[0].conf = &counter_id;
+    action[1].type = RTE_FLOW_ACTION_TYPE_DROP;
+    action[2].type = RTE_FLOW_ACTION_TYPE_END;
+
+    int retval = rte_flow_validate(port_id, &attr, items, action, &flow_error);
+    if (retval != 0) {
+        goto rule_failed;
+    }
+
+    *flow_handler = rte_flow_create(port_id, &attr, items, action, &flow_error);
+    if (*flow_handler == NULL) {
+        retval = -1;
+        goto rule_failed;
+    }
+    SCReturnInt(retval);
+
+rule_failed:
+    SCLogError("rte_flow dynamic bypass: create rte_flow rule error %s errmsg: %s",
+            rte_strerror(-retval), flow_error.message);
+    SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_rules_error, 1);
+    SCReturnInt(retval);
+}
+
+static void RteFlowHandleEmergency(ThreadVars *tv, Flow *f, void *data)
+{
+    if (f->flow_state != FLOW_STATE_CAPTURE_BYPASSED &&
+            (f->flow_end_flags & FLOW_END_FLAG_EMERGENCY) == 0) {
+        return;
+    }
+    FlowBypassInfo *fc = SCFlowGetStorageById(f, GetFlowBypassInfoID());
+    if (fc == NULL)
+        return;
+    RteFlowHandlerToFlow *flow_handler_info = (RteFlowHandlerToFlow *)fc->bypass_data;
+    if (flow_handler_info == NULL)
+        return;
+    if (flow_handler_info->src_handler != NULL && flow_handler_info->dst_handler != NULL) {
+        RteFlowBiRuleDestroy(flow_handler_info->livedev->dpdk_vars->port_id,
+                flow_handler_info->src_handler, flow_handler_info->dst_handler);
+        flow_handler_info->src_handler = NULL;
+        flow_handler_info->dst_handler = NULL;
+        SC_ATOMIC_SUB(flow_handler_info->rte_flow_bypass_data->rte_bypass_rules_active, 2);
+    }
+}
+
+/**
+ * \brief Destroy rte_flow rules for both directions of a flow
+ *
+ * \param port_id identificator of a port
+ * \param src_handler handler of rte_flow rule
+ * \param dst_handler handler of rte_flow rule
+ */
+static void RteFlowBiRuleDestroy(
+        uint16_t port_id, struct rte_flow *src_handler, struct rte_flow *dst_handler)
+{
+    int retval = 0;
+    struct rte_flow_error flow_error = { 0 };
+    if (src_handler != NULL) {
+        retval = rte_flow_destroy(port_id, src_handler, &flow_error);
+        if (retval != 0) {
+            SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                    rte_strerror(-retval), flow_error.message);
+        }
+    }
+
+    if (dst_handler != NULL) {
+        retval = rte_flow_destroy(port_id, dst_handler, &flow_error);
+        if (retval != 0) {
+            SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                    rte_strerror(-retval), flow_error.message);
+        }
+    }
+}
+
+/**
+ * \brief Poll flow data from rte_flow_ring structure and create rte_flow bypass rule to bypass flow
+ *        from both directions
+ *
+ * \param th_v thread vars
+ * \param bypassstats bypass stats
+ * \param curtime time
+ * \param data table of flows and rte_flow rule handlers
+ * \return int number of successfully created rte_flow rules
+ */
+int RteFlowBypassRuleLoad(
+        ThreadVars *th_v, struct flows_stats *bypassstats, struct timespec *curtime, void *data)
+{
+    SCEnter();
+    RteFlowBypassData *rte_flow_bypass_data = (RteFlowBypassData *)data;
+    struct rte_ring *bypass_ring = rte_flow_bypass_data->bypass_ring;
+    struct rte_mempool *bypass_mp = rte_flow_bypass_data->bypass_mp;
+    struct rte_flow_item items[] = { { 0 }, { 0 }, { 0 }, { 0 }, { 0 } };
+    uint16_t L2_INDEX = 0, L3_INDEX = 1, L4_INDEX = 2, END_INDEX = 3;
+    uint16_t ring_dequeue_num = 20;
+    uint32_t success_count = 0;
+    FlowKey *ring_data[ring_dequeue_num];
+
+    memset(ring_data, 0, sizeof(ring_data));
+    /* Initialize the reusable part of rte_flow rules */
+    items[L2_INDEX].type = RTE_FLOW_ITEM_TYPE_ETH;
+    items[END_INDEX].type = RTE_FLOW_ITEM_TYPE_END;
+
+    uint32_t to_bypass_packets =
+            rte_ring_dequeue_burst(bypass_ring, (void **)ring_data, ring_dequeue_num, NULL);
+    for (uint16_t i = 0; i < to_bypass_packets; i++) {
+        if (unlikely(suricata_ctl_flags != 0)) {
+            SCReturnInt(success_count);
+        }
+        struct rte_flow_item_ipv4 ipv4_spec = { 0 }, ipv4_mask = { 0 };
+        struct rte_flow_item_ipv6 ipv6_spec = { 0 }, ipv6_mask = { 0 };
+        struct rte_flow_item_tcp tcp_spec = { 0 }, tcp_mask = { 0 };
+        struct rte_flow_item_udp udp_spec = { 0 }, udp_mask = { 0 };
+        void *ip_spec = NULL, *ip_mask = NULL, *l4_spec = NULL, *l4_mask = NULL;
+
+        FlowKey *flow_key = ring_data[i];
+        uint16_t port_id = flow_key->livedev->dpdk_vars->port_id;
+        uint32_t flow_hash = FlowKeyGetHash(flow_key);
+        Flow *flow = FlowGetExistingFlowFromHash(flow_key, flow_hash);
+        rte_mempool_put(bypass_mp, flow_key);
+
+        /* If error, destroy the rule for flow in original direction and set flow state to local
+         * bypass*/
+        if (flow == NULL || SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_rules_active) + 2 >=
+                                    rte_flow_bypass_data->rte_bypass_rule_capacity) {
+            if (flow == NULL) {
+                SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_flow_error, 1);
+            } else {
+                FlowUpdateState(flow, FLOW_STATE_LOCAL_BYPASSED);
+                FLOWLOCK_UNLOCK(flow);
+            }
+            continue;
+        }
+
+        /* Create rte_flow rule for original direction */
+        if (flow_key->src.family == AF_INET) {
+            SCLogDebug("Add an IPv4 rte_flow bypass rule");
+            ipv4_spec.hdr.src_addr = flow_key->src.address.address_un_data32[0];
+            ipv4_mask.hdr.src_addr = 0xFFFFFFFF;
+            ipv4_spec.hdr.dst_addr = flow_key->dst.address.address_un_data32[0];
+            ipv4_mask.hdr.dst_addr = 0xFFFFFFFF;
+            ip_spec = &ipv4_spec;
+            ip_mask = &ipv4_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV4;
+        } else {
+#if RTE_VERSION >= RTE_VERSION_NUM(24, 0, 0, 0)
+            SCLogDebug("Add an IPv6 rte_flow bypass rule");
+            memcpy(ipv6_spec.hdr.src_addr.a, flow_key->src.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.src_addr.a, 0xFF, 16);
+            memcpy(ipv6_spec.hdr.dst_addr.a, flow_key->dst.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.dst_addr.a, 0xFF, 16);
+#else
+            SCLogDebug("Add an IPv6 rte_flow bypass rule");
+            memcpy(ipv6_spec.hdr.src_addr, flow_key->src.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.src_addr, 0xFF, 16);
+            memcpy(ipv6_spec.hdr.dst_addr, flow_key->dst.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.dst_addr, 0xFF, 16);
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(24, 0, 0, 0) */
+            ip_spec = &ipv6_spec;
+            ip_mask = &ipv6_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV6;
+        }
+
+        if (flow_key->proto == IPPROTO_TCP) {
+            tcp_spec.hdr.src_port = htons(flow_key->sp);
+            tcp_mask.hdr.src_port = 0xFFFF;
+            tcp_spec.hdr.dst_port = htons(flow_key->dp);
+            tcp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &tcp_spec;
+            l4_mask = &tcp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_TCP;
+        } else {
+            udp_spec.hdr.src_port = htons(flow_key->sp);
+            udp_mask.hdr.src_port = 0xFFFF;
+            udp_spec.hdr.dst_port = htons(flow_key->dp);
+            udp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &udp_spec;
+            l4_mask = &udp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_UDP;
+        }
+
+        items[L3_INDEX].spec = ip_spec;
+        items[L3_INDEX].mask = ip_mask;
+        items[L4_INDEX].spec = l4_spec;
+        items[L4_INDEX].mask = l4_mask;
+
+        struct rte_flow *src_rule_handler = NULL;
+        int retval =
+                RteFlowBypassRuleCreate(rte_flow_bypass_data, items, port_id, &src_rule_handler);
+
+        /* Create rte_flow rule for the opposite direction */
+        if (flow_key->src.family == AF_INET) {
+            SCLogDebug("Add an IPv4 rte_flow bypass rule in other direction");
+            ipv4_spec.hdr.src_addr = flow_key->dst.address.address_un_data32[0];
+            ipv4_mask.hdr.src_addr = 0xFFFFFFFF;
+            ipv4_spec.hdr.dst_addr = flow_key->src.address.address_un_data32[0];
+            ipv4_mask.hdr.dst_addr = 0xFFFFFFFF;
+            ip_spec = &ipv4_spec;
+            ip_mask = &ipv4_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV4;
+        } else {
+            SCLogDebug("Add an IPv6 rte_flow bypass rule");
+#if RTE_VERSION >= RTE_VERSION_NUM(24, 0, 0, 0)
+            memcpy(ipv6_spec.hdr.src_addr.a, flow_key->dst.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.src_addr.a, 0xFF, 16);
+            memcpy(ipv6_spec.hdr.dst_addr.a, flow_key->src.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.dst_addr.a, 0xFF, 16);
+#else
+            memcpy(ipv6_spec.hdr.src_addr, flow_key->src.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.src_addr, 0xFF, 16);
+            memcpy(ipv6_spec.hdr.dst_addr, flow_key->dst.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.dst_addr, 0xFF, 16);
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(24, 0, 0, 0) */
+            ip_spec = &ipv6_spec;
+            ip_mask = &ipv6_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV6;
+        }
+
+        if (flow_key->proto == IPPROTO_TCP) {
+            tcp_spec.hdr.src_port = htons(flow_key->dp);
+            tcp_mask.hdr.src_port = 0xFFFF;
+            tcp_spec.hdr.dst_port = htons(flow_key->sp);
+            tcp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &tcp_spec;
+            l4_mask = &tcp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_TCP;
+        } else {
+            udp_spec.hdr.src_port = htons(flow_key->dp);
+            udp_mask.hdr.src_port = 0xFFFF;
+            udp_spec.hdr.dst_port = htons(flow_key->sp);
+            udp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &udp_spec;
+            l4_mask = &udp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_UDP;
+        }
+
+        items[L3_INDEX].spec = ip_spec;
+        items[L3_INDEX].mask = ip_mask;
+        items[L4_INDEX].spec = l4_spec;
+        items[L4_INDEX].mask = l4_mask;
+
+        struct rte_flow *dst_rule_handler = NULL;
+        retval += RteFlowBypassRuleCreate(rte_flow_bypass_data, items, port_id, &dst_rule_handler);
+
+        /* If error, destroy the rule for flow in original direction and set flow state to local
+         * bypass*/
+        if (retval != 0) {
+            RteFlowBiRuleDestroy(port_id, src_rule_handler, dst_rule_handler);
+            FlowUpdateState(flow, FLOW_STATE_LOCAL_BYPASSED);
+            FLOWLOCK_UNLOCK(flow);
+            continue;
+        }
+
+        int inet_family = FLOW_IS_IPV4(flow) ? AF_INET : AF_INET6;
+
+        retval = RteFlowSetFlowBypassInfo(flow, src_rule_handler, dst_rule_handler, inet_family);
+        if (retval == 0) {
+            success_count++;
+            SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_rules_active, 2);
+            SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_rules_created, 2);
+        }
+        FLOWLOCK_UNLOCK(flow);
+    }
+    SCReturnInt(success_count);
+}
+
+bool RteBypassUpdate(Flow *flow, void *data, time_t tsec)
+{
+    RteFlowHandlerToFlow *flow_handler_info = (RteFlowHandlerToFlow *)data;
+    if (flow_handler_info == NULL) {
+        /* Data already freed */
+        return false;
+    }
+    FlowBypassInfo *fc = SCFlowGetStorageById(flow, GetFlowBypassInfoID());
+    if (fc == NULL) {
+        /* Data already freed */
+        return false;
+    }
+    if (flow_handler_info->src_handler == NULL || flow_handler_info->dst_handler == NULL) {
+        /* Rules already deleted */
+        return false;
+    }
+    bool activity = RteFlowUpdateStats(fc, flow->livedev->dpdk_vars->port_id,
+            flow_handler_info->src_handler, flow_handler_info->dst_handler);
+    if (activity)
+        flow->lastts = SCTIME_FROM_SECS(tsec);
+    if (!activity || unlikely(suricata_ctl_flags != 0)) {
+        if (flow_handler_info->src_handler != NULL && flow_handler_info->dst_handler != NULL) {
+            RteFlowBiRuleDestroy(flow_handler_info->livedev->dpdk_vars->port_id,
+                    flow_handler_info->src_handler, flow_handler_info->dst_handler);
+            flow_handler_info->src_handler = NULL;
+            flow_handler_info->dst_handler = NULL;
+            SC_ATOMIC_SUB(flow_handler_info->rte_flow_bypass_data->rte_bypass_rules_active, 2);
+        }
+    }
+    SCReturnBool(activity);
+}
+
+void RteBypassFree(void *data)
+{
+    RteFlowHandlerToFlow *flow_handler_info = (RteFlowHandlerToFlow *)data;
+    if (flow_handler_info != NULL) {
+        rte_mempool_put(flow_handler_info->livedev->dpdk_vars->rte_flow_bypass_data->bypass_info_mp,
+                flow_handler_info);
+    }
+}
+
+static int RteFlowSetFlowBypassInfo(
+        Flow *flow, struct rte_flow *src_handler, struct rte_flow *dst_handler, int family)
+{
+    FlowBypassInfo *fc = SCFlowGetStorageById(flow, GetFlowBypassInfoID());
+    if (fc) {
+        if (fc->bypass_data != NULL) {
+            SCReturnInt(0);
+        }
+        RteFlowHandlerToFlow *flow_handler_info;
+        if (rte_mempool_get(flow->livedev->dpdk_vars->rte_flow_bypass_data->bypass_info_mp,
+                    (void **)&flow_handler_info) < 0) {
+            SC_ATOMIC_ADD(flow->livedev->dpdk_vars->rte_flow_bypass_data
+                                  ->rte_bypass_info_mempool_get_error,
+                    1);
+            /* Mempool capacity has been reachead, switch to local bypass */
+            goto bypass_fail;
+        }
+        flow_handler_info->flow = flow;
+        flow_handler_info->src_handler = src_handler;
+        flow_handler_info->dst_handler = dst_handler;
+        flow_handler_info->livedev = flow->livedev;
+        flow_handler_info->rte_flow_bypass_data = flow->livedev->dpdk_vars->rte_flow_bypass_data;
+        fc->bypass_data = flow_handler_info;
+        fc->BypassUpdate = RteBypassUpdate;
+        fc->BypassFree = RteBypassFree;
+        LiveDevAddBypassStats(flow->livedev, 1, family);
+        LiveDevAddBypassSuccess(flow->livedev, 1, family);
+        SCReturnInt(0);
+    }
+
+bypass_fail:;
+    RteFlowBiRuleDestroy(flow->livedev->dpdk_vars->port_id, src_handler, dst_handler);
+    LiveDevAddBypassFail(flow->livedev, 1, family);
+    FlowUpdateState(flow, FLOW_STATE_LOCAL_BYPASSED);
+    SCReturnInt(-ENOMEM);
+}
+
+int RteFlowBypassCallback(Packet *p)
+{
+    if (p == NULL || p->flow == NULL) {
+        SCReturnInt(0);
+    }
+
+    /* Only bypass TCP and UDP */
+    if (!(PacketIsTCP(p) || PacketIsUDP(p))) {
+        SCReturnInt(0);
+    }
+
+    FlowKey *flow_key = NULL;
+    RteFlowBypassData *rte_flow_bypass_data = p->livedev->dpdk_vars->rte_flow_bypass_data;
+
+    /* The tested rte_flow rule capacity of the device has been exhausted, new rules will be added
+     * after bypassed flows will timeout and the existing rules are be deleted */
+    if (SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_rules_active) + 2 >=
+            rte_flow_bypass_data->rte_bypass_rule_capacity) {
+        SCReturnInt(0);
+    }
+
+    if (rte_mempool_get(rte_flow_bypass_data->bypass_mp, (void **)&flow_key) < 0) {
+        SCLogError("Memory allocation for rte_flow bypass data failed");
+        SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_mempool_get_error, 1);
+        SCReturnInt(0);
+    }
+
+    if (PacketIsIPv4(p)) {
+        flow_key->src.family = AF_INET;
+        flow_key->src.address.address_un_data32[0] = (GET_IPV4_SRC_ADDR_U32(p));
+        flow_key->dst.family = AF_INET;
+        flow_key->dst.address.address_un_data32[0] = (GET_IPV4_DST_ADDR_U32(p));
+    } else if (PacketIsIPv6(p)) {
+        flow_key->src.family = AF_INET6;
+        memcpy(flow_key->src.address.address_un_data8, GET_IPV6_SRC_ADDR(p), 16 * sizeof(uint8_t));
+        flow_key->dst.family = AF_INET6;
+        memcpy(flow_key->dst.address.address_un_data8, GET_IPV6_DST_ADDR(p), 16 * sizeof(uint8_t));
+    }
+    if (p->proto == IPPROTO_TCP) {
+        flow_key->proto = IPPROTO_TCP;
+    } else {
+        flow_key->proto = IPPROTO_UDP;
+    }
+    flow_key->sp = p->sp;
+    flow_key->dp = p->dp;
+    flow_key->livedev_id = p->livedev->id;
+    flow_key->livedev = p->livedev;
+    flow_key->vlan_id[0] = p->vlan_id[0];
+    flow_key->vlan_id[1] = p->vlan_id[1];
+    flow_key->vlan_id[2] = p->vlan_id[2];
+    flow_key->recursion_level = 0;
+
+    int retval = rte_ring_mp_enqueue(rte_flow_bypass_data->bypass_ring, flow_key);
+    /* If ring is full, continue with local bypass. Also, if Suricata shutdowns, do not increase
+     * counters */
+    if (retval < 0 || unlikely(suricata_ctl_flags != 0)) {
+        rte_mempool_put(rte_flow_bypass_data->bypass_mp, flow_key);
+        if (retval < 0)
+            SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_enqueue_error, 1);
+    }
+    retval = retval == 0 ? 1 : 0;
+    SCReturnInt(retval);
+}
+
 /**
  * @}
  */
+
+#endif /* HAVE_DPDK */

--- a/src/util-dpdk-rte-flow.c
+++ b/src/util-dpdk-rte-flow.c
@@ -43,6 +43,7 @@
 
 #define RULE_STORAGE_INIT_SIZE 8
 #define RULE_STORAGE_SIZE_INC  16
+#define COUNT_ACTION_ID        1
 
 #if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
 
@@ -51,6 +52,10 @@ static int RteFlowRuleStorageAddRule(RteFlowRuleStorage *, const char *);
 static int RteFlowRuleStorageExtendCapacity(RteFlowRuleStorage *, int);
 static char *DriverSpecificErrorMessage(const char *, struct rte_flow_item *);
 static int DeviceCheckDropFilterLimits(RteFlowRuleStorage *, const char *, char **);
+static void RteFlowDropFilterInitAttr(const char *, struct rte_flow_attr *);
+static void RteFlowDropFilterInitAction(
+        RteFlowRuleStorage *, const char *, const char *, struct rte_flow_action *);
+static bool RteFlowShouldGatherStats(RteFlowRuleStorage *, const char *, const char *);
 
 /**
  * \brief Specify ambiguous error messages as some drivers have specific
@@ -70,7 +75,6 @@ static char *DriverSpecificErrorMessage(const char *driver_name, struct rte_flow
             return ret;
         }
     }
-
     return NULL;
 }
 
@@ -80,6 +84,78 @@ static int DeviceCheckDropFilterLimits(
     if (strcmp(driver_name, "mlx5_pci") == 0)
         return mlx5DeviceCheckDropFilterLimits(rule_storage->rule_cnt, err_msg);
     return 0;
+}
+
+/**
+ * \brief Initializes the attributes of rte_flow rules
+ *
+ * \param driver_name name of the driver
+ * \param[out] attr attributes which configure how the rte_flow rules will behave
+ */
+static void RteFlowDropFilterInitAttr(const char *driver_name, struct rte_flow_attr *attr)
+{
+    attr->ingress = 1;
+    attr->priority = 0;
+    attr->group = 0;
+
+    /* ICE PMD has to have attribute group set to 2 on DPDK 23.11 and higher for the count action to
+     * work properly */
+    if (strcmp(driver_name, "net_ice") == 0) {
+#if RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0)
+        attr->group = 2;
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0) */
+    }
+}
+
+/**
+ * \brief Configures the action which will rte_flow rules perform and
+ *        decides whether statistic will be gathered or not
+ *
+ * \param rule_storage struct contaning number of rules and their string instances
+ * \param port_name name of the port
+ * \param driver_name name of the driver
+ * \param[out] action types of actions to be used in the rte_flow rules
+ */
+static void RteFlowDropFilterInitAction(RteFlowRuleStorage *rule_storage, const char *port_name,
+        const char *driver_name, struct rte_flow_action *action)
+{
+    /* ICE PMD does not support count action with wildcard pattern (mask and last pattern item
+     * types). The count action is omitted when wildcard pattern is detected */
+    if (strcmp(driver_name, "net_ice") == 0 &&
+            !iceDeviceDecideRteFlowActionType(rule_storage, port_name)) {
+        action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
+        action[1].type = RTE_FLOW_ACTION_TYPE_END;
+        return;
+    }
+    if (strcmp(driver_name, "net_ice") == 0 || strcmp(driver_name, "mlx5_pci") == 0) {
+        action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+        static uint32_t counter_id = COUNT_ACTION_ID;
+        action[0].conf = &counter_id;
+        action[1].type = RTE_FLOW_ACTION_TYPE_DROP;
+        action[2].type = RTE_FLOW_ACTION_TYPE_END;
+        return;
+    }
+    action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+    return;
+}
+
+/**
+ * \brief Function decides, based on the driver and type of rte_flow rules,
+ *        whether to gather statistics with counter in rte_flow rules or no.
+ *
+ * \param rule_storage rules loaded from suricata.yam
+ * \param driver_name name of the driver
+ * \param port_name name of the port
+ * \return true if gathering stats from rte_flow rules is possible, false otherwise
+ */
+static bool RteFlowShouldGatherStats(
+        RteFlowRuleStorage *rule_storage, const char *driver_name, const char *port_name)
+{
+    if (strcmp(driver_name, "net_ice") == 0 &&
+            !iceDeviceDecideRteFlowActionType(rule_storage, port_name))
+        return false;
+    return true;
 }
 #endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
 
@@ -211,6 +287,46 @@ int ConfigLoadRteFlowRules(
 }
 
 /**
+ * \brief Query the number of packets filtered by rte_flow rules defined by user in suricata.yaml
+ *
+ * \param rules array of rte_flow rule handlers
+ * \param rule_count number of existing rules
+ * \param device_name name of the device
+ * \param port_id id of a port
+ * \return number of filtered packets
+ */
+uint64_t RteFlowFilteredPacketsQuery(
+        struct rte_flow **rules, uint32_t rule_count, const char *device_name, int port_id)
+{
+    uint64_t retval = 0;
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
+    struct rte_flow_query_count query_count = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+    struct rte_flow_error flow_error = { 0 };
+    uint32_t counter_id = COUNT_ACTION_ID;
+    bool err = false;
+    int query_retval = 0;
+
+    query_count.reset = 0;
+    action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+    action[0].conf = &counter_id;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+    for (uint32_t i = 0; i < rule_count; i++) {
+        query_retval =
+                rte_flow_query(port_id, rules[i], &(action[0]), (void *)&query_count, &flow_error);
+        if (query_retval != 0 && !err) {
+            err = true;
+            SCLogError("%s: rte_flow count query error %s errmsg: %s", device_name,
+                    rte_strerror(-retval), flow_error.message);
+        } else
+            retval += query_count.hits;
+    }
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0) */
+    SCReturnInt(retval);
+}
+
+/**
  * \brief Create rte_flow drop rules with patterns stored in rule_storage on a port with id
  *        port_id
  *
@@ -236,9 +352,8 @@ int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const
         SCReturnInt(-ENOSPC);
     }
 
-    attr.ingress = 1;
-    action[0].type = RTE_FLOW_ACTION_TYPE_DROP;
-    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+    RteFlowDropFilterInitAttr(driver_name, &attr);
+    RteFlowDropFilterInitAction(rule_storage, port_name, driver_name, action);
 
     rule_storage->rule_handlers = SCCalloc(rule_storage->rule_size, sizeof(struct rte_flow *));
     if (rule_storage->rule_handlers == NULL) {
@@ -296,6 +411,11 @@ int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const
         SCReturnInt(-ENOTSUP);
     }
     SCLogInfo("%s: %i rte_flow rules created for drop-filter", port_name, rule_storage->rule_cnt);
+
+    if (!RteFlowShouldGatherStats(rule_storage, driver_name, port_name)) {
+        SCFree(rule_storage->rule_handlers);
+        rule_storage->rule_cnt = 0;
+    }
 #endif /* RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)*/
     SCReturnInt(0);
 }

--- a/src/util-dpdk-rte-flow.h
+++ b/src/util-dpdk-rte-flow.h
@@ -16,21 +16,43 @@
  */
 
 /**
+ *  \defgroup dpdk DPDK rte_flow rules util functions
+ *
+ *  @{
+ */
+
+/**
  * \file
  *
  * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
  */
 
-#ifndef UTIL_DPDK_MLX5_H
-#define UTIL_DPDK_MLX5_H
-
-#include "suricata-common.h"
+#ifndef SURICATA_RTE_FLOW_RULES_H
+#define SURICATA_RTE_FLOW_RULES_H
 
 #ifdef HAVE_DPDK
 
-int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
-int mlx5DeviceCheckDropFilterLimits(uint32_t rte_flow_rule_count, char **err_msg);
+#include "conf.h"
+#include "util-dpdk.h"
+
+typedef struct RteFlowRuleStorage_ {
+    uint32_t rule_cnt;
+    uint32_t rule_size;
+    char **rules;
+    struct rte_flow **rule_handlers;
+} RteFlowRuleStorage;
+
+void RteFlowRuleStorageFree(RteFlowRuleStorage *rule_storage);
+int ConfigLoadRteFlowRules(
+        SCConfNode *if_root, const char *drop_filter_str, RteFlowRuleStorage *rule_storage);
+int RteFlowRulesCreate(
+        uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name);
 
 #endif /* HAVE_DPDK */
-
-#endif /* UTIL_DPDK_MLX5_H */
+#endif /* SURICATA_RTE_FLOW_RULES_H */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.h
+++ b/src/util-dpdk-rte-flow.h
@@ -48,8 +48,9 @@ typedef struct RteFlowRuleStorage_ {
 void RteFlowRuleStorageFree(RteFlowRuleStorage *rule_storage);
 int ConfigLoadRteFlowRules(
         SCConfNode *if_root, const char *drop_filter_str, RteFlowRuleStorage *rule_storage);
-int RteFlowRulesCreate(
-        uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name);
+int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name);
+uint64_t RteFlowFilteredPacketsQuery(
+        struct rte_flow **rules, uint32_t rule_count, const char *device_name, int port_id);
 
 #endif /* HAVE_DPDK */
 #endif /* SURICATA_RTE_FLOW_RULES_H */

--- a/src/util-dpdk-rte-flow.h
+++ b/src/util-dpdk-rte-flow.h
@@ -36,7 +36,7 @@
 #ifdef HAVE_DPDK
 
 #include "conf.h"
-#include "util-dpdk.h"
+#include "util-dpdk-common.h"
 
 typedef struct RteFlowRuleStorage_ {
     uint32_t rule_cnt;

--- a/src/util-dpdk-rte-flow.h
+++ b/src/util-dpdk-rte-flow.h
@@ -36,14 +36,10 @@
 #ifdef HAVE_DPDK
 
 #include "conf.h"
+#include "flow-bypass.h"
+#include "flow-hash.h"
 #include "util-dpdk-common.h"
-
-typedef struct RteFlowRuleStorage_ {
-    uint32_t rule_cnt;
-    uint32_t rule_size;
-    char **rules;
-    struct rte_flow **rule_handlers;
-} RteFlowRuleStorage;
+#include "util-dpdk-rte-flow-structs.h"
 
 void RteFlowRuleStorageFree(RteFlowRuleStorage *rule_storage);
 int ConfigLoadRteFlowRules(
@@ -51,6 +47,13 @@ int ConfigLoadRteFlowRules(
 int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name);
 uint64_t RteFlowFilteredPacketsQuery(
         struct rte_flow **rules, uint32_t rule_count, const char *device_name, int port_id);
+int ConfigSetCaptureBypass(DPDKIfaceConfig *);
+int RteBypassInit(DPDKIfaceConfig *iconf, const char *driver_name);
+int RteFlowBypassCallback(Packet *);
+int RteFlowBypassRuleLoad(
+        ThreadVars *th_v, struct flows_stats *bypassstats, struct timespec *curtime, void *data);
+bool RteBypassUpdate(Flow *flow, void *data, time_t tsec);
+void RteBypassFree(void *data);
 
 #endif /* HAVE_DPDK */
 #endif /* SURICATA_RTE_FLOW_RULES_H */

--- a/src/util-dpdk.c
+++ b/src/util-dpdk.c
@@ -61,6 +61,11 @@ void DPDKFreeDevice(LiveDevice *ldev)
     (void)ldev; // avoid warnings of unused variable
 #ifdef HAVE_DPDK
     if (SCRunmodeGet() == RUNMODE_DPDK) {
+        if (ldev->dpdk_vars->drop_filter->rule_handlers != NULL &&
+                ldev->dpdk_vars->drop_filter->rule_cnt != 0) {
+            SCLogDebug("%s: releasing rte_flow rule handlers", ldev->dev);
+            SCFree(ldev->dpdk_vars->drop_filter->rule_handlers);
+        }
         SCLogDebug("%s: releasing packet mempools", ldev->dev);
         DPDKDeviceResourcesDeinit(&ldev->dpdk_vars);
     }

--- a/src/util-dpdk.c
+++ b/src/util-dpdk.c
@@ -107,6 +107,11 @@ void DPDKFreeDevice(LiveDevice *ldev)
             SCLogDebug("%s: releasing rte_flow rule handlers", ldev->dev);
             SCFree(ldev->dpdk_vars->drop_filter->rule_handlers);
         }
+        if (ldev->dpdk_vars->rte_flow_bypass_data != NULL &&
+                ldev->dpdk_vars->rte_flow_bypass_data->bypass_mp != NULL) {
+            rte_mempool_free(ldev->dpdk_vars->rte_flow_bypass_data->bypass_mp);
+            ldev->dpdk_vars->rte_flow_bypass_data->bypass_mp = NULL;
+        }
         SCLogDebug("%s: releasing packet mempools", ldev->dev);
         DPDKDeviceResourcesDeinit(&ldev->dpdk_vars);
     }

--- a/src/util-dpdk.c
+++ b/src/util-dpdk.c
@@ -27,6 +27,47 @@
 #include "util-debug.h"
 #include "util-device-private.h"
 
+int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt)
+{
+    SCEnter();
+    *dpdk_vars = SCCalloc(1, sizeof(*dpdk_vars[0]));
+    if (*dpdk_vars == NULL) {
+        SCLogError("failed to allocate memory for packet mempools structure");
+        SCReturnInt(-ENOMEM);
+    }
+
+    (*dpdk_vars)->pkt_mp = SCCalloc(mp_cnt, sizeof((*dpdk_vars)->pkt_mp[0]));
+    if ((*dpdk_vars)->pkt_mp == NULL) {
+        SCLogError("failed to allocate memory for packet mempools");
+        SCReturnInt(-ENOMEM);
+    }
+    (*dpdk_vars)->pkt_mp_capa = mp_cnt;
+    (*dpdk_vars)->pkt_mp_cnt = 0;
+
+    SCReturnInt(0);
+}
+
+void DPDKDeviceResourcesDeinit(DPDKDeviceResources **dpdk_vars)
+{
+#ifdef HAVE_DPDK
+    if ((*dpdk_vars) != NULL) {
+        if ((*dpdk_vars)->pkt_mp != NULL) {
+            for (int j = 0; j < (*dpdk_vars)->pkt_mp_capa; j++) {
+                if ((*dpdk_vars)->pkt_mp[j] != NULL) {
+                    rte_mempool_free((*dpdk_vars)->pkt_mp[j]);
+                }
+            }
+            SCFree((*dpdk_vars)->pkt_mp);
+            (*dpdk_vars)->pkt_mp_capa = 0;
+            (*dpdk_vars)->pkt_mp_cnt = 0;
+            (*dpdk_vars)->pkt_mp = NULL;
+        }
+        SCFree(*dpdk_vars);
+        *dpdk_vars = NULL;
+    }
+#endif /* HAVE_DPDK */
+}
+
 void DPDKCleanupEAL(void)
 {
 #ifdef HAVE_DPDK

--- a/src/util-dpdk.h
+++ b/src/util-dpdk.h
@@ -26,7 +26,7 @@
 
 #include "util-dpdk-common.h"
 #include "util-device.h"
-#include "util-dpdk-rte-flow.h"
+#include "util-dpdk-rte-flow-structs.h"
 
 typedef struct {
     struct rte_mempool **pkt_mp;
@@ -34,6 +34,7 @@ typedef struct {
     uint16_t pkt_mp_capa;
 #ifdef HAVE_DPDK
     RteFlowRuleStorage *drop_filter;
+    RteFlowBypassData *rte_flow_bypass_data;
 #endif /* HAVE_DPDK */
     uint16_t port_id;
 } DPDKDeviceResources;

--- a/src/util-dpdk.h
+++ b/src/util-dpdk.h
@@ -26,6 +26,20 @@
 
 #include "util-dpdk-common.h"
 #include "util-device.h"
+#include "util-dpdk-rte-flow.h"
+
+typedef struct {
+    struct rte_mempool **pkt_mp;
+    uint16_t pkt_mp_cnt;
+    uint16_t pkt_mp_capa;
+#ifdef HAVE_DPDK
+    RteFlowRuleStorage *drop_filter;
+#endif /* HAVE_DPDK */
+    uint16_t port_id;
+} DPDKDeviceResources;
+
+int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt);
+void DPDKDeviceResourcesDeinit(DPDKDeviceResources **dpdk_vars);
 
 void DPDKCleanupEAL(void);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -842,6 +842,11 @@ dpdk:
       # - ips: the same as tap mode but it also drops packets that are flagged by rules to be dropped
       copy-mode: none
       copy-iface: none # or PCIe address of the second interface
+      # Flow patterns in dpdk-testpmd syntax for flows that are supposed to be dropped directly in the NIC.
+      # If the pattern is invalid or unsupported, Suricata will not start.
+      # Example: "rule: pattern eth / ipv4 src is 16.0.25.0 / udp / end"
+      #          "rule: pattern eth / ipv4 dst is 19.1.2.15 / tcp / end" 
+      drop-filter: none 
 
     - interface: default
       threads: auto
@@ -859,6 +864,7 @@ dpdk:
       tx-descriptors: auto
       copy-mode: none
       copy-iface: none
+      drop-filter: none
 
 
 # Cross platform libpcap capture support

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -810,6 +810,11 @@ dpdk:
     proc-type: primary
 
   # DPDK capture support
+  # Toggle support of hardware accelerated flow bypass
+  capture-bypass: no
+  # Configures how many flows the NIC can offload at once
+  # Set only with 'capture-bypass: yes'
+  # bypass-info-mp-size: auto
   # RX queues (and TX queues in IPS mode) are assigned to cores in 1:1 ratio
   interfaces:
     - interface: 0000:3b:00.0 # PCIe address of the NIC port


### PR DESCRIPTION
# DPDK dynamic bypass with rte_flow rules

This is a draft of a feature that brings capture offload into the DPDK Suricata
runmode. The offload is based on the DPDK's rte_flow rules, mainly the drop
and count actions. The bypass utilizes the BypassManager thread and API for 
creating bypass rules and the FlowManager for collecting statistics and destroying 
rules.

## Description

The number of flows offloaded to the NIC differs based on the used NIC,
the current version was tested only on Mellanox ConnectX-6, where it
supports offload of around 2 million flows. The real number of rte_flow
rules inserted into the NIC is double the offloaded flows (maximum around
4 million rules in this case), because rte_flow needs 2 separate rules
to match both directions of a flow. The flows that cannot be
bypassed in the NIC are offloaded in Suricata by software bypass.
The number of rules and the limits of the Mellanox NICs are described in more detail
in this [article](https://dejankostic.com/documents/publications/nicbench-pam21.pdf).

The process of applying the bypass is as follows: 

1. Workers enqueue a `FlowKey` struct created from the bypassed flow into a ring structure,
2. `BypassManager` constantly polls the ring, tries to create and insert
the respective rte_flow rule into the NIC.
3. `FlowManager` is, in the meantime, responsible for checking the activity of the flows,
reads the counters attached to the bypassed flows, and
potentially destroys the rules in the case of the flow timeouts.

The statistics from the flows are collected periodically and 
in the shutdown stage (managed by
`FlowManager`) and they are captured in eve.json and stats.log.

The feature can be toggled on/off and the maximum number of
capture-bypassed flows (up to NICs maximum) can be set in suricata.yaml

## Related branches
Implementation of this feature starts at the commit  2706506b977548586d5ed5e6de56c63866fed386
The work is based on unmerged work from the branches:

- The base drop filter implementation:
https://github.com/adaki4/suricata/tree/dpdk-rte-flow-drop-filter-v5

- Gathering statistics at Suricata shutdown stage:
https://github.com/adaki4/suricata/tree/capture-bypass-stats-gather-v3

## Future work

This pull request serves as a showcase of the new feature and its logic.
The implementation of both the drop filter and the dynamic bypass 
is planned to be extracted into a plugin.

## Changes:
- fix CI commit-check
- rebase to main

Link to ticket: [#7871](https://redmine.openinfosecfoundation.org/issues/7871)

Previous PR: https://github.com/OISF/suricata/pull/15248