### PR TITLE
8.0.x: backport ntp keywords and firewall support - v1

### DIFF
--- a/doc/userguide/lua/libs/index.rst
+++ b/doc/userguide/lua/libs/index.rst
@@ -20,6 +20,7 @@ environment without access to additional modules.
    hashlib
    http
    log
+   ntp
    packetlib
    rule
    smtp

--- a/doc/userguide/lua/libs/ntp.rst
+++ b/doc/userguide/lua/libs/ntp.rst
@@ -1,0 +1,69 @@
+NTP
+###
+
+NTP transaction details are exposed to Lua scripts with the
+``suricata.ntp`` library, for example::
+
+  local ntp = require("suricata.ntp")
+
+Setup
+*****
+
+If your purpose is to create a logging script, initialize the buffer as:
+
+::
+
+  function init (args)
+     local needs = {}
+     needs["protocol"] = "ntp"
+     return needs
+  end
+
+Transaction
+***********
+
+NTP is transaction based, and the current transaction must be obtained
+before use::
+
+  local tx, err = ntp.get_tx()
+  if tx == nil then
+      print(err)
+  end
+
+All other functions are methods on the transaction table.
+
+Transaction Methods
+*******************
+
+``version()``
+=============
+
+Get the NTP version as an integer.
+
+``mode()``
+==========
+
+Get the NTP mode as an integer.
+
+``stratum()``
+=============
+
+Get the NTP stratum as an integer.
+
+``reference_id()``
+==================
+
+Get the NTP reference ID as a raw 4-byte binary string.
+
+Example::
+
+  local tx, err = ntp.get_tx()
+  local ref_id = tx:reference_id()
+  if ref_id == "\x4c\x4f\x43\x4c" then
+    -- ref_id matches "LOCL"
+  end
+
+  -- If looking for a specific printable string, this is also valid
+  if ref_id == "LOCL" then
+    ...
+  end

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -235,6 +235,8 @@ outputs:
         - ssh
         - arp:
             enabled: no
+        - ntp:
+            enabled: no
         - snmp
         - rfb
         - sip

--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -28,6 +28,7 @@ Suricata Rules
    kerberos-keywords
    smb-keywords
    snmp-keywords
+   ntp-keywords
    base64-keywords
    sip-keywords
    sdp-keywords

--- a/doc/userguide/rules/ntp-keywords.rst
+++ b/doc/userguide/rules/ntp-keywords.rst
@@ -3,6 +3,29 @@ NTP Keywords
 
 .. role:: example-rule-options
 
+ntp.stratum
+***********
+
+NTP stratum (integer).
+
+``ntp.stratum`` uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+
+Syntax::
+
+  ntp.stratum:[op]<number>
+
+The stratum can be matched exactly, or compared using the ``op`` setting::
+
+  ntp.stratum:2    # exactly 2
+  ntp.stratum:<16  # smaller than 16
+  ntp.stratum:>=1  # greater or equal than 1
+
+Signature Example:
+
+.. container:: example-rule
+
+  alert ntp any any -> any any (msg:"NTP stratum 2"; :example-rule-options:`ntp.stratum:2;` sid:1; rev:1;)
+
 ntp.version
 ***********
 
@@ -24,4 +47,4 @@ Signature Example:
 
 .. container:: example-rule
 
-  alert ntp any any -> any any (msg:"NTP version 4"; :example-rule-options:`ntp.version:4;` sid:1; rev:1;)
+  alert ntp any any -> any any (msg:"NTP version 4"; :example-rule-options:`ntp.version:4;` sid:2; rev:1;)

--- a/doc/userguide/rules/ntp-keywords.rst
+++ b/doc/userguide/rules/ntp-keywords.rst
@@ -36,6 +36,23 @@ Signature Example:
 
   alert ntp any any -> any any (msg:"NTP client mode"; :example-rule-options:`ntp.mode:client;` sid:1; rev:1;)
 
+ntp.reference_id
+****************
+
+``ntp.reference_id`` is a sticky buffer exposing the 4-byte NTP
+reference ID.
+
+Examples::
+
+  ntp.reference_id; content:"RATE";
+  ntp.reference_id; content:"|0a 00 00 01|";
+
+Signature Example:
+
+.. container:: example-rule
+
+  alert ntp any any -> any any (msg:"NTP reference ID RATE"; :example-rule-emphasis:`ntp.reference_id; content:"RATE";` sid:4; rev:1;)
+
 ntp.stratum
 ***********
 

--- a/doc/userguide/rules/ntp-keywords.rst
+++ b/doc/userguide/rules/ntp-keywords.rst
@@ -1,0 +1,27 @@
+NTP Keywords
+############
+
+.. role:: example-rule-options
+
+ntp.version
+***********
+
+NTP protocol version (integer). Expected values are 3 and 4.
+
+``ntp.version`` uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+
+Syntax::
+
+  ntp.version:[op]<number>
+
+The version can be matched exactly, or compared using the ``op`` setting::
+
+  ntp.version:4    # exactly 4
+  ntp.version:<4   # smaller than 4
+  ntp.version:>=3  # greater or equal than 3
+
+Signature Example:
+
+.. container:: example-rule
+
+  alert ntp any any -> any any (msg:"NTP version 4"; :example-rule-options:`ntp.version:4;` sid:1; rev:1;)

--- a/doc/userguide/rules/ntp-keywords.rst
+++ b/doc/userguide/rules/ntp-keywords.rst
@@ -3,6 +3,39 @@ NTP Keywords
 
 .. role:: example-rule-options
 
