### PR TITLE
doc: address config conversion note

### DIFF
--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -46,7 +46,7 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = {'.rst': 'restructuredtext'}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'


### PR DESCRIPTION
Message is:
```
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
```
