### PR TITLE
detect/xor: add inline variable key syntax

### DIFF
--- a/doc/userguide/devguide/extending/detect/index.rst
+++ b/doc/userguide/devguide/extending/detect/index.rst
@@ -1,6 +1,11 @@
 Detection
 #########
 
+.. toctree::
+   :maxdepth: 1
+
+   transforms.rst
+
 Rate Filter Callback
 ********************
 

--- a/doc/userguide/devguide/extending/detect/transforms.rst
+++ b/doc/userguide/devguide/extending/detect/transforms.rst
@@ -1,0 +1,52 @@
+Transforms
+**********
+
+Overview
+========
+
+Transforms modify the contents of an inspection buffer before content
+keywords inspect it. They are applied in the order they appear in the rule,
+with each transform's output becoming the next transform's input.
+
+Execution Order
+===============
+
+Transforms run at two points in the detection pipeline:
+
+1. **Prefilter (MPM):** when the buffer is set up for the multi-pattern
+   matcher. The MPM searches the *transformed* buffer for fast-pattern
+   content.
+2. **Full inspection:** when the rule's keywords are evaluated against the
+   (transformed) buffer.
+
+In both cases, transforms execute before detection-time keywords such as
+``byte_extract`` and ``byte_math``. The transformed buffer is what all
+subsequent keywords — including ``content`` — operate on.
+
+Variable Keys
+=============
+
+Because transforms run before detection-time variable resolution, a transform
+that needs key material from the buffer must read it directly at transform time.
+
+The ``xor`` transform supports this with the ``var <nbytes> <offset>`` syntax:
+the rule author specifies the buffer position and width of the key directly.
+At transform time the engine reads ``<nbytes>`` bytes starting at ``<offset>``
+in the raw (pre-transform) buffer. This works at both prefilter and full
+inspection because the key bytes are at a known, fixed position in the raw
+buffer.
+
+Transform Identity
+==================
+
+The engine deduplicates inspection buffers: rules that use the same buffer
+keyword with the same transform configuration share one pre-computed buffer.
+Equivalence is determined at rule load time by comparing an identity value
+that each transform instance produces from its configuration. Instances with
+identical identity share a buffer; instances with different identity (or where
+a transform produces no identity) get independent buffers.
+
+For ``xor`` with a static key the key bytes are the identity. For a variable
+key the identity is the key's offset and byte count — so two rules reading
+their key from the same buffer location share a buffer, while two rules with
+different key locations each get their own correctly transformed buffer.

--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -192,17 +192,41 @@ xor
 
 Takes the buffer, applies xor decoding.
 
-.. note:: this transform requires a mandatory option which is the hexadecimal encoded xor key.
+The key can be a hexadecimal string or a variable specified inline using
+``var <nbytes> <offset>``. When a variable key is used, the engine reads
+``<nbytes>`` bytes starting at ``<offset>`` in the raw inspection buffer
+at transform time.
 
+An optional ``offset`` parameter specifies the byte position in the buffer
+where XOR decoding starts. Bytes before this position are left as-is.
+For example, if the first byte of the buffer is the XOR key, use
+``offset 1`` so decoding begins after that key byte.
+
+Syntax::
+
+    xor:"<hex_key>"
+    xor:var <nbytes> <offset>
+    xor:offset <N>,"<hex_key>"
+    xor:offset <N>,var <nbytes> <offset>
 
 Quotes around a hex key are optional; ``xor:0d0ac8ff`` and ``xor:"0d0ac8ff"``
 are equivalent.
 
-This example alerts if ``http.uri`` contains ``password=`` xored with 4-bytes key ``0d0ac8ff``
+This example alerts if ``http.uri`` contains ``password=`` xored with 4-bytes key ``0d0ac8ff``:
+
 .. container:: example-rule
 
     alert http any any -> any any (msg:"HTTP with xor"; http.uri; \
         xor:"0d0ac8ff"; content:"password="; sid:1;)
+
+This example reads a 1-byte XOR key from offset 0 of the request body,
+then decodes the buffer starting at offset 1 (skipping the key byte) and
+matches ``infected`` in the decoded data:
+
+.. container:: example-rule
+
+    alert http any any -> any any (msg:"XOR with variable key"; \
+        http.request_body; xor:offset 1,var 1 0; content:"infected"; sid:2;)
 
 header_lowercase
 ----------------

--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -195,6 +195,9 @@ Takes the buffer, applies xor decoding.
 .. note:: this transform requires a mandatory option which is the hexadecimal encoded xor key.
 
 
+Quotes around a hex key are optional; ``xor:0d0ac8ff`` and ``xor:"0d0ac8ff"``
+are equivalent.
+
 This example alerts if ``http.uri`` contains ``password=`` xored with 4-bytes key ``0d0ac8ff``
 .. container:: example-rule
 