+ntp.mode
+********
+
+NTP mode. This keyword accepts either an integer or one of the known mode
+names.
+
+``ntp.mode`` uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+
+Syntax::
+
+  ntp.mode:[op]<number>
+  ntp.mode:[!]reserved
+  ntp.mode:[!]symmetric_active
+  ntp.mode:[!]symmetric_passive
+  ntp.mode:[!]client
+  ntp.mode:[!]server
+  ntp.mode:[!]broadcast
+  ntp.mode:[!]control
+  ntp.mode:[!]private
+
+Examples::
+
+  ntp.mode:3
+  ntp.mode:>3
+  ntp.mode:client
+  ntp.mode:!server
+
+Signature Example:
+
+.. container:: example-rule
+
+  alert ntp any any -> any any (msg:"NTP client mode"; :example-rule-options:`ntp.mode:client;` sid:1; rev:1;)
+
 ntp.stratum
 ***********
 
@@ -24,7 +57,7 @@ Signature Example:
 
 .. container:: example-rule
 
-  alert ntp any any -> any any (msg:"NTP stratum 2"; :example-rule-options:`ntp.stratum:2;` sid:1; rev:1;)
+  alert ntp any any -> any any (msg:"NTP stratum 2"; :example-rule-options:`ntp.stratum:2;` sid:2; rev:1;)
 
 ntp.version
 ***********
@@ -47,4 +80,4 @@ Signature Example:
 
 .. container:: example-rule
 
-  alert ntp any any -> any any (msg:"NTP version 4"; :example-rule-options:`ntp.version:4;` sid:2; rev:1;)
+  alert ntp any any -> any any (msg:"NTP version 4"; :example-rule-options:`ntp.version:4;` sid:3; rev:1;)

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4437,6 +4437,16 @@
             },
             "optional": true
         },
+        "ntp": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "reference_id": {
+                    "type": "integer",
+                    "description": "Identifies specific server or reference clock"
+                }
+            }
+        },
         "packet": {
             "type": "string"
         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4441,9 +4441,21 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "mode": {
+                    "type": "integer",
+                    "description": "The mode of the NTP message"
+                },
                 "reference_id": {
                     "type": "integer",
                     "description": "Identifies specific server or reference clock"
+                },
+                "stratum": {
+                    "type": "integer",
+                    "description": "Indicates distance from the reference clock"
+                },
+                "version": {
+                    "type": "integer",
+                    "description": "The NTP version number, typically 3 or 4"
                 }
             }
         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4446,8 +4446,8 @@
                     "description": "The mode of the NTP message"
                 },
                 "reference_id": {
-                    "type": "integer",
-                    "description": "Identifies specific server or reference clock"
+                    "type": "string",
+                    "description": "Identifies specific server or reference clock as a colon-separated 4-byte hex string"
                 },
                 "stratum": {
                     "type": "integer",

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4443,19 +4443,39 @@
             "properties": {
                 "mode": {
                     "type": "integer",
-                    "description": "The mode of the NTP message"
+                    "description": "The mode of the NTP message",
+                    "suricata": {
+                        "keywords": [
+                            "ntp.mode"
+                        ]
+                    }
                 },
                 "reference_id": {
                     "type": "string",
-                    "description": "Identifies specific server or reference clock as a colon-separated 4-byte hex string"
+                    "description": "Identifies specific server or reference clock as a colon-separated 4-byte hex string",
+                    "suricata": {
+                        "keywords": [
+                            "ntp.reference_id"
+                        ]
+                    }
                 },
                 "stratum": {
                     "type": "integer",
-                    "description": "Indicates distance from the reference clock"
+                    "description": "Indicates distance from the reference clock",
+                    "suricata": {
+                        "keywords": [
+                            "ntp.stratum"
+                        ]
+                    }
                 },
                 "version": {
                     "type": "integer",
-                    "description": "The NTP version number, typically 3 or 4"
+                    "description": "The NTP version number, typically 3 or 4",
+                    "suricata": {
+                        "keywords": [
+                            "ntp.version"
+                        ]
+                    }
                 }
             }
         },

--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -56,6 +56,12 @@ impl LuaState {
         }
     }
 
+    pub fn pushbytes(&self, val: &[u8]) {
+        unsafe {
+            lua_pushlstring(self.lua, val.as_ptr() as *const c_char, val.len());
+        }
+    }
+
     pub fn pushinteger(&self, val: i64) {
         unsafe {
             lua_pushinteger(self.lua, val);

--- a/rust/src/ntp/detect.rs
+++ b/rust/src/ntp/detect.rs
@@ -20,11 +20,15 @@ use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_parse_uint_enum, DetectUintData, SCDetectU8Free, SCDetectU8Match, SCDetectU8Parse,
 };
-use crate::detect::{SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT8};
+use crate::detect::{
+    helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
+    SIGMATCH_INFO_UINT8,
+};
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
-    DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectHelperBufferProgressRegister,
+    DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
+    SCDetectHelperBufferProgressMpmRegister, SCDetectHelperBufferProgressRegister,
     SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
     SCSigTableAppLiteElmt, SigMatchCtx, Signature,
 };
@@ -33,6 +37,7 @@ static mut G_NTP_VERSION_KW_ID: u16 = 0;
 static mut G_NTP_MODE_KW_ID: u16 = 0;
 static mut G_NTP_STRATUM_KW_ID: u16 = 0;
 static mut G_NTP_GENERIC_BUFFER_ID: c_int = 0;
+static mut G_NTP_REFERENCE_ID_BUFFER_ID: c_int = 0;
 
 #[derive(Clone, Debug, PartialEq, EnumStringU8)]
 #[repr(u8)]
@@ -165,6 +170,27 @@ unsafe extern "C" fn ntp_detect_stratum_match(
     return SCDetectU8Match(tx.stratum, ctx);
 }
 
