### PR TITLE
etc/schema: add missing ftp fields

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2192,10 +2192,20 @@
             "additionalProperties": false,
             "properties": {
                 "command": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "ftp.command"
+                        ]
+                    }
                 },
                 "command_data": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "ftp.command_data"
+                        ]
+                    }
                 },
                 "command_truncated": {
                     "type": "boolean"
@@ -2205,6 +2215,11 @@
                     "minItems": 1,
                     "items": {
                         "type": "string"
+                    },
+                    "suricata": {
+                        "keywords": [
+                            "ftp.completion_code"
+                        ]
                     }
                 },
                 "dynamic_port": {
@@ -2216,17 +2231,32 @@
                     }
                 },
                 "mode": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "ftp.mode"
+                        ]
+                    }
                 },
                 "reply": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "string"
+                    },
+                    "suricata": {
+                        "keywords": [
+                            "ftp.reply"
+                        ]
                     }
                 },
                 "reply_received": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "ftp.reply_received"
+                        ]
+                    }
                 },
                 "reply_truncated": {
                     "type": "boolean"
@@ -2238,7 +2268,12 @@
             "additionalProperties": false,
             "properties": {
                 "command": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "ftpdata_command"
+                        ]
+                    }
                 },
                 "filename": {
                     "type": "string"


### PR DESCRIPTION
Add ftp detect keywords to metadata

Issue: 7502, 7503, 7507, 7505, 7508, 7506

`python3 scripts/eve-parity.py unmapped-fields | grep ^ftp` identified the following are unmapped:
```
  ftp.command
  ftp.command_data
  ftp.command_truncated
  ftp.completion_code
  ftp.mode
  ftp.reply
  ftp.reply_received
  ftp.reply_truncated
  ftp_data.command
  ftp_data.filename
```

Of these, the following do not have detect keywords:
```
  ftp.command_truncated
  ftp.reply_truncated
  ftp_data.filename
```

## Changes (if applicable):

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6476

Describe changes:
- Added unmapped fields highlighted with command (see descr)
-
-

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
