### PR TITLE
unittests: convert util-spm tests to FAIL/PASS API

### DIFF
--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -575,10 +575,8 @@ static int UtilSpmBasicSearchTest01(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = BasicSearchWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 1;
-    else
-        return 0;
+    FAIL_IF_NULL(found);
+    PASS;
 }
 
 /**
@@ -590,10 +588,8 @@ static int UtilSpmBasicSearchNocaseTest01(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = BasicSearchNocaseWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 1;
-    else
-        return 0;
+    FAIL_IF_NULL(found);
+    PASS;
 }
 
 /**
@@ -605,10 +601,8 @@ static int UtilSpmBs2bmSearchTest01(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = Bs2bmWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 1;
-    else
-        return 0;
+    FAIL_IF_NULL(found);
+    PASS;
 }
 
 /**
@@ -620,10 +614,8 @@ static int UtilSpmBs2bmSearchNocaseTest01(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = Bs2bmNocaseWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 1;
-    else
-        return 0;
+    FAIL_IF_NULL(found);
+    PASS;
 }
 
 /**
@@ -635,10 +627,8 @@ static int UtilSpmBoyerMooreSearchTest01(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = BoyerMooreWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 1;
-    else
-        return 0;
+    FAIL_IF_NULL(found);
+    PASS;
 }
 
 /**
@@ -650,10 +640,8 @@ static int UtilSpmBoyerMooreSearchNocaseTest01(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = BoyerMooreNocaseWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 1;
-    else
-        return 0;
+    FAIL_IF_NULL(found);
+    PASS;
 }
 
 /**
@@ -674,10 +662,8 @@ static int UtilSpmBoyerMooreSearchNocaseTestIssue130(void)
                 "Expires: Mon, 23 Feb 2009 13:31:49 GMT\r\n\r\n";
     uint8_t *found = BoyerMooreNocaseWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 1;
-    else
-        return 0;
+    FAIL_IF_NULL(found);
+    PASS;
 }
 
 /* Generic tests that should not match */
@@ -687,10 +673,8 @@ static int UtilSpmBasicSearchTest02(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = BasicSearchWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 0;
-    else
-        return 1;
+    FAIL_IF_NOT_NULL(found);
+    PASS;
 }
 
 static int UtilSpmBasicSearchNocaseTest02(void)
@@ -699,10 +683,8 @@ static int UtilSpmBasicSearchNocaseTest02(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = BasicSearchNocaseWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 0;
-    else
-        return 1;
+    FAIL_IF_NOT_NULL(found);
+    PASS;
 }
 
 static int UtilSpmBs2bmSearchTest02(void)
@@ -711,10 +693,8 @@ static int UtilSpmBs2bmSearchTest02(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = Bs2bmWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 0;
-    else
-        return 1;
+    FAIL_IF_NOT_NULL(found);
+    PASS;
 }
 
 static int UtilSpmBs2bmSearchNocaseTest02(void)
@@ -723,10 +703,8 @@ static int UtilSpmBs2bmSearchNocaseTest02(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = Bs2bmNocaseWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 0;
-    else
-        return 1;
+    FAIL_IF_NOT_NULL(found);
+    PASS;
 }
 
 static int UtilSpmBoyerMooreSearchTest02(void)
@@ -735,10 +713,8 @@ static int UtilSpmBoyerMooreSearchTest02(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = BoyerMooreWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 0;
-    else
-        return 1;
+    FAIL_IF_NOT_NULL(found);
+    PASS;
 }
 
 static int UtilSpmBoyerMooreSearchNocaseTest02(void)
@@ -747,10 +723,8 @@ static int UtilSpmBoyerMooreSearchNocaseTest02(void)
     uint8_t *text = (uint8_t *)"aBcDeFgHiJkLmNoPqRsTuVwXyZ";
     uint8_t *found = BoyerMooreNocaseWrapper(text, needle, 1);
     //printf("found: %s\n", found);