+unsafe extern "C" fn ntp_detect_reference_id_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_NTP) != 0 {
+        return -1;
+    }
+    if SCDetectBufferSetActiveList(de, s, G_NTP_REFERENCE_ID_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn ntp_detect_reference_id_get_data(
+    tx: *const c_void, _flow_flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, NTPTransaction);
+    *buffer = tx.reference_id.as_ptr();
+    *buffer_len = tx.reference_id.len() as u32;
+    true
+}
+
 pub(super) unsafe extern "C" fn detect_ntp_register() {
     let kw = SCSigTableAppLiteElmt {
         name: b"ntp.version\0".as_ptr() as *const libc::c_char,
@@ -204,6 +230,22 @@ pub(super) unsafe extern "C" fn detect_ntp_register() {
         flags: SIGMATCH_INFO_UINT8,
     };
     G_NTP_STRATUM_KW_ID = SCDetectHelperKeywordRegister(&kw);
+
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("ntp.reference_id"),
+        desc: String::from("sticky buffer to match on the NTP reference ID"),
+        url: String::from("/rules/ntp-keywords.html#ntp-reference-id"),
+        setup: ntp_detect_reference_id_setup,
+    };
+    let _g_ntp_reference_id_kw_id = helper_keyword_register_sticky_buffer(&kw);
+    G_NTP_REFERENCE_ID_BUFFER_ID = SCDetectHelperBufferProgressMpmRegister(
+        b"ntp.reference_id\0".as_ptr() as *const libc::c_char,
+        b"NTP reference ID\0".as_ptr() as *const libc::c_char,
+        ALPROTO_NTP,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        Some(ntp_detect_reference_id_get_data),
+        1,
+    );
 }
 
 #[cfg(test)]

--- a/rust/src/ntp/detect.rs
+++ b/rust/src/ntp/detect.rs
@@ -1,0 +1,88 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use super::ntp::{NTPTransaction, ALPROTO_NTP};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::detect::uint::{DetectUintData, SCDetectU8Free, SCDetectU8Match, SCDetectU8Parse};
+use crate::detect::SIGMATCH_INFO_UINT8;
+use std::os::raw::{c_int, c_void};
+use suricata_sys::sys::{
+    DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectHelperBufferProgressRegister,
+    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
+    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+};
+
+static mut G_NTP_VERSION_KW_ID: u16 = 0;
+static mut G_NTP_GENERIC_BUFFER_ID: c_int = 0;
+
+unsafe extern "C" fn ntp_detect_version_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const libc::c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_NTP) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU8Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_NTP_VERSION_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_NTP_GENERIC_BUFFER_ID,
+    )
+    .is_null()
+    {
+        ntp_detect_version_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn ntp_detect_version_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, _flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, NTPTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    return SCDetectU8Match(tx.version, ctx);
+}
+
+unsafe extern "C" fn ntp_detect_version_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    SCDetectU8Free(ctx);
+}
+
+pub(super) unsafe extern "C" fn detect_ntp_register() {
+    let kw = SCSigTableAppLiteElmt {
+        name: b"ntp.version\0".as_ptr() as *const libc::c_char,
+        desc: b"match NTP version\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/ntp-keywords.html#ntp-version\0".as_ptr() as *const libc::c_char,
+        AppLayerTxMatch: Some(ntp_detect_version_match),
+        Setup: Some(ntp_detect_version_setup),
+        Free: Some(ntp_detect_version_free),
+        flags: SIGMATCH_INFO_UINT8,
+    };
+    G_NTP_VERSION_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_NTP_GENERIC_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"ntp.generic\0".as_ptr() as *const libc::c_char,
+        ALPROTO_NTP,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        1,
+    );
+}

--- a/rust/src/ntp/detect.rs
+++ b/rust/src/ntp/detect.rs
@@ -27,6 +27,7 @@ use suricata_sys::sys::{
 };
 
 static mut G_NTP_VERSION_KW_ID: u16 = 0;
+static mut G_NTP_STRATUM_KW_ID: u16 = 0;
 static mut G_NTP_GENERIC_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn ntp_detect_version_setup(
@@ -48,7 +49,7 @@ unsafe extern "C" fn ntp_detect_version_setup(
     )
     .is_null()
     {
-        ntp_detect_version_free(std::ptr::null_mut(), ctx);
+        ntp_detect_u8_free(std::ptr::null_mut(), ctx);
         return -1;
     }
     return 0;
@@ -63,9 +64,43 @@ unsafe extern "C" fn ntp_detect_version_match(
     return SCDetectU8Match(tx.version, ctx);
 }
 
-unsafe extern "C" fn ntp_detect_version_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+unsafe extern "C" fn ntp_detect_u8_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     let ctx = cast_pointer!(ctx, DetectUintData<u8>);
     SCDetectU8Free(ctx);
+}
+
+unsafe extern "C" fn ntp_detect_stratum_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const libc::c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_NTP) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU8Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_NTP_STRATUM_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_NTP_GENERIC_BUFFER_ID,
+    )
+    .is_null()
+    {
+        ntp_detect_u8_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn ntp_detect_stratum_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, _flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, NTPTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    return SCDetectU8Match(tx.stratum, ctx);
 }
 
 pub(super) unsafe extern "C" fn detect_ntp_register() {
@@ -75,7 +110,7 @@ pub(super) unsafe extern "C" fn detect_ntp_register() {
         url: b"/rules/ntp-keywords.html#ntp-version\0".as_ptr() as *const libc::c_char,
         AppLayerTxMatch: Some(ntp_detect_version_match),
         Setup: Some(ntp_detect_version_setup),
-        Free: Some(ntp_detect_version_free),
+        Free: Some(ntp_detect_u8_free),
         flags: SIGMATCH_INFO_UINT8,
     };
     G_NTP_VERSION_KW_ID = SCDetectHelperKeywordRegister(&kw);
@@ -85,4 +120,15 @@ pub(super) unsafe extern "C" fn detect_ntp_register() {
         STREAM_TOSERVER | STREAM_TOCLIENT,
         1,
     );
+
+    let kw = SCSigTableAppLiteElmt {
+        name: b"ntp.stratum\0".as_ptr() as *const libc::c_char,
+        desc: b"match NTP stratum\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/ntp-keywords.html#ntp-stratum\0".as_ptr() as *const libc::c_char,
+        AppLayerTxMatch: Some(ntp_detect_stratum_match),
+        Setup: Some(ntp_detect_stratum_setup),
+        Free: Some(ntp_detect_u8_free),
+        flags: SIGMATCH_INFO_UINT8,
+    };
+    G_NTP_STRATUM_KW_ID = SCDetectHelperKeywordRegister(&kw);
 }

