### PR TITLE
Clarify “frame” terminology and add glossary entry (#7921)

### DIFF
--- a/doc/userguide/rules/rules-internals.rst
+++ b/doc/userguide/rules/rules-internals.rst
@@ -92,6 +92,15 @@ Detect Engine will match against - if applicable:
 #. Packet/payload-related rules;
 #. Frame keywords;
 #. Application layer protocol transaction rules.
+.. note::
+
+   In Suricata’s rule language, the term *frame* refers to a logical
+   segment of the inspected data stream created internally by Suricata.
+   These Suricata frames are used by rule keywords to match specific
+   portions of the stream. This concept is different from protocol‑specific
+   frames such as HTTP/2 frames or Ethernet frames, which belong to the
+   protocol’s own framing structure.
+
 
 During packet inspection, if the signature uses the last two in this list,
 inspection is left to those steps.


### PR DESCRIPTION
This PR addresses issue #7921 by clarifying the use of the term *frame* in Suricata’s documentation.
Suricata’s rule language uses *frame* to refer to an internal logical segment of the inspected stream,
while various protocol documents (e.g., HTTP/2, Ethernet) use *frame* in their protocol-specific sense.

This update adds:
- A clarification note in the rule internals documentation
- A clarification sentence in protocol-specific documentation 
- A new glossary entry distinguishing the two meanings

This improves consistency and helps readers understand the difference between Suricata frames and protocol frames.


Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [X] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7921

Describe changes:
- Added clarification note in rules-internals.rst explaining Suricata’s internal frame concept
- Added clarification note in http2-keywords.rst distinguishing protocol frames from Suricata frames
- Added glossary entries for both Suricata frames and protocol frames




### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
