### PR TITLE
fuzz: extend fuzz_siginit to do engine-rule-analysis

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1311,7 +1311,7 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_applayerparserparse_SOURCES = force-cxx-linking.cxx
 
-fuzz_siginit_SOURCES = tests/fuzz/fuzz_siginit.c
+fuzz_siginit_SOURCES = tests/fuzz/fuzz_siginit.c tests/fuzz/confyaml.c
 fuzz_siginit_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_siginit_LDADD = $(LDADD_FUZZ)
 fuzz_siginit_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)

--- a/src/tests/fuzz/fuzz_siginit.c
+++ b/src/tests/fuzz/fuzz_siginit.c
@@ -12,46 +12,54 @@
 #include "detect-parse.h"
 #include "app-layer.h"
 #include "nallocinc.c"
+#include "detect-engine-analyzer.h"
+#include "detect-engine-build.h"
+#include "util-conf.h"
+#include "conf-yaml-loader.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
-static uint32_t cnt = 0;
 DetectEngineCtx *de_ctx = NULL;
 static int initialized = 0;
 SC_ATOMIC_EXTERN(unsigned int, engine_stage);
+bool fp_engine_analysis_set;
+extern bool rule_engine_analysis_set;
+extern const char *configNoChecksum;
+SCInstance surifuzz;
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    if (de_ctx == NULL) {
+    if (initialized == 0) {
+        // Redirects logs to /dev/null
         setenv("SC_LOG_OP_IFACE", "file", 0);
         setenv("SC_LOG_FILE", "/dev/null", 0);
-        //global init
+
         InitGlobal();
+        rule_engine_analysis_set = true;
         GlobalsInitPreConfig();
-        SCRunmodeSet(RUNMODE_UNITTEST);
-        MpmTableSetup();
-        SpmTableSetup();
-        EngineModeSetIDS();
-        SigTableInit();
-        AppLayerSetup();
-        SigTableSetup();
-        if (initialized == 0) {
-            nalloc_init(NULL);
-            nalloc_restrict_file_prefix(3);
-            SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
-            initialized = 1;
+        SCRunmodeSet(RUNMODE_ENGINE_ANALYSIS);
+        ConfigSetLogDirectory("/tmp/");
+        // disables checksums validation for fuzzing
+        if (SCConfYamlLoadString(configNoChecksum, strlen(configNoChecksum)) != 0) {
+            abort();
         }
-    }
-    if (cnt++ == 1024) {
-        DetectEngineCtxFree(de_ctx);
-        de_ctx = NULL;
-        cnt = 0;
+        SCConfSetFinal("engine-analysis.rules", "true");
+        surifuzz.sig_file_exclusive = 1;
+        // loads rules after init
+        surifuzz.delayed_detect = 1;
+        PostConfLoadedSetup(&surifuzz);
+        PostConfLoadedDetectSetup(&surifuzz);
+
+        nalloc_init(NULL);
+        nalloc_restrict_file_prefix(3);
+        SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
+        initialized = 1;
     }
     if (de_ctx == NULL) {
         de_ctx = DetectEngineCtxInit();
         BUG_ON(de_ctx == NULL);
-        de_ctx->flags |= DE_QUIET;
         de_ctx->rule_file = (char *)"fuzzer";
+        SetupEngineAnalysis(de_ctx, &fp_engine_analysis_set, &rule_engine_analysis_set);
     }
 
     char * buffer = malloc(size+1);
@@ -60,14 +68,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         //null terminate string
         buffer[size] = 0;
         nalloc_start(data, size);
-        Signature *s = SigInit(de_ctx, buffer);
-        free(buffer);
-        if (s && s->next) {
-            SigFree(de_ctx, s->next);
-            s->next = NULL;
+        Signature *sig = DetectEngineAppendSig(de_ctx, buffer);
+        if (sig) {
+            SigGroupBuild(de_ctx);
         }
-        SigFree(de_ctx, s);
+        CleanupEngineAnalysis(de_ctx);
+        DetectEngineCtxFree(de_ctx);
         nalloc_end();
+        de_ctx = NULL;
+        free(buffer);
     }
 
     return 0;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
Tracking https://redmine.openinfosecfoundation.org/issues/4125, inspired by https://github.com/OISF/suricata/pull/15286

Describe changes:
- fuzz: extend fuzz_siginit to do engine-rule-analysis

Found https://redmine.openinfosecfoundation.org/issues/8526 straight away in fuzz_siginit public corpus