### PR TITLE
Plugin crate zerodep 7666 v10.1

### DIFF
--- a/examples/plugins/altemplate/Cargo.toml
+++ b/examples/plugins/altemplate/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 nom7 = { version="7.0", package="nom" }
 libc = "~0.2.82"
-suricata = { path = "../../../rust/" }
 suricata-sys = { path = "../../../rust/sys" }
 suricata-ffi = { path = "../../../rust/ffi" }
 suricata-derive = { path = "../../../rust/derive" }

--- a/examples/plugins/altemplate/src/template.rs
+++ b/examples/plugins/altemplate/src/template.rs
@@ -26,11 +26,11 @@ use std;
 use std::collections::VecDeque;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
-use suricata::applayer::AppLayerTxData;
 use suricata_derive::AppLayerEvent;
 use suricata_ffi::applayer::{
-    state_get_tx_iterator, AppLayerEvent, AppLayerResultRust, State, StreamSliceRust, Transaction,
-    APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS, APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+    state_get_tx_iterator, AppLayerEvent, AppLayerResultRust, AppLayerTxData, State,
+    StreamSliceRust, Transaction, APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS,
+    APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
 };
 use suricata_ffi::conf::conf_get;
 use suricata_ffi::{

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -95,3 +95,4 @@ htp = { package = "suricata-htp", path = "./htp", version = "@PACKAGE_VERSION@" 
 
 [dev-dependencies]
 test-case = "~3.3.1"
+suricata-ffi = { path = "./ffi", version = "@PACKAGE_VERSION@", features = ["testing"] }

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -43,7 +43,7 @@ RUST_FEATURES +=	debug
 endif
 
 if DEBUG_VALIDATION
-RUST_FEATURES +=	debug-validate
+RUST_FEATURES +=	debug-validate suricata-ffi/debug-validate
 endif
 
 if RUST_CROSS_COMPILE 

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -69,7 +69,7 @@ CARGO_ENV +=	LOCALSTATEDIR=$(e_localstatedir)
 # To pass specific CFLAGS to Lua.
 CARGO_ENV +=	SURICATA_LUA_SYS_CFLAGS="$(SURICATA_LUA_SYS_CFLAGS)"
 
-all-local: Cargo.toml
+all-local: Cargo.toml ffi/Cargo.toml
 	mkdir -p $(abs_top_builddir)/rust/gen
 	cd $(abs_top_srcdir)/rust && \
 		CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)"\
@@ -232,3 +232,5 @@ Cargo.toml: Cargo.toml.in
 update-lock: Cargo.toml
 	$(CARGO_ENV) $(CARGO) update
 	mv Cargo.lock Cargo.lock.in
+
+ffi/Cargo.toml: ffi/Cargo.toml.in

--- a/rust/ffi/Cargo.toml.in
+++ b/rust/ffi/Cargo.toml.in
@@ -10,3 +10,4 @@ suricata-sys = { path = "../sys" }
 
 [features]
 debug = []
+debug-validate = []

--- a/rust/ffi/Cargo.toml.in
+++ b/rust/ffi/Cargo.toml.in
@@ -11,3 +11,4 @@ suricata-sys = { path = "../sys" }
 [features]
 debug = []
 debug-validate = []
+testing = []

--- a/rust/ffi/cbindgen.toml
+++ b/rust/ffi/cbindgen.toml
@@ -17,4 +17,4 @@ exclude = [
     "IPPROTO_UDP",
 ]
 
-item_types = ["constants"]
+item_types = ["constants", "functions"]

--- a/rust/ffi/src/applayer.rs
+++ b/rust/ffi/src/applayer.rs
@@ -18,6 +18,7 @@
 //! App-layer utils.
 
 use crate::cast_pointer;
+use crate::direction::Direction;
 use std::ffi::CStr;
 pub use suricata_sys::sys::AppLayerEventType;
 use suricata_sys::sys::{
@@ -339,4 +340,92 @@ pub unsafe fn get_event_info_by_id<T: AppLayerEvent>(
         return 0;
     }
     -1
+}
+
+#[cfg(not(any(test, feature = "testing")))]
+use suricata_sys::sys::{SCAppLayerDecoderEventsSetEventRaw, SCAppLayerTxDataCleanup};
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct AppLayerTxData(pub suricata_sys::sys::AppLayerTxData);
+
+impl AppLayerTxData {
+    /// Create new AppLayerTxData for a transaction that covers both
+    /// directions.
+    pub fn new() -> Self {
+        Self(suricata_sys::sys::AppLayerTxData {
+            updated_tc: true,
+            updated_ts: true,
+            ..Default::default()
+        })
+    }
+
+    /// Create new AppLayerTxData for a transaction in a single
+    /// direction.
+    pub fn for_direction(direction: Direction) -> Self {
+        let (flags, updated_ts, updated_tc) = match direction {
+            Direction::ToServer => (APP_LAYER_TX_SKIP_INSPECT_TC, true, false),
+            Direction::ToClient => (APP_LAYER_TX_SKIP_INSPECT_TS, false, true),
+        };
+        Self(suricata_sys::sys::AppLayerTxData {
+            updated_tc,
+            updated_ts,
+            flags,
+            ..Default::default()
+        })
+    }
+
+    pub fn init_files_opened(&mut self) {
+        self.0.files_opened = 1;
+    }
+
+    pub fn incr_files_opened(&mut self) {
+        self.0.files_opened += 1;
+    }
+
+    pub fn set_event(&mut self, _event: u8) {
+        #[cfg(not(any(test, feature = "testing")))]
+        unsafe {
+            SCAppLayerDecoderEventsSetEventRaw(&mut self.0.events, _event);
+        }
+    }
+
+    pub fn update_file_flags(&mut self, state_flags: u16) {
+        unsafe {
+            SCTxDataUpdateFileFlags(&mut self.0, state_flags);
+        }
+    }
+}
+
+impl Drop for AppLayerTxData {
+    fn drop(&mut self) {
+        #[cfg(not(any(test, feature = "testing")))]
+        unsafe {
+            SCAppLayerTxDataCleanup(&mut self.0);
+        }
+    }
+}
+
+/// # Safety
+///
+/// the caller must provide a valid AppLayerTxData pointer
+#[no_mangle]
+pub unsafe extern "C" fn SCTxDataUpdateFileFlags(
+    txd: &mut suricata_sys::sys::AppLayerTxData, state_flags: u16,
+) {
+    if (txd.file_flags & state_flags) != state_flags {
+        let mut nf = state_flags;
+        // With keyword filestore:both,flow :
+        // There may be some opened unclosed file in one direction without filestore
+        // As such it has tx file_flags had FLOWFILE_NO_STORE_TS or TC
+        // But a new file in the other direction may trigger filestore:both,flow
+        // And thus set state_flags FLOWFILE_STORE_TS
+        // If the file was opened without storing it, do not try to store just the end of it
+        if (txd.file_flags & FLOWFILE_NO_STORE_TS) != 0 && (state_flags & FLOWFILE_STORE_TS) != 0 {
+            nf &= !FLOWFILE_STORE_TS;
+        }
+        if (txd.file_flags & FLOWFILE_NO_STORE_TC) != 0 && (state_flags & FLOWFILE_STORE_TC) != 0 {
+            nf &= !FLOWFILE_STORE_TC;
+        }
+        txd.file_flags |= nf;
+    }
 }

--- a/rust/ffi/src/applayer.rs
+++ b/rust/ffi/src/applayer.rs
@@ -63,6 +63,18 @@ pub const APP_LAYER_PARSER_SFRAME_TC: u16 = 1 << 10;
 /* Flags for AppLayerParserProtoCtx. */
 pub const APP_LAYER_PARSER_OPT_ACCEPT_GAPS: u32 = 1 << 0;
 
+// Other flags are defined in C app-layer-parser.h
+/** should inspection be skipped in that direction */
+pub const APP_LAYER_TX_SKIP_INSPECT_TS: u8 = 1 << 0;
+pub const APP_LAYER_TX_SKIP_INSPECT_TC: u8 = 1 << 1;
+
+// Other flags are defined in C flow.h
+/* File flags */
+pub const FLOWFILE_NO_STORE_TS: u16 = 1 << 2;
+pub const FLOWFILE_NO_STORE_TC: u16 = 1 << 3;
+pub const FLOWFILE_STORE_TS: u16 = 1 << 12;
+pub const FLOWFILE_STORE_TC: u16 = 1 << 13;
+
 pub trait AppLayerResultRust {
     fn ok() -> Self;
     fn err() -> Self;

--- a/rust/ffi/src/debug.rs
+++ b/rust/ffi/src/debug.rs
@@ -191,3 +191,20 @@ macro_rules! SCFatalErrorOnInit {
         $crate::debug::fatalerror(&format!($($arg)*));
     }
 }
+
+#[cfg(not(feature = "debug-validate"))]
+#[macro_export]
+macro_rules! debug_validate_fail (
+  ($msg:expr) => {};
+);
+
+#[cfg(feature = "debug-validate")]
+#[macro_export]
+macro_rules! debug_validate_fail (
+  ($msg:expr) => {
+    // Wrap in a conditional to prevent unreachable code warning in caller.
+    if true {
+      panic!($msg);
+    }
+  };
+);

--- a/rust/ffi/src/direction.rs
+++ b/rust/ffi/src/direction.rs
@@ -15,13 +15,16 @@
  * 02110-1301, USA.
  */
 
+use crate::debug_validate_fail;
+
 pub const DIR_BOTH: u8 = 0b0000_1100;
 const DIR_TOSERVER: u8 = 0b0000_0100;
 const DIR_TOCLIENT: u8 = 0b0000_1000;
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub enum Direction {
+    #[default]
     ToServer = 0x04,
     ToClient = 0x08,
 }
@@ -42,12 +45,6 @@ impl Direction {
             Self::ToClient => 0,
             _ => 1,
         }
-    }
-}
-
-impl Default for Direction {
-    fn default() -> Self {
-        Direction::ToServer
     }
 }
 

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -19,6 +19,7 @@ pub mod applayer;
 pub mod conf;
 pub mod debug;
 pub mod detect;
