### PR TITLE
detect/thresh: expose threshold hash bucket depth stats

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -824,6 +824,11 @@ Thresholding uses a central hash table for tracking thresholds of the types: by_
 ``detect.thresholds.hash-size`` controls the number of hash rows in the hash table.
 ``detect.thresholds.memcap`` controls how much memory can be used for the hash table and the data stored in it.
 
+The stats counters ``detect.thresholds.avg_bucket_depth`` and
+``detect.thresholds.max_bucket_depth`` report the current collision
+pressure in the hash table. If ``max_bucket_depth`` is consistently
+high, increasing ``hash-size`` will improve lookup performance.
+
 .. _pattern-matcher-settings:
 
 Pattern matcher settings

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -7374,6 +7374,10 @@
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
+                                "avg_bucket_depth": {
+                                    "type": "integer",
+                                    "description": "Average depth of non-empty buckets in threshold hash table"
+                                },
                                 "bitmap_alloc_fail": {
                                     "type": "integer",
                                     "description": "Count of bitmap allocation failures"
@@ -7381,6 +7385,10 @@
                                 "bitmap_memuse": {
                                     "type": "integer",
                                     "description": "Memory usage by detection_filter bitmaps"
+                                },
+                                "max_bucket_depth": {
+                                    "type": "integer",
+                                    "description": "Current maximum bucket depth in threshold hash table"
                                 },
                                 "memcap": {
                                     "type": "integer",

--- a/src/counters.c
+++ b/src/counters.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2025 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -611,82 +611,72 @@ static uint16_t GetIdByName(const StatsPublicThreadContext *pctx, const char *na
 /**
  * \brief Registers a counter.
  *
- * \param name    Name of the counter, to be registered
- * \param pctx     StatsPublicThreadContext for this tm-tv instance
- * \param type_q   Qualifier describing the type of counter to be registered
+ * \param name         Name of the counter, to be registered
+ * \param pctx         StatsPublicThreadContext for this tm-tv instance
+ * \param type_q       Qualifier describing the type of counter to be registered
+ * \param Func         Poll-time getter, or NULL
+ * \param FuncWithCtx  Context-aware poll-time getter, or NULL
+ * \param FuncCtx      Context passed to \a FuncWithCtx on each poll
+ * \param dname1       First counter name (STATS_TYPE_DERIVE_DIV only)
+ * \param dname2       Second counter name (STATS_TYPE_DERIVE_DIV only)
  *
  * \retval the counter id for the newly registered counter, or the already
  *         present counter on success
  * \retval 0 on failure
  */
 static uint16_t StatsRegisterQualifiedCounter(const char *name, StatsPublicThreadContext *pctx,
-        enum StatsType type_q, uint64_t (*Func)(void), const char *dname1, const char *dname2)
+        enum StatsType type_q, uint64_t (*Func)(void), uint64_t (*FuncWithCtx)(void *),
+        void *FuncCtx, const char *dname1, const char *dname2)
 {
-    StatsCounter **head = &pctx->head;
-    StatsCounter *temp = NULL;
-    StatsCounter *prev = NULL;
-    StatsCounter *pc = NULL;
-
     if (name == NULL || pctx == NULL) {
         SCLogDebug("Counter name, StatsPublicThreadContext NULL");
         return 0;
     }
 
-    temp = prev = *head;
-    while (temp != NULL) {
+    StatsCounter *prev = NULL;
+    for (StatsCounter *temp = pctx->head; temp != NULL; temp = temp->next) {
+        if (strcmp(name, temp->name) == 0)
+            return temp->id;
         prev = temp;
-
-        if (strcmp(name, temp->name) == 0) {
-            break;
-        }
-
-        temp = temp->next;
     }
-
-    /* We already have a counter registered by this name */
-    if (temp != NULL)
-        return(temp->id);
 
     uint16_t did1 = 0;
     uint16_t did2 = 0;
     if (type_q == STATS_TYPE_DERIVE_DIV) {
         did1 = GetIdByName(pctx, dname1);
         did2 = GetIdByName(pctx, dname2);
-        if (did1 == 0 || did2 == 0) {
+        if (did1 == 0 || did2 == 0)
             return 0;
-        }
     }
 
-    /* if we reach this point we don't have a counter registered by this name */
-    if ((pc = SCCalloc(1, sizeof(StatsCounter))) == NULL)
+    StatsCounter *pc = SCCalloc(1, sizeof(StatsCounter));
+    if (pc == NULL)
         return 0;
 
-    /* assign a unique id to this StatsCounter.  The id is local to this
-     * thread context.  Please note that the id start from 1, and not 0 */
+    /* ids start at 1, not 0 */
     if (type_q == STATS_TYPE_DERIVE_DIV) {
         pc->id = ++pctx->derive_id;
     } else {
         pc->id = ++(pctx->curr_id);
     }
-    /* for AVG counters we use 2 indices into the tables: one for values,
-     * the other to track updates. */
+    /* AVG counters use 2 table slots: one for values, one for update counts */
     if (type_q == STATS_TYPE_AVERAGE)
         ++(pctx->curr_id);
+
     pc->name = name;
-
-    /* Precalculate the short name */
-    if (strrchr(name, '.') != NULL) {
-        pc->short_name = &name[strrchr(name, '.') - name + 1];
-    }
-
     pc->type = type_q;
     pc->Func = Func;
+    pc->FuncWithCtx = FuncWithCtx;
+    pc->FuncCtx = FuncCtx;
     pc->did1 = did1;
     pc->did2 = did2;
 
-    /* we now add the counter to the list */
+    const char *dot = strrchr(name, '.');
+    if (dot != NULL)
+        pc->short_name = dot + 1;
+
     if (prev == NULL)
-        *head = pc;
+        pctx->head = pc;
     else
         prev->next = pc;
 
@@ -790,7 +780,9 @@ static int StatsOutput(ThreadVars *tv)
 
             switch (pc->type) {
                 case STATS_TYPE_FUNC:
-                    if (pc->Func != NULL)
+                    if (pc->FuncWithCtx != NULL)
+                        thread_table[pc->gid].value = pc->FuncWithCtx(pc->FuncCtx);
+                    else if (pc->Func != NULL)
                         thread_table[pc->gid].value = pc->Func();
                     break;
                 case STATS_TYPE_AVERAGE:
@@ -1036,8 +1028,8 @@ void StatsSpawnThreads(void)
  */
 StatsCounterId StatsRegisterCounter(const char *name, StatsThreadContext *stats)
 {
-    uint16_t id =
-            StatsRegisterQualifiedCounter(name, &stats->pub, STATS_TYPE_NORMAL, NULL, NULL, NULL);
+    uint16_t id = StatsRegisterQualifiedCounter(
+            name, &stats->pub, STATS_TYPE_NORMAL, NULL, NULL, NULL, NULL, NULL);
     StatsCounterId s = { .id = id };
     return s;
 }
@@ -1055,8 +1047,8 @@ StatsCounterId StatsRegisterCounter(const char *name, StatsThreadContext *stats)
  */
 StatsCounterAvgId StatsRegisterAvgCounter(const char *name, StatsThreadContext *stats)
 {
-    uint16_t id =
-            StatsRegisterQualifiedCounter(name, &stats->pub, STATS_TYPE_AVERAGE, NULL, NULL, NULL);
+    uint16_t id = StatsRegisterQualifiedCounter(
+            name, &stats->pub, STATS_TYPE_AVERAGE, NULL, NULL, NULL, NULL, NULL);
     StatsCounterAvgId s = { .id = id };
     return s;
 }
@@ -1074,8 +1066,8 @@ StatsCounterAvgId StatsRegisterAvgCounter(const char *name, StatsThreadContext *
  */
 StatsCounterMaxId StatsRegisterMaxCounter(const char *name, StatsThreadContext *stats)
 {
-    uint16_t id =
-            StatsRegisterQualifiedCounter(name, &stats->pub, STATS_TYPE_MAXIMUM, NULL, NULL, NULL);
+    uint16_t id = StatsRegisterQualifiedCounter(
+            name, &stats->pub, STATS_TYPE_MAXIMUM, NULL, NULL, NULL, NULL, NULL);
     StatsCounterMaxId s = { .id = id };
     return s;
 }
@@ -1099,7 +1091,7 @@ StatsCounterGlobalId StatsRegisterGlobalCounter(const char *name, uint64_t (*Fun
     BUG_ON(stats_ctx == NULL);
 #endif
     uint16_t id = StatsRegisterQualifiedCounter(
-            name, &(stats_ctx->global_counter_ctx), STATS_TYPE_FUNC, Func, NULL, NULL);
+            name, &(stats_ctx->global_counter_ctx), STATS_TYPE_FUNC, Func, NULL, NULL, NULL, NULL);
     s.id = id;
     return s;
 }
@@ -1128,7 +1120,36 @@ StatsCounterDeriveId StatsRegisterDeriveDivCounter(
     BUG_ON(stats_ctx == NULL);
 #endif
     uint16_t id = StatsRegisterQualifiedCounter(
-            name, &stats->pub, STATS_TYPE_DERIVE_DIV, NULL, dname1, dname2);
+            name, &stats->pub, STATS_TYPE_DERIVE_DIV, NULL, NULL, NULL, dname1, dname2);
+    s.id = id;
+    return s;
+}
+
+/**
+ * \brief Registers a global counter backed by a context-aware getter function.
+ *
+ * Like StatsRegisterGlobalCounter() but passes \a ctx to \a Func on each poll,
+ * allowing multiple independent instances to share a single getter without
+ * requiring per-instance wrapper functions.
+ *
+ * \param name  Name of the counter.
+ * \param Func  Function returning the counter value given \a ctx.
+ * \param ctx   Context pointer passed to \a Func on every poll.
+ *
+ * \retval id Counter id for the newly registered counter.
+ */
+StatsCounterGlobalId StatsRegisterGlobalCounterWithContext(
+        const char *name, uint64_t (*Func)(void *), void *ctx)
+{
+    StatsCounterGlobalId s = { .id = 0 };
+#if defined(UNITTESTS) || defined(FUZZ)
+    if (stats_ctx == NULL)
+        return s;
+#else
+    BUG_ON(stats_ctx == NULL);
+#endif
+    uint16_t id = StatsRegisterQualifiedCounter(
+            name, &(stats_ctx->global_counter_ctx), STATS_TYPE_FUNC, NULL, Func, ctx, NULL, NULL);
     s.id = id;
     return s;
 }
@@ -1447,7 +1468,8 @@ void StatsThreadCleanup(StatsThreadContext *stats)
 static StatsCounterId RegisterCounter(
         const char *name, const char *tm_name, StatsPublicThreadContext *pctx)
 {
-    uint16_t id = StatsRegisterQualifiedCounter(name, pctx, STATS_TYPE_NORMAL, NULL, NULL, NULL);
+    uint16_t id = StatsRegisterQualifiedCounter(
+            name, pctx, STATS_TYPE_NORMAL, NULL, NULL, NULL, NULL, NULL);
     StatsCounterId s = { .id = id };
     return s;
 }

--- a/src/counters.h
+++ b/src/counters.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2025 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -69,6 +69,11 @@ typedef struct StatsCounter_ {
     /* when using type STATS_TYPE_FUNC this function is called once
      * to get the counter value, regardless of how many threads there are. */
     uint64_t (*Func)(void);
+
+    /* optional context-aware variant: if set, called as FuncWithCtx(FuncCtx)
+     * instead of Func(). Allows multiple instances to share a getter. */
+    uint64_t (*FuncWithCtx)(void *);
+    void *FuncCtx;
 
     /* name of the counter */
     const char *name;
@@ -149,6 +154,8 @@ StatsCounterId StatsRegisterCounter(const char *, StatsThreadContext *);
 StatsCounterAvgId StatsRegisterAvgCounter(const char *, StatsThreadContext *);
 StatsCounterMaxId StatsRegisterMaxCounter(const char *, StatsThreadContext *);
 StatsCounterGlobalId StatsRegisterGlobalCounter(const char *cname, uint64_t (*Func)(void));
+StatsCounterGlobalId StatsRegisterGlobalCounterWithContext(
+        const char *name, uint64_t (*Func)(void *), void *ctx);
 
 StatsCounterDeriveId StatsRegisterDeriveDivCounter(
         const char *cname, const char *dname1, const char *dname2, StatsThreadContext *);

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2024 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -134,6 +134,10 @@ void ThresholdRegisterGlobalCounters(void)
     StatsRegisterGlobalCounter("detect.thresholds.bitmap_memuse", ThresholdBitmapMemuseCounter);
     StatsRegisterGlobalCounter(
             "detect.thresholds.bitmap_alloc_fail", ThresholdBitmapAllocFailCounter);
+    StatsRegisterGlobalCounterWithContext(
+            "detect.thresholds.max_bucket_depth", THashGetterMaxBucketDepth, ctx.thash);
+    StatsRegisterGlobalCounterWithContext(
+            "detect.thresholds.avg_bucket_depth", THashGetterAvgBucketDepth, ctx.thash);
 }
 
 void ThresholdDestroy(void)

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2024 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -299,6 +299,66 @@ static int THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
     return 0;
 }
 
+/* Sentinel marking a consumed cache slot. Bucket depths and counts will
+ * never reach UINT32_MAX in practice, so it's safe to repurpose. */
+#define THASH_BUCKET_STATS_SENTINEL UINT32_MAX
+
+/* Single combined scan that refills both cached values. Takes each bucket
+ * lock briefly to read a stable hb->len. Cross-bucket atomicity is not
+ * guaranteed, but per-bucket values are consistent with the hot path. */
+static void THashRefreshBucketStats(THashTableContext *t, uint32_t *max_out, uint32_t *nonempty_out)
+{
+    uint32_t max = 0;
+    uint32_t nonempty = 0;
+    for (uint32_t i = 0; i < t->config.hash_size; i++) {
+        THashHashRow *hb = &t->array[i];
+        HRLOCK_LOCK(hb);
+        uint32_t len = hb->len;
+        HRLOCK_UNLOCK(hb);
+        if (len > 0) {
+            nonempty++;
+            if (len > max)
+                max = len;
+        }
+    }
+    t->bucket_stats_max = max;
+    t->bucket_stats_nonempty = nonempty;
+    *max_out = max;
+    *nonempty_out = nonempty;
+}
+
+uint64_t THashGetterMaxBucketDepth(void *ctx)
+{
+    THashTableContext *t = ctx;
+    uint32_t max;
+    if (t->bucket_stats_max == THASH_BUCKET_STATS_SENTINEL) {
+        uint32_t nonempty;
+        THashRefreshBucketStats(t, &max, &nonempty);
+    } else {
+        // refreshed value
+        max = t->bucket_stats_max;
+    }
+    t->bucket_stats_max = THASH_BUCKET_STATS_SENTINEL;
+    return max;
+}
+
+uint64_t THashGetterAvgBucketDepth(void *ctx)
+{
+    THashTableContext *t = ctx;
+    uint32_t nonempty;
+    if (t->bucket_stats_nonempty == THASH_BUCKET_STATS_SENTINEL) {
+        uint32_t max;
+        THashRefreshBucketStats(t, &max, &nonempty);
+    } else {
+        // refreshed value
+        nonempty = t->bucket_stats_nonempty;
+    }
+    t->bucket_stats_nonempty = THASH_BUCKET_STATS_SENTINEL;
+    if (nonempty == 0)
+        return 0;
+    return SC_ATOMIC_GET(t->counter) / nonempty;
+}
+
 THashTableContext *THashInit(const char *cnf_prefix, uint32_t data_size,
         int (*DataSet)(void *, void *), void (*DataFree)(void *),
         uint32_t (*DataHash)(uint32_t, void *), bool (*DataCompare)(void *, void *),
@@ -331,12 +391,15 @@ THashTableContext *THashInit(const char *cnf_prefix, uint32_t data_size,
     SC_ATOMIC_INIT(ctx->counter);
     SC_ATOMIC_INIT(ctx->memuse);
     SC_ATOMIC_INIT(ctx->prune_idx);
+    ctx->bucket_stats_max = THASH_BUCKET_STATS_SENTINEL;
+    ctx->bucket_stats_nonempty = THASH_BUCKET_STATS_SENTINEL;
     THashDataQueueInit(&ctx->spare_q);
 
     if (THashInitConfig(ctx, cnf_prefix) < 0) {
         THashShutdown(ctx);
-        ctx = NULL;
+        return NULL;
     }
+
     return ctx;
 }
 
@@ -468,6 +531,7 @@ uint32_t THashExpire(THashTableContext *ctx, const SCTime_t ts)
                     hb->head = h->next;
                 if (hb->tail == h)
                     hb->tail = h->prev;
+                hb->len--;
                 h->next = NULL;
                 h->prev = NULL;
                 SCLogDebug("timeout: removing data %p", h);
@@ -522,6 +586,7 @@ void THashCleanup(THashTableContext *ctx)
                     hb->head = h->next;
                 if (hb->tail == h)
                     hb->tail = h->prev;
+                hb->len--;
                 h->next = NULL;
                 h->prev = NULL;
                 if (ctx->config.DataSize) {
@@ -656,6 +721,7 @@ THashGetFromHash (THashTableContext *ctx, void *data)
         /* data is locked */
         hb->head = h;
         hb->tail = h;
+        hb->len++;
 
         /* initialize and return */
         (void) THashIncrUsecnt(h);
@@ -688,6 +754,7 @@ THashGetFromHash (THashTableContext *ctx, void *data)
                 /* data is locked */
 
                 h->prev = ph;
+                hb->len++;
 
                 /* initialize and return */
                 (void) THashIncrUsecnt(h);
@@ -858,6 +925,7 @@ static THashData *THashGetUsed(THashTableContext *ctx, uint32_t data_size)
             hb->head = h->next;
         if (hb->tail == h)
             hb->tail = h->prev;
+        hb->len--;
 
         h->next = NULL;
         h->prev = NULL;
@@ -919,6 +987,7 @@ int THashRemoveFromHash (THashTableContext *ctx, void *data)
             hb->head = h->next;
         if (hb->tail == h)
             hb->tail = h->prev;
+        hb->len--;
 
         h->next = NULL;
         h->prev = NULL;

--- a/src/util-thash.h
+++ b/src/util-thash.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2024 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -99,6 +99,7 @@ typedef struct THashHashRow_ {
     HRLOCK_TYPE lock;
     THashData *head;
     THashData *tail;
+    uint32_t len; /**< current number of entries in this bucket */
 } __attribute__((aligned(CLS))) THashHashRow;
 
 typedef struct THashDataQueue_
@@ -146,6 +147,13 @@ typedef struct THashTableContext_ {
     SC_ATOMIC_DECLARE(uint32_t, counter);
     SC_ATOMIC_DECLARE(uint32_t, prune_idx);
 
+    /** Cached bucket-depth telemetry. Each getter consumes its slot by
+     *  resetting it to UINT32_MAX; whichever getter sees the sentinel on
+     *  the next poll triggers a single combined scan that refills both.
+     *  Only accessed from the stats management thread, so no atomics. */
+    uint32_t bucket_stats_max;
+    uint32_t bucket_stats_nonempty;
+
     THashDataQueue spare_q;
 
     THashConfig config;
@@ -175,6 +183,9 @@ THashTableContext *THashInit(const char *cnf_prefix, uint32_t data_size,
         uint32_t (*DataHash)(uint32_t, void *), bool (*DataCompare)(void *, void *),
         bool (*DataExpired)(void *, SCTime_t), uint32_t (*DataSize)(void *), bool reset_memcap,
         uint64_t memcap, uint32_t hashsize);
+
+uint64_t THashGetterMaxBucketDepth(void *ctx);
+uint64_t THashGetterAvgBucketDepth(void *ctx);
 
 void THashShutdown(THashTableContext *ctx);
 


### PR DESCRIPTION
Continuation of #15255 

Add two new stats counters that report collision pressure in the threshold hash table:

- detect.thresholds.max_bucket_depth — current maximum bucket depth across all buckets
- detect.thresholds.avg_bucket_depth — average depth of non-empty buckets (total entries / non-empty buckets)

These counters allow operators to determine whether detect.thresholds.hash-size needs tuning. A consistently high
max_bucket_depth indicates hash collisions are degrading lookup performance. A low avg_bucket_depth with a high
max indicates skewed distribution into hot-spot buckets.

The bucket-depth values are computed by scanning the hash at *poll time*. A per-bucket len field is maintained under the existing bucket lock (no atomics on the hot path). A sentinel-based per-context cache ensures one combined scan serves both getters per poll cycle.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8401

Describe changes:
- Add infrastructure for context-dependent counters
- Expose threshold has bucket counters
- Document value 

Updates
- Alphabetically sort added schema entries
- Split counter api change into a separate commit
- Rebased after https://github.com/OISF/suricata/commit/3e9c726aa8070054c7c85b71ec409826ee20fdd5
- Simplified: removed histogram and atomics, moved calculations to poll-time, more test cases. Poll-time shift ok since this is done periodically (default -- every 8s) and there are no more atomics on the stat update path.
- Removed StatsFindOrAllocCounter/StatsRegisterQualifiedCounterWithCtx and extended StatsRegisterQualifiedCounter with extra parameters.
- Inlined hp->len updates, use lock to prevent "racy" retrievals.
- Removed atomics for bucket max/avg since they are unneeded (single thread touches these)
- Formatting fixup
- Rebase

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2985
SU_REPO=
SU_BRANCH=
