### PR TITLE
ftp: too-many-transactions event

### DIFF
--- a/rules/ftp-events.rules
+++ b/rules/ftp-events.rules
@@ -4,3 +4,4 @@
 
 alert ftp any any -> any any (msg:"SURICATA FTP Request command too long"; flow:to_server; app-layer-event:ftp.request_command_too_long; classtype:protocol-command-decode; sid:2232000; rev:1;)
 alert ftp any any -> any any (msg:"SURICATA FTP Response command too long"; flow:to_client; app-layer-event:ftp.response_command_too_long; classtype:protocol-command-decode; sid:2232001; rev:1;)
+alert ftp any any -> any any (msg:"SURICATA FTP too many transactions"; flow:to_server; app-layer-event:ftp.too_many_transactions; classtype:protocol-command-decode; sid:2232002; rev:1;)

--- a/rust/src/ftp/event.rs
+++ b/rust/src/ftp/event.rs
@@ -25,6 +25,8 @@ pub enum FtpEvent {
     FtpEventRequestCommandTooLong,
     #[name("response_command_too_long")]
     FtpEventResponseCommandTooLong,
+    #[name("too_many_transactions")]
+    FtpEventTooManyTransactions,
 }
 
 /// Wrapper around the Rust generic function for get_event_info.

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -223,7 +223,10 @@ static FTPTransaction *FTPTransactionCreate(FtpState *state)
     SCEnter();
     FTPTransaction *firsttx = TAILQ_FIRST(&state->tx_list);
     if (firsttx && state->tx_cnt - firsttx->tx_id > ftp_config_maxtx) {
-        // FTP does not set events yet...
+        FTPTransaction *event_tx = state->curr_tx ? state->curr_tx : firsttx;
+        event_tx->done = true;
+        event_tx->tx_data.updated_ts = true;
+        SCAppLayerDecoderEventsSetEventRaw(&event_tx->tx_data.events, FtpEventTooManyTransactions);
         return NULL;
     }
     FTPTransaction *tx = FTPCalloc(1, sizeof(*tx));

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -223,11 +223,17 @@ static FTPTransaction *FTPTransactionCreate(FtpState *state)
     SCEnter();
     FTPTransaction *firsttx = TAILQ_FIRST(&state->tx_list);
     if (firsttx && state->tx_cnt - firsttx->tx_id > ftp_config_maxtx) {
-        FTPTransaction *event_tx = state->curr_tx ? state->curr_tx : firsttx;
-        event_tx->done = true;
-        event_tx->tx_data.updated_ts = true;
-        SCAppLayerDecoderEventsSetEventRaw(&event_tx->tx_data.events, FtpEventTooManyTransactions);
-        return NULL;
+        FTPTransaction *tx_old;
+        TAILQ_FOREACH (tx_old, &state->tx_list, next) {
+            if (!tx_old->done) {
+                tx_old->done = true;
+                tx_old->tx_data.updated_ts = true;
+                tx_old->tx_data.updated_tc = true;
+                SCAppLayerDecoderEventsSetEventRaw(
+                        &tx_old->tx_data.events, FtpEventTooManyTransactions);
+                break;
+            }
+        }
     }
     FTPTransaction *tx = FTPCalloc(1, sizeof(*tx));
     if (tx == NULL) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1000,6 +1000,7 @@ app-layer:
     ftp:
       enabled: yes
       # memcap: 64 MiB
+      # max-tx: 1024
     websocket:
       #enabled: yes
       # Maximum used payload size, the rest is skipped


### PR DESCRIPTION
Continuation of #15247 

Raise an event when `app-layer.protocols.ftp.max-tx` is reached.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8489

Describe changes:
- Raise too_many_transaction event when max-tx is exceeded
- Continue with the flow when the event is raised by modeling SMB handling of the same situation and marking the oldest active TX with the event and then falling through and creating a new TX.

Updates:
- Cherry-picked commit 48fce40a4ac926d3a33990c80bfeb117f2974614 from #15213 

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3041
