### PR TITLE
pcap-file: skip setvbuf on non-seekable streams

### DIFF
--- a/doc/userguide/capture-hardware/pcap-file.rst
+++ b/doc/userguide/capture-hardware/pcap-file.rst
@@ -33,6 +33,10 @@ This can improve performance, especially for large files.
 The size can be specified through the command line option, see
 :ref:`--pcap-file-buffer-size <cmdline-option-pcap-file-buffer-size>`
 
+Setting ``buffer-size`` to ``0`` disables ``setvbuf`` buffering. This is the
+explicit opt-out for non-seekable sources such as ``/dev/stdin`` or named
+pipes, where buffering the underlying file descriptor is not supported.
+
 Directory-related options
 -------------------------
 

--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -103,7 +103,8 @@
 .. option:: --pcap-file-buffer-size <value>
 
    Set read buffer size using ``setvbuf`` to speed up pcap reading. Valid values
-   are 4 KiB to 64 MiB. Default value is 128 KiB. Supported on Linux only.
+   are 0 to 64 MiB, where 0 disables ``setvbuf`` buffering. Default value is
+   128 KiB. Supported on Linux only.
 
 .. option::  -i <interface>
 

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -271,10 +271,16 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
 
 #if defined(HAVE_SETVBUF) && defined(OS_LINUX)
     if (pcap_g.read_buffer_size > 0) {
-        errno = 0;
-        if (setvbuf(pcap_file(pfv->pcap_handle), pfv->buffer, _IOFBF, pcap_g.read_buffer_size) <
-                0) {
-            SCLogWarning("Failed to setvbuf on PCAP file handle: %s", strerror(errno));
+        struct stat sb;
+        int fd = fileno(pcap_file(pfv->pcap_handle));
+        if (fd >= 0 && fstat(fd, &sb) == 0 && !S_ISREG(sb.st_mode)) {
+            SCLogInfo("%s: skipping setvbuf, underlying fd is not a regular file", pfv->filename);
+        } else {
+            errno = 0;
+            if (setvbuf(pcap_file(pfv->pcap_handle), pfv->buffer, _IOFBF, pcap_g.read_buffer_size) <
+                    0) {
+                SCLogWarning("Failed to setvbuf on PCAP file handle: %s", strerror(errno));
+            }
         }
     }
 #endif

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -140,7 +140,7 @@ void TmModuleDecodePcapFileRegister (void)
 
 #if defined(HAVE_SETVBUF) && defined(OS_LINUX)
 #define PCAP_FILE_BUFFER_SIZE_DEFAULT 131072U   // 128 KiB
-#define PCAP_FILE_BUFFER_SIZE_MIN     4096U     // 4 KiB
+#define PCAP_FILE_BUFFER_SIZE_MIN     0U        // 0 disables setvbuf
 #define PCAP_FILE_BUFFER_SIZE_MAX     67108864U // 64MiB
 #endif
 
@@ -158,14 +158,14 @@ void PcapFileGlobalInit(void)
     if (SCConfGet("pcap-file.buffer-size", &str) == 1) {
         uint32_t value = 0;
         if (ParseSizeStringU32(str, &value) < 0) {
-            SCLogWarning("failed to parse pcap-file.buffer-size %s", str);
-        }
-        if (value >= PCAP_FILE_BUFFER_SIZE_MIN && value <= PCAP_FILE_BUFFER_SIZE_MAX) {
+            SCLogWarning("failed to parse pcap-file.buffer-size %s; keeping default %u", str,
+                    PCAP_FILE_BUFFER_SIZE_DEFAULT);
+        } else if (value <= PCAP_FILE_BUFFER_SIZE_MAX) {
             SCLogInfo("Pcap-file will use %u buffer size", value);
             pcap_g.read_buffer_size = value;
         } else {
-            SCLogWarning("pcap-file.buffer-size value of %u is invalid. Valid range is %u-%u",
-                    value, PCAP_FILE_BUFFER_SIZE_MIN, PCAP_FILE_BUFFER_SIZE_MAX);
+            SCLogWarning("pcap-file.buffer-size value of %u is invalid. Maximum is %u", value,
+                    PCAP_FILE_BUFFER_SIZE_MAX);
         }
     }
 #endif


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8464

Reading a pcap from /dev/stdin or a named pipe regressed in 8.0.0 with the setvbuf change in 7b730c2e6 and currently fails with `failed to get first packet timestamp. pcap_next_ex(): -1`. The reason is that InitPcapFile calls setvbuf on the FILE* underlying the pcap handle after libpcap has already consumed the pcap header, and on a non seekable fd glibc cannot recover from that and the very next read returns -1. This change detects non regular files via fstat on the underlying fd and skips setvbuf for that handle, so reading from stdin, named pipes, and other non seekable sources keeps working. It also lowers PCAP_FILE_BUFFER_SIZE_MIN to 0 so `pcap-file.buffer-size = 0` stays available as an explicit opt out, matching the workaround proposed on the ticket.

Describe changes:
- In InitPcapFile, fstat the fd behind pcap_file(handle) and skip setvbuf when the file is not a regular file. An info log explains the skip.
- Lower PCAP_FILE_BUFFER_SIZE_MIN from 4096 to 0 so users can opt out of setvbuf explicitly via pcap-file.buffer-size = 0.
- Verified locally that tcpdump piping a pcap into /dev/stdin and reading from a named pipe both now complete with 2 packets read and 0 errors. Regular file reads are unchanged.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3108