### PR TITLE
etc/schema: add missing ftp fields

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2192,19 +2192,35 @@
             "additionalProperties": false,
             "properties": {
                 "command": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "ftp.command"
+                        ]
+                    }
                 },
                 "command_data": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "ftp.command_data"
+                        ]
+                    }
                 },
                 "command_truncated": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "$comment": "keyword: app-layer-event:ftp.request_command_too_long"
                 },
                 "completion_code": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "string"
+                    },
+                    "suricata": {
+                        "keywords": [
+                            "ftp.completion_code"
+                        ]
                     }
                 },
                 "dynamic_port": {
@@ -2216,20 +2232,36 @@
                     }
                 },
                 "mode": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "ftp.mode"
+                        ]
+                    }
                 },
                 "reply": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "string"
+                    },
+                    "suricata": {
+                        "keywords": [
+                            "ftp.reply"
+                        ]
                     }
                 },
                 "reply_received": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "ftp.reply_received"
+                        ]
+                    }
                 },
                 "reply_truncated": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "$comment": "keyword: app-layer-event:ftp.response_command_too_long"
                 }
             }
         },
@@ -2238,10 +2270,20 @@
             "additionalProperties": false,
             "properties": {
                 "command": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "ftpdata_command"
+                        ]
+                    }
                 },
                 "filename": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "file.name"
+                        ]
+                    }
                 }
             }
         },


### PR DESCRIPTION
Add ftp detect keywords to metadata

Issue: 7502, 7503, 7507, 7505, 7508, 7506

`python3 scripts/eve-parity.py unmapped-fields | grep ^ftp` identified the following are unmapped:
```
  ftp.command
  ftp.command_data
  ftp.command_truncated
  ftp.completion_code
  ftp.mode
  ftp.reply
  ftp.reply_received
  ftp.reply_truncated
  ftp_data.command
  ftp_data.filename
```

#15405 with ftp_data.filename addition and comments for x_truncated as is done for mdns

PS: we can also write a rule like `alert ftp any any -> any any (msg:"SURICATA FTP Response command too long"; flow:to_client; ftp.reply; bsize: >4096; sid:1;)` but `ftp_max_line_len` is a configurable value, not always 4096