### PR TITLE
affinity: bind worker memory to local NUMA node

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1415,13 +1415,22 @@
         AC_CHECK_FUNCS([bpf_xdp_query_id])
     ])
 
+  # Optional libnuma probe (used for memory affinity binding, also
+  # mandatory for DPDK and Napatech below). Sets HAVE_LIBNUMA and links
+  # -lnuma when available.
+    AC_CHECK_LIB(numa, numa_available, [
+        have_libnuma=yes
+        AC_DEFINE([HAVE_LIBNUMA], [1], [Define to 1 if you have libnuma.])
+        LIBS="${LIBS} -lnuma"
+    ], [have_libnuma=no])
+
   # DPDK support
     enable_dpdk_bond_pmd="no"
     AC_ARG_ENABLE(dpdk,
             AS_HELP_STRING([--enable-dpdk], [Enable DPDK support [default=no]]),
                         [enable_dpdk=$enableval],[enable_dpdk=no])
     AS_IF([test "x$enable_dpdk" = "xyes"], [
-        AC_CHECK_LIB(numa, numa_available,, [numa_found="no"])
+        if test "$have_libnuma" = "no"; then numa_found="no"; fi
         if test "$numa_found" = "no"; then
             echo
             echo "  ERROR! libnuma not found by pkg-config, go get it"

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -919,6 +919,17 @@ packets to process. The detect threads running on other cores will
 process more packets. This is only the case after setting the option
 to 'yes'.
 
+On NUMA systems where ``set-cpu-affinity`` is enabled you can also opt
+into binding each thread's memory to its local NUMA node so per-flow,
+per-thread and packet pool allocations stay on the same node as the
+worker CPU::
+
+  set-memory-affinity: yes
+
+This requires Suricata to be built with libnuma (already pulled in by
+``--enable-dpdk`` and the Napatech build). On a single NUMA node system
+the option has no effect.
+
 *Example 7	Balancing workload*
 
 .. image:: suricata-yaml/balancing_workload.png

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -60,6 +60,7 @@
 
 int debuglog_enabled = 0;
 bool threading_set_cpu_affinity = false;
+bool threading_set_memory_affinity = false;
 uint64_t threading_set_stack_size = 0;
 
 /* Runmode Global Thread Names */
@@ -963,6 +964,25 @@ void RunModeInitializeThreadSettings(void)
     if (threading_set_cpu_affinity) {
         AffinitySetupLoadFromConfig();
     }
+
+    int memory_affinity = 0;
+    if ((SCConfGetBool("threading.set-memory-affinity", &memory_affinity)) == 0) {
+        threading_set_memory_affinity = false;
+    } else {
+        threading_set_memory_affinity = memory_affinity == 1;
+    }
+    if (threading_set_memory_affinity && !threading_set_cpu_affinity) {
+        SCLogWarning("threading.set-memory-affinity has no effect without "
+                     "threading.set-cpu-affinity, ignoring");
+        threading_set_memory_affinity = false;
+    }
+#ifndef HAVE_LIBNUMA
+    if (threading_set_memory_affinity) {
+        SCLogWarning("threading.set-memory-affinity requested but Suricata "
+                     "was built without libnuma, ignoring");
+        threading_set_memory_affinity = false;
+    }
+#endif
     if ((SCConfGetFloat("threading.detect-thread-ratio", &threading_detect_ratio)) != 1) {
         if (SCConfGetNode("threading.detect-thread-ratio") != NULL)
             WarnInvalidConfEntry("threading.detect-thread-ratio", "%s", "1");

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -104,6 +104,7 @@ void RunModeEnablesBypassManager(void);
 int RunModeNeedsBypassManager(void);
 
 extern bool threading_set_cpu_affinity;
+extern bool threading_set_memory_affinity;
 extern float threading_detect_ratio;
 extern uint64_t threading_set_stack_size;
 

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -49,6 +49,10 @@
 #include "util-validate.h"
 #include "source-pcap-file-helper.h"
 
+#ifdef HAVE_LIBNUMA
+#include <numa.h>
+#endif
+
 #ifdef PROFILE_LOCKING
 thread_local uint64_t mutex_lock_contention;
 thread_local uint64_t mutex_lock_wait_ticks;
@@ -857,6 +861,33 @@ int TmThreadGetNbThreads(uint8_t type)
 }
 
 /**
+ * \brief Bind subsequent allocations on this thread to the local NUMA node.
+ *
+ * Must be called after the thread's CPU affinity has been pinned. Uses
+ * MPOL_LOCAL (via numa_set_localalloc) so allocations prefer the node of
+ * the running CPU but can fall back to other nodes when local memory is
+ * exhausted. No-op when libnuma is not compiled in or the system has a
+ * single NUMA node.
+ */
+static void SetMemoryAffinityLocal(const char *name)
+{
+#ifdef HAVE_LIBNUMA
+    if (!threading_set_memory_affinity)
+        return;
+    if (numa_available() == -1)
+        return;
+    if (numa_max_node() < 1)
+        return;
+    numa_set_localalloc();
+    SCLogPerf("Setting memory affinity for thread \"%s\" to local NUMA node, "
+              "thread id %lu",
+            name, SCGetThreadIdLong());
+#else
+    (void)name;
+#endif
+}
+
+/**
  * \brief Set the thread options (cpu affinitythread).
  *        Priority should be already set by pthread_create.
  *
@@ -869,6 +900,7 @@ TmEcode TmThreadSetupOptions(ThreadVars *tv)
                   "%"PRIu16", thread id %lu", tv->name, tv->cpu_affinity,
                   SCGetThreadIdLong());
         SetCPUAffinity(tv->cpu_affinity);
+        SetMemoryAffinityLocal(tv->name);
     }
 
 #if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
@@ -915,6 +947,7 @@ TmEcode TmThreadSetupOptions(ThreadVars *tv)
                       "thread id %lu", tv->thread_priority,
                       tv->name, SCGetThreadIdLong());
         }
+        SetMemoryAffinityLocal(tv->name);
         TmThreadSetPrio(tv);
     }
 #endif

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1907,6 +1907,12 @@ spm-algo: auto
 # Suricata is multi-threaded. Here the threading can be influenced.
 threading:
   set-cpu-affinity: no
+  # When set-cpu-affinity is enabled, also bind thread heap allocations
+  # to the local NUMA node so per-flow, per-thread and packet pool memory
+  # stays on the same NUMA as the worker CPU. Requires libnuma at build
+  # time (already present when DPDK or Napatech is enabled). Has no effect
+  # on single-NUMA systems.
+  set-memory-affinity: no
   autopin: no
   # Tune cpu affinity of threads. Each family of threads can be bound
   # to specific CPUs.


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8141

Suricata already pins worker threads to NUMA-local CPUs through the existing cpu-affinity logic, but the heap allocations those workers make still go through plain malloc and land on whatever NUMA node the kernel happens to pick for the first touch. On dual socket DPDK boxes this lines up cleanly only when every worker's first allocation happens after pinning, which is not always the case for shared structures created by the main thread before fan out, so cross NUMA traffic shows up as packet loss on the worker side. This change adds a new opt in threading.set-memory-affinity setting that calls numa_set_localalloc on each worker right after the CPU pin, so every subsequent allocation on that thread prefers the local node and falls back to other nodes only if the local one is full. The option is gated on libnuma at build time and is a no-op on single node systems, so default behavior is unchanged.

Describe changes:
- Add a new threading.set-memory-affinity bool option in runmodes that defaults to false and warns when requested without libnuma support.
- In tm-threads, after CPU pinning in TmThreadSetupOptions, call a small helper that runs numa_set_localalloc on the worker thread when libnuma is available and more than one NUMA node is online.
- Probe libnuma in configure.ac so HAVE_LIBNUMA is also defined for non DPDK builds and the new option works there too.
- Document the new yaml setting in suricata.yaml.in and in the user guide.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
