### PR TITLE
Detect integers allmulti 7929 v9.1

### DIFF
--- a/doc/userguide/rules/enip-keyword.rst
+++ b/doc/userguide/rules/enip-keyword.rst
@@ -86,6 +86,8 @@ It uses a 32-bit unsigned integer as value.
 
 enip.cip_instance uses an :ref:`unsigned 32-bits integer <rules-integer-keywords>`.
 
+enip.cip_instance is also a :ref:`multi-integer <multi-integers>`.
+
 Examples::
 
   enip.cip_instance:1;
@@ -98,6 +100,8 @@ Match on the cip class in CIP request path.
 It uses a 32-bit unsigned integer as value.
 
 enip.cip_class uses an :ref:`unsigned 32-bits integer <rules-integer-keywords>`.
+
+enip.cip_class is also a :ref:`multi-integer <multi-integers>`.
 
 This allows to match without needing to match on cip.service.
 

--- a/doc/userguide/rules/enip-keyword.rst
+++ b/doc/userguide/rules/enip-keyword.rst
@@ -71,6 +71,8 @@ This allows to match without needing to match on cip.service.
 
 enip.cip_attribute uses an :ref:`unsigned 32-bits integer <rules-integer-keywords>`.
 
+enip.cip_attribute is also a :ref:`multi-integer <multi-integers>`.
+
 Examples::
 
   enip.cip_attribute:1;

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -1612,7 +1612,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         AppLayerTxMatch: Some(cip_status_match),
         Setup: Some(cip_status_setup),
         Free: Some(cip_status_free),
