### PR TITLE
af-packet: respect vlan.use-for-tracking in eBPF bypass

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2297,8 +2297,8 @@ static int AFPBypassCallback(Packet *p)
         keys[0]->dst = htonl(GET_IPV4_DST_ADDR_U32(p));
         keys[0]->port16[0] = p->sp;
         keys[0]->port16[1] = p->dp;
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2322,8 +2322,8 @@ static int AFPBypassCallback(Packet *p)
         keys[1]->dst = htonl(GET_IPV4_SRC_ADDR_U32(p));
         keys[1]->port16[0] = p->dp;
         keys[1]->port16[1] = p->sp;
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
@@ -2356,8 +2356,8 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[0]->port16[0] = p->sp;
         keys[0]->port16[1] = p->dp;
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2383,8 +2383,8 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[1]->port16[0] = p->dp;
         keys[1]->port16[1] = p->sp;
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
@@ -2451,8 +2451,8 @@ static int AFPXDPBypassCallback(Packet *p)
          * (as in eBPF filter) so we need to pass from host to network order */
         keys[0]->port16[0] = htons(p->sp);
         keys[0]->port16[1] = htons(p->dp);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2475,8 +2475,8 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[1]->dst = p->src.addr_data32[0];
         keys[1]->port16[0] = htons(p->dp);
         keys[1]->port16[1] = htons(p->sp);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
@@ -2507,8 +2507,8 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         keys[0]->port16[0] = htons(p->sp);
         keys[0]->port16[1] = htons(p->dp);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2533,8 +2533,8 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         keys[1]->port16[0] = htons(p->dp);
         keys[1]->port16[1] = htons(p->sp);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request. Thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8242

Describe changes:
- `AFPBypassCallback` and `AFPXDPBypassCallback` in `src/source-af-packet.c` now AND `p->vlan_id[N]` with `g_vlan_mask` before writing it into the eBPF `flow_table_v4` / `flow_table_v6` map keys, so the userspace key matches the kernel side when `vlan.use-for-tracking` is false (kernel side writes zero, so userspace must too)
- Affects all 8 insert sites across the two callbacks (IPv4 and IPv6, forward and reverse half-flows), matching the masking pattern already used 30+ times in `src/flow-hash.c`
- Original patch by John Graat on Redmine #8242, rebased onto current main, the patch in the ticket targeted a `vlan2` field that has since been removed from the `flowvN_keys` struct in `src/util-ebpf.h`, so only `vlan0` and `vlan1` are masked here

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=https://github.com/ssam18/suricata-verify
SV_BRANCH=test/issue-8242-vlan-mask-ebpf-bypass
SU_REPO=
SU_BRANCH=