--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -175,7 +175,8 @@ Takes the buffer, applies the required regular expression, and outputs the *firs
 .. note:: this transform requires a mandatory option string containing a regular expression.
 
 
-This example alerts if ``http.request_line`` contains ``/dropper.php``
+This example alerts if ``http.request_line`` contains ``/dropper.php``:
+
 .. container:: example-rule
 
     alert http any any -> any any (msg:"HTTP with pcrexform"; http.request_line; \
@@ -238,7 +239,8 @@ The implementation uses a state machine :
 - it lowercases until it finds ``:```
 - it does not change until it finds a new line and switch back to first state
 
-This example alerts for both HTTP/1 and HTTP/2 with a authorization header
+This example alerts for both HTTP/1 and HTTP/2 with a authorization header:
+
 .. container:: example-rule
 
     alert http any any -> any any (msg:"HTTP authorization"; http.header_names; \
@@ -252,7 +254,8 @@ It strips HTTP2 pseudo-headers (names and values).
 
 The implementation just strips every line beginning by ``:``.
 
-This example alerts for both HTTP/1 and HTTP/2 with only a user agent
+This example alerts for both HTTP/1 and HTTP/2 with only a user agent:
+
 .. container:: example-rule
 
     alert http any any -> any any (msg:"HTTP ua only"; http.header_names; \
@@ -441,7 +444,8 @@ If the decompressed data were to be larger than max-size,
 the transform will decompress data up to max-size.
 Value 0 is forbidden for max-size (there is no unlimited value).
 
-This example alerts if ``http.uri`` contains base64-encoded gzipped value
+This example alerts if ``http.uri`` contains base64-encoded gzipped value:
+
 .. container:: example-rule
 
     alert http any any -> any any (msg:"from_base64 + gunzip";
@@ -463,7 +467,8 @@ If the decompressed data were to be larger than max-size,
 the transform will decompress data up to max-size.
 Value 0 is forbidden for max-size (there is no unlimited value).
 
-This example alerts if ``http.uri`` contains base64-encoded zlib-compressed value
+This example alerts if ``http.uri`` contains base64-encoded zlib-compressed value:
+
 .. container:: example-rule
 
     alert http any any -> any any (msg:"from_base64 + gunzip";

--- a/rust/src/detect/transforms/mod.rs
+++ b/rust/src/detect/transforms/mod.rs
@@ -28,4 +28,5 @@ pub mod http_headers;
 pub mod strip_whitespace;
 pub mod subslice;
 pub mod urldecode;
+pub mod varkey;
 pub mod xor;

--- a/rust/src/detect/transforms/varkey.rs
+++ b/rust/src/detect/transforms/varkey.rs
@@ -1,0 +1,176 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! Shared helpers for transforms that read key bytes from a fixed
+//! position within the inspection buffer at transform time.
+
+/// Location in an inspection buffer from which key bytes are read at
+/// transform time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VarKeyLocation {
+    /// Absolute byte offset in the inspection buffer.
+    pub offset: u16,
+    /// Number of bytes to read starting at `offset`.
+    pub nbytes: u8,
+}
+
+/// Return the key bytes at `loc` within `input`, or `None` if the
+/// location is out of bounds or `nbytes` is zero.
+pub fn var_key_bytes(input: &[u8], loc: VarKeyLocation) -> Option<&[u8]> {
+    let start = loc.offset as usize;
+    let end = start + loc.nbytes as usize;
+    if loc.nbytes == 0 || end > input.len() {
+        return None;
+    }
+    Some(&input[start..end])
+}
+
+/// Strip a leading keyword from `s` if it is followed by whitespace.
+/// Returns the trimmed remainder, or `None` if the keyword is absent or
+/// not followed by whitespace.
+pub fn strip_keyword_prefix<'a>(s: &'a str, keyword: &str) -> Option<&'a str> {
+    s.strip_prefix(keyword)
+        .filter(|r| r.starts_with(|c: char| c.is_ascii_whitespace()))
+        .map(|r| r.trim_start())
+}
+
+/// Parse `<nbytes> <offset>` from a trimmed string (the `var` keyword
+/// has already been stripped by the caller). Returns a `VarKeyLocation`
+/// or `None` if the format is wrong or a value overflows its type.
+pub fn parse_var_spec(s: &str) -> Option<VarKeyLocation> {
+    let mut parts = s.splitn(2, |c: char| c.is_ascii_whitespace());
+    let nbytes_str = parts.next()?.trim();
+    let offset_str = parts.next()?.trim();
+    if offset_str.is_empty() {
+        return None;
+    }
+    let nbytes: u8 = nbytes_str.parse().ok()?;
+    let offset: u16 = offset_str.parse().ok()?;
+    Some(VarKeyLocation { nbytes, offset })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_keyword_prefix_match() {
+        assert_eq!(strip_keyword_prefix("var 1 0", "var"), Some("1 0"));
+    }
+
+    #[test]
+    fn test_strip_keyword_prefix_offset() {
+        assert_eq!(strip_keyword_prefix("offset 4,key", "offset"), Some("4,key"));
+    }
+
+    #[test]
+    fn test_strip_keyword_prefix_no_trailing_whitespace() {
+        assert_eq!(strip_keyword_prefix("var1 0", "var"), None);
+    }
+
+    #[test]
+    fn test_strip_keyword_prefix_absent() {
+        assert_eq!(strip_keyword_prefix("aabb", "var"), None);
+    }
+
+    #[test]
+    fn test_parse_var_spec_basic() {
+        assert_eq!(
+            parse_var_spec("1 0"),
+            Some(VarKeyLocation {
+                nbytes: 1,
+                offset: 0
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_var_spec_large_offset() {
+        assert_eq!(
+            parse_var_spec("4 1024"),
+            Some(VarKeyLocation {
+                nbytes: 4,
+                offset: 1024
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_var_spec_missing_offset() {
+        assert_eq!(parse_var_spec("1"), None);
+    }
+
+    #[test]
+    fn test_parse_var_spec_nbytes_overflow() {
+        assert_eq!(parse_var_spec("256 0"), None);
+    }
+
+    #[test]
+    fn test_parse_var_spec_offset_overflow() {
+        assert_eq!(parse_var_spec("1 65536"), None);
+    }
+
+    #[test]
+    fn test_var_key_bytes_in_bounds() {
+        let input = b"\x42hello";
+        let loc = VarKeyLocation {
+            offset: 0,
+            nbytes: 1,
+        };
+        assert_eq!(var_key_bytes(input, loc), Some(&[0x42u8][..]));
+    }
+
+    #[test]
+    fn test_var_key_bytes_offset_out_of_bounds() {
+        let input = b"\x42hello";
+        let loc = VarKeyLocation {
+            offset: 100,
+            nbytes: 1,
+        };
+        assert_eq!(var_key_bytes(input, loc), None);
+    }
+
+    #[test]
+    fn test_var_key_bytes_end_out_of_bounds() {
+        let input = b"\x42hello";
+        let loc = VarKeyLocation {
+            offset: 5,
+            nbytes: 3,
+        };
+        assert_eq!(var_key_bytes(input, loc), None);
+    }
+
+    #[test]
+    fn test_var_key_bytes_multi() {
+        let input = b"\x42\x37data";
+        let loc = VarKeyLocation {
+            offset: 0,
+            nbytes: 2,
+        };
+        assert_eq!(var_key_bytes(input, loc), Some(&[0x42u8, 0x37][..]));
+    }
+
+    #[test]
+    fn test_var_key_bytes_zero_nbytes() {
+        let input = b"\x42hello";
+        let loc = VarKeyLocation {
+            offset: 0,
+            nbytes: 0,
+        };
+        assert_eq!(var_key_bytes(input, loc), None);
+    }
+}

--- a/rust/src/detect/transforms/xor.rs
+++ b/rust/src/detect/transforms/xor.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2024 Open Information Security Foundation
+/* Copyright (C) 2024-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,69 +15,200 @@
  * 02110-1301, USA.
  */
 
-use crate::detect::SIGMATCH_QUOTES_MANDATORY;
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, InspectionBuffer, SCDetectHelperTransformRegister,
     SCDetectSignatureAddTransform, SCInspectionBufferCheckAndExpand, SCInspectionBufferTruncate,
-    SCTransformTableElmt, Signature,
+    SCTransformTableElmt, Signature, SIGMATCH_QUOTES_OPTIONAL,
 };
 
+use super::varkey::{parse_var_spec, strip_keyword_prefix, var_key_bytes, VarKeyLocation};
 use std::ffi::CStr;
-use std::os::raw::{c_int, c_void};
+use std::os::raw::{c_char, c_int, c_void};
 
 static mut G_TRANSFORM_XOR_ID: c_int = 0;
 
-#[derive(Debug, PartialEq)]
+/// Where to obtain the XOR key at transform time.
+#[derive(Debug)]
+enum XorKeySource {
+    /// A static hex key provided in the rule.
+    Static(Vec<u8>),
+    /// Key read directly from the inspection buffer at a fixed location.
+    Variable(VarKeyLocation),
+}
+
+#[derive(Debug)]
 struct DetectTransformXorData {
-    key: Vec<u8>,
+    key_source: XorKeySource,
+    /// Offset in the buffer where XOR decoding starts. Bytes before this
+    /// offset are copied unchanged. This allows skipping embedded key bytes.
+    xor_offset: u32,
+    /// Precomputed identity bytes returned by xor_id. Layout:
+    ///   Static:   [0x00, key_bytes..., xor_offset_le4]
+    ///   Variable: [0x01, key_offset_lo, key_offset_hi, nbytes, xor_offset_le4]
+    /// The leading discriminant byte ensures static and variable identities
+    /// can never collide. Including xor_offset ensures rules with the same
+    /// key but different decode-start positions get independent buffers.
+    id_buf: Vec<u8>,
 }
 
-fn xor_parse_do(i: &str) -> Option<DetectTransformXorData> {
-    if i.len() % 2 != 0 {
-        SCLogError!("XOR transform key's length must be an even number");
-        return None;
-    }
-    if i.len() / 2 > usize::from(u8::MAX) {
-        SCLogError!("Key length too big for XOR transform");
-        return None;
-    }
-    if let Ok(key) = hex::decode(i) {
-        return Some(DetectTransformXorData { key });
-    }
-    SCLogError!("XOR transform key must be hexadecimal characters only");
-    return None;
+/// Parsed key specifier — either a hex string or an inline buffer location.
+#[derive(Debug, PartialEq)]
+enum XorKeySpec {
+    Hex(String),
+    Var(VarKeyLocation),
 }
 
-unsafe fn xor_parse(raw: *const std::os::raw::c_char) -> *mut c_void {
-    let raw: &CStr = CStr::from_ptr(raw); //unsafe
-    if let Ok(s) = raw.to_str() {
-        if let Some(ctx) = xor_parse_do(s) {
-            let boxed = Box::new(ctx);
-            return Box::into_raw(boxed) as *mut _;
+/// Intermediate parse result.
+#[derive(Debug, PartialEq)]
+struct XorParseResult {
+    key_spec: XorKeySpec,
+    /// Optional offset where XOR decoding starts.
+    xor_offset: Option<u32>,
+}
+
+/// Parse a key specifier — either `var <nbytes> <offset>` or a hex string.
+fn parse_key_part(s: &str) -> Option<XorKeySpec> {
+    if let Some(rest) = strip_keyword_prefix(s, "var") {
+        if let Some(loc) = parse_var_spec(rest) {
+            return Some(XorKeySpec::Var(loc));
         }
+        SCLogError!("XOR transform: 'var' requires format 'var <nbytes> <offset>'");
+        return None;
     }
-    return std::ptr::null_mut();
+    let s = strip_quotes(s);
+    if s.is_empty() {
+        SCLogError!("XOR transform: missing hex key");
+        return None;
+    }
+    Some(XorKeySpec::Hex(s.to_string()))
+}
+
+/// Parse the xor option string. Accepts:
+///   - `<hex_key>`
+///   - `var <nbytes> <offset>`
+///   - `offset <N>,<hex_key>`
+///   - `offset <N>,var <nbytes> <offset>`
+fn xor_parse_options(input: &str) -> Option<XorParseResult> {
+    let input = input.trim();
+    if input.is_empty() {
+        SCLogError!("XOR transform: empty argument");
+        return None;
+    }
+
+    if let Some(rest) = strip_keyword_prefix(input, "offset") {
+        let (offset_str, key_part) = match rest.split_once(',') {
+            Some(pair) => pair,
+            None => {
+                SCLogError!("XOR transform: 'offset' requires format 'offset <N>,<key>'");
+                return None;
+            }
+        };
+        let xor_offset: u32 = match offset_str.trim().parse() {
+            Ok(v) => v,
+            Err(_) => {
+                SCLogError!(
+                    "XOR transform: invalid offset value '{}'",
+                    offset_str.trim()
+                );
+                return None;
+            }
+        };
+        return Some(XorParseResult {
+            key_spec: parse_key_part(key_part.trim())?,
+            xor_offset: Some(xor_offset),
+        });
+    }
+
+    Some(XorParseResult {
+        key_spec: parse_key_part(input)?,
+        xor_offset: None,
+    })
+}
+
+/// Strip surrounding double quotes from a string if present.
+fn strip_quotes(s: &str) -> &str {
+    s.strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(s)
+}
+
+/// Try to decode a string as a hex key. Returns `None` if the string is not
+/// valid hexadecimal, is empty, or exceeds 255 bytes.
+fn try_parse_hex_key(s: &str) -> Option<Vec<u8>> {
+    hex::decode(s)
+        .ok()
+        .filter(|k| !k.is_empty() && k.len() <= usize::from(u8::MAX))
 }
 
 unsafe extern "C" fn xor_setup(
-    de: *mut DetectEngineCtx, s: *mut Signature, opt_str: *const std::os::raw::c_char,
+    de: *mut DetectEngineCtx, s: *mut Signature, opt_str: *const c_char,
 ) -> c_int {
-    let ctx = xor_parse(opt_str);
-    if ctx.is_null() {
-        return -1;
-    }
+    let input = match CStr::from_ptr(opt_str).to_str() {
+        Ok(s) => s,
+        Err(_) => return -1,
+    };
+
+    let parsed = match xor_parse_options(input) {
+        Some(p) => p,
+        None => return -1,
+    };
+
+    let xor_offset = parsed.xor_offset.unwrap_or(0);
+
+    let key_source = match parsed.key_spec {
+        XorKeySpec::Hex(ref s) => match try_parse_hex_key(s) {
+            Some(key) => XorKeySource::Static(key),
+            None => {
+                SCLogError!("XOR transform: '{}' is not a valid hex key", s);
+                return -1;
+            }
+        },
+        XorKeySpec::Var(loc) => {
+            if loc.nbytes == 0 {
+                SCLogError!("XOR transform: var key byte count must be at least 1");
+                return -1;
+            }
+            XorKeySource::Variable(loc)
+        }
+    };
+
+    let id_buf: Vec<u8> = match &key_source {
+        XorKeySource::Static(key) => {
+            let mut buf = vec![0x00];
+            buf.extend_from_slice(key);
+            buf.extend_from_slice(&xor_offset.to_le_bytes());
+            buf
+        }
+        XorKeySource::Variable(loc) => {
+            let [lo, hi] = loc.offset.to_le_bytes();
+            let mut buf = vec![0x01, lo, hi, loc.nbytes];
+            buf.extend_from_slice(&xor_offset.to_le_bytes());
+            buf
+        }
+    };
+
+    let data = DetectTransformXorData {
+        key_source,
+        xor_offset,
+        id_buf,
+    };
+    let ctx = Box::into_raw(Box::new(data)) as *mut c_void;
     let r = SCDetectSignatureAddTransform(s, G_TRANSFORM_XOR_ID, ctx);
     if r != 0 {
         xor_free(de, ctx);
     }
-    return r;
+    r
 }
 
-fn xor_transform_do(input: &[u8], output: &mut [u8], ctx: &DetectTransformXorData) {
-    let mut ki = 0;
-    for (i, o) in input.iter().zip(output.iter_mut()) {
-        *o = (*i) ^ ctx.key[ki];
-        ki = (ki + 1) % ctx.key.len();
+/// Apply XOR to `input[xor_offset..]`, copying `input[..xor_offset]` unchanged.
+fn xor_transform_do(input: &[u8], output: &mut [u8], key: &[u8], xor_offset: usize) {
+    output[..xor_offset].copy_from_slice(&input[..xor_offset]);
+    for ((inp, out), k) in input[xor_offset..]
+        .iter()
+        .zip(output[xor_offset..].iter_mut())
+        .zip(key.iter().cycle())
+    {
+        *out = *inp ^ *k;
     }
 }
 
@@ -93,29 +224,41 @@ unsafe extern "C" fn xor_transform(
 
     let output = SCInspectionBufferCheckAndExpand(buffer, input_len);
     if output.is_null() {
-        // allocation failure
         return;
     }
     let output = std::slice::from_raw_parts_mut(output, input_len as usize);
 
     let ctx = cast_pointer!(ctx, DetectTransformXorData);
-    xor_transform_do(input, output, ctx);
+    let xor_offset = ctx.xor_offset as usize;
 
+    if xor_offset > input.len() {
+        return;
+    }
+
+    let key: &[u8] = match &ctx.key_source {
+        XorKeySource::Static(key) => key,
+        XorKeySource::Variable(location) => match var_key_bytes(input, *location) {
+            Some(k) => k,
+            None => return,
+        },
+    };
+
+    xor_transform_do(input, output, key, xor_offset);
     SCInspectionBufferTruncate(buffer, input_len);
 }
 
 unsafe extern "C" fn xor_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
-    std::mem::drop(Box::from_raw(ctx as *mut DetectTransformXorData));
+    drop(Box::from_raw(ctx as *mut DetectTransformXorData));
 }
 
-unsafe extern "C" fn xor_id(data: *mut *const u8, length: *mut u32, ctx: *const c_void,) {
+unsafe extern "C" fn xor_id(data: *mut *const u8, length: *mut u32, ctx: *const c_void) {
     if data.is_null() || length.is_null() || ctx.is_null() {
         return;
     }
 
     let ctx = cast_pointer!(ctx, DetectTransformXorData);
-    *data = ctx.key.as_ptr();
-    *length = ctx.key.len() as u32;
+    *data = ctx.id_buf.as_ptr();
+    *length = ctx.id_buf.len() as u32;
 }
 
 #[no_mangle]
@@ -125,7 +268,7 @@ pub unsafe extern "C" fn DetectTransformXorRegister() {
         desc: b"modify buffer via XOR decoding before inspection\0".as_ptr() as *const libc::c_char,
         url: b"/rules/transforms.html#xor\0".as_ptr() as *const libc::c_char,
         Setup: Some(xor_setup),
-        flags: SIGMATCH_QUOTES_MANDATORY,
+        flags: SIGMATCH_QUOTES_OPTIONAL,
         Transform: Some(xor_transform),
         Free: Some(xor_free),
         TransformValidate: None,
@@ -144,52 +287,280 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_xor_parse() {
-        assert!(xor_parse_do("nohexa").is_none());
-        let key = b"\x0a\x0d\xc8\xff";
+    fn test_parse_hex_key() {
+        let r = xor_parse_options("0a0DC8ff").unwrap();
+        assert_eq!(r.key_spec, XorKeySpec::Hex("0a0DC8ff".into()));
+        assert_eq!(r.xor_offset, None);
         assert_eq!(
-            xor_parse_do("0a0DC8ff"),
-            Some(DetectTransformXorData { key: key.to_vec() })
+            try_parse_hex_key("0a0DC8ff"),
+            Some(vec![0x0a, 0x0d, 0xc8, 0xff])
         );
     }
 
     #[test]
-    fn test_xor_id() {
+    fn test_parse_variable() {
+        let r = xor_parse_options("var 1 0").unwrap();
+        assert_eq!(
+            r.key_spec,
+            XorKeySpec::Var(VarKeyLocation {
+                nbytes: 1,
+                offset: 0
+            })
+        );
+        assert_eq!(r.xor_offset, None);
+    }
+
+    #[test]
+    fn test_parse_variable_large_offset() {
+        let r = xor_parse_options("var 4 1024").unwrap();
+        assert_eq!(
+            r.key_spec,
+            XorKeySpec::Var(VarKeyLocation {
+                nbytes: 4,
+                offset: 1024
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_offset_variable() {
+        let r = xor_parse_options("offset 1,var 1 0").unwrap();
+        assert_eq!(
+            r.key_spec,
+            XorKeySpec::Var(VarKeyLocation {
+                nbytes: 1,
+                offset: 0
+            })
+        );
+        assert_eq!(r.xor_offset, Some(1));
+    }
+
+    #[test]
+    fn test_parse_offset_hex() {
+        let r = xor_parse_options("offset 4,0d0ac8ff").unwrap();
+        assert_eq!(r.key_spec, XorKeySpec::Hex("0d0ac8ff".into()));
+        assert_eq!(r.xor_offset, Some(4));
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        assert!(xor_parse_options("").is_none());
+    }
+
+    #[test]
+    fn test_parse_offset_missing_key() {
+        assert!(xor_parse_options("offset 1,").is_none());
+    }
+
+    #[test]
+    fn test_parse_offset_no_comma() {
+        assert!(xor_parse_options("offset 1").is_none());
+    }
+
+    #[test]
+    fn test_parse_empty_hex_key() {
+        assert!(try_parse_hex_key("").is_none());
+    }
+
+    #[test]
+    fn test_parse_hex_key_odd_length() {
+        assert!(try_parse_hex_key("abc").is_none());
+    }
+
+    #[test]
+    fn test_parse_variable_missing_offset() {
+        assert!(xor_parse_options("var 1").is_none());
+    }
+
+    #[test]
+    fn test_parse_variable_nbytes_overflow() {
+        // 256 does not fit in u8.
+        assert!(xor_parse_options("var 256 0").is_none());
+    }
+
+    #[test]
+    fn test_xor_transform_no_offset() {
+        let input = b"example.com";
+        let mut out = vec![0u8; input.len()];
+        let key = hex::decode("0a0DC8ff").unwrap();
+        xor_transform_do(input, &mut out, &key, 0);
+        assert_eq!(out, b"ou\xa9\x92za\xad\xd1ib\xa5");
+    }
+
+    #[test]
+    fn test_xor_transform_with_offset() {
+        let key_byte = 0x42u8;
+        let plaintext = b"hello";
+        let mut body = vec![key_byte];
+        for &b in plaintext {
+            body.push(b ^ key_byte);
+        }
+        let mut out = vec![0u8; body.len()];
+        xor_transform_do(&body, &mut out, &[key_byte], 1);
+        assert_eq!(out[0], key_byte);
+        assert_eq!(&out[1..], plaintext);
+    }
+
+    #[test]
+    fn test_xor_transform_roundtrip() {
+        // XOR is its own inverse: applying the same key twice recovers the original.
+        let input = b"example.com";
+        let key = hex::decode("0a0DC8ff").unwrap();
+        let mut encrypted = vec![0u8; input.len()];
+        xor_transform_do(input, &mut encrypted, &key, 0);
+        let mut recovered = vec![0u8; encrypted.len()];
+        xor_transform_do(&encrypted, &mut recovered, &key, 0);
+        assert_eq!(recovered, input);
+    }
+
+    // Build an id_buf for a variable key the same way xor_setup does.
+    fn make_id_buf_var(key_offset: u16, nbytes: u8, xor_offset: u32) -> Vec<u8> {
+        let [lo, hi] = key_offset.to_le_bytes();
+        let mut buf = vec![0x01, lo, hi, nbytes];
+        buf.extend_from_slice(&xor_offset.to_le_bytes());
+        buf
+    }
+
+    // Build an id_buf for a static key the same way xor_setup does.
+    fn make_id_buf_static(key: &[u8], xor_offset: u32) -> Vec<u8> {
+        let mut buf = vec![0x00];
+        buf.extend_from_slice(key);
+        buf.extend_from_slice(&xor_offset.to_le_bytes());
+        buf
+    }
+
+    #[test]
+    fn test_xor_id_variable_key() {
+        // key_offset=0, nbytes=1, xor_offset=0 → [0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]
+        let id_buf = make_id_buf_var(0, 1, 0);
         let ctx = Box::new(DetectTransformXorData {
-            key: vec![1, 2, 3, 4, 5],
+            key_source: XorKeySource::Variable(VarKeyLocation {
+                offset: 0,
+                nbytes: 1,
+            }),
+            xor_offset: 0,
+            id_buf,
         });
-
         let ctx_ptr: *const c_void = &*ctx as *const _ as *const c_void;
-
         let mut data_ptr: *const u8 = std::ptr::null();
         let mut length: u32 = 0;
-
         unsafe {
-            xor_id(
-                &mut data_ptr as *mut *const u8,
-                &mut length as *mut u32,
-                ctx_ptr as *mut c_void,
+            xor_id(&mut data_ptr, &mut length, ctx_ptr as *mut c_void);
+            assert!(!data_ptr.is_null());
+            assert_eq!(length, 8);
+            assert_eq!(
+                std::slice::from_raw_parts(data_ptr, 8),
+                &[0x01u8, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]
             );
-
-            assert!(!data_ptr.is_null(), "data_ptr should not be null");
-            assert_eq!(length, 5);
-
-            let actual = std::slice::from_raw_parts(data_ptr, length as usize);
-            assert_eq!(actual, &[1, 2, 3, 4, 5]);
         }
     }
 
     #[test]
-    fn test_xor_transform() {
-        let mut buf = Vec::new();
-        buf.extend_from_slice(b"example.com");
-        let mut out = vec![0; buf.len()];
-        let ctx = xor_parse_do("0a0DC8ff").unwrap();
-        xor_transform_do(&buf, &mut out, &ctx);
-        assert_eq!(out, b"ou\xa9\x92za\xad\xd1ib\xa5");
-        // test in place
-        let still_buf = unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) };
-        xor_transform_do(still_buf, &mut buf, &ctx);
-        assert_eq!(&still_buf, b"ou\xa9\x92za\xad\xd1ib\xa5");
+    fn test_xor_id_variable_key_large_offset() {
+        // key_offset=300 (0x012c LE = [0x2c, 0x01]), nbytes=4, xor_offset=0
+        let id_buf = make_id_buf_var(300, 4, 0);
+        let ctx = Box::new(DetectTransformXorData {
+            key_source: XorKeySource::Variable(VarKeyLocation {
+                offset: 300,
+                nbytes: 4,
+            }),
+            xor_offset: 0,
+            id_buf,
+        });
+        let ctx_ptr: *const c_void = &*ctx as *const _ as *const c_void;
+        let mut data_ptr: *const u8 = std::ptr::null();
+        let mut length: u32 = 0;
+        unsafe {
+            xor_id(&mut data_ptr, &mut length, ctx_ptr as *mut c_void);
+            assert!(!data_ptr.is_null());
+            assert_eq!(length, 8);
+            assert_eq!(
+                std::slice::from_raw_parts(data_ptr, 8),
+                &[0x01u8, 0x2c, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00]
+            );
+        }
+    }
+
+    #[test]
+    fn test_xor_id_variable_key_nonzero_xor_offset() {
+        // Verify that two rules with the same key location but different xor_offset
+        // produce distinct id_bufs and therefore get independent buffers.
+        let id_a = make_id_buf_var(0, 1, 0);
+        let id_b = make_id_buf_var(0, 1, 5);
+        assert_ne!(id_a, id_b);
+    }
+
+    #[test]
+    fn test_var_key_transform() {
+        // Buffer: [key_byte, encoded[0], encoded[1], ...]
+        // Key is 1 byte at offset 0; XOR starts at offset 1.
+        let key_byte = 0x42u8;
+        let plaintext = b"world";
+        let mut buf = vec![key_byte];
+        buf.extend(plaintext.iter().map(|&b| b ^ key_byte));
+
+        let loc = VarKeyLocation {
+            offset: 0,
+            nbytes: 1,
+        };
+        let key = var_key_bytes(&buf, loc).expect("key should be in bounds");
+
+        let mut out = vec![0u8; buf.len()];
+        xor_transform_do(&buf, &mut out, key, 1);
+
+        assert_eq!(out[0], key_byte);
+        assert_eq!(&out[1..], plaintext.as_ref());
+    }
+
+    #[test]
+    fn test_xor_id() {
+        // Static key [1,2,3,4,5] with xor_offset=0: id = [0x00, key_bytes..., 0,0,0,0]
+        let key = vec![1u8, 2, 3, 4, 5];
+        let id_buf = make_id_buf_static(&key, 0);
+        let ctx = Box::new(DetectTransformXorData {
+            key_source: XorKeySource::Static(key),
+            xor_offset: 0,
+            id_buf,
+        });
+
+        let ctx_ptr: *const c_void = &*ctx as *const _ as *const c_void;
+        let mut data_ptr: *const u8 = std::ptr::null();
+        let mut length: u32 = 0;
+
+        unsafe {
+            xor_id(&mut data_ptr, &mut length, ctx_ptr as *mut c_void);
+            assert!(!data_ptr.is_null());
+            assert_eq!(length, 10);
+            let actual = std::slice::from_raw_parts(data_ptr, length as usize);
+            assert_eq!(actual, &[0, 1, 2, 3, 4, 5, 0, 0, 0, 0]);
+        }
+    }
+
+    #[test]
+    fn test_xor_id_static_key_nonzero_xor_offset() {
+        // Two rules with the same static key but different xor_offset must
+        // produce distinct identities.
+        let key = vec![0x42u8];
+        let id_a = make_id_buf_static(&key, 0);
+        let id_b = make_id_buf_static(&key, 1);
+        assert_ne!(id_a, id_b);
+    }
+
+    #[test]
+    fn test_xor_id_static_vs_variable_no_collision() {
+        // A 3-byte static key whose bytes happen to equal [offset_lo, offset_hi, nbytes]
+        // of a variable key must still produce a distinct identity.
+        let key = vec![0x00u8, 0x00, 0x01];
+        let static_id = make_id_buf_static(&key, 0);
+        let var_id = make_id_buf_var(0, 1, 0);
+        assert_ne!(static_id, var_id);
+    }
+
+    #[test]
+    fn test_parse_offset_hex_quoted() {
+        // The inner hex key in "offset N,..." may be quoted; strip_quotes must handle it.
+        let r = xor_parse_options("offset 4,\"0d0ac8ff\"").unwrap();
+        assert_eq!(r.key_spec, XorKeySpec::Hex("0d0ac8ff".into()));
+        assert_eq!(r.xor_offset, Some(4));
     }
 }


### PR DESCRIPTION
Continuation of #15406 

@catenacyber suggested eliminating the dependency on a `byte_extract` variable since the value to be extracted is done statically. Now, `xor` will directly pull the xor-key from a spec that includes `var <nbytes> <offset>`

Note that `offset` and `var <nbytes> <offset>` are new.

Syntax:
`xor:"<hex_key>"`
`xor:var <nbytes> <offset>`
`xor:offset <N>,"<hex_key>"`
`xor:offset <N>,var <nbytes> <offset>`

`var <nbytes> <offset>` reads `<nbytes>` bytes at buffer position `<offset>` at transform time. Because `byte_extract` is not involved, the same-buffer and absolute-offset constraints from the previous approach disappear entirely — the inline spec works with any buffer in both prefilter (MPM) and full inspection contexts.

Changes:
- Add varkey.rs module with reusable helpers (VarKeyLocation, var_key_bytes, parse_var_spec, strip_keyword_prefix) so other transforms can adopt the same pattern without duplicating the parsing and bounds-checking logic.
- Extend the xor transform to parse and apply var <nbytes> <offset>, with an id_buf discriminant byte (0x00 static / 0x01 variable) to prevent inspection buffer sharing collisions between static keys and variable-key descriptors that encode to the same byte sequence.
- Document the new syntax in rules/transforms.rst and add a devguide section covering transform execution order and the engine's buffer deduplication for variable-key rules.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3102