+pub mod direction;
 pub mod eve;
 pub mod flow;
 pub mod jsonbuilder;

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -104,11 +104,9 @@ impl Drop for AppLayerTxData {
 }
 
 
-// need to keep in sync with C flow.h
-pub const FLOWFILE_NO_STORE_TS: u16 = BIT_U16!(2);
-pub const FLOWFILE_NO_STORE_TC: u16 = BIT_U16!(3);
-pub const FLOWFILE_STORE_TS: u16 = BIT_U16!(12);
-pub const FLOWFILE_STORE_TC: u16 = BIT_U16!(13);
+pub use suricata_ffi::applayer::{
+    FLOWFILE_NO_STORE_TS, FLOWFILE_NO_STORE_TC, FLOWFILE_STORE_TS, FLOWFILE_STORE_TC,
+};
 
 #[no_mangle]
 pub unsafe extern "C" fn SCTxDataUpdateFileFlags(txd: &mut suricata_sys::sys::AppLayerTxData, state_flags: u16) {
@@ -320,10 +318,9 @@ pub use suricata_ffi::applayer::{
     APP_LAYER_PARSER_BYPASS_READY, APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS,
     APP_LAYER_PARSER_NO_INSPECTION, APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD,
     APP_LAYER_PARSER_NO_REASSEMBLY, APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+    APP_LAYER_TX_SKIP_INSPECT_TS, APP_LAYER_TX_SKIP_INSPECT_TC,
 };
 
-pub const APP_LAYER_TX_SKIP_INSPECT_TS: u8 = BIT_U8!(0);
-pub const APP_LAYER_TX_SKIP_INSPECT_TC: u8 = BIT_U8!(1);
 pub const _APP_LAYER_TX_INSPECTED_TS: u8 = BIT_U8!(2);
 pub const _APP_LAYER_TX_INSPECTED_TC: u8 = BIT_U8!(3);
 pub const APP_LAYER_TX_ACCEPT: u8 = BIT_U8!(4);

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -35,103 +35,11 @@ pub use suricata_sys::sys::{
     AppLayerTxConfig, StreamSlice,
 };
 
-#[cfg(not(test))]
-use suricata_sys::sys::SCAppLayerDecoderEventsSetEventRaw;
-
 pub use suricata_ffi::cast_pointer;
-
-#[derive(Debug, Default, Eq, PartialEq)]
-pub struct AppLayerTxData(pub suricata_sys::sys::AppLayerTxData);
-
-impl AppLayerTxData {
-    /// Create new AppLayerTxData for a transaction that covers both
-    /// directions.
-    pub fn new() -> Self {
-        Self (suricata_sys::sys::AppLayerTxData {
-            updated_tc: true,
-            updated_ts: true,
-            ..Default::default()
-        })
-    }
-
-    /// Create new AppLayerTxData for a transaction in a single
-    /// direction.
-    pub fn for_direction(direction: Direction) -> Self {
-        let (flags, updated_ts, updated_tc) = match direction {
-            Direction::ToServer => (APP_LAYER_TX_SKIP_INSPECT_TC, true, false),
-            Direction::ToClient => (APP_LAYER_TX_SKIP_INSPECT_TS, false, true),
-        };
-        Self (suricata_sys::sys::AppLayerTxData{
-            updated_tc,
-            updated_ts,
-            flags,
-            ..Default::default()
-        })
-    }
-
-    pub fn init_files_opened(&mut self) {
-        self.0.files_opened = 1;
-    }
-
-    pub fn incr_files_opened(&mut self) {
-        self.0.files_opened += 1;
-    }
-
-    pub fn set_event(&mut self, _event: u8) {
-        #[cfg(not(test))]
-        unsafe {
-            SCAppLayerDecoderEventsSetEventRaw(&mut self.0.events, _event);
-        }
-    }
-
-    pub fn update_file_flags(&mut self, state_flags: u16) {
-        unsafe {
-            SCTxDataUpdateFileFlags(&mut self.0, state_flags);
-        }
-    }
-}
-
-#[cfg(not(test))]
-use suricata_sys::sys::SCAppLayerTxDataCleanup;
-
-impl Drop for AppLayerTxData {
-    fn drop(&mut self) {
-        #[cfg(not(test))]
-        unsafe {
-            SCAppLayerTxDataCleanup(&mut self.0);
-        }
-    }
-}
-
-
-pub use suricata_ffi::applayer::{
-    FLOWFILE_NO_STORE_TS, FLOWFILE_NO_STORE_TC, FLOWFILE_STORE_TS, FLOWFILE_STORE_TC,
-};
-
-#[no_mangle]
-pub unsafe extern "C" fn SCTxDataUpdateFileFlags(txd: &mut suricata_sys::sys::AppLayerTxData, state_flags: u16) {
-    if (txd.file_flags & state_flags) != state_flags {
-        SCLogDebug!("updating tx file_flags {:04x} with state flags {:04x}", txd.file_flags, state_flags);
-        let mut nf = state_flags;
-        // With keyword filestore:both,flow :
-        // There may be some opened unclosed file in one direction without filestore
-        // As such it has tx file_flags had FLOWFILE_NO_STORE_TS or TC
-        // But a new file in the other direction may trigger filestore:both,flow
-        // And thus set state_flags FLOWFILE_STORE_TS
-        // If the file was opened without storing it, do not try to store just the end of it
-        if (txd.file_flags & FLOWFILE_NO_STORE_TS) != 0 && (state_flags & FLOWFILE_STORE_TS) != 0 {
-            nf &= !FLOWFILE_STORE_TS;
-        }
-        if (txd.file_flags & FLOWFILE_NO_STORE_TC) != 0 && (state_flags & FLOWFILE_STORE_TC) != 0 {
-            nf &= !FLOWFILE_STORE_TC;
-        }
-        txd.file_flags |= nf;
-    }
-}
 
 pub use suricata_ffi::{export_tx_data_get, export_state_data_get};
 
-pub use suricata_ffi::applayer::{AppLayerEvent, AppLayerEventType, AppLayerResultRust, StreamSliceRust};
+pub use suricata_ffi::applayer::{AppLayerEvent, AppLayerEventType, AppLayerResultRust, AppLayerTxData, StreamSliceRust};
 
 /// Rust parser declaration
 #[repr(C)]

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -44,9 +44,9 @@ macro_rules!BIT_U8 {
     ($x:expr) => (1 << $x);
 }
 
-macro_rules!BIT_U16 {
+/*unused macro_rules!BIT_U16 {
     ($x:expr) => (1 << $x);
-}
+}*/
 
 macro_rules!BIT_U32 {
     ($x:expr) => (1 << $x);

--- a/rust/src/debug.rs
+++ b/rust/src/debug.rs
@@ -190,23 +190,6 @@ macro_rules! debug_validate_bug_on (
   };
 );
 
-#[cfg(not(feature = "debug-validate"))]
-#[macro_export]
-macro_rules! debug_validate_fail (
-  ($msg:expr) => {};
-);
-
-#[cfg(feature = "debug-validate")]
-#[macro_export]
-macro_rules! debug_validate_fail (
-  ($msg:expr) => {
-    // Wrap in a conditional to prevent unreachable code warning in caller.
-    if true {
-      panic!($msg);
-    }
-  };
-);
-
 #[macro_export]
 macro_rules! unwrap_or_return (
     ($e:expr, $r:expr) => {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -139,7 +139,7 @@ pub mod feature;
 pub mod sdp;
 pub mod ldap;
 pub mod flow;
-pub mod direction;
+pub use suricata_ffi::direction;
 
 #[allow(unused_imports)]
 pub use suricata_lua_sys;

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -44,8 +44,9 @@ typedef struct AppLayerGetFileState AppLayerGetFileState;
 /* for use with the detect_progress_ts|detect_progress_tc fields */
 
 /** should inspection be skipped in that direction */
-#define APP_LAYER_TX_SKIP_INSPECT_TS BIT_U8(0)
-#define APP_LAYER_TX_SKIP_INSPECT_TC BIT_U8(1)
+// defined in rust
+// #define APP_LAYER_TX_SKIP_INSPECT_TS BIT_U8(0)
+// #define APP_LAYER_TX_SKIP_INSPECT_TC BIT_U8(1)
 /** is tx fully inspected? */
 #define APP_LAYER_TX_INSPECTED_TS BIT_U8(2)
 #define APP_LAYER_TX_INSPECTED_TC BIT_U8(3)

--- a/src/flow.h
+++ b/src/flow.h
@@ -130,8 +130,9 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOWFILE_NO_MAGIC_TC            BIT_U16(1)
 
 /** even if the flow has files, don't store 'm */
-#define FLOWFILE_NO_STORE_TS            BIT_U16(2)
-#define FLOWFILE_NO_STORE_TC            BIT_U16(3)
+// defined in rust
+// #define FLOWFILE_NO_STORE_TS            BIT_U16(2)
+// #define FLOWFILE_NO_STORE_TC            BIT_U16(3)
 /** no md5 on files in this flow */
 #define FLOWFILE_NO_MD5_TS              BIT_U16(4)
 #define FLOWFILE_NO_MD5_TC              BIT_U16(5)
@@ -147,8 +148,9 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 // vacancy(2)
 
 /** store files in the flow */
-#define FLOWFILE_STORE_TS BIT_U16(12)
-#define FLOWFILE_STORE_TC BIT_U16(13)
+// defined in rust
+// #define FLOWFILE_STORE_TS BIT_U16(12)
+// #define FLOWFILE_STORE_TC BIT_U16(13)
 
 #define FLOWFILE_NONE_TS                                                                           \
     (FLOWFILE_NO_MAGIC_TS | FLOWFILE_NO_STORE_TS | FLOWFILE_NO_MD5_TS | FLOWFILE_NO_SHA1_TS |      \


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7666

Describe changes:

- rust/ffi: move ultimate example plugins dependencies on suricata to ffi crate (AppLayerTxData)

#15369 with additional commit for autotool build dependency magic
