### PR TITLE
eve: add rule generation source to alert record - v1

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -405,6 +405,10 @@ It can also contain information about Source and Target of the attack in the
 ``alert.source`` and ``alert.target`` field if target keyword is used in
 the signature.
 
+In firewall mode, the ``alert.engine`` field identifies which rule engine
+generated the alert: ``fw`` for firewall rules and ``td`` for threat detect
+rules. This field is omitted outside of firewall mode.
+
 This event will also have the ``pcap_cnt`` field, when running in pcap mode, to
 indicate which packet triggered the signature.
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -21,6 +21,14 @@
                     "additionalProperties": true,
                     "description": "Extra context data created by keywords such as dataset with JSON"
                 },
+                "engine": {
+                    "type": "string",
+                    "enum": [
+                        "fw",
+                        "td"
+                    ],
+                    "description": "Engine that generated the alert in firewall mode: fw for firewall rules, td for threat detect rules."
+                },
                 "gid": {
                     "type": "integer"
                 },

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -231,6 +231,9 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, SCJsonBuilder *js, 
     SCJbOpenObject(js, "alert");
 
     SCJbSetString(js, "action", action);
+    if (EngineModeIsFirewall()) {
+        SCJbSetString(js, "engine", (pa->s->flags & SIG_FLAG_FIREWALL) ? "fw" : "td");
+    }
     SCJbSetUint(js, "gid", pa->s->gid);
     SCJbSetUint(js, "signature_id", pa->s->id);
     SCJbSetUint(js, "rev", pa->s->rev);


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8456

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3072

Draft to see how "alert.engine" feels... Examples:

```json
"alert": {
  "engine": "fw"
}

"alert": {
  "engine": "td"
}
```
