### PR TITLE
source/ipfw: retry divert socket sendto on transient failure

### DIFF
--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -99,6 +99,8 @@ TmEcode NoIPFWSupportExit(ThreadVars *tv, const void *initdata, void **data)
 
 #define IPFW_SOCKET_POLL_MSEC 300
 
+#define IPFW_VERDICT_RETRY_COUNT 3
+
 extern uint32_t max_pending_packets;
 
 /**
@@ -561,7 +563,14 @@ TmEcode IPFWSetVerdict(ThreadVars *tv, IPFWThreadVars *ptv, Packet *p)
 #endif
 
         IPFWMutexLock(nq);
-        if (sendto(nq->fd, GET_PKT_DATA(p), GET_PKT_LEN(p), 0,(struct sockaddr *)&nq->ipfw_sin, nq->ipfw_sinlen) == -1) {
+        ssize_t ret;
+        int iter = 0;
+        do {
+            ret = sendto(nq->fd, GET_PKT_DATA(p), GET_PKT_LEN(p), 0,
+                    (struct sockaddr *)&nq->ipfw_sin, nq->ipfw_sinlen);
+        } while (ret == -1 && (iter++ < IPFW_VERDICT_RETRY_COUNT));
+
+        if (ret == -1) {
             int r = errno;
             switch (r) {
                 default:


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8377

Describe changes:
- The ipfw verdict path issues a single `sendto()` to the divert socket and treats any errno other than `EHOSTDOWN`/`ENETDOWN` as a hard failure that silently drops the packet. Under sustained load (e.g., many TCP segments of a large response on OPNsense divert-to), the kernel's divert socket can return `ENOBUFS` / `EAGAIN` / `EINTR` transiently, and today Suricata aborts the verdict and the segment is lost on the wire, causing the client to time out (~10s in the Axios repro on #8377).
- Mirror the existing NFQ retry pattern (`NFQ_VERDICT_RETRY_COUNT` in `source-nfq.c`) on the ipfw side: wrap the `sendto()` in a `do/while` bounded by a new `IPFW_VERDICT_RETRY_COUNT` (3). The errno classification on the final failure is unchanged, so persistent errors still surface as before.
- Marked as draft because I do not have a FreeBSD/IPFW environment to compile or runtime-test the IPFW-gated code path. The patch is a structural mirror of the existing NFQ pattern. Ideally, a maintainer or the original reporter tests against the #8377 repro with a build that includes this change.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=