### PR TITLE
[main-7.0.x] backport CVE-2025-59149: stack overflow in ShortenString on zero output_size

### DIFF
--- a/src/util-misc.c
+++ b/src/util-misc.c
@@ -27,6 +27,7 @@
 #include "util-debug.h"
 #include "util-unittest.h"
 #include "util-misc.h"
+#include "util-validate.h"
 
 #define PARSE_REGEX "^\\s*(\\d+(?:.\\d+)?)\\s*([a-zA-Z]{2,3})?\\s*$"
 static pcre2_code *parse_regex = NULL;
@@ -215,6 +216,9 @@ int ParseSizeStringU64(const char *size, uint64_t *res)
 void ShortenString(const char *input,
     char *output, size_t output_size, char c)
 {
+    if (output_size == 0)
+        return;
+
     const size_t str_len = strlen(input);
     size_t half = (output_size - 1) / 2;
 
@@ -222,6 +226,9 @@ void ShortenString(const char *input,
     if (half * 2 == (output_size - 1)) {
         half = half - 1;
     }
+    DEBUG_VALIDATE_BUG_ON(half > output_size);
+    if (half == 0 || half > output_size)
+        return;
 
     size_t spaces = (output_size - 1) - (half * 2);
 


### PR DESCRIPTION
`38a2cba5c397` hardens `ShortenString` and it's missing from main-7.0.x. with `output_size == 0` the code computes `half = (0-1)/2` (a huge value) and snprintf writes well past the output buffer. reachable from rules using a long `ldap.responses.attribute_type` with transforms, on startup/reload.

called the function verbatim with `output_size == 0`: pre-fix asan flags a stack-buffer-overflow, post-fix the new zero/half guards return cleanly. clean cherry-pick to main-7.0.x.

upstream: https://github.com/OISF/suricata/commit/38a2cba5c397
CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-59149

didn't run the suite locally.