### PR TITLE
redis: guard stream format allocation

### DIFF
--- a/qa/coccinelle/malloc-error-check.cocci
+++ b/qa/coccinelle/malloc-error-check.cocci
@@ -1,7 +1,7 @@
 @malloced@
 expression x;
 position p1;
-identifier func =~ "(SCMalloc|SCStrdup|SCCalloc|SCMallocAligned|SCRealloc)";
+identifier func =~ "SCMalloc\|SCStrdup\|SCCalloc\|SCMallocAligned\|SCRealloc";
 @@
 
 x@p1 = func(...)
@@ -10,7 +10,7 @@ x@p1 = func(...)
 expression x, E;
 statement S;
 position malloced.p1;
-identifier func =~ "(SCMalloc|SCStrdup|SCCalloc|SCMallocAligned|SCRealloc)";
+identifier func =~ "SCMalloc\|SCStrdup\|SCCalloc\|SCMallocAligned\|SCRealloc";
 @@
 
 (
@@ -22,7 +22,7 @@ if (E && (x@p1 = func(...)) == NULL) S
 @realloc exists@
 position malloced.p1;
 expression x, E1;
-identifier func =~ "(SCMalloc|SCCalloc|SCMallocAligned)";
+identifier func =~ "SCMalloc\|SCCalloc\|SCMallocAligned";
 @@
 
 x@p1 = func(...)
@@ -33,13 +33,11 @@ x = SCRealloc(x, E1)
 expression x, E1;
 position malloced.p1;
 statement S1, S2;
-identifier func =~ "(SCMalloc|SCStrdup|SCCalloc|SCMallocAligned|SCRealloc)";
-identifier callee;
+identifier func =~ "SCMalloc\|SCStrdup\|SCCalloc\|SCMallocAligned\|SCRealloc";
 @@
 
 x@p1 = func(...)
 ... when != x
-    when != callee(..., x, ...)
 (
 if (unlikely(x == NULL)) S1
 |

--- a/qa/coccinelle/malloc-error-check.cocci
+++ b/qa/coccinelle/malloc-error-check.cocci
@@ -34,10 +34,12 @@ expression x, E1;
 position malloced.p1;
 statement S1, S2;
 identifier func =~ "(SCMalloc|SCStrdup|SCCalloc|SCMallocAligned|SCRealloc)";
+identifier callee;
 @@
 
 x@p1 = func(...)
 ... when != x
+    when != callee(..., x, ...)
 (
 if (unlikely(x == NULL)) S1
 |

--- a/src/decode.c
+++ b/src/decode.c
@@ -144,7 +144,9 @@ ExceptionPolicyStatsSetts flow_memcap_eps_stats = {
 PacketAlert *PacketAlertCreate(void)
 {
     PacketAlert *pa_array = SCCalloc(packet_alert_max, sizeof(PacketAlert));
-    DEBUG_VALIDATE_BUG_ON(pa_array == NULL);
+    if (unlikely(pa_array == NULL)) {
+        FatalError("Failed to allocate packet alert array");
+    }
 
     return pa_array;
 }

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -337,6 +337,9 @@ static inline int PacketAlertSetContext(
                     }
                 }
                 current_json->json_string = SCStrdup(det_ctx->json_content[i].json_content);
+                if (current_json->json_string == NULL) {
+                    return -1;
+                }
                 SCLogDebug("json content %u, value '%s' (%p)", (unsigned int)i,
                         current_json->json_string, s);
             }

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -791,11 +791,11 @@ int DetectFlowbitsAnalyze(DetectEngineCtx *de_ctx)
                     uint32_t new_fb_array_size = s->init_data->rule_state_flowbits_ids_size + 1;
                     void *tmp_fb_ptr = SCRealloc(s->init_data->rule_state_flowbits_ids_array,
                             new_fb_array_size * sizeof(uint32_t));
-                    s->init_data->rule_state_flowbits_ids_array = tmp_fb_ptr;
-                    if (s->init_data->rule_state_flowbits_ids_array == NULL) {
+                    if (tmp_fb_ptr == NULL) {
                         SCLogError("Failed to reallocate memory for rule_state_variable_idx");
                         goto error;
                     }
+                    s->init_data->rule_state_flowbits_ids_array = tmp_fb_ptr;
                     SCLogDebug(
                             "realloc'ed array for flowbits ids, new size is %u", new_fb_array_size);
                     s->init_data->rule_state_dependant_sids_size = new_array_size;

--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -153,6 +153,9 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
     if (strlen(scheme)) {
         SCLogConfig("scheme value %s overrides key %s", scheme, key);
         ref->key = SCStrdup(scheme);
+        if (ref->key == NULL) {
+            goto error;
+        }
         /* already bound checked to be REFERENCE_SYSTEM_NAME_MAX or less */
         ref->key_len = (uint16_t)strlen(scheme);
     } else {
@@ -160,6 +163,9 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
         SCRConfReference *lookup_ref_conf = SCRConfGetReference(key, de_ctx);
         if (lookup_ref_conf != NULL) {
             ref->key = SCStrdup(lookup_ref_conf->url);
+            if (ref->key == NULL) {
+                goto error;
+            }
             /* already bound checked to be REFERENCE_SYSTEM_NAME_MAX or less */
             ref->key_len = (uint16_t)strlen(ref->key);
         } else {

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -673,6 +673,9 @@ int SCConfLogOpenRedis(SCConfNode *redis_node, void *lf_ctx)
             format string, whose length is limited by the length of the
             maxlen integer formatted as a string */
             log_ctx->redis_setup.stream_format = SCCalloc(100, sizeof(char));
+            if (unlikely(log_ctx->redis_setup.stream_format == NULL)) {
+                FatalError("Unable to allocate redis stream format");
+            }
             snprintf(log_ctx->redis_setup.stream_format, 100, redis_stream_format_maxlen_tmpl, "%s",
                     "%s", exact ? '=' : '~', maxlen, "%s");
             log_ctx->redis_setup.format = log_ctx->redis_setup.stream_format;

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -641,7 +641,7 @@ static int CompileDataExtensionsInit(hs_expr_ext_t **ext, const SCHSPattern *p)
 {
     if (p->flags & (MPM_PATTERN_FLAG_OFFSET | MPM_PATTERN_FLAG_DEPTH)) {
         *ext = SCCalloc(1, sizeof(hs_expr_ext_t));
-        if ((*ext) == NULL) {
+        if (*ext == NULL) {
             return -1;
         }
         if (p->flags & MPM_PATTERN_FLAG_OFFSET) {
@@ -1179,6 +1179,9 @@ void SCHSPrintInfo(MpmCtx *mpm_ctx)
 static MpmConfig *SCHSConfigInit(void)
 {
     MpmConfig *c = SCCalloc(1, sizeof(MpmConfig));
+    if (unlikely(c == NULL)) {
+        FatalError("Failed to allocate MpmConfig");
+    }
     return c;
 }
 


### PR DESCRIPTION
Ticket: 8588

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8588

Describe changes:
- Check the Redis stream format allocation before passing it to `snprintf()`.
- Use `FatalError()` for this unrecoverable Redis output initialization failure, matching the existing Redis setup error handling style.
- Prevent a NULL pointer dereference when Redis stream/xadd mode is configured with a positive `stream-maxlen` and memory allocation fails.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