--- a/rust/src/ntp/detect.rs
+++ b/rust/src/ntp/detect.rs
@@ -17,8 +17,11 @@
 
 use super::ntp::{NTPTransaction, ALPROTO_NTP};
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
-use crate::detect::uint::{DetectUintData, SCDetectU8Free, SCDetectU8Match, SCDetectU8Parse};
-use crate::detect::SIGMATCH_INFO_UINT8;
+use crate::detect::uint::{
+    detect_parse_uint_enum, DetectUintData, SCDetectU8Free, SCDetectU8Match, SCDetectU8Parse,
+};
+use crate::detect::{SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT8};
+use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectHelperBufferProgressRegister,
@@ -27,8 +30,22 @@ use suricata_sys::sys::{
 };
 
 static mut G_NTP_VERSION_KW_ID: u16 = 0;
+static mut G_NTP_MODE_KW_ID: u16 = 0;
 static mut G_NTP_STRATUM_KW_ID: u16 = 0;
 static mut G_NTP_GENERIC_BUFFER_ID: c_int = 0;
+
+#[derive(Clone, Debug, PartialEq, EnumStringU8)]
+#[repr(u8)]
+pub enum NTPMode {
+    Reserved = 0,
+    SymmetricActive = 1,
+    SymmetricPassive = 2,
+    Client = 3,
+    Server = 4,
+    Broadcast = 5,
+    Control = 6,
+    Private = 7,
+}
 
 unsafe extern "C" fn ntp_detect_version_setup(
     de: *mut DetectEngineCtx, s: *mut Signature, raw: *const libc::c_char,
@@ -67,6 +84,51 @@ unsafe extern "C" fn ntp_detect_version_match(
 unsafe extern "C" fn ntp_detect_u8_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     let ctx = cast_pointer!(ctx, DetectUintData<u8>);
     SCDetectU8Free(ctx);
+}
+
+unsafe extern "C" fn ntp_detect_mode_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const libc::c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_NTP) != 0 {
+        return -1;
+    }
+    let ctx = ntp_parse_mode(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_NTP_MODE_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_NTP_GENERIC_BUFFER_ID,
+    )
+    .is_null()
+    {
+        ntp_detect_u8_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn ntp_parse_mode(ustr: *const std::os::raw::c_char) -> *mut DetectUintData<u8> {
+    let ft_name: &CStr = CStr::from_ptr(ustr);
+    if let Ok(s) = ft_name.to_str() {
+        if let Some(ctx) = detect_parse_uint_enum::<u8, NTPMode>(s) {
+            let boxed = Box::new(ctx);
+            return Box::into_raw(boxed);
+        }
+    }
+    return std::ptr::null_mut();
+}
+
+unsafe extern "C" fn ntp_detect_mode_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, _flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, NTPTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    return SCDetectU8Match(tx.mode, ctx);
 }
 
 unsafe extern "C" fn ntp_detect_stratum_setup(
@@ -122,6 +184,17 @@ pub(super) unsafe extern "C" fn detect_ntp_register() {
     );
 
     let kw = SCSigTableAppLiteElmt {
+        name: b"ntp.mode\0".as_ptr() as *const libc::c_char,
+        desc: b"match NTP mode\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/ntp-keywords.html#ntp-mode\0".as_ptr() as *const libc::c_char,
+        AppLayerTxMatch: Some(ntp_detect_mode_match),
+        Setup: Some(ntp_detect_mode_setup),
+        Free: Some(ntp_detect_u8_free),
+        flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_ENUM_UINT,
+    };
+    G_NTP_MODE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+
+    let kw = SCSigTableAppLiteElmt {
         name: b"ntp.stratum\0".as_ptr() as *const libc::c_char,
         desc: b"match NTP stratum\0".as_ptr() as *const libc::c_char,
         url: b"/rules/ntp-keywords.html#ntp-stratum\0".as_ptr() as *const libc::c_char,
@@ -131,4 +204,59 @@ pub(super) unsafe extern "C" fn detect_ntp_register() {
         flags: SIGMATCH_INFO_UINT8,
     };
     G_NTP_STRATUM_KW_ID = SCDetectHelperKeywordRegister(&kw);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::detect::uint::DetectUintMode;
+
+    #[test]
+    fn test_ntp_parse_known_mode_strings() {
+        let ctx = detect_parse_uint_enum::<u8, NTPMode>("reserved").unwrap();
+        assert_eq!(ctx.arg1, 0);
+        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
+
+        let ctx = detect_parse_uint_enum::<u8, NTPMode>("symmetric_active").unwrap();
+        assert_eq!(ctx.arg1, 1);
+        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
+
+        let ctx = detect_parse_uint_enum::<u8, NTPMode>("symmetric_passive").unwrap();
+        assert_eq!(ctx.arg1, 2);
+        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
+
+        let ctx = detect_parse_uint_enum::<u8, NTPMode>("client").unwrap();
+        assert_eq!(ctx.arg1, 3);
+        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
+
+        let ctx = detect_parse_uint_enum::<u8, NTPMode>("server").unwrap();
+        assert_eq!(ctx.arg1, 4);
+        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
+
+        let ctx = detect_parse_uint_enum::<u8, NTPMode>("broadcast").unwrap();
+        assert_eq!(ctx.arg1, 5);
+        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
+
+        let ctx = detect_parse_uint_enum::<u8, NTPMode>("control").unwrap();
+        assert_eq!(ctx.arg1, 6);
+        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
+
+        let ctx = detect_parse_uint_enum::<u8, NTPMode>("private").unwrap();
+        assert_eq!(ctx.arg1, 7);
+        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
+    }
+
+    #[test]
+    fn test_ntp_parse_mode_integer() {
+        let ctx = detect_parse_uint_enum::<u8, NTPMode>("255").unwrap();
+        assert_eq!(ctx.arg1, 255);
+        assert_eq!(ctx.mode, DetectUintMode::DetectUintModeEqual);
+    }
+
+    #[test]
+    fn test_ntp_parse_mode_invalid() {
+        assert!(detect_parse_uint_enum::<u8, NTPMode>("invalid_mode").is_none());
+        assert!(detect_parse_uint_enum::<u8, NTPMode>("symmetric_private").is_none());
+        assert!(detect_parse_uint_enum::<u8, NTPMode>("256").is_none());
+    }
 }

--- a/rust/src/ntp/detect.rs
+++ b/rust/src/ntp/detect.rs
@@ -21,8 +21,7 @@ use crate::detect::uint::{
     detect_parse_uint_enum, DetectUintData, SCDetectU8Free, SCDetectU8Match, SCDetectU8Parse,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
-    SIGMATCH_INFO_UINT8,
+    helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_SUPPORT_FIREWALL,
 };
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
@@ -199,7 +198,7 @@ pub(super) unsafe extern "C" fn detect_ntp_register() {
         AppLayerTxMatch: Some(ntp_detect_version_match),
         Setup: Some(ntp_detect_version_setup),
         Free: Some(ntp_detect_u8_free),
-        flags: SIGMATCH_INFO_UINT8,
+        flags: SIGMATCH_SUPPORT_FIREWALL,
     };
     G_NTP_VERSION_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_NTP_GENERIC_BUFFER_ID = SCDetectHelperBufferProgressRegister(
@@ -216,7 +215,7 @@ pub(super) unsafe extern "C" fn detect_ntp_register() {
         AppLayerTxMatch: Some(ntp_detect_mode_match),
         Setup: Some(ntp_detect_mode_setup),
         Free: Some(ntp_detect_u8_free),
-        flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_ENUM_UINT,
+        flags: SIGMATCH_SUPPORT_FIREWALL,
     };
     G_NTP_MODE_KW_ID = SCDetectHelperKeywordRegister(&kw);
 
@@ -227,7 +226,7 @@ pub(super) unsafe extern "C" fn detect_ntp_register() {
         AppLayerTxMatch: Some(ntp_detect_stratum_match),
         Setup: Some(ntp_detect_stratum_setup),
         Free: Some(ntp_detect_u8_free),
-        flags: SIGMATCH_INFO_UINT8,
+        flags: SIGMATCH_SUPPORT_FIREWALL,
     };
     G_NTP_STRATUM_KW_ID = SCDetectHelperKeywordRegister(&kw);
 

--- a/rust/src/ntp/log.rs
+++ b/rust/src/ntp/log.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,9 +15,20 @@
  * 02110-1301, USA.
  */
 
-//! NTP application layer, parser and logger module.
+use super::ntp::NTPTransaction;
+use crate::jsonbuilder::{JsonBuilder, JsonError};
 
-// written by Pierre Chifflier  <chifflier@wzdftpd.net>
+fn log(jb: &mut JsonBuilder, tx: &NTPTransaction) -> Result<(), JsonError> {
+    jb.open_object("ntp")?;
+    jb.set_uint("reference_id", tx.reference_id)?;
+    jb.close()?;
+    Ok(())
+}
 
-pub mod log;
-pub mod ntp;
+pub(super) unsafe extern "C" fn ntp_log_json(
+    tx: *const std::os::raw::c_void, jb: *mut std::os::raw::c_void,
+) -> bool {
+    let tx = cast_pointer!(tx, NTPTransaction);
+    let jb = cast_pointer!(jb, JsonBuilder);
+    log(jb, tx).is_ok()
+}

--- a/rust/src/ntp/log.rs
+++ b/rust/src/ntp/log.rs
@@ -23,7 +23,13 @@ fn log(jb: &mut JsonBuilder, tx: &NTPTransaction) -> Result<(), JsonError> {
     jb.set_uint("version", tx.version)?;
     jb.set_uint("mode", tx.mode)?;
     jb.set_uint("stratum", tx.stratum)?;
-    jb.set_uint("reference_id", tx.reference_id)?;
+    jb.set_string(
+        "reference_id",
+        &format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}",
+            tx.reference_id[0], tx.reference_id[1], tx.reference_id[2], tx.reference_id[3]
+        ),
+    )?;
     jb.close()?;
     Ok(())
 }