-    if (found != NULL)
-        return 0;
-    else
-        return 1;
+    FAIL_IF_NOT_NULL(found);
+    PASS;
 }
 
 /**
@@ -1170,23 +1144,14 @@ static int UtilSpmSearchOffsetsTest01(void)
     for (i = 0; i < 26; i++) {
         for (j = 0; j <= (26 - i); j++) {
             found = BasicSearchWrapper((uint8_t *)text[i][j], (uint8_t *)needle[i], 1);
-            if (found == 0) {
-                printf("Error1 searching for %s in text %s\n", needle[i], text[i][j]);
-                return 0;
-            }
+            FAIL_IF(found == 0);
             found = Bs2bmWrapper((uint8_t *)text[i][j], (uint8_t *)needle[i], 1);
-            if (found == 0) {
-                printf("Error2 searching for %s in text %s\n", needle[i], text[i][j]);
-                return 0;
-            }
+            FAIL_IF(found == 0);
             found = BoyerMooreWrapper((uint8_t *)text[i][j], (uint8_t *)needle[i], 1);
-            if (found == 0) {
-                printf("Error3 searching for %s in text %s\n", needle[i], text[i][j]);
-                return 0;
-            }
+            FAIL_IF(found == 0);
         }
     }
-    return 1;
+    PASS;
 }
 
 /**
@@ -1606,23 +1571,14 @@ static int UtilSpmSearchOffsetsNocaseTest01(void)
     for (i = 0; i < 26; i++) {
         for (j = 0; j <= (26-i); j++) {
             found = BasicSearchNocaseWrapper((uint8_t *)text[i][j], (uint8_t *)needle[i], 1);
-            if (found == 0) {
-                printf("Error1 searching for %s in text %s\n", needle[i], text[i][j]);
-                return 0;
-            }
+            FAIL_IF(found == 0);
             found = Bs2bmNocaseWrapper((uint8_t *)text[i][j], (uint8_t *)needle[i], 1);
-            if (found == 0) {
-                printf("Error2 searching for %s in text %s\n", needle[i], text[i][j]);
-                return 0;
-            }
+            FAIL_IF(found == 0);
             found = BoyerMooreNocaseWrapper((uint8_t *)text[i][j], (uint8_t *)needle[i], 1);
-            if (found == 0) {
-                printf("Error3 searching for %s in text %s\n", needle[i], text[i][j]);
-                return 0;
-            }
+            FAIL_IF(found == 0);
         }
     }
-    return 1;
+    PASS;
 }
 
 #ifdef ENABLE_SEARCH_STATS
@@ -1673,25 +1629,16 @@ static int UtilSpmSearchStatsTest01(void)
     for (i = 0; i < 16; i++) {
         printf("Pattern length %d with BasicSearch:", i+1);
         found = BasicSearchWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
         printf("Pattern length %d with Bs2BmSearch:", i+1);
         found = Bs2bmWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
         printf("Pattern length %d with BoyerMooreSearch:", i+1);
         found = BoyerMooreWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 /**
@@ -1741,25 +1688,16 @@ static int UtilSpmSearchStatsTest02(void)
     for (i = 0; i < 16; i++) {
         printf("Pattern length %d with BasicSearch:", i+1);
         found = BasicSearchWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
         printf("Pattern length %d with Bs2BmSearch:", i+1);
         found = Bs2bmWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
         printf("Pattern length %d with BoyerMooreSearch:", i+1);
         found = BoyerMooreWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 
@@ -1807,25 +1745,18 @@ static int UtilSpmSearchStatsTest03(void)
     for (i = 0; i < 16; i++) {
         printf("Pattern length %d with BasicSearch:", i+1);
         found = BasicSearchWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch:", i+1);
         found = Bs2bmWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
         printf("Pattern length %d with BoyerMooreSearch:", i+1);
         found = BoyerMooreWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 /**
@@ -1876,31 +1807,23 @@ static int UtilSpmSearchStatsTest04(void)
     for (i = 0; i < 16; i++) {
         printf("Pattern length %d with BasicSearch (Building Context):", i + 1);
         found = BasicSearchCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch (Building Context):", i + 1);
         found = Bs2bmCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch (Building Context):", i + 1);
         found = BoyerMooreCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with SpmSearch (Building Context):", i + 1);
         found = RawCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 /**
@@ -1950,25 +1873,19 @@ static int UtilSpmSearchStatsTest05(void)
     for (i = 0; i < 16; i++) {
         printf("Pattern length %d with BasicSearch (Building Context):", i+1);
         found = BasicSearchCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch (Building Context):", i+1);
         found = Bs2bmCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch (Building Context):", i+1);
         found = BoyerMooreCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 
@@ -1994,25 +1911,19 @@ static int UtilSpmSearchStatsTest06(void)
     for (i = 0; i < 5; i++) {
         printf("Pattern length %d with BasicSearch (Building Context):", i+1);
         found = BasicSearchCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch (Building Context):", i+1);
         found = Bs2bmCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch (Building Context):", i+1);
         found = BoyerMooreCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 static int UtilSpmSearchStatsTest07(void)
@@ -2037,25 +1948,21 @@ static int UtilSpmSearchStatsTest07(void)
     for (i = 0; i < 5; i++) {
         printf("Pattern length %d with BasicSearch (Building Context):", i+1);
         found = BasicSearchCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch (Building Context):", i+1);
         found = Bs2bmCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch (Building Context):", i+1);
         found = BoyerMooreCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 /**
@@ -2105,25 +2012,19 @@ static int UtilSpmNocaseSearchStatsTest01(void)
     for (i = 0; i < 16; i++) {
         printf("Pattern length %d with BasicSearch:", i+1);
         found = BasicSearchNocaseWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch:", i+1);
         found = Bs2bmNocaseWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch:", i+1);
         found = BoyerMooreNocaseWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 static int UtilSpmNocaseSearchStatsTest02(void)
@@ -2170,25 +2071,19 @@ static int UtilSpmNocaseSearchStatsTest02(void)
     for (i = 0; i < 16; i++) {
         printf("Pattern length %d with BasicSearch:", i+1);
         found = BasicSearchNocaseWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch:", i+1);
         found = Bs2bmNocaseWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch:", i+1);
         found = BoyerMooreNocaseWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 
@@ -2214,25 +2109,20 @@ static int UtilSpmNocaseSearchStatsTest03(void)
     for (i = 0; i < 5; i++) {
         printf("Pattern length %d with BasicSearch:", i+1);
         found = BasicSearchNocaseWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch:", i+1);
         found = Bs2bmNocaseWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch:", i+1);
         found = BoyerMooreNocaseWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 /**
@@ -2282,25 +2172,19 @@ static int UtilSpmNocaseSearchStatsTest04(void)
     for (i = 0; i < 16; i++) {
         printf("Pattern length %d with BasicSearch (Building Context):", i+1);
         found = BasicSearchNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch (Building Context):", i+1);
         found = Bs2bmNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch (Building Context):", i+1);
         found = BoyerMooreNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 static int UtilSpmNocaseSearchStatsTest05(void)
@@ -2347,25 +2231,19 @@ static int UtilSpmNocaseSearchStatsTest05(void)
     for (i = 0; i < 16; i++) {
         printf("Pattern length %d with BasicSearch (Building Context):", i+1);
         found = BasicSearchNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch (Building Context):", i+1);
         found = Bs2bmNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch (Building Context):", i+1);
         found = BoyerMooreNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 
@@ -2391,25 +2269,19 @@ static int UtilSpmNocaseSearchStatsTest06(void)
     for (i = 0; i < 5; i++) {
         printf("Pattern length %d with BasicSearch (Building Context):", i+1);
         found = BasicSearchNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch (Building Context):", i+1);
         found = Bs2bmNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch (Building Context):", i+1);
         found = BoyerMooreNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 
 static int UtilSpmNocaseSearchStatsTest07(void)
@@ -2434,25 +2306,19 @@ static int UtilSpmNocaseSearchStatsTest07(void)
     for (i = 0; i < 5; i++) {
         printf("Pattern length %d with BasicSearch (Building Context):", i+1);
         found = BasicSearchNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error1 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with Bs2BmSearch (Building Context):", i+1);
         found = Bs2bmNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error2 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("Pattern length %d with BoyerMooreSearch (Building Context):", i+1);
         found = BoyerMooreNocaseCtxWrapper((uint8_t *)text[i], (uint8_t *)needle[i], STATS_TIMES);
-        if (found == 0) {
-            printf("Error3 searching for %s in text %s\n", needle[i], text[i]);
-            return 0;
-        }
+        FAIL_IF(found == 0);
+
         printf("\n");
     }
-    return 1;
+    PASS;
 }
 #endif
 
@@ -2473,54 +2339,31 @@ typedef struct SpmTestData_ {
 /* Helper function to conduct a search with a particular SPM matcher. */
 static int SpmTestSearch(const SpmTestData *d, uint8_t matcher)
 {
-    int ret = 1;
     SpmGlobalThreadCtx *global_thread_ctx = NULL;
     SpmThreadCtx *thread_ctx = NULL;
     SpmCtx *ctx = NULL;
     uint8_t *found = NULL;
 
     global_thread_ctx = SpmInitGlobalThreadCtx(matcher);
-    if (global_thread_ctx == NULL) {
-        ret = 0;
-        goto exit;
-    }
+    FAIL_IF_NULL(global_thread_ctx);
 
     ctx = SpmInitCtx((const uint8_t *)d->needle, d->needle_len, d->nocase,
                      global_thread_ctx);
-    if (ctx == NULL) {
-        ret = 0;
-        goto exit;
-    }
+    FAIL_IF_NULL(ctx);
 
     thread_ctx = SpmMakeThreadCtx(global_thread_ctx);
-    if (thread_ctx == NULL) {
-        ret = 0;
-        goto exit;
-    }
+    FAIL_IF_NULL(thread_ctx);
 
     found = SpmScan(ctx, thread_ctx, (const uint8_t *)d->haystack,
                     d->haystack_len);
-    if (found == NULL) {
-        if (d->match_offset != SPM_NO_MATCH) {
-            printf("  should have matched at %" PRIu32 " but didn't\n",
-                   d->match_offset);
-            ret = 0;
-        }
-    } else {
-        uint32_t offset = (uint32_t)(found - (const uint8_t *)d->haystack);
-        if (offset != d->match_offset) {
-            printf("  should have matched at %" PRIu32
-                   " but matched at %" PRIu32 "\n",
-                   d->match_offset, offset);
-            ret = 0;
-        }
-    }
+    const uint8_t *haystack = (const uint8_t *)d->haystack;
+    const uint8_t *expected = d->match_offset == SPM_NO_MATCH ? NULL : haystack + d->match_offset;
+    FAIL_IF(found != expected);
 
-exit:
     SpmDestroyCtx(ctx);
     SpmDestroyThreadCtx(thread_ctx);
     SpmDestroyGlobalThreadCtx(global_thread_ctx);
-    return ret;
+    PASS;
 }
 
 static int SpmSearchTest01(void) {
@@ -2595,8 +2438,6 @@ static int SpmSearchTest02(void) {
         "Suricata", "CAPS LOCK", "mIxEd cAsE",
     };
 
-    int ret = 1;
-
     uint8_t matcher;
     for (matcher = 0; matcher < SPM_TABLE_SIZE; matcher++) {
         const SpmTableElmt *m = &spm_table[matcher];
@@ -2616,10 +2457,7 @@ static int SpmSearchTest02(void) {
                 d.needle_len = (uint16_t)strlen(needle);
                 uint16_t haystack_len = prefix + d.needle_len;
                 char *haystack = SCMalloc(haystack_len);
-                if (haystack == NULL) {
-                    printf("alloc failure\n");
-                    return 0;
-                }
+                FAIL_IF_NULL(haystack);
                 memset(haystack, ' ', haystack_len);
                 memcpy(haystack + prefix, d.needle, d.needle_len);
                 d.haystack = haystack;
@@ -2630,7 +2468,7 @@ static int SpmSearchTest02(void) {
                 /* Case-sensitive scan */
                 if (SpmTestSearch(&d, matcher) == 0) {
                     printf("  test %" PRIu32 ": fail (case-sensitive)\n", i);
-                    ret = 0;
+                    FAIL;
                 }
 
                 /* Case-insensitive scan */
@@ -2639,18 +2477,14 @@ static int SpmSearchTest02(void) {
                 for (j = 0; j < haystack_len; j++) {
                     haystack[j] = u8_toupper(haystack[j]);
                 }
-                if (SpmTestSearch(&d, matcher) == 0) {
-                    printf("  test %" PRIu32 ": fail (case-insensitive)\n", i);
-                    ret = 0;
-                }
-
+                FAIL_IF(SpmTestSearch(&d, matcher) == 0);
                 SCFree(haystack);
             }
         }
         printf("  %" PRIu32 " tests passed\n", i);
     }
 
-    return ret;
+    PASS;
 }
 
 /* Register unittests */


### PR DESCRIPTION
Update to address comments on 
- [Previous PR v3](https://github.com/OISF/suricata/pull/15368)
- [Previous PR v2](https://github.com/OISF/suricata/pull/15341)
- [Previous PR v1](https://github.com/OISF/suricata/pull/15336)

Changes since [PR v3](https://github.com/OISF/suricata/pull/15368):
- refactored `SpmTestSearch` to use non-branching FAIL_IF
- removed printf from fail block in `SpmSearchTest02`

Issue: [6334](https://redmine.openinfosecfoundation.org/issues/6334)
