### PR TITLE
Fw updates/v26

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2014,6 +2014,16 @@
                 }
             }
         },
+        "firewall": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hook": {
+                    "type": "string",
+                    "description": "Firewall hook for the match"
+                }
+            }
+        },
         "flow": {
             "type": "object",
             "additionalProperties": false,

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2021,6 +2021,10 @@
                 "hook": {
                     "type": "string",
                     "description": "Firewall hook for the match"
+                },
+                "policy": {
+                    "type": "string",
+                    "description": "Firewall actions for the match (from rule or default policy)"
                 }
             }
         },

--- a/rules/README.md
+++ b/rules/README.md
@@ -10,6 +10,7 @@ signature IDs.
 | Component         | Start   | End     |
 | ----------------- | ------- | ------- |
 | Decoder           | 2200000 | 2200999 |
+| Firewall          | 2201000 | 2201999 |
 | Stream            | 2210000 | 2210999 |
 | Generic App-Layer | 2260000 | 2260999 |
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -19,6 +19,7 @@
 #include "suricata.h"
 
 #include "detect.h"
+#include "detect-parse.h"
 #include "detect-engine-alert.h"
 #include "detect-engine-threshold.h"
 #include "detect-engine-tag.h"
@@ -158,7 +159,7 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f)
 {
     if (action & ACTION_ACCEPT) {
         f->flags |= FLOW_ACTION_ACCEPT;
-        SCLogDebug("setting flow action pass");
+        SCLogDebug("setting flow action accept");
     }
 
     /* pass:flow can be set if accept:flow is present */
@@ -196,8 +197,8 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f)
  *  \param pa packet alert struct -- match, including actions after thresholding (rate_filter) */
 static void PacketApplySignatureActions(Packet *p, const Signature *s, const PacketAlert *pa)
 {
-    SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x", PcapPacketCntGet(p), s->id,
-            pa->action, pa->flags);
+    SCLogDebug("packet %" PRIu64 ", sid %u: action %02x alert_flags %02x", PcapPacketCntGet(p),
+            s->id, pa->action, pa->flags);
 
     /* REJECT also sets ACTION_DROP, just make it more visible with this check */
     if (pa->action & ACTION_DROP_REJECT) {
@@ -381,7 +382,7 @@ void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet
     /* we do that even before inserting into the queue, so we save it even if appending fails */
     if (p->alerts.drop.action == 0 && s->action & ACTION_DROP) {
         p->alerts.drop = PacketAlertSet(det_ctx, s, tx_id, alert_flags);
-        SCLogDebug("Set PacketAlert drop action. s->iid %" PRIu32 "", s->iid);
+        SCLogDebug("sid %u: set PacketAlert drop action. s->iid %" PRIu32 "", s->id, s->iid);
     }
 
     uint16_t pos = det_ctx->alert_queue_size;
@@ -395,7 +396,8 @@ void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet
     }
     det_ctx->alert_queue[pos] = PacketAlertSet(det_ctx, s, tx_id, alert_flags);
 
-    SCLogDebug("Appending sid %" PRIu32 ", s->iid %" PRIu32 " to alert queue", s->id, s->iid);
+    SCLogDebug("packet %" PRIu64 ": appending sid %" PRIu32 ", s->iid %" PRIu32 " to alert queue",
+            PcapPacketCntGet(p), s->id, s->iid);
     det_ctx->alert_queue_size++;
 }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -581,12 +581,12 @@ static inline void PacketAlertFinalizeProcessQueue(
                 continue;
             }
 
