### PR TITLE
LLMNR protocol parser and logger v2

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -999,6 +999,69 @@ Example of a DNS answer with "grouped" format::
       }
   }
 
+Event type: LLMNR
+-----------------
+
+LLMNR (Link-Local Multicast Name Resolution, RFC 4795) is a protocol
+that allows hosts on the same local link to perform name resolution.
+It uses DNS message format, but operates on multicast (224.0.0.252 for
+IPv4, ff02::1:3 for IPv6) over UDP and TCP port 5355.
+
+Suricata logs both requests and responses as separate events. For UDP,
+queries are sent to multicast and responses come back as unicast from
+the responder's IP, resulting in separate flows.
+
+Fields
+~~~~~~
+
+Outline of fields seen in LLMNR events:
+
+* "type": Indicating LLMNR message type, can be "request" or "response"
+* "id": On-wire LLMNR transaction identifier
+* "queries": A list of query objects, each containing "rrname" and "rrtype"
+* "answers": A list of answer objects, each containing "rrname", "rrtype" with "rdata"
+* "authorities": A list of authority objects
+* "additionals": A list of additional objects
+
+Examples
+~~~~~~~~
+
+Example of an LLMNR request for the A record of "hs2011"::
+
+  "llmnr": {
+      "type": "request",
+      "tx_id": 0,
+      "id": 49985,
+      "opcode": 0,
+      "queries": [
+        {
+          "rrname": "hs2011",
+          "rrtype": "a"
+        }
+      ]
+  }
+
+Example of an LLMNR response with an A record answer::
+
+  "llmnr": {
+      "type": "response",
+      "tx_id": 0,
+      "id": 49985,
+      "opcode": 0,
+      "queries": [
+        {
+          "rrname": "hs2011",
+          "rrtype": "a"
+        }
+      ],
+      "answers": [
+        {
+          "rrname": "HS2011",
+          "a": "192.168.10.101"
+        }
+      ],
+  }
+
 Event type: FTP
 ---------------
 

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -44,6 +44,7 @@ Major Changes
   be ``bypass``, ``track-only`` or ``full``.
 - Default value for ``stream.reassembly.depth`` when the value is not specified in
   suricata.yaml is now 1 MiB instead of 0/unlimited.
+- LLMNR protocol parser and logger are implemented.
 
 Logging Changes
 ~~~~~~~~~~~~~~~

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3302,6 +3302,413 @@
                 }
             }
         },