--- a/rust/src/ntp/log.rs
+++ b/rust/src/ntp/log.rs
@@ -20,6 +20,9 @@ use crate::jsonbuilder::{JsonBuilder, JsonError};
 
 fn log(jb: &mut JsonBuilder, tx: &NTPTransaction) -> Result<(), JsonError> {
     jb.open_object("ntp")?;
+    jb.set_uint("version", tx.version)?;
+    jb.set_uint("mode", tx.mode)?;
+    jb.set_uint("stratum", tx.stratum)?;
     jb.set_uint("reference_id", tx.reference_id)?;
     jb.close()?;
     Ok(())

--- a/rust/src/ntp/lua.rs
+++ b/rust/src/ntp/lua.rs
@@ -1,0 +1,49 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use std::os::raw::c_int;
+
+use super::ntp::NTPTransaction;
+use crate::lua::*;
+
+#[no_mangle]
+pub extern "C" fn SCNtpLuaGetVersion(clua: &mut CLuaState, tx: &mut NTPTransaction) -> c_int {
+    let lua = LuaState { lua: clua };
+    lua.pushinteger(tx.version as i64);
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn SCNtpLuaGetMode(clua: &mut CLuaState, tx: &mut NTPTransaction) -> c_int {
+    let lua = LuaState { lua: clua };
+    lua.pushinteger(tx.mode as i64);
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn SCNtpLuaGetStratum(clua: &mut CLuaState, tx: &mut NTPTransaction) -> c_int {
+    let lua = LuaState { lua: clua };
+    lua.pushinteger(tx.stratum as i64);
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn SCNtpLuaGetReferenceId(clua: &mut CLuaState, tx: &mut NTPTransaction) -> c_int {
+    let lua = LuaState { lua: clua };
+    lua.pushbytes(&tx.reference_id);
+    1
+}

--- a/rust/src/ntp/mod.rs
+++ b/rust/src/ntp/mod.rs
@@ -19,5 +19,6 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
+pub mod detect;
 pub mod log;
 pub mod ntp;

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -60,7 +60,7 @@ pub struct NTPState {
 #[derive(Debug, Default)]
 pub struct NTPTransaction {
     /// The NTP reference ID
-    pub reference_id: u32,
+    pub reference_id: [u8; 4],
 
     pub version: u8,
     pub mode: u8,
@@ -169,7 +169,7 @@ impl NTPState {
 impl NTPTransaction {
     pub fn new(direction: Direction, id: u64, reference_id: u32) -> NTPTransaction {
         NTPTransaction {
-            reference_id,
+            reference_id: reference_id.to_be_bytes(),
             id,
             tx_data: applayer::AppLayerTxData::for_direction(direction),
             ..Default::default()

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -40,8 +40,6 @@ use suricata_sys::sys::{
 pub enum NTPEvent {
     UnsolicitedResponse,
     MalformedData,
-    NotRequest,
-    NotResponse,
 }
 
 #[derive(Default)]

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -61,6 +61,10 @@ pub struct NTPTransaction {
     /// The NTP reference ID
     pub reference_id: u32,
 
+    pub version: u8,
+    pub mode: u8,
+    pub stratum: u8,
+
     /// The internal transaction id
     id: u64,
 
@@ -97,14 +101,23 @@ impl NTPState {
         match parse_ntp(i) {
             Ok((_, ref msg)) => {
                 // SCLogDebug!("parse_ntp: {:?}",msg);
-                let (mode, ref_id) = match msg {
-                    NtpPacket::V3(pkt) => (pkt.mode, pkt.ref_id),
-                    NtpPacket::V4(pkt) => (pkt.mode, pkt.ref_id),
+                let tx = match msg {
+                    NtpPacket::V3(p) => {
+                        let mut tx = self.new_tx(direction, p.ref_id);
+                        tx.version = 3;
+                        tx.mode = p.mode.0;
+                        tx.stratum = p.stratum;
+                        tx
+                    }
+                    NtpPacket::V4(p) => {
+                        let mut tx = self.new_tx(direction, p.ref_id);
+                        tx.version = 4;
+                        tx.mode = p.mode.0;
+                        tx.stratum = p.stratum;
+                        tx
+                    }
                 };
-                if mode == NtpMode::SymmetricActive || mode == NtpMode::Client {
-                    let tx = self.new_tx(direction, ref_id);
-                    self.transactions.push(tx);
-                }
+                self.transactions.push(tx);
                 0
             }
             Err(Err::Incomplete(_)) => {
@@ -158,6 +171,7 @@ impl NTPTransaction {
             reference_id,
             id,
             tx_data: applayer::AppLayerTxData::for_direction(direction),
+            ..Default::default()
         }
     }
 }

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -19,6 +19,7 @@
 
 extern crate ntp_parser;
 use self::ntp_parser::*;
+use super::detect::detect_ntp_register;
 use super::log::ntp_log_json;
 use crate::applayer::{self, *};
 use crate::core;
@@ -33,7 +34,7 @@ use suricata_sys::sys::{
     AppLayerParserState, AppProto, EveJsonTxLoggerRegistrationData,
     SCAppLayerParserConfParserEnabled, SCAppLayerParserRegisterLogger,
     SCAppLayerProtoDetectConfProtoDetectionEnabled, SCOutputEvePreRegisterLogger,
-    SCOutputJsonLogDirection,
+    SCOutputJsonLogDirection, SCSigTablePreRegister,
 };
 
 #[derive(AppLayerEvent)]
@@ -240,7 +241,7 @@ extern "C" fn ntp_tx_get_alstate_progress(
     1
 }
 
-static mut ALPROTO_NTP: AppProto = ALPROTO_UNKNOWN;
+pub(super) static mut ALPROTO_NTP: AppProto = ALPROTO_UNKNOWN;
 
 extern "C" fn ntp_probing_parser(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
@@ -317,6 +318,7 @@ pub unsafe extern "C" fn SCRegisterNtpParser() {
             LogTx: Some(ntp_log_json),
         };
         SCOutputEvePreRegisterLogger(reg_data);
+        SCSigTablePreRegister(Some(detect_ntp_register));
         if SCAppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
             let _ = AppLayerRegisterParser(&parser, ALPROTO_NTP);
         }

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2021 Open Information Security Foundation
+/* Copyright (C) 2017-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -19,6 +19,7 @@
 
 extern crate ntp_parser;
 use self::ntp_parser::*;
+use super::log::ntp_log_json;
 use crate::applayer::{self, *};
 use crate::core;
 use crate::core::{ALPROTO_FAILED, ALPROTO_UNKNOWN};
@@ -29,8 +30,10 @@ use std::ffi::CString;
 
 use nom7::Err;
 use suricata_sys::sys::{
-    AppLayerParserState, AppProto, SCAppLayerParserConfParserEnabled,
-    SCAppLayerProtoDetectConfProtoDetectionEnabled,
+    AppLayerParserState, AppProto, EveJsonTxLoggerRegistrationData,
+    SCAppLayerParserConfParserEnabled, SCAppLayerParserRegisterLogger,
+    SCAppLayerProtoDetectConfProtoDetectionEnabled, SCOutputEvePreRegisterLogger,
+    SCOutputJsonLogDirection,
 };
 
 #[derive(AppLayerEvent)]
@@ -58,7 +61,7 @@ pub struct NTPState {
 #[derive(Debug, Default)]
 pub struct NTPTransaction {
     /// The NTP reference ID
-    pub xid: u32,
+    pub reference_id: u32,
 
     /// The internal transaction id
     id: u64,
@@ -101,9 +104,7 @@ impl NTPState {
                     NtpPacket::V4(pkt) => (pkt.mode, pkt.ref_id),
                 };
                 if mode == NtpMode::SymmetricActive || mode == NtpMode::Client {
-                    let mut tx = self.new_tx(direction);
-                    // use the reference id as identifier
-                    tx.xid = ref_id;
+                    let tx = self.new_tx(direction, ref_id);
                     self.transactions.push(tx);
                 }
                 0
@@ -127,9 +128,9 @@ impl NTPState {
         self.transactions.clear();
     }
 
-    fn new_tx(&mut self, direction: Direction) -> NTPTransaction {
+    fn new_tx(&mut self, direction: Direction, ref_id: u32) -> NTPTransaction {
         self.tx_id += 1;
-        NTPTransaction::new(direction, self.tx_id)
+        NTPTransaction::new(direction, self.tx_id, ref_id)
     }
 
     pub fn get_tx_by_id(&mut self, tx_id: u64) -> Option<&NTPTransaction> {
@@ -154,9 +155,9 @@ impl NTPState {
 }
 
 impl NTPTransaction {
-    pub fn new(direction: Direction, id: u64) -> NTPTransaction {
+    pub fn new(direction: Direction, id: u64, reference_id: u32) -> NTPTransaction {
         NTPTransaction {
-            xid: 0,
+            reference_id,
             id,
             tx_data: applayer::AppLayerTxData::for_direction(direction),
         }
@@ -295,12 +296,19 @@ pub unsafe extern "C" fn SCRegisterNtpParser() {
 
     let ip_proto_str = CString::new("udp").unwrap();
     if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
-        let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
-        // store the allocated ID for the probe function
-        ALPROTO_NTP = alproto;
+        ALPROTO_NTP = AppLayerRegisterProtocolDetection(&parser, 1);
+        let reg_data = EveJsonTxLoggerRegistrationData {
+            confname: b"eve-log.ntp\0".as_ptr() as *const std::os::raw::c_char,
+            logname: b"JsonNTPLog\0".as_ptr() as *const std::os::raw::c_char,
+            alproto: ALPROTO_NTP,
+            dir: SCOutputJsonLogDirection::LOG_DIR_PACKET as u8,
+            LogTx: Some(ntp_log_json),
+        };
+        SCOutputEvePreRegisterLogger(reg_data);
         if SCAppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
-            let _ = AppLayerRegisterParser(&parser, alproto);
+            let _ = AppLayerRegisterParser(&parser, ALPROTO_NTP);
         }
+        SCAppLayerParserRegisterLogger(core::IPPROTO_UDP, ALPROTO_NTP);
     } else {
         SCLogDebug!("Protocol detector and parser disabled for NTP.");
     }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -551,6 +551,7 @@ noinst_HEADERS = \
 	util-lua-http.h \
 	util-lua-ja3.h \
 	util-lua-log.h \
+	util-lua-ntp.h \
 	util-lua-packetlib.h \
 	util-lua-rule.h \
 	util-lua-sandbox.h \
@@ -1134,6 +1135,7 @@ libsuricata_c_a_SOURCES = \
 	util-lua-http.c \
 	util-lua-ja3.c \
 	util-lua-log.c \
+	util-lua-ntp.c \
 	util-lua-packetlib.c \
 	util-lua-rule.c \
 	util-lua-sandbox.c \

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -524,6 +524,8 @@ static int LuaScriptInit(const char *filename, LogLuaScriptOptions *options, Log
             options->alproto = ALPROTO_SSH;
         else if (strcmp(k,"protocol") == 0 && strcmp(v, "smtp") == 0)
             options->alproto = ALPROTO_SMTP;
+        else if (strcmp(k, "protocol") == 0 && strcmp(v, "ntp") == 0)
+            options->alproto = ALPROTO_NTP;
         else if (strcmp(k, "type") == 0 && strcmp(v, "packet") == 0)
             options->packet = 1;
         else if (strcmp(k, "filter") == 0 && strcmp(v, "alerts") == 0)
@@ -808,6 +810,12 @@ static OutputInitResult OutputLuaLogInit(SCConfNode *conf)
             om->ts_log_progress = -1;
             om->tc_log_progress = -1;
             SCAppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_SMTP);
+        } else if (opts.alproto == ALPROTO_NTP) {
+            om->TxLogFunc = LuaTxLogger;
+            om->alproto = ALPROTO_NTP;
+            om->ts_log_progress = -1;
+            om->tc_log_progress = -1;
+            SCAppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_NTP);
         } else if (opts.packet && opts.alerts) {
             om->PacketLogFunc = LuaPacketLoggerAlerts;
             om->PacketConditionFunc = LuaPacketConditionAlerts;

--- a/src/util-lua-builtins.c
+++ b/src/util-lua-builtins.c
@@ -36,6 +36,7 @@
 #include "util-lua-ja3.h"
 #include "util-lua-filelib.h"
 #include "util-lua-log.h"
+#include "util-lua-ntp.h"
 #include "util-lua-util.h"
 
 #include "lauxlib.h"
@@ -55,6 +56,7 @@ static const luaL_Reg builtins[] = {
     { "suricata.http", SCLuaLoadHttpLib },
     { "suricata.ja3", SCLuaLoadJa3Lib },
     { "suricata.log", SCLuaLoadLogLib },
+    { "suricata.ntp", SCLuaLoadNtpLib },
     { "suricata.packet", LuaLoadPacketLib },
     { "suricata.rule", SCLuaLoadRuleLib },
     { "suricata.smtp", SCLuaLoadSmtpLib },

--- a/src/util-lua-ntp.c
+++ b/src/util-lua-ntp.c
@@ -1,0 +1,117 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "util-lua-ntp.h"
+#include "util-lua.h"
+#include "util-lua-common.h"
+#include "rust.h"
+
+static const char ntp_tx[] = "suricata:ntp:tx";
+
+struct LuaTx {
+    NTPTransaction *tx;
+};
+
+static int LuaNtpGetTx(lua_State *L)
+{
+    if (!(LuaStateNeedProto(L, ALPROTO_NTP))) {
+        return LuaCallbackError(L, "error: protocol not ntp");
+    }
+    NTPTransaction *tx = LuaStateGetTX(L);
+    if (tx == NULL) {
+        return LuaCallbackError(L, "error: no tx available");
+    }
+    struct LuaTx *ltx = (struct LuaTx *)lua_newuserdata(L, sizeof(*ltx));
+    if (ltx == NULL) {
+        return LuaCallbackError(L, "error: fail to allocate user data");
+    }
+    ltx->tx = tx;
+
+    luaL_getmetatable(L, ntp_tx);
+    lua_setmetatable(L, -2);
+
+    return 1;
+}
+
+static int LuaNtpTxGetVersion(lua_State *L)
+{
+    struct LuaTx *tx = luaL_testudata(L, 1, ntp_tx);
+    if (tx == NULL) {
+        lua_pushnil(L);
+        return 1;
+    }
+    return SCNtpLuaGetVersion(L, tx->tx);
+}
+
+static int LuaNtpTxGetMode(lua_State *L)
+{
+    struct LuaTx *tx = luaL_testudata(L, 1, ntp_tx);
+    if (tx == NULL) {
+        lua_pushnil(L);
+        return 1;
+    }
+    return SCNtpLuaGetMode(L, tx->tx);
+}
+
+static int LuaNtpTxGetStratum(lua_State *L)
+{
+    struct LuaTx *tx = luaL_testudata(L, 1, ntp_tx);
+    if (tx == NULL) {
+        lua_pushnil(L);
+        return 1;
+    }
+    return SCNtpLuaGetStratum(L, tx->tx);
+}
+
+static int LuaNtpTxGetReferenceId(lua_State *L)
+{
+    struct LuaTx *tx = luaL_testudata(L, 1, ntp_tx);
+    if (tx == NULL) {
+        lua_pushnil(L);
+        return 1;
+    }
+    return SCNtpLuaGetReferenceId(L, tx->tx);
+}
+
+static const struct luaL_Reg txlib[] = {
+    // clang-format off
+    { "mode", LuaNtpTxGetMode },
+    { "reference_id", LuaNtpTxGetReferenceId },
+    { "stratum", LuaNtpTxGetStratum },
+    { "version", LuaNtpTxGetVersion },
+    { NULL, NULL, }
+    // clang-format on
+};
+
+static const struct luaL_Reg ntplib[] = {
+    // clang-format off
+    { "get_tx", LuaNtpGetTx },
+    { NULL, NULL,}
+    // clang-format on
+};
+
+int SCLuaLoadNtpLib(lua_State *L)
+{
+    luaL_newmetatable(L, ntp_tx);
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -2, "__index");
+    luaL_setfuncs(L, txlib, 0);
+
+    luaL_newlib(L, ntplib);
+    return 1;
+}

--- a/src/util-lua-ntp.h
+++ b/src/util-lua-ntp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,11 +15,11 @@
  * 02110-1301, USA.
  */
 
-//! NTP application layer, parser and logger module.
+#ifndef SURICATA_UTIL_LUA_NTP_H
+#define SURICATA_UTIL_LUA_NTP_H
 
-// written by Pierre Chifflier  <chifflier@wzdftpd.net>
+#include "lua.h"
 
-pub mod detect;
-pub mod log;
-pub mod lua;
-pub mod ntp;
+int SCLuaLoadNtpLib(lua_State *L);
+
+#endif /* SURICATA_UTIL_LUA_NTP_H */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -321,6 +321,8 @@ outputs:
         - ftp
         - rdp
         - nfs
+        #- ntp:
+        #    enabled: no
         - smb:
             # restrict to only certain types in the following list
             #types: [file, tree_connect, negotiate, dcerpc, create,


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8562

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3089

Adds NTP keywords and firewall support for 8.0.

As ntp transaction logging is disabled by default, there should be no impact on
users.

More message types are converted to transactions, so perhaps a small amount of
extra load, but these messages were already being parsed.

The Lua keywords were backported for completeness, but could be dropped.