-            // TODO we can also drop if alert is suppressed, right?
-            if (s->action & ACTION_DROP) {
-                dropped = true;
-            }
         } else {
             p->alerts.discarded++;
+        }
+
+        if (s->action & ACTION_DROP) {
+            dropped = true;
         }
     }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -176,7 +176,14 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f)
 
         // TODO firewall drop:flow should override FLOW_ACTION_PASS
     } else if (action & (ACTION_DROP | ACTION_REJECT_ANY)) {
-        if (f->flags & (FLOW_ACTION_DROP | FLOW_ACTION_PASS | FLOW_ACTION_ACCEPT)) {
+        /* drop:flow from TD rules will override a accept:flow from
+         * firewall rules. */
+        if (f->flags & FLOW_ACTION_ACCEPT) {
+            f->flags &= ~FLOW_ACTION_ACCEPT;
+            f->flags |= FLOW_ACTION_DROP;
+            SCLogDebug("replaced FLOW_ACTION_ACCEPT with FLOW_ACTION_DROP");
+        }
+        if (f->flags & (FLOW_ACTION_DROP | FLOW_ACTION_PASS)) {
             /* drop or pass already set. First to set wins. */
             SCLogDebug("not setting %s flow already set to %s",
                     (action & ACTION_PASS) ? "pass" : "drop",

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -485,6 +485,97 @@ static inline void FlowApplySignatureActions(
     }
 }
 
+/** \internal
+ * \brief handle immediate actions for a firewall rule match
+ *
+ * Delayed action (accept) is handled after TD has also run, as TD drop
+ * can overrule a FW accept. So returning `accept` here means "will accept if TD agrees".
+ *
+ * \retval pol firewall policy with action that is (drop) or should possibly be (accept)
+ * applied to the packet and flow.
+ */
+static struct DetectFirewallPolicy HandleFirewallRule(
+        const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p, PacketAlert *pa)
+{
+    const Signature *s = pa->s;
+    struct DetectFirewallPolicy pol = { .action = 0, .action_scope = 0 };
+    int res = PacketAlertHandle(de_ctx, det_ctx, s, p, pa);
+    SCLogDebug("packet %" PRIu64 ": fw sid %u: res %d", PcapPacketCntGet(p), s->id, res);
+    if (res > 0) {
+        /* Now, if we have an alert, we have to check if we want
+         * to tag this session or src/dst host */
+        if (s->sm_arrays[DETECT_SM_LIST_TMATCH] != NULL) {
+            KEYWORD_PROFILING_SET_LIST(det_ctx, DETECT_SM_LIST_TMATCH);
+            SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_TMATCH];
+            while (1) {
+                /* tags are set only for alerts */
+                KEYWORD_PROFILING_START;
+                sigmatch_table[smd->type].Match(det_ctx, p, (Signature *)s, smd->ctx);
+                KEYWORD_PROFILING_END(det_ctx, smd->type, 1);
+                if (smd->is_last)
+                    break;
+                smd++;
+            }
+        }
+        /* if this is a terminating action, pass the action to the caller. */
+        if (s->action_scope != ACTION_SCOPE_HOOK ||
+                pa->flags & PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET) {
+            pol.action = s->action;
+            pol.action_scope = s->action_scope;
+            if (pol.action & ACTION_DROP) {
+                uint8_t drop_reason = PKT_DROP_REASON_RULES;
+                if (s->detect_table == DETECT_TABLE_PACKET_PRE_STREAM) {
+                    drop_reason = PKT_DROP_REASON_STREAM_PRE_HOOK;
+                } else if (s->detect_table == DETECT_TABLE_PACKET_PRE_FLOW) {
+                    drop_reason = PKT_DROP_REASON_FLOW_PRE_HOOK;
+                }
+                PacketDrop(p, pol.action, drop_reason);
+                if (p->flow && pol.action_scope == ACTION_SCOPE_FLOW) {
+                    p->flow->flags |= FLOW_ACTION_DROP;
+                    SCLogDebug("packet %" PRIu64 ": FLOW_ACTION_DROP set by firewall by sid %u",
+                            PcapPacketCntGet(p), s->id);
+                }
+            }
+            if (pol.action & ACTION_PASS) {
+                if (p->flow && pol.action_scope == ACTION_SCOPE_FLOW) {
+                    p->flow->flags |= FLOW_ACTION_PASS;
+                    SCLogDebug("packet %" PRIu64 ": FLOW_ACTION_PASS set by firewall by sid %u",
+                            PcapPacketCntGet(p), s->id);
+                }
+            }
+        }
+        /* add the alert for logging if required. */
+        if (s->action & ACTION_ALERT) {
+            if (p->alerts.cnt < packet_alert_max) {
+                p->alerts.alerts[p->alerts.cnt++] = *pa;
+            } else {
+                p->alerts.discarded++;
+            }
+        }
+    }
+    return pol;
+}
+
+/*
+ * Queue order after sorting:
+ *
+ * Firewall use case: rules are sorted by Signature::detect_table, Signature::iid (which reflects
+ * order in the rule file(s)) This means:
+ * - pre_flow
+ * - pre_stream
+ * - packet:filter (firewall)
+ * - packet:td (IDS/IPS rules)
+ * - app:filter (firewall)
+ * - app:td (IDS/IPS rules)
+ *
+ * Firewall DROPs are immediate.
+ * Firewall ACCEPTs depend on TD not dropping.
+ * Firewall rules are not affected by PASS.
+ * TD rules are affected by PASS, both set by Firewall and TD rules.
+ *
+ * Non-Firewall use case: rules are sorted by Signature::iid (which reflect order based on flowbits,
+ * action-order, priority, etc)
+ */
 static inline void PacketAlertFinalizeProcessQueue(
         const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p)
 {
@@ -499,17 +590,63 @@ static inline void PacketAlertFinalizeProcessQueue(
     bool alerted = false;
     bool dropped = false;
     bool skip_td = false;
+    bool skip_fw = false;
+    bool fw_accept_packet = false; // same as skip_fw?
+    bool fw_accept_flow = false;
+
+#ifdef DEBUG
+    SCLogDebug("packet %" PRIu64 ": starting alert event queue", PcapPacketCntGet(p));
+    for (uint16_t x = 0; x < det_ctx->alert_queue_size; x++) {
+        const PacketAlert *pa = &det_ctx->alert_queue[x];
+        const Signature *s = pa->s;
+        SCLogDebug("(list) %s sid %u: action %02x scope %u iid %u detect_table %u",
+                (s->flags & SIG_FLAG_FIREWALL) ? "fw" : "td", s->id, s->action, s->action_scope,
+                s->iid, s->detect_table);
+    }
+#endif /* DEBUG */
     for (uint16_t i = 0; i < det_ctx->alert_queue_size; i++) {
         PacketAlert *pa = &det_ctx->alert_queue[i];
         const Signature *s = pa->s;
 
+        if (s->flags & SIG_FLAG_FIREWALL) {
+            if (skip_fw || dropped)
+                continue;
+
+            const uint16_t pre_alert_cnt = p->alerts.cnt;
+            struct DetectFirewallPolicy pol = HandleFirewallRule(de_ctx, det_ctx, p, pa);
+            /* drop is immediate */
+            if (pol.action & ACTION_DROP) {
+                dropped = true;
+            } else if (pol.action & ACTION_ACCEPT) {
+                SCLogDebug("fw sid %u setting skip_fw for action %02x scope %s", s->id, pol.action,
+                        ActionScopeToString(pol.action_scope));
+                skip_fw = true;
+                fw_accept_packet = true;
+                if (pol.action_scope == ACTION_SCOPE_FLOW)
+                    fw_accept_flow = true;
+            }
+            if (pol.action & ACTION_PASS) {
+                skip_td = true;
+            }
+            if (pre_alert_cnt < p->alerts.cnt)
+                alerted = true;
+            if (dropped)
+                goto fw_dropped;
+
+            continue;
+        }
+
+        SCLogDebug("sid: %u, action %02x, firewall? %s", s->id, pa->action,
+                BOOL2STR(s->flags & SIG_FLAG_FIREWALL));
+
         /* if a firewall rule told us to skip, we don't count the skipped
          * alerts. */
-        if (have_fw_rules && skip_td && (s->flags & SIG_FLAG_FIREWALL) == 0) {
+        if (have_fw_rules && skip_td) {
             continue;
         }
 
         int res = PacketAlertHandle(de_ctx, det_ctx, s, p, pa);
+        SCLogDebug("sid %u: res %d", pa->s->id, res);
         if (res > 0) {
             /* Now, if we have an alert, we have to check if we want
              * to tag this session or src/dst host */
@@ -545,7 +682,7 @@ static inline void PacketAlertFinalizeProcessQueue(
                 /* set actions on the flow */
                 FlowApplySignatureActions(p, pa, s, pa->flags);
 
-                SCLogDebug("det_ctx->alert_queue[i].action %02x (DROP %s, PASS %s)", pa->action,
+                SCLogDebug("sid %u: action %02x (DROP %s, PASS %s)", pa->s->id, pa->action,
                         BOOL2STR(pa->action & ACTION_DROP), BOOL2STR(pa->action & ACTION_PASS));
 
                 /* set actions on packet */
@@ -553,12 +690,8 @@ static inline void PacketAlertFinalizeProcessQueue(
             }
         }
 
-        /* skip firewall sigs following a drop: IDS mode still shows alerts after an alert. */
-        if ((s->flags & SIG_FLAG_FIREWALL) && dropped) {
-            p->alerts.discarded++;
-
-            /* Thresholding removes this alert */
-        } else if (res == 0 || res == 2 || (s->action & (ACTION_ALERT | ACTION_PASS)) == 0) {
+        /* Thresholding removes this alert */
+        if (res == 0 || res == 2 || (s->action & (ACTION_ALERT | ACTION_PASS)) == 0) {
             SCLogDebug("sid:%u: skipping alert because of thresholding (res=%d) or NOALERT (%02x)",
                     s->id, res, s->action);
             /* we will not copy this to the AlertQueue */
@@ -587,6 +720,22 @@ static inline void PacketAlertFinalizeProcessQueue(
 
         if (s->action & ACTION_DROP) {
             dropped = true;
+        }
+    }
+
+fw_dropped:
+    /* after threat detection has been handled, see if the fw intended to accept (drop is handled
+     * immediately by the fw), as fw accept can be overruled by td drop. */
+    if (have_fw_rules) {
+        if (p->action & ACTION_DROP) {
+            SCLogDebug("packet %" PRIu64 ": dropped by TD", PcapPacketCntGet(p));
+        } else if (fw_accept_packet) {
+            p->action |= ACTION_ACCEPT;
+            if (p->flow && fw_accept_flow) {
+                p->flow->flags |= FLOW_ACTION_ACCEPT;
+                SCLogDebug("packet %" PRIu64 ": FLOW_ACTION_ACCEPT set from firewall",
+                        PcapPacketCntGet(p));
+            }
         }
     }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -189,10 +189,8 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f)
                     (action & ACTION_PASS) ? "pass" : "drop",
                     (f->flags & FLOW_ACTION_DROP) ? "drop" : "pass");
         } else {
-            if (action & (ACTION_DROP | ACTION_REJECT_ANY)) {
-                f->flags |= FLOW_ACTION_DROP;
-                SCLogDebug("setting flow action drop");
-            }
+            f->flags |= FLOW_ACTION_DROP;
+            SCLogDebug("setting flow action drop");
         }
     }
 }

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -2103,25 +2103,6 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
 
 #include "app-layer-parser.h"
 
-static const char *ActionScopeToString(enum ActionScope s)
-{
-    switch (s) {
-        case ACTION_SCOPE_PACKET:
-            return "packet";
-        case ACTION_SCOPE_FLOW:
-            return "flow";
-            break;
-        case ACTION_SCOPE_HOOK:
-            return "hook";
-        case ACTION_SCOPE_TX:
-            return "tx";
-        case ACTION_SCOPE_AUTO:
-            return "auto";
-    }
-    DEBUG_VALIDATE_BUG_ON(1);
-    return "unknown";
-}
-
 static void AddPolicy(const DetectEngineCtx *de_ctx, RuleAnalyzer *ctx, const AppProto a,
         const uint8_t state, const uint8_t direction)
 {

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -2186,6 +2186,11 @@ static void FirewallAddRulesForState(const DetectEngineCtx *de_ctx, const AppPro
             }
         }
 
+        if ((s->flags & SIG_FLAG_FW_HOOK_LTE) && state < s->app_progress_hook) {
+            SCJbAppendString(ctx->js, s->sig_str);
+            accept_rules += ((s->action & ACTION_ACCEPT) != 0);
+        }
+
         if (s->app_progress_hook == state) {
             SCJbAppendString(ctx->js, s->sig_str);
             accept_rules += ((s->action & ACTION_ACCEPT) != 0);

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -936,6 +936,28 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
             continue; // done for this sig
         }
 
+        /* special case: insert sigs at hook before Signature::app_progress_hook for the HOOK_LTE
+         * case: we need a addition per hook to make sure that the sig is called when needed. For
+         * hook 0 it could have a preceding rule that makes sure this sig isn't triggered, but then
+         * for hook 1 we would need to be called. */
+        if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+            for (uint8_t state = 0; state < s->app_progress_hook; state++) {
+                SCLogDebug("handle HOOK %u LTE", state);
+                const int dir = (s->flags & SIG_FLAG_TOSERVER) ? 0 : 1;
+                const char *pname = AppLayerParserGetStateNameById(IPPROTO_TCP, // TODO
+                        s->alproto, state, dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT);
+                if (pname == NULL)
+                    goto error;
+                const int sm_list = DetectEngineAppHookToSmlist(
+                        s->alproto, state, dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT);
+                if (TxNonPFAddSig(de_ctx, tx_engines_hash, s->alproto, dir, (int16_t)state, sm_list,
+                            pname, s) != 0) {
+                    goto error;
+                }
+                tx_non_pf = true;
+            }
+        }
+
         for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
             const int list_id = s->init_data->buffers[x].id;
             const DetectBufferType *buf = DetectEngineBufferTypeGetById(de_ctx, list_id);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2801,6 +2801,9 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
     if (de_ctx->non_pf_engine_names) {
         HashTableFree(de_ctx->non_pf_engine_names);
     }
+    if (de_ctx->fw_policies) {
+        HashTableFree(de_ctx->fw_policies->policy_signatures);
+    }
     SCFree(de_ctx->fw_policies);
     SCFree(de_ctx);
     //DetectAddressGroupPrintMemory();

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2802,6 +2802,12 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
         HashTableFree(de_ctx->non_pf_engine_names);
     }
     if (de_ctx->fw_policies) {
+        for (uint32_t i = 0; i < DETECT_FIREWALL_POLICY_SIZE; i++) {
+            if (de_ctx->fw_policies->pkt_policy_signatures[i]) {
+                SCFree(de_ctx->fw_policies->pkt_policy_signatures[i]->msg);
+                SCFree(de_ctx->fw_policies->pkt_policy_signatures[i]);
+            }
+        }
         HashTableFree(de_ctx->fw_policies->policy_signatures);
     }
     SCFree(de_ctx->fw_policies);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -794,6 +794,32 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
     s->init_data->init_flags |= SIG_FLAG_INIT_STATE_MATCH;
 }
 
+/** \brief get the sm_list for a app hook */
+int DetectEngineAppHookToSmlist(const AppProto p, const uint8_t state, const int direction)
+{
+    const char *app_proto = AppProtoToString(p);
+    if (app_proto == NULL) {
+        SCLogError("unknown app_proto %u", p);
+        return -1;
+    }
+    if (strcmp(app_proto, "http") == 0)
+        app_proto = "http1";
+
+    const char *name = AppLayerParserGetStateNameById(
+            IPPROTO_TCP, p, state, direction & (STREAM_TOSERVER | STREAM_TOCLIENT));
+    if (name == NULL)
+        return -1;
+
+    char generic_hook_name[256];
+    snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", app_proto, name);
+    int list = DetectBufferTypeGetByName(generic_hook_name);
+    if (list < 0) {
+        SCLogError("no list registered as %s for %s hook %s", generic_hook_name, app_proto, name);
+        return -1;
+    }
+    return list;
+}
+
 /**
  *  \note for the file inspect engine, the id DE_STATE_ID_FILE_INSPECT
  *        is assigned.
@@ -805,6 +831,41 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
     bool head_is_mpm = false;
     uint8_t last_id = DE_STATE_FLAG_BASE;
     SCLogDebug("%u: setup app inspect engines. %u buffers", s->id, s->init_data->buffer_index);
+
+    if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+        SCLogDebug("need an inspect engine per state, range 0-%u", s->app_progress_hook);
+        for (uint8_t state = 0; state < s->app_progress_hook; state++) {
+            uint8_t dir = 0;
+            int direction = 0;
+            BUG_ON((s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)) ==
+                    (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT));
+            BUG_ON((s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)) == 0);
+            if (s->flags & SIG_FLAG_TOSERVER) {
+                direction = STREAM_TOSERVER;
+                dir = 0;
+            } else if (s->flags & SIG_FLAG_TOCLIENT) {
+                direction = STREAM_TOCLIENT;
+                dir = 1;
+            }
+
+            int sm_list =
+                    DetectEngineAppHookToSmlist(s->init_data->hook.t.app.alproto, 0, direction);
+            if (sm_list < 0)
+                return -1;
+
+            DetectEngineAppInspectionEngine t = {
+                .alproto = s->init_data->hook.t.app.alproto,
+                .progress = (uint16_t)state,
+                .sm_list = (uint16_t)sm_list,
+                .sm_list_base = (uint16_t)sm_list,
+                .dir = dir,
+            };
+            AppendAppInspectEngine(de_ctx, &t, s, NULL, mpm_list, files_id, &last_id, &head_is_mpm);
+            SCLogDebug("sid %u: appended pass-tru engine at hook:%u sm_list:%d for "
+                       "SIG_FLAG_INIT_HOOK_LTE",
+                    s->id, state, sm_list);
+        }
+    }
 
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
         SigMatchData *smd = SigMatchList2DataArray(s->init_data->buffers[x].head);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -210,4 +210,6 @@ void DetectLowerSetupCallback(
 
 void DeStateRegisterTests(void);
 
+int DetectEngineAppHookToSmlist(const AppProto p, const uint8_t state, const int direction);
+
 #endif /* SURICATA_DETECT_ENGINE_H */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2564,6 +2564,17 @@ static bool DetectFirewallRuleValidate(const DetectEngineCtx *de_ctx, const Sign
                 break;
         }
     }
+    if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+        if (!(((s->action & ACTION_ACCEPT) != 0) &&
+                    (s->action_scope == ACTION_SCOPE_FLOW || s->action_scope == ACTION_SCOPE_TX ||
+                            s->action_scope == ACTION_SCOPE_HOOK))) {
+            SCLogError("rule %u: auto-accept notation (<hook) can only be used with accept:flow, "
+                       "accept:tx and accept:hook",
+                    s->id);
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3828,6 +3828,44 @@ void DetectFirewallPolicyToString(const struct DetectFirewallPolicy *p, char *ou
     }
 }
 
+static int AddPktPolicySignature(struct DetectFirewallPolicies *fw_policies,
+        struct DetectFirewallPolicy *pol, enum DetectFirewallPacketPolicies pkt_pol)
+{
+    Signature *s = SCCalloc(1, sizeof(*s)); // SigAlloc does way more than we need
+    if (s == NULL)
+        return -1;
+    char msg[256];
+    switch (pkt_pol) {
+        case DETECT_FIREWALL_POLICY_PACKET_FILTER:
+            s->detect_table = DETECT_TABLE_PACKET_FILTER;
+            break;
+        case DETECT_FIREWALL_POLICY_PRE_FLOW:
+            s->detect_table = DETECT_TABLE_PACKET_PRE_FLOW;
+            break;
+        case DETECT_FIREWALL_POLICY_PRE_STREAM:
+            s->detect_table = DETECT_TABLE_PACKET_PRE_STREAM;
+            break;
+    }
+    snprintf(msg, sizeof(msg), "SURICATA FW default packet policy");
+    s->msg = SCStrdup(msg);
+    if (s->msg == NULL) {
+        SCFree(s);
+        return -1;
+    }
+    s->action = pol->action;
+    s->action_scope = pol->action_scope;
+    s->flags = SIG_FLAG_FIREWALL;
+    s->type = SIG_TYPE_PKT;
+    s->id = 2201000;
+    s->rev = 1;
+    s->gid = 1;
+    s->prio = 3;
+
+    fw_policies->pkt_policy_signatures[pkt_pol] = s;
+    SCLogDebug("added to array");
+    return 0;
+}
+
 static int AddAppPolicySignature(HashTable *ht, const int direction, const AppProto alproto,
         const char *app_name, const uint8_t hook, const char *hookname,
         struct DetectFirewallPolicy *pol)
@@ -4023,6 +4061,11 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
     r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER]);
     if (r < 0)
         return -1;