-        flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT,
+        flags: SIGMATCH_INFO_UINT8,
     };
     G_ENIP_CIP_STATUS_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_ENIP_CIP_STATUS_BUFFER_ID = SCDetectHelperBufferProgressRegister(
@@ -1645,7 +1645,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         AppLayerTxMatch: Some(cip_extendedstatus_match),
         Setup: Some(cip_extendedstatus_setup),
         Free: Some(cip_extendedstatus_free),
-        flags: SIGMATCH_INFO_UINT16 | SIGMATCH_INFO_MULTI_UINT,
+        flags: SIGMATCH_INFO_UINT16,
     };
     G_ENIP_CIP_EXTENDEDSTATUS_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_ENIP_CIP_EXTENDEDSTATUS_BUFFER_ID = SCDetectHelperBufferProgressRegister(

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -26,8 +26,8 @@ use std::os::raw::{c_int, c_void};
 use super::constant::{EnipCommand, EnipStatus};
 use super::enip::{EnipTransaction, ALPROTO_ENIP};
 use super::parser::{
-    CipData, CipDir, EnipCipRequestPayload, EnipCipResponsePayload, EnipItemPayload, EnipPayload,
-    CIP_MULTIPLE_SERVICE,
+    CipData, CipDir, EnipCipPathSegment, EnipCipRequestPayload, EnipCipResponsePayload,
+    EnipItemPayload, EnipPayload, CIP_MULTIPLE_SERVICE,
 };
 
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
@@ -294,18 +294,34 @@ fn enip_get_status(tx: &EnipTransaction, direction: Direction) -> Option<u32> {
     return None;
 }
 
+macro_rules! get_enip_segment_val {
+    ($segment_type:expr) => {
+        |seg: &EnipCipPathSegment| {
+            if seg.segment_type >> 2 == $segment_type {
+                Some(seg.value)
+            } else {
+                None
+            }
+        }
+    };
+}
+
 fn enip_cip_match_segment(
-    d: &CipData, ctx: &DetectUintData<u32>, segment_type: u8,
+    d: &CipData, ctx: &DetectUintArrayData<u32>, segment_type: u8, done: bool,
 ) -> std::os::raw::c_int {
     if let CipDir::Request(req) = &d.cipdir {
-        for seg in req.path.iter() {
-            if seg.segment_type >> 2 == segment_type && detect_match_uint(ctx, seg.value) {
-                return 1;
-            }
+        let r = detect_uint_match_at_index::<EnipCipPathSegment, u32>(
+            &req.path,
+            ctx,
+            get_enip_segment_val!(segment_type),
+            done,
+        );
+        if r == 1 {
+            return 1;
         }
         if let EnipCipRequestPayload::Multiple(m) = &req.payload {
             for p in m.packet_list.iter() {
-                if enip_cip_match_segment(p, ctx, segment_type) == 1 {
+                if enip_cip_match_segment(p, ctx, segment_type, done) == 1 {
                     return 1;
                 }
             }
@@ -315,13 +331,13 @@ fn enip_cip_match_segment(
 }
 
 fn enip_tx_has_cip_segment(
-    tx: &EnipTransaction, ctx: &DetectUintData<u32>, segment_type: u8,
+    tx: &EnipTransaction, ctx: &DetectUintArrayData<u32>, segment_type: u8,
 ) -> std::os::raw::c_int {
     if let Some(pdu) = &tx.request {
         if let EnipPayload::Cip(c) = &pdu.payload {
             for item in c.items.iter() {
                 if let EnipItemPayload::Data(d) = &item.payload {
-                    return enip_cip_match_segment(&d.cip, ctx, segment_type);
+                    return enip_cip_match_segment(&d.cip, ctx, segment_type, tx.done);
                 }
             }
         }
@@ -329,7 +345,9 @@ fn enip_tx_has_cip_segment(
     return 0;
 }
 
-fn enip_cip_match_attribute(d: &CipData, ctx: &DetectUintArrayData<u32>, done: bool) -> std::os::raw::c_int {
+fn enip_cip_match_attribute(
+    d: &CipData, ctx: &DetectUintArrayData<u32>, done: bool,
+) -> std::os::raw::c_int {
     if let CipDir::Request(req) = &d.cipdir {
         let mut vals = Vec::new();
         for seg in req.path.iter() {
@@ -609,7 +627,7 @@ unsafe extern "C" fn cip_class_setup(
     if SCDetectSignatureSetAppProto(s, ALPROTO_ENIP) != 0 {
         return -1;
     }
-    let ctx = SCDetectU32Parse(raw) as *mut c_void;
+    let ctx = SCDetectU32ArrayParse(raw) as *mut c_void;
     if ctx.is_null() {
         return -1;
     }
@@ -633,14 +651,14 @@ unsafe extern "C" fn cip_class_match(
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
     let tx = cast_pointer!(tx, EnipTransaction);
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
     return enip_tx_has_cip_segment(tx, ctx, 8);
 }
 
 unsafe extern "C" fn cip_class_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     // Just unbox...
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
-    SCDetectU32Free(ctx);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
+    SCDetectU32ArrayFree(ctx);
 }
 
 unsafe extern "C" fn vendor_id_setup(
@@ -1222,7 +1240,7 @@ unsafe extern "C" fn cip_instance_setup(
     if SCDetectSignatureSetAppProto(s, ALPROTO_ENIP) != 0 {
         return -1;
     }
-    let ctx = SCDetectU32Parse(raw) as *mut c_void;
+    let ctx = SCDetectU32ArrayParse(raw) as *mut c_void;
     if ctx.is_null() {
         return -1;
     }
@@ -1246,14 +1264,14 @@ unsafe extern "C" fn cip_instance_match(
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
     let tx = cast_pointer!(tx, EnipTransaction);
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
     return enip_tx_has_cip_segment(tx, ctx, 9);
 }
 
 unsafe extern "C" fn cip_instance_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     // Just unbox...
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
-    SCDetectU32Free(ctx);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
+    SCDetectU32ArrayFree(ctx);
 }
 
 unsafe extern "C" fn cip_extendedstatus_setup(

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -18,8 +18,8 @@
 use nom8::character::complete::{char, digit1, space0};
 use nom8::combinator::{map_opt, opt, verify};
 use nom8::error::{make_error, ErrorKind};
-use nom8::Parser;
 use nom8::IResult;
+use nom8::Parser;
 
 use std::os::raw::{c_int, c_void};
 
@@ -32,9 +32,10 @@ use super::parser::{
 
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
-    detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU16Free, SCDetectU16Match,
-    SCDetectU16Parse, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse, SCDetectU8Free,
-    SCDetectU8Match, SCDetectU8Parse,
+    detect_match_uint, detect_parse_uint_enum, detect_uint_match_at_index, DetectUintArrayData,
+    DetectUintData, DetectUintIndex, SCDetectU16Free, SCDetectU16Match, SCDetectU16Parse,
+    SCDetectU32ArrayFree, SCDetectU32ArrayParse, SCDetectU32Free, SCDetectU32Match,
+    SCDetectU32Parse, SCDetectU8Free, SCDetectU8Match, SCDetectU8Parse,
 };
 use crate::detect::{
     helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
@@ -42,9 +43,9 @@ use crate::detect::{
 };
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
-    SCDetectHelperBufferMpmRegister, SCDetectHelperBufferProgressRegister, SCDetectHelperKeywordRegister,
-    SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx,
-    Signature,
+    SCDetectHelperBufferMpmRegister, SCDetectHelperBufferProgressRegister,
+    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
+    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
 };
 
 use crate::direction::Direction;
@@ -84,7 +85,8 @@ fn enip_parse_cip_service(i: &str) -> IResult<&str, DetectCipServiceData> {
     let (i, _) = space0.parse(i)?;
     let (i, service) = verify(map_opt(digit1, |s: &str| s.parse::<u8>().ok()), |&v| {
         v < 0x80
-    }).parse(i)?;
+    })
+    .parse(i)?;
     let mut class = None;
     let mut attribute = None;
     let (i, _) = space0.parse(i)?;
@@ -327,49 +329,63 @@ fn enip_tx_has_cip_segment(
     return 0;
 }
 
-fn enip_cip_match_attribute(d: &CipData, ctx: &DetectUintData<u32>) -> std::os::raw::c_int {
+fn enip_cip_match_attribute(d: &CipData, ctx: &DetectUintArrayData<u32>, done: bool) -> std::os::raw::c_int {
     if let CipDir::Request(req) = &d.cipdir {
+        let mut vals = Vec::new();
         for seg in req.path.iter() {
-            if seg.segment_type >> 2 == 12 && detect_match_uint(ctx, seg.value) {
-                return 1;
+            if seg.segment_type >> 2 == 12 {
+                if ctx.index != DetectUintIndex::Any {
+                    vals.push(seg.value);
+                } else if detect_match_uint(&ctx.du, seg.value) {
+                    return 1;
+                }
             }
         }
         match &req.payload {
             EnipCipRequestPayload::GetAttributeList(ga) => {
                 for attrg in ga.attr_list.iter() {
-                    if detect_match_uint(ctx, (*attrg).into()) {
+                    if ctx.index != DetectUintIndex::Any {
+                        vals.push((*attrg).into());
+                    } else if detect_match_uint(&ctx.du, (*attrg).into()) {
                         return 1;
                     }
                 }
             }
             EnipCipRequestPayload::SetAttributeList(sa) => {
                 if let Some(val) = sa.first_attr {
-                    if detect_match_uint(ctx, val.into()) {
+                    if ctx.index != DetectUintIndex::Any {
+                        vals.push(val.into());
+                    } else if detect_match_uint(&ctx.du, val.into()) {
                         return 1;
                     }
                 }
             }
             EnipCipRequestPayload::Multiple(m) => {
                 for p in m.packet_list.iter() {
-                    if enip_cip_match_attribute(p, ctx) == 1 {
+                    // treat each array independently
+                    if enip_cip_match_attribute(p, ctx, done) == 1 {
                         return 1;
                     }
                 }
             }
             _ => {}
         }
+        if ctx.index != DetectUintIndex::Any {
+            return detect_uint_match_at_index::<u32, u32>(&vals, ctx, |v| Some(*v), done);
+        }
     }
     return 0;
 }
 
 fn enip_tx_has_cip_attribute(
-    tx: &EnipTransaction, ctx: &DetectUintData<u32>,
+    tx: &EnipTransaction, ctx: &DetectUintArrayData<u32>,
 ) -> std::os::raw::c_int {
     if let Some(pdu) = &tx.request {
         if let EnipPayload::Cip(c) = &pdu.payload {
             for item in c.items.iter() {
                 if let EnipItemPayload::Data(d) = &item.payload {
-                    return enip_cip_match_attribute(&d.cip, ctx);
+                    // there should be only one EnipItemPayload item
+                    return enip_cip_match_attribute(&d.cip, ctx, tx.done);
                 }
             }
         }
@@ -553,7 +569,7 @@ unsafe extern "C" fn cip_attribute_setup(
     if SCDetectSignatureSetAppProto(s, ALPROTO_ENIP) != 0 {
         return -1;
     }
-    let ctx = SCDetectU32Parse(raw) as *mut c_void;
+    let ctx = SCDetectU32ArrayParse(raw) as *mut c_void;
     if ctx.is_null() {
         return -1;
     }
@@ -577,14 +593,14 @@ unsafe extern "C" fn cip_attribute_match(
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
     let tx = cast_pointer!(tx, EnipTransaction);
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
     return enip_tx_has_cip_attribute(tx, ctx);
 }
 
 unsafe extern "C" fn cip_attribute_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     // Just unbox...
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
-    SCDetectU32Free(ctx);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
+    SCDetectU32ArrayFree(ctx);
 }
 
 unsafe extern "C" fn cip_class_setup(

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -29,7 +29,7 @@ use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Match,
 };
-use crate::detect::{SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_MULTI_UINT, SIGMATCH_INFO_UINT32};
+use crate::detect::{SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT32};
 use kerberos_parser::krb5::EncryptionType;
 
 use nom8::branch::alt;
@@ -437,7 +437,7 @@ pub unsafe extern "C" fn SCDetectKrb5MsgTypeRegister() {
         AppLayerTxMatch: Some(krb5_msg_type_match),
         Setup: Some(krb5_msg_type_setup),
         Free: Some(krb5_msg_type_free),
-        flags: SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT | SIGMATCH_INFO_UINT32,
+        flags: SIGMATCH_INFO_ENUM_UINT | SIGMATCH_INFO_UINT32,
     };
     G_KRB5_MSG_TYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_KRB5_MSG_TYPE_BUFFER_ID = SCDetectHelperBufferProgressRegister(


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7929

Describe changes:
- remove wrongly flagged SIGMATCH_INFO_MULTI_UINT for certain keywords like krb5_msg_type
- make enip keywords support multi-integer options

Follow-up on https://github.com/OISF/suricata/pull/15297

Still TODO after
- bitflags mqtt.flags and mqtt.connect.flags
- nfs_procedure (not sure it makes sense as only used for bigger non-atomic file txs)
- filesize