### PR TITLE
defrag: drop unsigned underflow in RB_NFIND search key

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -642,7 +642,7 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
 
     if (!RB_EMPTY(&tracker->fragment_tree)) {
         Frag key = {
-            .offset = frag_offset - 1,
+            .offset = frag_offset,
         };
         next = RB_NFIND(IP_FRAGMENTS, &tracker->fragment_tree, &key);
         if (next == NULL) {


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request. Thank you

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8232

Describe changes:
- `DefragInsertFrag` seeds the RB tree search with `frag_offset - 1` as the key. `frag_offset` is `uint16_t`, so the first fragment of any IP datagram (`frag_offset == 0`) wraps the key to 65535. RB_NFIND then returns NULL and the existing RB_MIN fallback walks the tree forward. The end result is correct but the path is reached by accident, and the underflow is what fuzzer integer-overflow sanitizers flag.
- The `-1` is functionally a no-op even on inputs where it does not underflow. Fragment offsets are always multiples of 8 (`IPV4_GET_RAW_FRAGOFFSET << 3` for IPv4, the IPv6 fragment header offset field for IPv6), so no fragment can ever have `offset == frag_offset - 1`. RB_NFIND returns the same neighbour for keys `frag_offset` and `frag_offset - 1` on every realistic input.
- Patch is one character: drop the `- 1`. The RB_PREV / RB_MIN fallback logic that follows is intentionally left intact. In the no-strict-greater case the existing code starts at the tree minimum and walks forward, which is the only safe choice given the defrag policies do not enforce a non-overlapping invariant on `offset + data_len` (overlaps are handled through `ltrim`, not by trimming `data_len`). Switching to `RB_MAX` would miss overlaps where an earlier long fragment extends past later ones.

Verification:
- All 35 defrag unit tests pass locally with `--enable-unittests`, including every Sturges-Novak overlap-evasion pattern for BSD, Linux, Windows, Solaris, First, and Last policies on IPv4 and IPv6, the BSD subsequent-overlap-of-original tests, the missing-fragment tests, and the trailing no-MF-fragment tests.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3098
SU_REPO=
SU_BRANCH=
