### PR TITLE
github-ci: add FreeBSD build test v3

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -3382,6 +3382,48 @@ jobs:
           python3 $(which suricata-update) -V
       - run: suricatasc -h
 
+  freebsd-15-0:
+    name: FreeBSD 15.0
+    runs-on: ubuntu-latest
+    needs: [prepare-deps]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Downloading prep archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: prep
+          path: prep
+      - uses: vmactions/freebsd-vm@d1e65811565151536c0c894fff74f06351ed26e6
+        with:
+          release: "15.0"
+          arch: x86_64
+          usesh: true
+          sync: rsync
+          copyback: false
+          prepare: |
+            pkg install -y \
+              autoconf \
+              automake \
+              gmake \
+              jq \
+              rust-cbindgen \
+              jansson \
+              libpcap \
+              libtool \
+              libyaml \
+              pcre2 \
+              pkgconf \
+              python3 \
+              py311-pyyaml \
+              rust
+          run: |
+            tar xf prep/suricata-verify.tar.gz
+            ./autogen.sh
+            CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests
+            gmake -j$(sysctl -n hw.ncpu)
+            ./src/suricata -u -l /tmp/
+            python3 ./suricata-verify/run.py -q --debug-failed
+
   windows-msys2-mingw64-npcap:
     name: Windows MSYS2 MINGW64 (NPcap)
     runs-on: windows-latest


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata/pull/15346

Expand the GitHub-CI build coverage by adding another OS that Suricata targets.

Ticket: https://redmine.openinfosecfoundation.org/issues/8487

