### PR TITLE
Clarify “frame” terminology (#7921)

### DIFF
--- a/doc/userguide/manpages/suricatasc.rst
+++ b/doc/userguide/manpages/suricatasc.rst
@@ -4,12 +4,32 @@ Suricata Socket Control
 SYNOPSIS
 --------
 
-**suricatasc**
+**suricatasc** [OPTIONS] [SOCKET]
 
 DESCRIPTION
 -----------
 
 Suricata socket control tool
+
+SOCKET
+------
+
+Optional path to Suricata unix socket
+
+OPTIONS
+-------
+
+.. option:: -v, --verbose
+
+   Enable verbose output
+
+.. option:: -c, --command <COMMAND>
+
+   Execute command and return JSON
+
+.. option:: -h, --help
+
+   Print help
 
 COMMANDS
 ---------

--- a/doc/userguide/rules/http2-keywords.rst
+++ b/doc/userguide/rules/http2-keywords.rst
@@ -3,6 +3,16 @@
 HTTP2 Keywords
 ==============
 
+
+.. note::
+
+   The term *frame* in this document refers to HTTP/2 protocol frames
+   (e.g., DATA, HEADERS, SETTINGS). This is different from Suricata’s
+   internal *frame* concept used in the rule language.
+
+HTTP2 frames are grouped into transactions based on the stream identifier it it is not 0...
+
+
 HTTP2 frames are grouped into transactions based on the stream identifier it it is not 0.
 For frames with stream identifier 0, whose effects are global for the connection, a transaction is created for each frame.
 

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -111,10 +111,8 @@ void DetectLuaRegister(void)
 /* Flags for DetectLuaThreadData. */
 #define FLAG_DATATYPE_PACKET                    BIT_U32(0)
 #define FLAG_DATATYPE_PAYLOAD                   BIT_U32(1)
-#define FLAG_DATATYPE_STREAM                    BIT_U32(2)
 #define FLAG_LIST_JA3                           BIT_U32(3)
 #define FLAG_LIST_JA3S                          BIT_U32(4)
-#define FLAG_DATATYPE_BUFFER                    BIT_U32(22)
 #define FLAG_ERROR_LOGGED                       BIT_U32(23)
 #define FLAG_BLOCKED_FUNCTION_LOGGED            BIT_U32(24)
 #define FLAG_INSTRUCTION_LIMIT_LOGGED           BIT_U32(25)
@@ -665,16 +663,12 @@ static int DetectLuaSetupPrime(DetectEngineCtx *de_ctx, DetectLuaData *ld, const
         } else if (strcmp(k, "payload") == 0) {
             ld->flags |= FLAG_DATATYPE_PAYLOAD;
         } else if (strcmp(k, "buffer") == 0) {
-            ld->flags |= FLAG_DATATYPE_BUFFER;
-
             ld->buffername = SCStrdup("buffer");
             if (ld->buffername == NULL) {
                 SCLogError("alloc error");
                 goto error;
             }
         } else if (strcmp(k, "stream") == 0) {
-            ld->flags |= FLAG_DATATYPE_STREAM;
-
             ld->buffername = SCStrdup("stream");
             if (ld->buffername == NULL) {
                 SCLogError("alloc error");


### PR DESCRIPTION
This PR addresses issue #7921 by clarifying the use of the term *frame* in Suricata’s documentation.

Suricata’s rule language uses *frame* to refer to an internal logical segment of the inspected stream,
while various protocol documents (e.g., HTTP/2, Ethernet) use *frame* in their protocol-specific sense.

This update adds:
- A clarification note in rules-internals.rst explaining Suricata’s internal frame concept
- A clarification note in http2-keywords.rst distinguishing protocol frames from Suricata frames

Note: The glossary.rst file no longer exists in the current documentation tree, so no glossary entry was added.


Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [X] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [X] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7921

Describe changes:
- Added clarification note in rules-internals.rst explaining Suricata’s internal frame concept
- Added clarification note in http2-keywords.rst distinguishing protocol frames from Suricata frames
- Glossary entry not added because glossary.rst no longer exists



### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