+        "llmnr": {
+            "description": "LLMNR requests and responses",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "additionals": {
+                    "description": "LLMNR additional records",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "a": {
+                                "description": "IPv4 address",
+                                "type": "string"
+                            },
+                            "aaaa": {
+                                "description": "IPv6 address",
+                                "type": "string"
+                            },
+                            "cname": {
+                                "description": "Canonical name",
+                                "type": "string"
+                            },
+                            "mx": {
+                                "description": "Mail exchange",
+                                "type": "string"
+                            },
+                            "ns": {
+                                "description": "Name server",
+                                "type": "string"
+                            },
+                            "null": {
+                                "description": "NULL record data",
+                                "type": "string"
+                            },
+                            "opt": {
+                                "description": "EDNS OPT records",
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "code": {
+                                            "description": "EDNS option code",
+                                            "type": "integer"
+                                        },
+                                        "data": {
+                                            "description": "EDNS option data",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "ptr": {
+                                "description": "Pointer record",
+                                "type": "string"
+                            },
+                            "rrname": {
+                                "description": "Resource name of the record",
+                                "type": "string"
+                            },
+                            "rrname_truncated": {
+                                "description": "Name was truncated by Suricata due to length",
+                                "type": "boolean"
+                            },
+                            "rrtype": {
+                                "description": "Resource record type",
+                                "type": "string"
+                            },
+                            "ttl": {
+                                "description": "Time to live in seconds",
+                                "type": "integer"
+                            },
+                            "txt": {
+                                "description": "TXT record values",
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "unknown": {
+                                "description": "Unknown record type data",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "answers": {
+                    "description": "LLMNR answer records",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "a": {
+                                "description": "IPv4 address",
+                                "type": "string"
+                            },
+                            "aaaa": {
+                                "description": "IPv6 address",
+                                "type": "string"
+                            },
+                            "cname": {
+                                "description": "Canonical name",
+                                "type": "string"
+                            },
+                            "mx": {
+                                "description": "Mail exchange",
+                                "type": "string"
+                            },
+                            "ns": {
+                                "description": "Name server",
+                                "type": "string"
+                            },
+                            "null": {
+                                "description": "NULL record data",
+                                "type": "string"
+                            },
+                            "ptr": {
+                                "description": "Pointer record",
+                                "type": "string"
+                            },
+                            "rrname": {
+                                "description": "Resource name of the record",
+                                "type": "string"
+                            },
+                            "rrname_truncated": {
+                                "description": "Name was truncated by Suricata due to length",
+                                "type": "boolean"
+                            },
+                            "rrtype": {
+                                "description": "Resource record type",
+                                "type": "string"
+                            },
+                            "soa": {
+                                "description": "SOA record data",
+                                "$ref": "#/$defs/dns.soa"
+                            },
+                            "srv": {
+                                "description": "SRV record data",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "description": "Target hostname",
+                                        "type": "string"
+                                    },
+                                    "port": {
+                                        "description": "Target port",
+                                        "type": "integer"
+                                    },
+                                    "priority": {
+                                        "description": "Priority value",
+                                        "type": "integer"
+                                    },
+                                    "weight": {
+                                        "description": "Weight value",
+                                        "type": "integer"
+                                    }
+                                }
+                            },
+                            "sshfp": {
+                                "description": "SSH fingerprint record",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "algo": {
+                                        "description": "Algorithm number",
+                                        "type": "integer"
+                                    },
+                                    "fingerprint": {
+                                        "description": "Fingerprint value",
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "description": "Fingerprint type",
+                                        "type": "integer"
+                                    }
+                                }
+                            },
+                            "ttl": {
+                                "description": "Time to live in seconds",
+                                "type": "integer"
+                            },
+                            "txt": {
+                                "description": "TXT record values",
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "unknown": {
+                                "description": "Unknown record type data",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "authorities": {
+                    "description": "LLMNR authority records",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "a": {
+                                "description": "IPv4 address",
+                                "type": "string"
+                            },
+                            "aaaa": {
+                                "description": "IPv6 address",
+                                "type": "string"
+                            },
+                            "cname": {
+                                "description": "Canonical name",
+                                "type": "string"
+                            },
+                            "mx": {
+                                "description": "Mail exchange",
+                                "type": "string"
+                            },
+                            "ns": {
+                                "description": "Name server",
+                                "type": "string"
+                            },
+                            "null": {
+                                "description": "NULL record data",
+                                "type": "string"
+                            },
+                            "ptr": {
+                                "description": "Pointer record",
+                                "type": "string"
+                            },
+                            "rrname": {
+                                "description": "Resource name of the record",
+                                "type": "string"
+                            },
+                            "rrname_truncated": {
+                                "description": "Name was truncated by Suricata due to length",
+                                "type": "boolean"
+                            },
+                            "rrtype": {
+                                "description": "Resource record type",
+                                "type": "string"
+                            },
+                            "soa": {
+                                "description": "SOA record data",
+                                "$ref": "#/$defs/dns.soa"
+                            },
+                            "ttl": {
+                                "description": "Time to live in seconds",
+                                "type": "integer"
+                            },
+                            "txt": {
+                                "description": "TXT record values",
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "unknown": {
+                                "description": "Unknown record type data",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "flags": {
+                    "description": "LLMNR message flags",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["c", "tc", "t"]
+                    }
+                },
+                "grouped": {
+                    "description": "Grouped answer records by type",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "A": {
+                            "description": "IPv4 address records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "AAAA": {
+                            "description": "IPv6 address records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "CNAME": {
+                            "description": "Canonical name records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "MX": {
+                            "description": "Mail exchange records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "NS": {
+                            "description": "Name server records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "NULL": {
+                            "description": "NULL record data",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "PTR": {
+                            "description": "Pointer records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "SOA": {
+                            "description": "Start of authority records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "#/$defs/dns.soa"
+                            }
+                        },
+                        "TXT": {
+                            "description": "Text records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "id": {
+                    "description": "LLMNR transaction ID",
+                    "type": "integer"
+                },
+                "opcode": {
+                    "description": "LLMNR opcode value",
+                    "type": "integer"
+                },
+                "queries": {
+                    "description": "LLMNR query records",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "rrname": {
+                                "description": "Resource name being requested",
+                                "type": "string"
+                            },
+                            "rrname_truncated": {
+                                "description": "Name was truncated by Suricata due to length",
+                                "type": "boolean"
+                            },
+                            "rrtype": {
+                                "type": "string",
+                                "description": "Type of resource being requested"
+                            }
+                        }
+                    }
+                },
+                "tx_id": {
+                    "description": "Internal transaction ID",
+                    "type": "integer"
+                },
+                "type": {
+                    "description": "Type of message, either a request or response",
+                    "type": "string",
+                    "enum": [
+                        "request",
+                        "response"
+                    ]
+                }
+            }
+        },
         "log_level": {
             "type": "string"
         },
@@ -5830,6 +6237,14 @@
                                     "description": "Errors encountered parsing LDAP/UDP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
+                                "llmnr_tcp": {
+                                    "description": "Errors encountered parsing LLMNR/TCP protocol",
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
+                                "llmnr_udp": {
+                                    "description": "Errors encountered parsing LLMNR/UDP protocol",
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
                                 "mdns": {
                                     "description": "Errors encountered parsing mDNS",
                                     "$ref": "#/$defs/stats_applayer_error"
@@ -6013,6 +6428,14 @@
                                     "type": "integer",
                                     "description": "Number of flows LDAP/UDP protocol"
                                 },
+                                "llmnr_tcp": {
+                                    "type": "integer",
+                                    "description": "Number of flows for LLMNR/TCP protocol"
+                                },
+                                "llmnr_udp": {
+                                    "type": "integer",
+                                    "description": "Number of flows for LLMNR/UDP protocol"
+                                },
                                 "mdns": {
                                     "description": "Number of flows for mDNS",
                                     "type": "integer"
@@ -6186,6 +6609,14 @@
                                 "ldap_udp": {
                                     "type": "integer",
                                     "description": "Number of transactions for LDAP/UDP protocol"
+                                },
+                                "llmnr_tcp": {
+                                    "type": "integer",
+                                    "description": "Number of transactions for LLMNR/TCP protocol"
+                                },
+                                "llmnr_udp": {
+                                    "type": "integer",
+                                    "description": "Number of transactions for LLMNR/UDP protocol"
                                 },
                                 "mdns": {
                                     "description": "Number of transactions for mDNS",

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -140,6 +140,7 @@ pub mod sdp;
 pub mod ldap;
 pub mod flow;
 pub use suricata_ffi::direction;
+pub mod llmnr;
 
 #[allow(unused_imports)]
 pub use suricata_lua_sys;

--- a/rust/src/llmnr/llmnr.rs
+++ b/rust/src/llmnr/llmnr.rs
@@ -1,0 +1,710 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+use std;
+use std::collections::VecDeque;
+use std::ffi::CString;
+
+use crate::applayer::*;
+use crate::core::{self, *};
+use crate::direction::Direction;
+use crate::direction::DIR_BOTH;
+use crate::dns::dns::{DNSHeader, DNSMessage};
+use crate::dns::*;
+use crate::flow::Flow;
+use crate::frames::Frame;
+
+use nom8::number::streaming::be_u16;
+use nom8::{Err, IResult};
+use suricata_sys::sys::{
+    AppLayerParserState, AppProto, SCAppLayerParserConfParserEnabled,
+    SCAppLayerProtoDetectConfProtoDetectionEnabled,
+};
+
+static mut ALPROTO_LLMNR: AppProto = ALPROTO_UNKNOWN;
+
+#[derive(AppLayerFrameType)]
+enum LLMNRFrameType {
+    Pdu,
+}
+
+#[derive(Debug, PartialEq, Eq, AppLayerEvent)]
+pub enum LLMNREvent {
+    MalformedData,
+    NotRequest,
+    NotResponse,
+    ZFlagSet,
+    InvalidOpcode,
+}
+
+#[derive(Debug, Default)]
+pub struct LLMNRTransaction {
+    pub id: u64,
+    pub request: Option<DNSMessage>,
+    pub response: Option<DNSMessage>,
+    pub tx_data: AppLayerTxData,
+}
+
+impl Transaction for LLMNRTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
+impl LLMNRTransaction {
+    fn new(direction: Direction) -> Self {
+        Self {
+            tx_data: AppLayerTxData::for_direction(direction),
+            ..Default::default()
+        }
+    }
+
+    /// Get the LLMNR transactions ID (not the internal tracking ID).
+    pub fn tx_id(&self) -> u16 {
+        if let Some(request) = &self.request {
+            return request.header.tx_id;
+        }
+        if let Some(response) = &self.response {
+            return response.header.tx_id;
+        }
+
+        // Shouldn't happen.
+        return 0;
+    }
+}
+
+#[derive(Default)]
+pub struct LLMNRState {
+    state_data: AppLayerStateData,
+
+    // Internal transaction ID.
+    tx_id: u64,
+
+    // Transactions.
+    transactions: VecDeque<LLMNRTransaction>,
+
+    // TCP gap tracking.
+    gap: bool,
+}
+
+impl State<LLMNRTransaction> for LLMNRState {
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&LLMNRTransaction> {
+        self.transactions.get(index)
+    }
+}
+
+impl LLMNRState {
+    fn new() -> Self {
+        Default::default()
+    }
+
+    fn new_tx(&mut self, direction: Direction) -> LLMNRTransaction {
+        let mut tx = LLMNRTransaction::new(direction);
+        self.tx_id += 1;
+        tx.id = self.tx_id;
+        return tx;
+    }
+
+    fn free_tx(&mut self, tx_id: u64) {
+        let len = self.transactions.len();
+        let mut found = false;
+        let mut index = 0;
+        for i in 0..len {
+            let tx = &self.transactions[i];
+            if tx.id == tx_id + 1 {
+                found = true;
+                index = i;
+                break;
+            }
+        }
+        if found {
+            self.transactions.remove(index);
+        }
+    }
+
+    fn get_tx(&mut self, tx_id: u64) -> Option<&LLMNRTransaction> {
+        return self.transactions.iter().find(|&tx| tx.id == tx_id + 1);
+    }
+
+    /// Set an event. The event is set on the most recent transaction.
+    fn set_event(&mut self, event: LLMNREvent) {
+        let len = self.transactions.len();
+        if len == 0 {
+            return;
+        }
+
+        let tx = &mut self.transactions[len - 1];
+        tx.tx_data.set_event(event as u8);
+    }
+
+    fn validate_header<'a>(&self, input: &'a [u8]) -> Option<(&'a [u8], DNSHeader)> {
+        if let Ok((body, header)) = crate::dns::parser::dns_parse_header(input) {
+            if crate::dns::dns::probe_header_validity(&header, input.len()).0 {
+                return Some((body, header));
+            }
+        }
+        None
+    }
+
+    fn parse_request(
+        &mut self, input: &[u8], is_tcp: bool, frame: Option<Frame>, flow: *mut Flow,
+    ) -> bool {
+        let (body, header) = if let Some((body, header)) = self.validate_header(input) {
+            (body, header)
+        } else {
+            return !is_tcp;
+        };
+
+        match crate::dns::parser::dns_parse_body(body, input, header) {
+            Ok((_, (request, _parse_flags))) => {
+                if request.header.flags & 0x8000 != 0 {
+                    SCLogDebug!("LLMNR message is not a request");
+                    self.set_event(LLMNREvent::NotRequest);
+                    return false;
+                }
+
+                let flags = request.header.flags;
+                let opcode = ((flags >> 11) & 0xf) as u8;
+
+                let mut tx = self.new_tx(Direction::ToServer);
+                if let Some(frame) = frame {
+                    frame.set_tx(flow, tx.id);
+                }
+                tx.request = Some(request);
+                self.transactions.push_back(tx);
+
+                if opcode != 0 {
+                    self.set_event(LLMNREvent::InvalidOpcode);
+                }
+
+                if flags & 0x00F0 != 0 {
+                    self.set_event(LLMNREvent::ZFlagSet);
+                }
+
+                return true;
+            }
+            Err(Err::Incomplete(_)) => {
+                // Insufficient data.
+                SCLogDebug!("Insufficient data while parsing LLMNR request");
+                self.set_event(LLMNREvent::MalformedData);
+                return false;
+            }
+            Err(_) => {
+                // Error, probably malformed data.
+                SCLogDebug!("An error occurred while parsing LLMNR request");
+                self.set_event(LLMNREvent::MalformedData);
+                return false;
+            }
+        }
+    }
+
+    fn parse_request_udp(&mut self, flow: *mut Flow, stream_slice: StreamSlice) -> bool {
+        let input = stream_slice.as_slice();
+        let frame = Frame::new(
+            flow,
+            &stream_slice,
+            input,
+            input.len() as i64,
+            LLMNRFrameType::Pdu as u8,
+            None,
+        );
+        self.parse_request(input, false, frame, flow)
+    }
+
+    fn request_gap(&mut self, gap: u32) {
+        if gap > 0 {
+            self.gap = true;
+        }
+    }
+
+    fn response_gap(&mut self, gap: u32) {
+        if gap > 0 {
+            self.gap = true;
+        }
+    }
+
+    fn parse_request_tcp(&mut self, flow: *mut Flow, stream_slice: StreamSlice) -> AppLayerResult {
+        let input = stream_slice.as_slice();
+        if self.gap {
+            let (is_llmnr, _, is_incomplete) = probe_tcp(input);
+            if is_llmnr || is_incomplete {
+                self.gap = false;
+            } else {
+                return AppLayerResult::ok();
+            }
+        }
+
+        let mut cur_i = input;
+        let mut consumed = 0;
+        while !cur_i.is_empty() {
+            if cur_i.len() == 1 {
+                return AppLayerResult::incomplete(consumed as u32, 2_u32);
+            }
+            let size = match be_u16(cur_i) as IResult<&[u8], u16> {
+                Ok((_, len)) => len,
+                _ => 0,
+            } as usize;
+            if size > 0 && cur_i.len() >= size + 2 {
+                let msg = &cur_i[2..(size + 2)];
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
+                let frame = Frame::new(
+                    flow,
+                    &stream_slice,
+                    msg,
+                    msg.len() as i64,
+                    LLMNRFrameType::Pdu as u8,
+                    None,
+                );
+                if self.parse_request(msg, true, frame, flow) {
+                    cur_i = &cur_i[(size + 2)..];
+                    consumed += size + 2;
+                } else {
+                    return AppLayerResult::err();
+                }
+            } else if size == 0 {
+                cur_i = &cur_i[2..];
+                consumed += 2;
+            } else {
+                return AppLayerResult::incomplete(consumed as u32, (size + 2) as u32);
+            }
+        }
+        AppLayerResult::ok()
+    }
+
+    fn parse_response_tcp(&mut self, flow: *mut Flow, stream_slice: StreamSlice) -> AppLayerResult {
+        let input = stream_slice.as_slice();
+        if self.gap {
+            let (is_llmnr, _, is_incomplete) = probe_tcp(input);
+            if is_llmnr || is_incomplete {
+                self.gap = false;
+            } else {
+                return AppLayerResult::ok();
+            }
+        }
+
+        let mut cur_i = input;
+        let mut consumed = 0;
+        while !cur_i.is_empty() {
+            if cur_i.len() == 1 {
+                return AppLayerResult::incomplete(consumed as u32, 2_u32);
+            }
+            let size = match be_u16(cur_i) as IResult<&[u8], u16> {
+                Ok((_, len)) => len,
+                _ => 0,
+            } as usize;
+            if size > 0 && cur_i.len() >= size + 2 {
+                let msg = &cur_i[2..(size + 2)];
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
+                let frame = Frame::new(
+                    flow,
+                    &stream_slice,
+                    msg,
+                    msg.len() as i64,
+                    LLMNRFrameType::Pdu as u8,
+                    None,
+                );
+                if self.parse_response(msg, true, frame, flow) {
+                    cur_i = &cur_i[(size + 2)..];
+                    consumed += size + 2;
+                } else {
+                    return AppLayerResult::err();
+                }
+            } else if size == 0 {
+                cur_i = &cur_i[2..];
+                consumed += 2;
+            } else {
+                return AppLayerResult::incomplete(consumed as u32, (size + 2) as u32);
+            }
+        }
+        AppLayerResult::ok()
+    }
+
+    fn parse_response_udp(&mut self, flow: *mut Flow, stream_slice: StreamSlice) -> bool {
+        let input = stream_slice.as_slice();
+        let frame = Frame::new(
+            flow,
+            &stream_slice,
+            input,
+            input.len() as i64,
+            LLMNRFrameType::Pdu as u8,
+            None,
+        );
+        self.parse_response(input, false, frame, flow)
+    }
+
+    fn parse_response(
+        &mut self, input: &[u8], is_tcp: bool, frame: Option<Frame>, flow: *mut Flow,
+    ) -> bool {
+        let (body, header) = if let Some((body, header)) = self.validate_header(input) {
+            (body, header)
+        } else {
+            return !is_tcp;
+        };
+
+        match crate::dns::parser::dns_parse_body(body, input, header) {
+            Ok((_, (response, _parse_flags))) => {
+                SCLogDebug!("Response header flags: {}", response.header.flags);
+
+                if response.header.flags & 0x8000 == 0 {
+                    SCLogDebug!("LLMNR message is not a response");
+                    self.set_event(LLMNREvent::NotResponse);
+                    return false;
+                }
+
+                let flags = response.header.flags;
+                let opcode = ((flags >> 11) & 0xf) as u8;
+
+                let mut tx = self.new_tx(Direction::ToClient);
+                if let Some(frame) = frame {
+                    frame.set_tx(flow, tx.id);
+                }
+
+                tx.response = Some(response);
+                self.transactions.push_back(tx);
+
+                if opcode != 0 {
+                    self.set_event(LLMNREvent::InvalidOpcode);
+                }
+
+                if flags & 0x00F0 != 0 {
+                    self.set_event(LLMNREvent::ZFlagSet);
+                }
+
+                return true;
+            }
+            Err(Err::Incomplete(_)) => {
+                // Insufficient data.
+                SCLogDebug!("Insufficient data while parsing LLMNR response");
+                self.set_event(LLMNREvent::MalformedData);
+                return false;
+            }
+            Err(_) => {
+                // Error, probably malformed data.
+                SCLogDebug!("An error occurred while parsing LLMNR response");
+                self.set_event(LLMNREvent::MalformedData);
+                return false;
+            }
+        }
+    }
+}
+
+/// Probe input to see if it looks like LLMNR.
+///
+/// Returns a tuple of booleans: (is_llmnr, is_request, incomplete)
+fn probe(input: &[u8], dlen: usize) -> (bool, bool, bool) {
+    // Trim input to dlen if larger.
+    let input = if input.len() <= dlen {
+        input
+    } else {
+        &input[..dlen]
+    };
+
+    // If input is less than dlen then we know we don't have enough data to
+    // parse a complete message, so perform header validation only.
+    if input.len() < dlen {
+        if let Ok((_, header)) = crate::dns::parser::dns_parse_header(input) {
+            return crate::dns::dns::probe_header_validity(&header, dlen);
+        } else {
+            return (false, false, false);
+        }
+    }
+
+    match parser::dns_parse_header(input) {
+        Ok((body, header)) => match crate::dns::parser::dns_parse_body(body, input, header) {
+            Ok((_, (request, _flags))) => {
+                crate::dns::dns::probe_header_validity(&request.header, dlen)
+            }
+            Err(Err::Incomplete(_)) => (false, false, true),
+            Err(_) => (false, false, false),
+        },
+        Err(_) => (false, false, false),
+    }
+}
+
+unsafe extern "C" fn probe_udp(
+    _flow: *const Flow, _dir: u8, input: *const u8, len: u32, rdir: *mut u8,
+) -> AppProto {
+    if input.is_null() || len < std::mem::size_of::<DNSHeader>() as u32 {
+        return core::ALPROTO_UNKNOWN;
+    }
+    let slice: &[u8] = std::slice::from_raw_parts(input as *mut u8, len as usize);
+    let (is_dns, is_request, _) = probe(slice, slice.len());
+    if is_dns {
+        let dir = if is_request {
+            Direction::ToServer
+        } else {
+            Direction::ToClient
+        };
+        *rdir = dir as u8;
+        return ALPROTO_LLMNR;
+    }
+    return 0;
+}
+
+/// Probe TCP input to see if it looks like LLMNR.
+fn probe_tcp(input: &[u8]) -> (bool, bool, bool) {
+    match be_u16(input) as IResult<&[u8], u16> {
+        Ok((rem, dlen)) => {
+            return probe(rem, dlen as usize);
+        }
+        Err(Err::Incomplete(_)) => {
+            return (false, false, true);
+        }
+        _ => {}
+    }
+    return (false, false, false);
+}
+
+unsafe extern "C" fn probe_tcp_c(
+    _flow: *const Flow, direction: u8, input: *const u8, len: u32, rdir: *mut u8,
+) -> AppProto {
+    if input.is_null() || len < std::mem::size_of::<DNSHeader>() as u32 + 2 {
+        return core::ALPROTO_UNKNOWN;
+    }
+    let slice: &[u8] = std::slice::from_raw_parts(input as *mut u8, len as usize);
+    let (is_llmnr, is_request, _) = probe_tcp(slice);
+    if is_llmnr {
+        let dir = if is_request {
+            Direction::ToServer
+        } else {
+            Direction::ToClient
+        };
+        if (direction & DIR_BOTH) != u8::from(dir) {
+            *rdir = dir as u8;
+        }
+        return ALPROTO_LLMNR;
+    }
+    return 0;
+}
+
+/// Returns *mut LLMNRState
+unsafe extern "C" fn state_new(
+    _orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto,
+) -> *mut std::os::raw::c_void {
+    let state = LLMNRState::new();
+    let boxed = Box::new(state);
+    return Box::into_raw(boxed) as *mut _;
+}
+
+/// Params:
+/// - state: *mut LLMNRState as void pointer
+extern "C" fn state_free(state: *mut std::os::raw::c_void) {
+    // Just unbox...
+    std::mem::drop(unsafe { Box::from_raw(state as *mut LLMNRState) });
+}
+
+unsafe extern "C" fn state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
+    let state = cast_pointer!(state, LLMNRState);
+    state.free_tx(tx_id);
+}
+
+extern "C" fn tx_get_alstate_progress(
+    _tx: *mut std::os::raw::c_void, _direction: u8,
+) -> std::os::raw::c_int {
+    // This is a stateless parser, just the existence of a transaction
+    // means its complete.
+    SCLogDebug!("rs_llmnr_tx_get_alstate_progress");
+    return 1;
+}
+
+unsafe extern "C" fn state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
+    let state = cast_pointer!(state, LLMNRState);
+    SCLogDebug!("rs_llmnr_state_get_tx_count: returning {}", state.tx_id);
+    return state.tx_id;
+}
+
+unsafe extern "C" fn state_get_tx(
+    state: *mut std::os::raw::c_void, tx_id: u64,
+) -> *mut std::os::raw::c_void {
+    let state = cast_pointer!(state, LLMNRState);
+    match state.get_tx(tx_id) {
+        Some(tx) => {
+            return tx as *const _ as *mut _;
+        }
+        None => {
+            return std::ptr::null_mut();
+        }
+    }
+}
+
+/// C binding parse a LLMNR request. Returns 1 on success, -1 on failure.
+unsafe extern "C" fn parse_request(
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut AppLayerParserState,
+    stream_slice: StreamSlice, _data: *mut std::os::raw::c_void,
+) -> AppLayerResult {
+    let state = cast_pointer!(state, LLMNRState);
+    state.parse_request_udp(flow, stream_slice);
+    AppLayerResult::ok()
+}
+
+unsafe extern "C" fn parse_response(
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut AppLayerParserState,
+    stream_slice: StreamSlice, _data: *mut std::os::raw::c_void,
+) -> AppLayerResult {
+    let state = cast_pointer!(state, LLMNRState);
+    state.parse_response_udp(flow, stream_slice);
+    AppLayerResult::ok()
+}
+
+unsafe extern "C" fn parse_request_tcp_c(
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut AppLayerParserState,
+    stream_slice: StreamSlice, _data: *mut std::os::raw::c_void,
+) -> AppLayerResult {
+    let state = cast_pointer!(state, LLMNRState);
+    if stream_slice.is_gap() {
+        state.request_gap(stream_slice.gap_size());
+    } else if !stream_slice.is_empty() {
+        return state.parse_request_tcp(flow, stream_slice);
+    }
+    AppLayerResult::ok()
+}
+
+unsafe extern "C" fn parse_response_tcp_c(
+    flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut AppLayerParserState,
+    stream_slice: StreamSlice, _data: *mut std::os::raw::c_void,
+) -> AppLayerResult {
+    let state = cast_pointer!(state, LLMNRState);
+    if stream_slice.is_gap() {
+        state.response_gap(stream_slice.gap_size());
+    } else if !stream_slice.is_empty() {
+        return state.parse_response_tcp(flow, stream_slice);
+    }
+    AppLayerResult::ok()
+}
+
+unsafe extern "C" fn state_get_tx_data(
+    tx: *mut std::os::raw::c_void,
+) -> *mut suricata_sys::sys::AppLayerTxData {
+    let tx = cast_pointer!(tx, LLMNRTransaction);
+    return &mut tx.tx_data.0;
+}
+
+#[no_mangle]
+pub extern "C" fn SCLLMNRTxIsRequest(tx: &mut LLMNRTransaction) -> bool {
+    tx.request.is_some()
+}
+
+#[no_mangle]
+pub extern "C" fn SCLLMNRTxIsResponse(tx: &mut LLMNRTransaction) -> bool {
+    tx.response.is_some()
+}
+
+export_state_data_get!(rs_llmnr_get_state_data, LLMNRState);
+
+#[no_mangle]
+pub unsafe extern "C" fn SCRegisterLLMNRUdpParser() {
+    let default_port = std::ffi::CString::new("5355").unwrap();
+    let parser = RustParser {
+        name: b"llmnr\0".as_ptr() as *const std::os::raw::c_char,
+        default_port: default_port.as_ptr(),
+        ipproto: IPPROTO_UDP,
+        probe_ts: Some(probe_udp),
+        probe_tc: Some(probe_udp),
+        min_depth: 0,
+        max_depth: std::mem::size_of::<DNSHeader>() as u16,
+        state_new,
+        state_free,
+        tx_free: state_tx_free,
+        parse_ts: parse_request,
+        parse_tc: parse_response,
+        get_tx_count: state_get_tx_count,
+        get_tx: state_get_tx,
+        tx_comp_st_ts: 1,
+        tx_comp_st_tc: 1,
+        tx_get_progress: tx_get_alstate_progress,
+        get_eventinfo: Some(LLMNREvent::get_event_info),
+        get_eventinfo_byid: Some(LLMNREvent::get_event_info_by_id),
+        localstorage_new: None,
+        localstorage_free: None,
+        get_tx_files: None,
+        get_tx_iterator: Some(
+            crate::applayer::state_get_tx_iterator::<LLMNRState, LLMNRTransaction>,
+        ),
+        get_tx_data: state_get_tx_data,
+        get_state_data: rs_llmnr_get_state_data,
+        apply_tx_config: None,
+        flags: 0,
+        get_frame_id_by_name: Some(LLMNRFrameType::ffi_id_from_name),
+        get_frame_name_by_id: Some(LLMNRFrameType::ffi_name_from_id),
+        get_state_id_by_name: None,
+        get_state_name_by_id: None,
+    };
+
+    let ip_proto_str = CString::new("udp").unwrap();
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+        let alproto = applayer_register_protocol_detection(&parser, 1);
+        ALPROTO_LLMNR = alproto;
+        if SCAppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+            let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCRegisterLLMNRTcpParser() {
+    let default_port = std::ffi::CString::new("5355").unwrap();
+    let parser = RustParser {
+        name: b"llmnr\0".as_ptr() as *const std::os::raw::c_char,
+        default_port: default_port.as_ptr(),
+        ipproto: IPPROTO_TCP,
+        probe_ts: Some(probe_tcp_c),
+        probe_tc: Some(probe_tcp_c),
+        min_depth: 0,
+        max_depth: std::mem::size_of::<DNSHeader>() as u16 + 2,
+        state_new,
+        state_free,
+        tx_free: state_tx_free,
+        parse_ts: parse_request_tcp_c,
+        parse_tc: parse_response_tcp_c,
+        get_tx_count: state_get_tx_count,
+        get_tx: state_get_tx,
+        tx_comp_st_ts: 1,
+        tx_comp_st_tc: 1,
+        tx_get_progress: tx_get_alstate_progress,
+        get_eventinfo: Some(LLMNREvent::get_event_info),
+        get_eventinfo_byid: Some(LLMNREvent::get_event_info_by_id),
+        localstorage_new: None,
+        localstorage_free: None,
+        get_tx_files: None,
+        get_tx_iterator: Some(
+            crate::applayer::state_get_tx_iterator::<LLMNRState, LLMNRTransaction>,
+        ),
+        get_tx_data: state_get_tx_data,
+        get_state_data: rs_llmnr_get_state_data,
+        apply_tx_config: None,
+        flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+        get_frame_id_by_name: Some(LLMNRFrameType::ffi_id_from_name),
+        get_frame_name_by_id: Some(LLMNRFrameType::ffi_name_from_id),
+        get_state_id_by_name: None,
+        get_state_name_by_id: None,
+    };
+
+    let ip_proto_str = CString::new("tcp").unwrap();
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+        let alproto = applayer_register_protocol_detection(&parser, 1);
+        ALPROTO_LLMNR = alproto;
+        if SCAppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+            let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+    }
+}

--- a/rust/src/llmnr/log.rs
+++ b/rust/src/llmnr/log.rs
@@ -1,0 +1,169 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+use crate::dns::dns::*;
+use crate::dns::log::{
+    dns_log_opt, dns_log_soa, dns_log_srv, dns_log_sshfp, dns_print_addr, dns_rrtype_string,
+};
+use crate::jsonbuilder::{JsonBuilder, JsonError};
+use crate::llmnr::llmnr::LLMNRTransaction;
+
+fn llmnr_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, JsonError> {
+    let mut jsa = JsonBuilder::try_new_object()?;
+
+    jsa.set_string_from_bytes("rrname", &answer.name.value)?;
+    if answer.name.flags.contains(DNSNameFlags::TRUNCATED) {
+        jsa.set_bool("rrname_truncated", true)?;
+    }
+    let rrtype = dns_rrtype_string(answer.rrtype).to_lowercase();
+
+    match &answer.data {
+        DNSRData::A(addr) | DNSRData::AAAA(addr) => {
+            jsa.set_string(&rrtype, &dns_print_addr(addr))?;
+        }
+        DNSRData::CNAME(name) | DNSRData::MX(name) | DNSRData::NS(name) | DNSRData::PTR(name) => {
+            jsa.set_string_from_bytes(&rrtype, &name.value)?;
+            if name.flags.contains(DNSNameFlags::TRUNCATED) {
+                jsa.set_bool("rdata_truncated", true)?;
+            }
+        }
+        DNSRData::TXT(txt) => {
+            jsa.open_array(&rrtype)?;
+            for txt in txt {
+                jsa.append_string_from_bytes(txt)?;
+            }
+            jsa.close()?;
+        }
+        DNSRData::NULL(bytes) | DNSRData::Unknown(bytes) => {
+            jsa.set_string_from_bytes(&rrtype, bytes)?;
+        }
+        DNSRData::SOA(soa) => {
+            jsa.set_object(&rrtype, &dns_log_soa(soa)?)?;
+        }
+        DNSRData::SSHFP(sshfp) => {
+            jsa.set_object(&rrtype, &dns_log_sshfp(sshfp)?)?;
+        }
+        DNSRData::SRV(srv) => {
+            jsa.set_object(&rrtype, &dns_log_srv(srv)?)?;
+        }
+        DNSRData::OPT(opt) => {
+            jsa.open_array(&rrtype)?;
+            for val in opt {
+                jsa.append_object(&dns_log_opt(val)?)?;
+            }
+            jsa.close()?;
+        }
+    }
+
+    jsa.close()?;
+    return Ok(jsa);
+}
+
+fn log_json(tx: &LLMNRTransaction, jb: &mut JsonBuilder) -> Result<(), JsonError> {
+    jb.open_object("llmnr")?;
+
+    let message = if let Some(request) = &tx.request {
+        jb.set_string("type", "request")?;
+        request
+    } else if let Some(response) = &tx.response {
+        jb.set_string("type", "response")?;
+        response
+    } else {
+        debug_validate_fail!("unreachable");
+        return Ok(());
+    };
+
+    // The on the wire LLMNR transaction ID.
+    jb.set_uint("id", tx.tx_id() as u64)?;
+
+    let header = &message.header;
+    if header.flags & (0x0400 | 0x0200 | 0x0100) != 0 {
+        jb.open_array("flags")?;
+        if header.flags & 0x0400 != 0 {
+            jb.append_string("c")?;
+        }
+        if header.flags & 0x0200 != 0 {
+            jb.append_string("tc")?;
+        }
+        if header.flags & 0x0100 != 0 {
+            jb.append_string("t")?;
+        }
+        jb.close()?;
+    }
+
+    let opcode = ((header.flags >> 11) & 0xf) as u8;
+    jb.set_uint("opcode", opcode as u64)?;
+
+    if !message.queries.is_empty() {
+        jb.open_array("queries")?;
+        for query in &message.queries {
+            jb.start_object()?
+                .set_string_from_bytes("rrname", &query.name.value)?
+                .set_string("rrtype", &dns_rrtype_string(query.rrtype).to_lowercase())?;
+            if query.name.flags.contains(DNSNameFlags::TRUNCATED) {
+                jb.set_bool("rrname_truncated", true)?;
+            }
+            jb.close()?;
+        }
+        jb.close()?;
+    }
+
+    if !message.answers.is_empty() {
+        jb.open_array("answers")?;
+        for entry in &message.answers {
+            jb.append_object(&llmnr_log_json_answer_detail(entry)?)?;
+        }
+        jb.close()?;
+    }
+
+    if !message.authorities.is_empty() {
+        jb.open_array("authorities")?;
+        for entry in &message.authorities {
+            jb.append_object(&llmnr_log_json_answer_detail(entry)?)?;
+        }
+        jb.close()?;
+    }
+
+    if !message.additionals.is_empty() {
+        let mut is_jb_open = false;
+        for entry in &message.additionals {
+            if let DNSRData::OPT(rdata) = &entry.data {
+                if rdata.is_empty() {
+                    continue;
+                }
+            }
+            if !is_jb_open {
+                jb.open_array("additionals")?;
+                is_jb_open = true;
+            }
+            jb.append_object(&llmnr_log_json_answer_detail(entry)?)?;
+        }
+        if is_jb_open {
+            jb.close()?;
+        }
+    }
+
+    jb.close()?;
+    Ok(())
+}
+
+#[no_mangle]
+pub extern "C" fn SCLLMNRLogJson(tx: &mut LLMNRTransaction, jb: &mut JsonBuilder) -> bool {
+    log_json(tx, jb).is_ok()
+}

--- a/rust/src/llmnr/mod.rs
+++ b/rust/src/llmnr/mod.rs
@@ -1,0 +1,22 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! LLMNR protocol parser and logger module.
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+pub mod llmnr;

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -65,8 +65,9 @@ pub enum AppProtoEnum {
     ALPROTO_BITTORRENT_DHT = 35,
     ALPROTO_POP3 = 36,
     ALPROTO_MDNS = 37,
-    ALPROTO_HTTP = 38,
-    ALPROTO_MAX_STATIC = 39,
+    ALPROTO_LLMNR = 38,
+    ALPROTO_HTTP = 39,
+    ALPROTO_MAX_STATIC = 40,
 }
 pub type AppProto = u16;
 extern "C" {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -369,6 +369,7 @@ noinst_HEADERS = \
 	output-json-ftp.h \
 	output-json-http.h \
 	output-json-ike.h \
+	output-json-llmnr.h \
 	output-json-mdns.h \
 	output-json-metadata.h \
 	output-json-mqtt.h \
@@ -943,6 +944,7 @@ libsuricata_c_a_SOURCES = \
 	output-json-ftp.c \
 	output-json-http.c \
 	output-json-ike.c \
+	output-json-llmnr.c \
 	output-json-mdns.c \
 	output-json-metadata.c \
 	output-json-mqtt.c \

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1851,6 +1851,8 @@ void AppLayerParserRegisterProtocolParsers(void)
     RegisterHTTP2Parsers();
     SCRegisterTelnetParser();
     RegisterIMAPParsers();
+    SCRegisterLLMNRUdpParser();
+    SCRegisterLLMNRTcpParser();
 
     for (size_t i = 0; i < preregistered_callbacks_nb; i++) {
         PreRegisteredCallbacks[i]();

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -70,6 +70,7 @@ enum AppProtoEnum {
     ALPROTO_BITTORRENT_DHT,
     ALPROTO_POP3,
     ALPROTO_MDNS,
+    ALPROTO_LLMNR,
 
     // signature-only (ie not seen in flow)
     // HTTP for any version (ALPROTO_HTTP1 (version 1) or ALPROTO_HTTP2)

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1072,6 +1072,7 @@ static void AppLayerNamesSetup(void)
     AppProtoRegisterProtoString(ALPROTO_LDAP, "ldap");
     AppProtoRegisterProtoString(ALPROTO_DOH2, "doh2");
     AppProtoRegisterProtoString(ALPROTO_MDNS, "mdns");
+    AppProtoRegisterProtoString(ALPROTO_LLMNR, "llmnr");
     AppProtoRegisterProtoString(ALPROTO_TEMPLATE, "template");
     AppProtoRegisterProtoString(ALPROTO_RDP, "rdp");
     AppProtoRegisterProtoString(ALPROTO_HTTP2, "http2");

--- a/src/output-json-llmnr.c
+++ b/src/output-json-llmnr.c
@@ -1,0 +1,161 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+#include "suricata-common.h"
+#include "conf.h"
+
+#include "threadvars.h"
+
+#include "util-byte.h"
+#include "util-debug.h"
+#include "util-mem.h"
+#include "app-layer-parser.h"
+#include "output.h"
+
+#include "output-json.h"
+#include "output-json-llmnr.h"
+#include "rust.h"
+
+typedef struct SCLLMNRLogFileCtx_ {
+    uint64_t flags; /** Store mode */
+    OutputJsonCtx *eve_ctx;
+} SCLLMNRLogFileCtx;
+
+typedef struct LogLLMNRLogThread_ {
+    SCLLMNRLogFileCtx *llmnrlog_ctx;
+    OutputJsonThreadCtx *ctx;
+} SCLLMNRLogThread;
+
+bool AlertJsonLLMNR(void *txptr, SCJsonBuilder *js)
+{
+    return SCLLMNRLogJson(txptr, js);
+}
+
+static int JsonLLMNRLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f,
+        void *alstate, void *txptr, uint64_t tx_id)
+{
+    SCLLMNRLogThread *td = (SCLLMNRLogThread *)thread_data;
+    SCLLMNRLogFileCtx *llmnrlog_ctx = td->llmnrlog_ctx;
+
+    SCJsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "llmnr", NULL, llmnrlog_ctx->eve_ctx);
+    if (unlikely(jb == NULL)) {
+        return TM_ECODE_OK;
+    }
+
+    if (SCLLMNRLogJson(txptr, jb)) {
+        OutputJsonBuilderBuffer(tv, p, p->flow, jb, td->ctx);
+    }
+    SCJbFree(jb);
+
+    return TM_ECODE_OK;
+}
+
+static TmEcode SCLLMNRLogThreadInit(ThreadVars *t, const void *initdata, void **data)
+{
+    SCLLMNRLogThread *aft = SCCalloc(1, sizeof(SCLLMNRLogThread));
+    if (unlikely(aft == NULL))
+        return TM_ECODE_FAILED;
+
+    if (initdata == NULL) {
+        SCLogDebug("Error getting context for EveLogLLMNR.  \"initdata\" argument NULL");
+        goto error_exit;
+    }
+
+    /* Use the Output Context (file pointer and mutex) */
+    aft->llmnrlog_ctx = ((OutputCtx *)initdata)->data;
+    aft->ctx = CreateEveThreadCtx(t, aft->llmnrlog_ctx->eve_ctx);
+    if (!aft->ctx) {
+        goto error_exit;
+    }
+
+    *data = (void *)aft;
+    return TM_ECODE_OK;
+
+error_exit:
+    SCFree(aft);
+    return TM_ECODE_FAILED;
+}
+
+static TmEcode SCLLMNRLogThreadDeinit(ThreadVars *t, void *data)
+{
+    SCLLMNRLogThread *aft = (SCLLMNRLogThread *)data;
+    if (aft == NULL) {
+        return TM_ECODE_OK;
+    }
+    FreeEveThreadCtx(aft->ctx);
+
+    /* clear memory */
+    memset(aft, 0, sizeof(SCLLMNRLogThread));
+
+    SCFree(aft);
+    return TM_ECODE_OK;
+}
+
+static void SCLLMNRLogDeInitCtxSub(OutputCtx *output_ctx)
+{
+    SCLogDebug("cleaning up sub output_ctx %p", output_ctx);
+    SCLLMNRLogFileCtx *llmnrlog_ctx = (SCLLMNRLogFileCtx *)output_ctx->data;
+    SCFree(llmnrlog_ctx);
+    SCFree(output_ctx);
+}
+
+static OutputInitResult JsonLLMNRLogInitCtxSub(SCConfNode *conf, OutputCtx *parent_ctx)
+{
+    OutputInitResult result = { NULL, false };
+    const char *enabled = SCConfNodeLookupChildValue(conf, "enabled");
+    if (enabled != NULL && !SCConfValIsTrue(enabled)) {
+        result.ok = true;
+        return result;
+    }
+
+    OutputJsonCtx *ojc = parent_ctx->data;
+
+    SCLLMNRLogFileCtx *llmnrlog_ctx = SCCalloc(1, sizeof(SCLLMNRLogFileCtx));
+    if (unlikely(llmnrlog_ctx == NULL)) {
+        return result;
+    }
+
+    llmnrlog_ctx->eve_ctx = ojc;
+    llmnrlog_ctx->flags = ~0ULL;
+
+    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
+    if (unlikely(output_ctx == NULL)) {
+        SCFree(llmnrlog_ctx);
+        return result;
+    }
+
+    output_ctx->data = llmnrlog_ctx;
+    output_ctx->DeInit = SCLLMNRLogDeInitCtxSub;
+
+    SCLogDebug("LLMNR log sub-module initialized");
+
+    SCAppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_LLMNR);
+    SCAppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_LLMNR);
+
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
+}
+
+void JsonLLMNRLogRegister(void)
+{
+    OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", "JsonLLMNRLog", "eve-log.llmnr",
+            JsonLLMNRLogInitCtxSub, ALPROTO_LLMNR, JsonLLMNRLogger, SCLLMNRLogThreadInit,
+            SCLLMNRLogThreadDeinit);
+}

--- a/src/output-json-llmnr.h
+++ b/src/output-json-llmnr.h
@@ -15,9 +15,12 @@
  * 02110-1301, USA.
  */
 
-//! LLMNR protocol parser and logger module.
-
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
-pub mod llmnr;
-pub mod log;
+#ifndef SURICATA_OUTPUT_JSON_LLMNR_H
+#define SURICATA_OUTPUT_JSON_LLMNR_H
+
+void JsonLLMNRLogRegister(void);
+bool AlertJsonLLMNR(void *txptr, SCJsonBuilder *js);
+
+#endif /* SURICATA_OUTPUT_JSON_LLMNR_H */

--- a/src/output.c
+++ b/src/output.c
@@ -83,6 +83,7 @@
 #include "app-layer-parser.h"
 #include "output-filestore.h"
 #include "output-json-arp.h"
+#include "output-json-llmnr.h"
 
 typedef struct RootLogger_ {
     OutputLogFunc LogFunc;
@@ -1225,6 +1226,8 @@ void OutputRegisterLoggers(void)
     }
     /* ARP JSON logger */
     JsonArpLogRegister();
+    /* LLMNR JSON logger */
+    JsonLLMNRLogRegister();
 
     for (size_t i = 0; i < preregistered_loggers_nb; i++) {
         OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", preregistered_loggers[i].logname,

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -345,6 +345,7 @@ outputs:
         - quic
         - ldap
         - pop3
+        - llmnr
         #- modbus
         - arp:
             enabled: no        # Many events can be logged. Disabled by default

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1296,6 +1296,12 @@ app-layer:
     mdns:
       enabled: yes
 
+    llmnr:
+      enabled: yes
+      detection-ports:
+        dp: 5355
+        sp: 5355
+
 # Limit for the maximum number of asn1 frames to decode (default 256)
 asn1-max-frames: 256
 


### PR DESCRIPTION
Changes:
- Removed `grouped` output
- Made LLMNR event aligned with mDNS 

```
{
  "timestamp": "2014-06-25T05:56:12.274461+0200",
  "flow_id": 1178804379179163,
  "pcap_cnt": 1,
  "event_type": "llmnr",
  "src_ip": "192.168.10.233",
  "src_port": 54022,
  "dest_ip": "224.0.0.252",
  "dest_port": 5355,
  "proto": "UDP",
  "ip_v": 4,
  "pkt_src": "wire/pcap",
  "llmnr": {
    "type": "request",
    "id": 49985,
    "flags": "0",
    "opcode": 0,
    "queries": [
      {
        "rrname": "hs2011",
        "rrtype": "a"
      }
    ]
  }
}
{
  "timestamp": "2014-06-25T05:56:12.275825+0200",
  "flow_id": 1184659775823477,
  "pcap_cnt": 2,
  "event_type": "llmnr",
  "src_ip": "192.168.10.233",
  "src_port": 54022,
  "dest_ip": "192.168.10.101",
  "dest_port": 5355,
  "proto": "UDP",
  "ip_v": 4,
  "pkt_src": "wire/pcap",
  "llmnr": {
    "type": "response",
    "id": 49985,
    "opcode": 0,
    "queries": [
      {
        "rrname": "hs2011",
        "rrtype": "a"
      }
    ],
    "answers": [
      {
        "rrname": "HS2011",
        "a": "192.168.10.101"
      }
    ],
  }
}
```

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8366

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3047