+    if (fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER].action & ACTION_ALERT)
+        if (AddPktPolicySignature(fw_policies,
+                    &fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER],
+                    DETECT_FIREWALL_POLICY_PACKET_FILTER) < 0)
+            return -1;
 
     r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-flow", prefix);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
@@ -4031,6 +4074,10 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
     r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW]);
     if (r < 0)
         return -1;
+    if (fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW].action & ACTION_ALERT)
+        if (AddPktPolicySignature(fw_policies, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW],
+                    DETECT_FIREWALL_POLICY_PRE_FLOW) < 0)
+            return -1;
 
     r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-stream", prefix);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
@@ -4039,6 +4086,10 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
     r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM]);
     if (r < 0)
         return -1;
+    if (fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM].action & ACTION_ALERT)
+        if (AddPktPolicySignature(fw_policies, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM],
+                    DETECT_FIREWALL_POLICY_PRE_STREAM) < 0)
+            return -1;
 
     for (AppProto a = 0; a < g_alproto_max; a++) {
         if (!AppProtoIsValid(a))

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3748,6 +3748,122 @@ void DetectSetupParseRegexes(const char *parse_str, DetectParseRegex *detect_par
     }
 }
 
+static uint32_t PolicySignatureHashFunc(HashTable *ht, void *data, uint16_t datalen)
+{
+    const Signature *s = data;
+    const int dir = 1 + (s->flags & SIG_FLAG_TOSERVER) != 0; // 2 for ts, 1 for tc
+    uint32_t hash = s->alproto * s->app_progress_hook * dir;
+    hash = hash % ht->array_size;
+    return hash;
+}
+
+static char PolicySignatureCompareFunc(
+        void *data1, uint16_t datalen1, void *data2, uint16_t datalen2)
+{
+    const Signature *s1 = data1;
+    const Signature *s2 = data2;
+
+    if (s1 == NULL || s2 == NULL)
+        return 0;
+
+    return s1->flags == s2->flags && s1->alproto == s2->alproto &&
+           s1->app_progress_hook == s2->app_progress_hook;
+}
+
+static void PolicySignatureHashFree(void *data)
+{
+    Signature *s = data;
+    SCFree(s->msg);
+    SCFree(s);
+}
+
+const char *ActionScopeToString(enum ActionScope s)
+{
+    switch (s) {
+        case ACTION_SCOPE_PACKET:
+            return "packet";
+        case ACTION_SCOPE_FLOW:
+            return "flow";
+        case ACTION_SCOPE_HOOK:
+            return "hook";
+        case ACTION_SCOPE_TX:
+            return "tx";
+        case ACTION_SCOPE_AUTO:
+            return "auto";
+    }
+    DEBUG_VALIDATE_BUG_ON(1);
+    return "unknown";
+}
+
+void DetectFirewallPolicyToString(const struct DetectFirewallPolicy *p, char *out, size_t out_size)
+{
+    const char *as = ActionScopeToString(p->action_scope);
+    DEBUG_VALIDATE_BUG_ON(as == NULL);
+    if (as == NULL)
+        return;
+    if (p->action & ACTION_REJECT_ANY) {
+        if (p->action & ACTION_REJECT_DST) {
+            snprintf(out, out_size, "rejectdst:%s", as);
+        } else if (p->action & ACTION_REJECT_BOTH) {
+            snprintf(out, out_size, "rejectboth:%s", as);
+        } else {
+            snprintf(out, out_size, "rejectsrc:%s", as);
+        }
+    } else if (p->action & ACTION_DROP) {
+        snprintf(out, out_size, "drop:%s", as);
+    } else if (p->action & ACTION_ACCEPT) {
+        snprintf(out, out_size, "accept:%s", as);
+    } else {
+        DEBUG_VALIDATE_BUG_ON(1);
+    }
+    if (p->action & ACTION_PASS) {
+        if (p->action_scope == ACTION_SCOPE_FLOW) {
+            strlcat(out, ",pass:flow", out_size);
+        } else {
+            DEBUG_VALIDATE_BUG_ON(1);
+        }
+    }
+    if (p->action & ACTION_ALERT) {
+        strlcat(out, ",alert", out_size);
+    }
+}
+
+static int AddAppPolicySignature(HashTable *ht, const int direction, const AppProto alproto,
+        const char *app_name, const uint8_t hook, const char *hookname,
+        struct DetectFirewallPolicy *pol)
+{
+    Signature *s = SCCalloc(1, sizeof(*s)); // SigAlloc does way more than we need
+    if (s == NULL)
+        return -1;
+    char msg[256];
+    snprintf(msg, sizeof(msg), "SURICATA FW default app policy");
+    s->msg = SCStrdup(msg);
+    if (s->msg == NULL) {
+        SCFree(s);
+        return -1;
+    }
+    s->app_progress_hook = hook;
+    s->action = pol->action;
+    s->action_scope = pol->action_scope;
+    s->alproto = alproto;
+    s->flags = (direction == STREAM_TOSERVER) ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;
+    s->flags |= SIG_FLAG_FIREWALL;
+    s->type = SIG_TYPE_APP_TX;
+    s->detect_table = DETECT_TABLE_APP_FILTER;
+    s->id = 2201001;
+    s->rev = 1;
+    s->gid = 1;
+    s->prio = 3;
+
+    if (HashTableAdd(ht, s, 0) != 0) {
+        SCFree(s->msg);
+        SCFree(s);
+        return -1;
+    }
+    SCLogDebug("added to hash");
+    return 0;
+}
+
 static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *pol)
 {
     SCConfNode *policy_actions = SCConfGetNode(policy_name);
@@ -3773,7 +3889,7 @@ static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *p
 
 static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const char *hookname,
         const uint8_t state, const uint8_t complete_state, const int direction,
-        struct DetectFirewallAppPolicy *app_fw_policies)
+        struct DetectFirewallPolicies *fw_policies, struct DetectFirewallAppPolicy *app_fw_policies)
 {
     char policy_name[256];
     const char *in_name = hookname;
@@ -3807,10 +3923,12 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
         FatalError("internal error: failed to assemble firewall policy config string");
     }
 
