### PR TITLE
capture-bypass: fix worker timeout of bypassed flows v1

### DIFF
--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -851,6 +851,10 @@ static inline bool FlowIsTimedOut(
         const FlowThreadId ftid, const Flow *f, const SCTime_t pktts, const bool emerg)
 {
     SCTime_t timesout_at;
+#ifdef CAPTURE_OFFLOAD
+    if (f->flow_state == FLOW_STATE_CAPTURE_BYPASSED)
+        return false;
+#endif /* CAPTURE_OFFLOAD */
     if (emerg) {
         extern FlowProtoTimeout flow_timeouts_emerg[FLOW_PROTO_MAX];
         timesout_at = SCTIME_ADD_SECS(f->lastts,


### PR DESCRIPTION
This PR resolves an issue where Suricata does not check the statistics of bypassed flows that have been timed out by workers. 
### Proposed Solution
I propose to solve this issue by forbidding workers from timing out capture-bypassed flows and allowing only FlowManager to handle them.

Changes:
- Forbid workers from timing out capture-bypassed flows and having only FlowManager thread manage these flows.
- This issue was originally part of https://github.com/OISF/suricata/pull/15289, this PR separates it for clarity.

Links to ticket: [8442](https://redmine.openinfosecfoundation.org/issues/8442)