### PR TITLE
add exception_policy field to netflow eve records

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4350,6 +4350,21 @@
                     "type": "string",
                     "description": "Date of the end of the flow"
                 },
+                "exception_policy": {
+                    "type": "array",
+                    "properties": {
+                        "policy": {
+                            "type": "string",
+                            "description": "Which exception policy was applied"
+                        },
+                        "target": {
+                            "type": "string",
+                            "description": "What triggered the exception"
+                        }
+                    },
+                    "description":
+                            "The exception policy(ies) triggered by the flow. Not logged if none was triggered"
+                },
                 "max_ttl": {
                     "type": "integer",
                     "description": "Maximum observed Time-To-Live (TTL) value"

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -226,7 +226,7 @@ void EveAddFlow(Flow *f, SCJsonBuilder *js)
     SCJbSetString(js, "start", timebuf1);
 }
 
-static void EveExceptionPolicyLog(SCJsonBuilder *js, uint16_t flag)
+void EveExceptionPolicyLog(SCJsonBuilder *js, uint16_t flag)
 {
     if (flag & EXCEPTION_TARGET_FLAG_DEFRAG_MEMCAP) {
         SCJbStartObject(js);

--- a/src/output-json-flow.h
+++ b/src/output-json-flow.h
@@ -27,5 +27,6 @@
 void JsonFlowLogRegister(void);
 void EveAddFlow(Flow *f, SCJsonBuilder *js);
 void EveAddAppProto(Flow *f, SCJsonBuilder *js);
+void EveExceptionPolicyLog(SCJsonBuilder *js, uint16_t flag);
 
 #endif /* SURICATA_OUTPUT_JSON_FLOW_H */

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -46,6 +46,7 @@
 #include "util-logopenfile.h"
 #include "util-time.h"
 #include "output-json.h"
+#include "output-json-flow.h"
 #include "output-json-netflow.h"
 
 #include "stream-tcp-private.h"
@@ -211,6 +212,12 @@ static void NetFlowLogEveToServer(SCJsonBuilder *js, Flow *f)
         }
     }
 
+    if (f->applied_exception_policy != 0) {
+        SCJbOpenArray(js, "exception_policy");
+        EveExceptionPolicyLog(js, f->applied_exception_policy);
+        SCJbClose(js); /* close array */
+    }
+
     /* Close netflow. */
     SCJbClose(js);
 
@@ -262,6 +269,12 @@ static void NetFlowLogEveToClient(SCJsonBuilder *js, Flow *f)
         if (tx_id) {
             SCJbSetUint(js, "tx_cnt", tx_id);
         }
+    }
+
+    if (f->applied_exception_policy != 0) {
+        SCJbOpenArray(js, "exception_policy");
+        EveExceptionPolicyLog(js, f->applied_exception_policy);
+        SCJbClose(js); /* close array */
     }
 
     /* Close netflow. */


### PR DESCRIPTION
Issue #8499 reports that exception_policy shows up under flow events but not under netflow events, even when the same flow triggers a midstream drop. Both loggers consume the same applied_exception_policy state on the flow object, but the helper that formats the array was static to the flow logger so the netflow logger had no way to emit it. This change drops the static qualifier and declares the helper in output-json-flow.h, then calls it from both netflow records so the field shows up in toserver and toclient events. I also updated etc/schema.json to document the new field and verified the fix end to end with a midstream pcap and drop-flow stream policy.