+    struct DetectFirewallPolicy *pol;
     if (direction == STREAM_TOSERVER)
-        r = DoParsePolicy(policy_name, &app_fw_policies[app_proto].ts[state]);
+        pol = &app_fw_policies[app_proto].ts[state];
     else
-        r = DoParsePolicy(policy_name, &app_fw_policies[app_proto].tc[state]);
+        pol = &app_fw_policies[app_proto].tc[state];
+    r = DoParsePolicy(policy_name, pol);
     if (r == 0 && in_name != NULL) {
         if (state == 0) {
             if (direction == STREAM_TOSERVER)
@@ -3830,10 +3948,14 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
             FatalError("internal error: failed to assemble firewall policy config string");
         }
 
-        if (direction == STREAM_TOSERVER)
-            return DoParsePolicy(policy_name, &app_fw_policies[app_proto].ts[state]);
-        else
-            return DoParsePolicy(policy_name, &app_fw_policies[app_proto].tc[state]);
+        r = DoParsePolicy(policy_name, pol);
+    }
+
+    /* for policies with an alert action, create a policy sig */
+    if (r == 1 && pol->action & ACTION_ALERT) {
+        SCLogDebug("adding policy signature");
+        return AddAppPolicySignature(fw_policies->policy_signatures, direction, app_proto, app_name,
+                state, hookname, pol);
     }
     return r;
 }
@@ -3847,6 +3969,10 @@ int DetectFirewallInitDefaultPolicies(DetectEngineCtx *de_ctx)
         return -1;
     struct DetectFirewallAppPolicy *app_fw_policies = fw_policies->app;
     if (app_fw_policies == NULL)
+        goto error;
+    fw_policies->policy_signatures = HashTableInit(
+            512, PolicySignatureHashFunc, PolicySignatureCompareFunc, PolicySignatureHashFree);
+    if (fw_policies->policy_signatures == NULL)
         goto error;
 
     fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER].action = ACTION_DROP;
@@ -3924,7 +4050,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
             const char *name =
                     AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOSERVER);
             if (DoParseAppPolicy(prefix, a, name, state, complete_state_ts, STREAM_TOSERVER,
-                        app_fw_policies) < 0)
+                        fw_policies, app_fw_policies) < 0)
                 return -1;
         }
 
@@ -3934,12 +4060,28 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
             const char *name =
                     AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOCLIENT);
             if (DoParseAppPolicy(prefix, a, name, state, complete_state_tc, STREAM_TOCLIENT,
-                        app_fw_policies) < 0)
+                        fw_policies, app_fw_policies) < 0)
                 return -1;
         }
     }
 
     return 0;
