### PR TITLE
Encryption bypass 8336 v3

### DIFF
--- a/src/app-layer-frames.c
+++ b/src/app-layer-frames.c
@@ -856,7 +856,8 @@ void FramesPrune(Flow *f, Packet *p)
 
     TcpSession *ssn = f->protoctx;
 
-    if (ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED) {
+    if ((ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED) &&
+            (p->flags & PKT_PSEUDO_DETECTLOG_FLUSH) == 0) {
         AppLayerFramesFreeContainer(f);
         return;
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1273,7 +1273,9 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
                             "engine->mpm: t->tx_progress %u == engine->progress %u, so set "
                             "mpm_in_progress",
                             tx->tx_progress, engine->progress);
-                    mpm_in_progress = true;
+                    if ((p->flags & PKT_PSEUDO_DETECTLOG_FLUSH) == 0) {
+                        mpm_in_progress = true;
+                    }
                 }
             }
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -7105,8 +7105,8 @@ void StreamTcpDetectLogFlush(ThreadVars *tv, StreamTcpThread *stt, Flow *f, Pack
     ssn->server.flags |= STREAMTCP_STREAM_FLAG_TRIGGER_RAW;
     bool ts = PKT_IS_TOSERVER(p);
     ts ^= StreamTcpInlineMode();
-    StreamTcpPseudoPacketCreateDetectLogFlush(tv, stt, p, ssn, pq, ts^0);
     StreamTcpPseudoPacketCreateDetectLogFlush(tv, stt, p, ssn, pq, ts^1);
+    StreamTcpPseudoPacketCreateDetectLogFlush(tv, stt, p, ssn, pq, ts ^ 0);
 }
 
 /**


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8336

Describe changes:
- detect: do not wait for more in log_flush
- stream: log flush packets in the other order (as the comment stated)

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2983

#15087 with a bit better commit messages