### PR TITLE
detect: guard rate filter callback registration

### DIFF
--- a/examples/lib/custom/main.c
+++ b/examples/lib/custom/main.c
@@ -253,7 +253,9 @@ int main(int argc, char **argv)
      * ThreadVars will be ready. */
     SuricataInit();
 
-    SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    if (DetectEngineEnabled()) {
+        SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    }
 
     /* Spawn our worker threads. */
     pthread_t worker;

--- a/examples/lib/live/main.c
+++ b/examples/lib/live/main.c
@@ -306,7 +306,9 @@ int main(int argc, char **argv)
      * ThreadVars will be ready. */
     SuricataInit();
 
-    SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    if (DetectEngineEnabled()) {
+        SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    }
 
     /* Spawn our worker threads, one for each interface. */
     pthread_t workers[MAX_INTERFACES];

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -5122,17 +5122,18 @@ void DetectLowerSetupCallback(
     }
 }
 
-void SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc fn, void *arg)
+bool SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc fn, void *arg)
 {
     DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
     if (de_ctx == NULL) {
         SCLogError("no detection engine available for rate filter callback registration");
-        return;
+        return false;
     }
 
     de_ctx->RateFilterCallback = fn;
     de_ctx->rate_filter_callback_arg = arg;
     DetectEngineDeReference(&de_ctx);
+    return true;
 }
 
 int DetectEngineThreadCtxGetJsonContext(DetectEngineThreadCtx *det_ctx)

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -5125,6 +5125,11 @@ void DetectLowerSetupCallback(
 void SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc fn, void *arg)
 {
     DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    if (de_ctx == NULL) {
+        SCLogError("no detection engine available for rate filter callback registration");
+        return;
+    }
+
     de_ctx->RateFilterCallback = fn;
     de_ctx->rate_filter_callback_arg = arg;
     DetectEngineDeReference(&de_ctx);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1175,7 +1175,7 @@ typedef struct DetectEngineCtx_ {
  * This callback is added to the current detection engine and will be
  * copied to all future detection engines over rule reloads.
  */
-void SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc cb, void *arg);
+bool SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc cb, void *arg);
 
 /* Engine groups profiles (low, medium, high, custom) */
 enum {


### PR DESCRIPTION
Ticket: 8560

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8560

Describe changes:
- Guard `SCDetectEngineRegisterRateFilterCallback()` against a NULL return from `DetectEngineGetCurrent()`.
- Avoid a NULL pointer dereference when this public extension API is called while no suitable current detect engine is available.
- This API is documented in the devguide and used by the bundled library examples, so callers should not be able to crash Suricata due to a missing internal detect-engine context.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