+}
+
+Signature *DetectFirewallGetPolicySignature(struct DetectFirewallPolicies *fw_policies,
+        const AppProto alproto, const int direction, const uint8_t hook)
+{
+    if (fw_policies != NULL && fw_policies->policy_signatures != NULL) {
+        Signature lookup;
+        lookup.alproto = alproto;
+        lookup.flags = SIG_FLAG_FIREWALL |
+                       (direction == STREAM_TOSERVER ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT);
+        lookup.app_progress_hook = hook;
+
+        Signature *s = HashTableLookup(fw_policies->policy_signatures, &lookup, 0);
+        return s;
+    }
+    return NULL;
 }
 
 /*

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1309,6 +1309,7 @@ static SignatureHook SetAppHook(const AppProto alproto, int progress)
  */
 static int SigParseProtoHookApp(Signature *s, const char *proto_hook, const char *p, const char *h)
 {
+    SCLogDebug("h:'%s'", h);
     if (strcmp(h, "request_started") == 0) {
         s->flags |= SIG_FLAG_TOSERVER;
         s->init_data->hook =
@@ -1343,7 +1344,7 @@ static int SigParseProtoHookApp(Signature *s, const char *proto_hook, const char
     }
 
     char generic_hook_name[64];
-    snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:generic", proto_hook);
+    snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", p, h);
     int list = DetectBufferTypeGetByName(generic_hook_name);
     if (list < 0) {
         SCLogError("no list registered as %s for hook %s", generic_hook_name, proto_hook);
@@ -1411,6 +1412,13 @@ static int SigParseProto(Signature *s, const char *protostr)
             AppLayerProtoDetectSupportedIpprotos(s->alproto, s->init_data->proto.proto);
 
             if (h) {
+                /* FW hook LTE mode */
+                SCLogDebug("hook '%s'", h);
+                if (*h == '<') {
+                    h++;
+                    SCLogDebug("hook and prior hooks: '%s'", h);
+                    s->flags |= SIG_FLAG_FW_HOOK_LTE;
+                }
                 if (SigParseProtoHookApp(s, protostr, p, h) < 0) {
                     SCLogError("protocol \"%s\" does not support hook \"%s\"", p, h);
                     SCReturnInt(-1);
@@ -2440,6 +2448,11 @@ static void SigSetupPrefilter(DetectEngineCtx *de_ctx, Signature *s)
     SCEnter();
     SCLogDebug("s %u: set up prefilter/mpm", s->id);
     DEBUG_VALIDATE_BUG_ON(s->init_data->mpm_sm != NULL);
+
+    if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+        SCLogDebug("no prefilter for SIG_FLAG_FW_HOOK_LTE sig");
+        SCReturn;
+    }
 
     if (s->init_data->prefilter_sm != NULL) {
         if (s->init_data->prefilter_sm->type == DETECT_CONTENT) {

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -24,6 +24,7 @@
 #ifndef SURICATA_DETECT_PARSE_H
 #define SURICATA_DETECT_PARSE_H
 
+#include "action-globals.h"
 #include "app-layer-protos.h"
 #include "detect-engine-register.h"
 // types from detect.h with only forward declarations for bindgen
@@ -32,6 +33,7 @@ typedef struct Signature_ Signature;
 typedef struct SigMatchCtx_ SigMatchCtx;
 typedef struct SigMatch_ SigMatch;
 typedef struct SigMatchData_ SigMatchData;
+struct DetectFirewallPolicies;
 
 /** Flags to indicate if the Signature parsing must be done
 *   switching the source and dest (for ip addresses and ports)
@@ -114,7 +116,13 @@ int SC_Pcre2SubstringGet(pcre2_match_data *match_data, uint32_t number, PCRE2_UC
 void DetectRegisterAppLayerHookLists(void);
 void DetectListSupportedProtocols(void);
 
+const char *ActionScopeToString(enum ActionScope s);
+
+struct DetectFirewallPolicy;
+void DetectFirewallPolicyToString(const struct DetectFirewallPolicy *p, char *out, size_t out_size);
 int DetectFirewallInitDefaultPolicies(DetectEngineCtx *);
 int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *);
+Signature *DetectFirewallGetPolicySignature(struct DetectFirewallPolicies *fw_policies,
+        const AppProto alproto, const int direction, const uint8_t hook);
 
 #endif /* SURICATA_DETECT_PARSE_H */

--- a/src/detect.c
+++ b/src/detect.c
@@ -693,7 +693,8 @@ static inline bool SkipFwRules(const Packet *p)
  * packet:filter accept:hook to the packet as well.
  */
 static uint8_t DetectRunApplyPacketPolicy(const DetectEngineCtx *de_ctx,
-        const enum DetectFirewallPacketPolicies policy, Packet *p, const bool final)
+        DetectEngineThreadCtx *det_ctx, const enum DetectFirewallPacketPolicies policy, Packet *p,
+        const bool final)
 {
     DEBUG_VALIDATE_BUG_ON(de_ctx->fw_policies == NULL);
     const struct DetectFirewallPolicy *pol = &de_ctx->fw_policies->pkt[policy];
@@ -726,6 +727,10 @@ static uint8_t DetectRunApplyPacketPolicy(const DetectEngineCtx *de_ctx,
     } else {
         /* should be unreachable */
         DEBUG_VALIDATE_BUG_ON(1);
+    }
+    Signature *s = de_ctx->fw_policies->pkt_policy_signatures[policy];
+    if (s != NULL) {
+        AlertQueueAppend(det_ctx, s, p, 0, PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET);
     }
     return p->action;
 }
@@ -979,7 +984,7 @@ next:
         } else {
             DEBUG_VALIDATE_BUG_ON(action & ACTION_DROP);
             /* non-final call as we may have to consider app-layer still */
-            action |= DetectRunApplyPacketPolicy(de_ctx, scratch->fw_pkt_policy, p, false);
+            action |= DetectRunApplyPacketPolicy(de_ctx, det_ctx, scratch->fw_pkt_policy, p, false);
         }
     }
     return action;
@@ -1118,7 +1123,7 @@ static inline void DetectRunPostRules(ThreadVars *tv, const DetectEngineCtx *de_
             p->pkt_src == PKT_SRC_WIRE) {
         SCLogDebug("packet %" PRIu64 ": default action as no verdict set %02x (pkt %s)",
                 PcapPacketCntGet(p), p->action, PktSrcToString(p->pkt_src));
-        (void)DetectRunApplyPacketPolicy(de_ctx, scratch->fw_pkt_policy, p, true);
+        (void)DetectRunApplyPacketPolicy(de_ctx, det_ctx, scratch->fw_pkt_policy, p, true);
         DEBUG_VALIDATE_BUG_ON((p->action & (ACTION_DROP | ACTION_ACCEPT)) == 0);
     }
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1782,6 +1782,9 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         const Signature *s, const uint32_t can_idx, struct DetectFirewallAppTxState *fw_state,
         const bool last_tx)
 {
+    if ((s->flags & SIG_FLAG_FIREWALL) != 0 && fw_state->fw_skip_app_filter) {
+        return DETECT_TX_FW_FC_SKIP;
+    }
     if (p->flow->flags & FLOW_ACTION_ACCEPT) {
         if (fw_state->tx_fw_verdict == false) {
             fw_state->tx_fw_verdict = true;
@@ -2271,9 +2274,6 @@ static void DetectRunTx(ThreadVars *tv,
                     tx.detect_progress, tx.detect_progress_orig, s->app_progress_hook);
 
             if (have_fw_rules) {
-                if ((s->flags & SIG_FLAG_FIREWALL) != 0 && fw_state.fw_skip_app_filter) {
-                    continue;
-                }
                 const enum DetectTxFirewallFlowControl fw_r = DetectRunTxPreCheckFirewallPolicy(
                         det_ctx, p, &tx, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT), s, i,
                         &fw_state, last_tx);

--- a/src/detect.c
+++ b/src/detect.c
@@ -1253,27 +1253,21 @@ void *DetectGetInnerTx(void *tx_ptr, AppProto alproto, AppProto engine_alproto, 
  *         If stored_flags is set it means we're continuing
  *         inspection from an earlier run.
  *
- *  \retval bool true sig matched, false didn't match
+ *  \retval  1 sig matched
+ *  \retval  0 partial incomplete match
+ *  \retval -1 failed to match
  */
-static bool DetectRunTxInspectRule(ThreadVars *tv,
-        DetectEngineCtx *de_ctx,
-        DetectEngineThreadCtx *det_ctx,
-        Packet *p,
-        Flow *f,
-        const uint8_t in_flow_flags,   // direction, EOF, etc
-        void *alstate,
-        DetectTransaction *tx,
-        const Signature *s,
-        uint32_t *stored_flags,
-        RuleMatchCandidateTx *can,
-        DetectRunScratchpad *scratch)
+static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, Packet *p, Flow *f,
+        const uint8_t in_flow_flags, // direction, EOF, etc
+        void *alstate, DetectTransaction *tx, const Signature *s, uint32_t *stored_flags,
+        RuleMatchCandidateTx *can, DetectRunScratchpad *scratch)
 {
     const uint8_t flow_flags = in_flow_flags;
     const int direction = (flow_flags & STREAM_TOSERVER) ? 0 : 1;
     uint32_t inspect_flags = stored_flags ? *stored_flags : 0;
     int total_matches = 0;
     uint16_t file_no_match = 0;
-    bool retval = false;
     bool mpm_before_progress = false;   // is mpm engine before progress?
     bool mpm_in_progress = false;       // is mpm engine in a buffer we will revisit?
 
@@ -1284,17 +1278,19 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         TRACE_SID_TXS(s->id, tx, "first inspect, run packet matches");
         if (DetectRunInspectRuleHeader(p, f, s, s->flags) == false) {
             TRACE_SID_TXS(s->id, tx, "DetectRunInspectRuleHeader() no match");
-            return false;
+            return -1;
         }
         if (!DetectEnginePktInspectionRun(tv, det_ctx, s, f, p, NULL)) {
             TRACE_SID_TXS(s->id, tx, "DetectEnginePktInspectionRun no match");
-            return false;
+            return -1;
         }
         /* stream mpm and negated mpm sigs can end up here with wrong proto */
         if (!(AppProtoEquals(s->alproto, f->alproto) || s->alproto == ALPROTO_UNKNOWN)) {
             TRACE_SID_TXS(s->id, tx, "alproto mismatch");
-            return false;
+            return -1;
         }
+    } else {
+        TRACE_SID_TXS(s->id, tx, "continue, inspect_flags %x", inspect_flags);
     }
 
     const DetectEngineAppInspectionEngine *engine = s->app_inspect;
@@ -1360,8 +1356,9 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
 
                 /* we don't have to store a "hook" match, also don't want to keep any state to make
                  * sure the hook gets invoked again until tx progress progresses. */
-                if (tx->tx_progress <= engine->progress)
-                    return DETECT_ENGINE_INSPECT_SIG_MATCH;
+                if ((s->flags & SIG_FLAG_FW_HOOK_LTE) == 0 && tx->tx_progress <= engine->progress) {
+                    return 1; // DETECT_ENGINE_INSPECT_SIG_MATCH;
+                }
 
                 /* if progress > engine progress, track state to avoid additional matches */
                 match = DETECT_ENGINE_INSPECT_SIG_MATCH;
@@ -1421,10 +1418,11 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
     TRACE_SID_TXS(s->id, tx, "inspect_flags %x, total_matches %u, engine %p",
             inspect_flags, total_matches, engine);
 
+    bool full_match = false;
     if (engine == NULL && total_matches) {
         inspect_flags |= DE_STATE_FLAG_FULL_INSPECT;
         TRACE_SID_TXS(s->id, tx, "MATCH");
-        retval = true;
+        full_match = true;
     }
 
     if (stored_flags) {
@@ -1462,14 +1460,27 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         } else if ((inspect_flags & DE_STATE_FLAG_FULL_INSPECT) == 0 && mpm_in_progress) {
             TRACE_SID_TXS(s->id, tx, "no need to store no-match sig, "
                     "mpm will revisit it");
+            return -1; /* no match */
         } else if (inspect_flags != 0 || file_no_match != 0) {
             TRACE_SID_TXS(s->id, tx, "storing state: flags %08x", inspect_flags);
             DetectRunStoreStateTx(scratch->sgh, f, tx->tx_ptr, tx->tx_id, s,
                     inspect_flags, flow_flags, file_no_match);
+        } else {
+            if (inspect_flags == 0) {
+                TRACE_SID_TXS(s->id, tx, "no match: inspect_flags %08x", inspect_flags);
+                return -1;
+            }
         }
     }
-
-    return retval;
+    if (full_match) {
+        return 1;
+        /* can't be a partial match if we're at the end state */
+    } else if ((inspect_flags & DE_STATE_FLAG_SIG_CANT_MATCH) == 0 &&
+               tx->tx_progress < tx->tx_end_state) {
+        return 0;
+    } else {
+        return -1;
+    }
 }
 
 #define NO_TX                                                                                      \
@@ -1769,6 +1780,10 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         fw_state->fw_next_progress_missing = false;
         fw_state->fw_last_for_progress = false;
 
+        if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+            SCLogDebug("SIG_FLAG_FW_HOOK_LTE");
+            return DETECT_TX_FW_FC_OK; // TODO check for other cases
+        }
         /* if our first rule is beyond the starting state, we need to check if
          * there are rules missing for states in between. */
         // TODO detect_progress_orig already is +1?
@@ -2309,6 +2324,7 @@ static void DetectRunTx(ThreadVars *tv,
             RULE_PROFILING_START(p);
             const int r = DetectRunTxInspectRule(tv, de_ctx, det_ctx, p, f, flow_flags,
                     alstate, &tx, s, inspect_flags, can, scratch);
+            SCLogDebug("s %u r %d", s->id, r);
             if (r == 1) {
                 /* match */
                 DetectRunPostMatch(tv, det_ctx, p, s);
@@ -2340,7 +2356,21 @@ static void DetectRunTx(ThreadVars *tv,
                     }
                 }
                 AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
-
+            } else if (r == 0) {
+                SCLogDebug("sid %u partial match", s->id);
+                if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT)) {
+                    /* partial match always uses ACTION_SCOPE_HOOK. Final action only on the full
+                     * match */
+                    if (last_tx) {
+                        SCLogDebug("need to apply accept to packet");
+                        DetectRunAppendDefaultAccept(det_ctx, p);
+                    }
+                    if (s->action_scope == ACTION_SCOPE_FLOW) {
+                        SCLogDebug("only applying accept:flow on full match, downgrading to "
+                                   "accept:hook");
+                    }
+                    break;
+                }
             } else if (fw_state.fw_last_for_progress && (s->flags & SIG_FLAG_FIREWALL)) {
                 SCLogDebug("%" PRIu64 ": %s default policy for progress %u", PcapPacketCntGet(p),
                         flow_flags & STREAM_TOSERVER ? "toserver" : "toclient",

--- a/src/detect.c
+++ b/src/detect.c
@@ -161,7 +161,10 @@ static void DetectRun(ThreadVars *th_v,
         if (p->proto == IPPROTO_TCP) {
             if ((p->flags & PKT_STREAM_EST) == 0) {
                 SCLogDebug("packet %" PRIu64 ": skip tcp non-established", PcapPacketCntGet(p));
-                DetectRunAppendDefaultAccept(det_ctx, p);
+                if (EngineModeIsFirewall()) {
+                    SCLogDebug("default accept: no PKT_STREAM_EST");
+                    DetectRunAppendDefaultAccept(det_ctx, p);
+                }
                 goto end;
             }
             const TcpSession *ssn = p->flow->protoctx;
@@ -181,7 +184,10 @@ static void DetectRun(ThreadVars *th_v,
                     ((PKT_IS_TOSERVER(p) && (p->flow->flags & FLOW_TS_APP_UPDATED) == 0) ||
                             (PKT_IS_TOCLIENT(p) && (p->flow->flags & FLOW_TC_APP_UPDATED) == 0))) {
                 SCLogDebug("packet %" PRIu64 ": no app-layer update", PcapPacketCntGet(p));
-                DetectRunAppendDefaultAccept(det_ctx, p);
+                if (EngineModeIsFirewall()) {
+                    SCLogDebug("default accept: no app update");
+                    DetectRunAppendDefaultAccept(det_ctx, p);
+                }
                 goto end;
             }
         } else if (p->proto == IPPROTO_UDP) {
@@ -198,7 +204,10 @@ static void DetectRun(ThreadVars *th_v,
         PACKET_PROFILING_DETECT_END(p, PROF_DETECT_TX_UPDATE);
     } else {
         SCLogDebug("packet %" PRIu64 ": no flow / app-layer", PcapPacketCntGet(p));
-        DetectRunAppendDefaultAccept(det_ctx, p);
+        if (EngineModeIsFirewall()) {
+            SCLogDebug("default accept: no flow/app");
+            DetectRunAppendDefaultAccept(det_ctx, p);
+        }
     }
 
 end:
@@ -1721,6 +1730,7 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
         SCLogDebug("%" PRIu64 ": %s default policy for hook %u", PcapPacketCntGet(p),
                 direction & STREAM_TOSERVER ? "toserver" : "toclient", hook);
 
+        const bool apply_to_packet = is_last && hook == tx->tx_end_state;
         const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
                 det_ctx, det_ctx->de_ctx->fw_policies->app, p, alproto, direction, hook);
         SCLogDebug("fw: hook:%u policy:%02x", hook, policy->action);
@@ -1735,8 +1745,9 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
             if (policy->action_scope == ACTION_SCOPE_FLOW) {
                 if (policy->action & ACTION_ALERT) {
                     DetectRunAppendDefaultAppPolicyAlert(
-                            det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
+                            det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
                 } else {
+                    SCLogDebug("default aacept");
                     DetectRunAppendDefaultAccept(det_ctx, p);
                 }
                 return DETECT_TX_FW_FC_SKIP;
@@ -1755,12 +1766,13 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
         } else {
             if (policy->action & ACTION_ALERT) {
                 DetectRunAppendDefaultAppPolicyAlert(
-                        det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
+                        det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
             }
         }
     }
 
     if ((is_last && (actions & (ACTION_ACCEPT | ACTION_DROP)) == ACTION_ACCEPT)) {
+        SCLogDebug("default accept: last tx and at least one accept");
         DetectRunAppendDefaultAccept(det_ctx, p);
     }
     return DETECT_TX_FW_FC_OK;
@@ -1769,9 +1781,10 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
 /** \internal
  *  \brief run pre-rule inspection firewall policy checks
  *
- *  Check if:
+ *  Check for:
  *  - check if we're in accept:tx mode
  *  - check for missing accept hooks
+ *  -
  *
  * \retval DETECT_TX_FW_FC_OK no action needed
  * \retval DETECT_TX_FW_FC_BREAK rest of rules shouldn't be inspected
@@ -1788,6 +1801,7 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
     if (p->flow->flags & FLOW_ACTION_ACCEPT) {
         if (fw_state->tx_fw_verdict == false) {
             fw_state->tx_fw_verdict = true;
+            SCLogDebug("default accept due to flow accept");
             DetectRunAppendDefaultAccept(det_ctx, p);
         }
         if (s->flags & SIG_FLAG_FIREWALL) {
@@ -1801,7 +1815,7 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         if (!fw_state->tx_fw_verdict) {
             const bool accept_tx_applies_to_packet = last_tx;
             if (accept_tx_applies_to_packet) {
-                SCLogDebug("accept:(tx|hook): should be applied to the packet");
+                SCLogDebug("accept:tx: should be applied to the packet");
                 DetectRunAppendDefaultAccept(det_ctx, p);
             }
             fw_state->tx_fw_verdict = true;
@@ -1846,10 +1860,10 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
  * \param skip_fw_hook bool to indicate firewall rules skips
  * For state `skip_before_progress` should be skipped.
  *
- * \param skip_before_progress progress value to skip rules before.
- * Only used if `skip_fw_hook` is set.
+ * \param skip_before_progress progress value to skip rules before.* Only used if `skip_fw_hook` is
+ * set.
  *
- * \param fw_last_for_progress[out] set to true if this is the last firewall rule for a progress
+ * \param fw_last_for_progress[out] set to true if this is  firewall rule for a progress
  * value
  *
  * \param fw_next_progress_missing[out] set to true if the next fw rule does not target the next
@@ -1924,17 +1938,19 @@ static enum DetectTxFirewallFlowControl DetectRunTxCheckFirewallPolicy(
 
 // TODO move into det_ctx?
 thread_local Signature default_accept;
-static inline void DetectRunAppendDefaultAccept(DetectEngineThreadCtx *det_ctx, Packet *p)
+static void DetectRunAppendDefaultAccept(DetectEngineThreadCtx *det_ctx, Packet *p)
 {
-    if (EngineModeIsFirewall()) {
-        memset(&default_accept, 0, sizeof(default_accept));
-        default_accept.action = ACTION_ACCEPT;
-        default_accept.action_scope = ACTION_SCOPE_PACKET;
-        default_accept.iid = UINT32_MAX;
-        default_accept.type = SIG_TYPE_PKT;
-        default_accept.flags = SIG_FLAG_FIREWALL;
-        AlertQueueAppend(det_ctx, &default_accept, p, 0, PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET);
-    }
+    DEBUG_VALIDATE_BUG_ON(!EngineModeIsFirewall());
+    SCLogDebug("packet %" PRIu64 ": appending default firewall accept", PcapPacketCntGet(p));
+    memset(&default_accept, 0, sizeof(default_accept));
+    default_accept.action = ACTION_ACCEPT;
+    default_accept.action_scope = ACTION_SCOPE_PACKET;
+    default_accept.iid = UINT32_MAX;
+    default_accept.type = SIG_TYPE_PKT;
+    default_accept.flags = SIG_FLAG_FIREWALL;
+    default_accept.detect_table =
+            DETECT_TABLE_APP_FILTER; // TODO review, hope this makes it last in sorting
+    AlertQueueAppend(det_ctx, &default_accept, p, 0, PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET);
 }
 
 /** \internal
@@ -2015,7 +2031,7 @@ static bool ApplyAccept(DetectEngineThreadCtx *det_ctx, Packet *p, const uint8_t
     } else if (as == ACTION_SCOPE_PACKET) {
         return true;
     } else if (as == ACTION_SCOPE_FLOW) {
-        SCLogDebug("ACTION_ACCEPT with ACTION_SCOPE_FLOW");
+        SCLogDebug("sid %u: ACTION_ACCEPT with ACTION_SCOPE_FLOW", s->id);
         return true;
     }
     return false;
@@ -2040,12 +2056,14 @@ static int DetectTxFirewallNoRulesApplyPolicies(DetectEngineThreadCtx *det_ctx, 
         /* if there are no rules, make sure to handle accept:flow and accept:tx */
         if (rule_cnt == 0) {
             if (f->flags & FLOW_ACTION_ACCEPT) {
+                SCLogDebug("default accept:flow: no rules");
                 DetectRunAppendDefaultAccept(det_ctx, p);
                 return 1;
             }
             if (tx->tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
                 /* current tx is the last we have, append a blank accept:packet */
                 if (last_tx) {
+                    SCLogDebug("default accept:tx: no rules");
                     DetectRunAppendDefaultAccept(det_ctx, p);
                     return 1;
                 }
@@ -2319,8 +2337,11 @@ static void DetectRunTx(ThreadVars *tv,
                         const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
                         fw_state.fw_skip_app_filter = ApplyAccept(
                                 det_ctx, p, flow_flags, s, &tx, tx_end_state, last_tx, &fw_state);
-                        if (fw_accept_to_packet)
+                        if (fw_accept_to_packet) {
+                            SCLogDebug("packet %" PRIu64 ": apply accept to packet",
+                                    PcapPacketCntGet(p));
                             DetectRunAppendDefaultAccept(det_ctx, p);
+                        }
                     }
                     continue;
                 }
@@ -2377,6 +2398,8 @@ static void DetectRunTx(ThreadVars *tv,
                          * accept:tx or accept:hook is the last match.*/
                         const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
                         if (fw_accept_to_packet) {
+                            SCLogDebug("packet %" PRIu64 ": apply accept to packet",
+                                    PcapPacketCntGet(p));
                             SCLogDebug("accept:(tx|hook): should be applied to the packet");
                             alert_flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET;
                         }
@@ -2430,6 +2453,7 @@ static void DetectRunTx(ThreadVars *tv,
                     /* if this is also the last fw rule we'll inspect we have to issue a default
                      * accept to the packet */
                     if (last_tx && s->app_progress_hook == tx.tx_progress) {
+                        SCLogDebug("default accept: last_tx");
                         DetectRunAppendDefaultAccept(det_ctx, p);
                     }
                 }
@@ -2513,6 +2537,7 @@ static void DetectRunTx(ThreadVars *tv,
             tx_inspected, fw_verdicted);
     /* if all tables have been bypassed, we accept:packet */
     if (tx_inspected == 0 && fw_verdicted == 0 && have_fw_rules) {
+        SCLogDebug("default accept: no app inspect performed");
         DetectRunAppendDefaultAccept(det_ctx, p);
     }
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -36,6 +36,7 @@
 #include "app-layer-frames.h"
 
 #include "detect.h"
+#include "detect-parse.h"
 #include "detect-dsize.h"
 #include "detect-engine.h"
 #include "detect-engine-build.h"
@@ -1635,6 +1636,20 @@ struct DetectFirewallAppTxState {
     bool last_fw_rule; /**< processing the last fw rule, so we need to eval all hooks after it. */
 };
 
+static inline void DetectRunAppendDefaultAppPolicyAlert(DetectEngineThreadCtx *det_ctx, Packet *p,
+        const bool apply_to_packet, const int direction, const uint64_t tx_id,
+        const AppProto alproto, const uint8_t hook)
+{
+    if (EngineModeIsFirewall()) {
+        Signature *s = DetectFirewallGetPolicySignature(
+                det_ctx->de_ctx->fw_policies, alproto, direction, hook);
+        BUG_ON(s == NULL);
+        uint8_t alert_flags = apply_to_packet ? PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET : 0;
+        alert_flags |= PACKET_ALERT_FLAG_TX;
+        AlertQueueAppend(det_ctx, s, p, tx_id, alert_flags);
+    }
+}
+
 /** \internal
  *  \brief apply default policy
  *  \param p packet to apply policy to
@@ -1645,8 +1660,8 @@ struct DetectFirewallAppTxState {
  *        to look up configurable default policies later
  */
 static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
-        const struct DetectFirewallAppPolicy *policies, Packet *p, const AppProto alproto,
-        const uint8_t direction, const uint8_t progress)
+        DetectEngineThreadCtx *det_ctx, const struct DetectFirewallAppPolicy *policies, Packet *p,
+        const AppProto alproto, const uint8_t direction, const uint8_t progress)
 {
     const struct DetectFirewallPolicy *policy;
     if (direction & STREAM_TOSERVER) {
@@ -1702,7 +1717,7 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
                 direction & STREAM_TOSERVER ? "toserver" : "toclient", hook);
 
         const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
-                det_ctx->de_ctx->fw_policies->app, p, alproto, direction, hook);
+                det_ctx, det_ctx->de_ctx->fw_policies->app, p, alproto, direction, hook);
         SCLogDebug("fw: hook:%u policy:%02x", hook, policy->action);
         actions |= policy->action;
         if (policy->action & ACTION_DROP) {
@@ -1713,19 +1728,33 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
 
             /* accepting flow, so skip rest of the fw rules */
             if (policy->action_scope == ACTION_SCOPE_FLOW) {
-                DetectRunAppendDefaultAccept(det_ctx, p);
+                if (policy->action & ACTION_ALERT) {
+                    DetectRunAppendDefaultAppPolicyAlert(
+                            det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
+                } else {
+                    DetectRunAppendDefaultAccept(det_ctx, p);
+                }
                 return DETECT_TX_FW_FC_SKIP;
             } else if (policy->action_scope == ACTION_SCOPE_TX) {
                 tx->tx_data_ptr->flags |= APP_LAYER_TX_ACCEPT;
                 SCLogDebug("ACTION_SCOPE_TX, setting APP_LAYER_TX_ACCEPT");
-                if (is_last) {
+                if (policy->action & ACTION_ALERT) {
+                    DetectRunAppendDefaultAppPolicyAlert(
+                            det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
+                } else if (is_last) {
                     DetectRunAppendDefaultAccept(det_ctx, p);
                     SCLogDebug("DetectRunAppendDefaultAccept for last tx");
                 }
                 return DETECT_TX_FW_FC_SKIP;
             }
+        } else {
+            if (policy->action & ACTION_ALERT) {
+                DetectRunAppendDefaultAppPolicyAlert(
+                        det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
+            }
         }
     }
+
     if ((is_last && (actions & (ACTION_ACCEPT | ACTION_DROP)) == ACTION_ACCEPT)) {
         DetectRunAppendDefaultAccept(det_ctx, p);
     }
@@ -2377,9 +2406,9 @@ static void DetectRunTx(ThreadVars *tv,
                         s->app_progress_hook);
                 /* if this rule was the last for our progress state, and it didn't match,
                  * we have to invoke the default policy. We only check the current rule hook. */
-                const struct DetectFirewallPolicy *policy =
-                        DetectFirewallApplyDefaultAppPolicy(det_ctx->de_ctx->fw_policies->app, p,
-                                s->alproto, flow_flags, s->app_progress_hook);
+                const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
+                        det_ctx, det_ctx->de_ctx->fw_policies->app, p, s->alproto, flow_flags,
+                        s->app_progress_hook);
                 SCLogDebug("fw_last_for_progress policy %02x", policy->action);
                 if (policy->action & ACTION_DROP) {
                     fw_state.fw_skip_app_filter = true;

--- a/src/detect.c
+++ b/src/detect.c
@@ -2365,7 +2365,7 @@ static void DetectRunTx(ThreadVars *tv,
 
                     /* if this is also the last fw rule we'll inspect we have to issue a default
                      * accept to the packet */
-                    if (s->app_progress_hook == tx.tx_progress) {
+                    if (last_tx && s->app_progress_hook == tx.tx_progress) {
                         DetectRunAppendDefaultAccept(det_ctx, p);
                     }
                 }

--- a/src/detect.h
+++ b/src/detect.h
@@ -248,7 +248,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_APPLAYER               BIT_U32(6) /**< signature applies to app layer instead of packets */
 #define SIG_FLAG_TXBOTHDIR              BIT_U32(7) /**< signature needs tx with both directions to match */
 
-// vacancy
+#define SIG_FLAG_FW_HOOK_LTE BIT_U32(8) /**< Signature::app_progress_hook is to be used as LTE */
 
 #define SIG_FLAG_REQUIRE_PACKET         BIT_U32(9)  /**< signature is requiring packet match */
 #define SIG_FLAG_REQUIRE_STREAM         BIT_U32(10) /**< signature is requiring stream match */

--- a/src/detect.h
+++ b/src/detect.h
@@ -935,6 +935,9 @@ struct DetectFirewallPolicies {
     /** policy for packet_filter, pre_flow, pre_stream hooks */
     struct DetectFirewallPolicy pkt[DETECT_FIREWALL_POLICY_SIZE];
 
+    /* hash table with a Signature object per default policy that has `alert` enabled. */
+    HashTable *policy_signatures;
+
     /** app layer policies, one per alproto */
     struct DetectFirewallAppPolicy app[];
 };

--- a/src/detect.h
+++ b/src/detect.h
@@ -934,6 +934,7 @@ struct DetectFirewallAppPolicy {
 struct DetectFirewallPolicies {
     /** policy for packet_filter, pre_flow, pre_stream hooks */
     struct DetectFirewallPolicy pkt[DETECT_FIREWALL_POLICY_SIZE];
+    Signature *pkt_policy_signatures[DETECT_FIREWALL_POLICY_SIZE];
 
     /* hash table with a Signature object per default policy that has `alert` enabled. */
     HashTable *policy_signatures;

--- a/src/detect.h
+++ b/src/detect.h
@@ -550,6 +550,9 @@ enum SignatureHookType {
     SIGNATURE_HOOK_TYPE_APP,
 };
 
+/** detect table identifiers, ordered by how they logically
+ *  evaluated. Used in rule ordering to ensure the correct order
+ *  of rule actions. */
 enum DetectTable {
     DETECT_TABLE_NOT_SET = 0,
     DETECT_TABLE_PACKET_PRE_FLOW,

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -40,6 +40,7 @@
 #include "util-misc.h"
 #include "util-time.h"
 
+#include "detect-parse.h"
 #include "detect-engine.h"
 #include "detect-metadata.h"
 #include "app-layer-parser.h"
@@ -647,6 +648,49 @@ static bool AlertJsonStreamData(const AlertJsonOutputCtx *json_output_ctx, JsonA
     return false;
 }
 
+static void AlertJsonAddFirewall(SCJsonBuilder *jb, const Signature *s)
+{
+    struct DetectFirewallPolicy pol = { .action = s->action, .action_scope = s->action_scope };
+
+    SCJbOpenObject(jb, "firewall");
+    const char *hook = NULL;
+    char hook_string[256];
+    switch (s->detect_table) {
+        case DETECT_TABLE_APP_FILTER:
+            if (s->flags & SIG_FLAG_TOSERVER) {
+                hook = AppLayerParserGetStateNameById(
+                        IPPROTO_TCP, s->alproto, s->app_progress_hook, STREAM_TOSERVER);
+            } else {
+                hook = AppLayerParserGetStateNameById(
+                        IPPROTO_TCP, s->alproto, s->app_progress_hook, STREAM_TOCLIENT);
+            }
+            if (hook) {
+                snprintf(hook_string, sizeof(hook_string), "%s:%s", AppProtoToString(s->alproto),
+                        hook);
+                hook = hook_string;
+            }
+            break;
+        case DETECT_TABLE_PACKET_FILTER:
+            hook = "packet:filter";
+            break;
+        case DETECT_TABLE_PACKET_PRE_FLOW:
+            hook = "packet:pre_flow";
+            break;
+        case DETECT_TABLE_PACKET_PRE_STREAM:
+            hook = "packet:pre_stream";
+            break;
+    }
+    if (hook) {
+        SCJbSetString(jb, "hook", hook);
+    }
+    char policy_string[64] = "";
+    DetectFirewallPolicyToString(&pol, policy_string, sizeof(policy_string));
+    if (strlen(policy_string) > 0) {
+        SCJbSetString(jb, "policy", policy_string);
+    }
+    SCJbClose(jb);
+}
+
 static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 {
     AlertJsonOutputCtx *json_output_ctx = aft->json_output_ctx;
@@ -709,6 +753,10 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
         if (PacketIsTunnel(p)) {
             AlertJsonTunnel(p, jb, &json_output_ctx->eve_ctx->cfg);
+        }
+
+        if (pa->s->flags & SIG_FLAG_FIREWALL) {
+            AlertJsonAddFirewall(jb, pa->s);
         }
 
         if (p->flow != NULL) {


### PR DESCRIPTION
    Allow a single rule to accept a hook and the hooks prior to it.
    
    Example:
    
            accept:flow tls:<client_hello_done ... \
                    tls.sni; content:"suricata.io"; endswith;
    
    This will evaluate the SNI at the client_hello_done hook, but will
    act as if there is a `accept:hook tls:client_in_progress ...` as well.
    
    Implementation is currently specific to this `<` operator. During
    parsing the sig gets flagged for this case. During setup this has 3 main
    effects:
    
    1. prefilter is disabled as we need to eval this right at the first
       state (0)
    2. for state 0 a non-PF "prefilter" engine is setup to make sure the
       rule is flagged for evaluation
    3. In the Signature::app_inspect list a dummy inspect engine is
       registered per state before Signature::app_progress_hook
    
    The matching logic is building on the stateful rule handling. The
    stateful rule handling can now tell the inspection loop that a partial
    match occured. For this rule type the partial match will act as a match
    with action accept:hook.
    
    Next app updates will then use the continue detection logic to continue
    the stateful match. When that fully matches, the final actions are
    applied, like accept:flow or accept:tx.
    
    Ticket: #8472.

https://redmine.openinfosecfoundation.org/issues/8472

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3095


Additionally, policy alert logging
https://redmine.openinfosecfoundation.org/issues/8566