### PR TITLE
Backport of 8489 to main-8.0.x

### DIFF
--- a/rules/ftp-events.rules
+++ b/rules/ftp-events.rules
@@ -4,3 +4,4 @@
 
 alert ftp any any -> any any (msg:"SURICATA FTP Request command too long"; flow:to_server; app-layer-event:ftp.request_command_too_long; classtype:protocol-command-decode; sid:2232000; rev:1;)
 alert ftp any any -> any any (msg:"SURICATA FTP Response command too long"; flow:to_client; app-layer-event:ftp.response_command_too_long; classtype:protocol-command-decode; sid:2232001; rev:1;)
+alert ftp any any -> any any (msg:"SURICATA FTP too many transactions"; app-layer-event:ftp.too_many_transactions; classtype:protocol-command-decode; sid:2232002; rev:1;)

--- a/rust/src/ftp/event.rs
+++ b/rust/src/ftp/event.rs
@@ -25,6 +25,8 @@ pub enum FtpEvent {
     FtpEventRequestCommandTooLong,
     #[name("response_command_too_long")]
     FtpEventResponseCommandTooLong,
+    #[name("too_many_transactions")]
+    FtpEventTooManyTransactions,
 }
 
 /// Wrapper around the Rust generic function for get_event_info.

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -222,7 +222,10 @@ static FTPTransaction *FTPTransactionCreate(FtpState *state)
     SCEnter();
     FTPTransaction *firsttx = TAILQ_FIRST(&state->tx_list);
     if (firsttx && state->tx_cnt - firsttx->tx_id > ftp_config_maxtx) {
-        // FTP does not set events yet...
+        FTPTransaction *event_tx = state->curr_tx ? state->curr_tx : firsttx;
+        event_tx->done = true;
+        event_tx->tx_data.updated_ts = true;
+        SCAppLayerDecoderEventsSetEventRaw(&event_tx->tx_data.events, FtpEventTooManyTransactions);
         return NULL;
     }
     FTPTransaction *tx = FTPCalloc(1, sizeof(*tx));

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -222,11 +222,17 @@ static FTPTransaction *FTPTransactionCreate(FtpState *state)
     SCEnter();
     FTPTransaction *firsttx = TAILQ_FIRST(&state->tx_list);
     if (firsttx && state->tx_cnt - firsttx->tx_id > ftp_config_maxtx) {
-        FTPTransaction *event_tx = state->curr_tx ? state->curr_tx : firsttx;
-        event_tx->done = true;
-        event_tx->tx_data.updated_ts = true;
-        SCAppLayerDecoderEventsSetEventRaw(&event_tx->tx_data.events, FtpEventTooManyTransactions);
-        return NULL;
+        FTPTransaction *tx_old;
+        TAILQ_FOREACH (tx_old, &state->tx_list, next) {
+            if (!tx_old->done) {
+                tx_old->done = true;
+                tx_old->tx_data.updated_ts = true;
+                tx_old->tx_data.updated_tc = true;
+                AppLayerDecoderEventsSetEventRaw(
+                        &tx_old->tx_data.events, FtpEventTooManyTransactions);
+                break;
+            }
+        }
     }
     FTPTransaction *tx = FTPCalloc(1, sizeof(*tx));
     if (tx == NULL) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -984,6 +984,7 @@ app-layer:
     ftp:
       enabled: yes
       # memcap: 64 MiB
+      # max-tx: 1024
     websocket:
       #enabled: yes
       # Maximum used payload size, the rest is skipped


### PR DESCRIPTION
Cherry-pick commits for 8489 into main-8.0.x

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8490
Backport of: https://redmine.openinfosecfoundation.org/issues/8489

Describe changes:
- Cherry-pick 9ea2e29, 5ddd808, 86fe20d, c48bb1b
- Fixup use of main-only `SCAppLayerDecoderEventsSetEventRaw` with `AppLayerDecoderEventsSetEventRaw`

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3076
SU_REPO=
SU_BRANCH=
