### PR TITLE
rust: format http2 files

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -393,6 +393,7 @@ jobs:
               rust/src/ldap/*.rs rust/src/mime/*.rs rust/src/ntp/*.rs rust/src/quic/*.rs
               rust/src/rfb/*.rs rust/src/ssh/*.rs rust/src/utils/*.rs rust/src/websocket/*.rs
               rust/src/dhcp/*.rs rust/src/krb/*.rs rust/src/mdns/*.rs rust/src/pop3/*.rs
+              rust/src/http2/*.rs
       - name: Check if Cargo.lock.in is up to date
         run: |
           cp rust/Cargo.lock rust/Cargo.lock.in

--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -154,8 +154,7 @@ fn http2_decompress<'a>(
             Ok(n) => {
                 offset += n;
                 if offset == output.len() {
-                    if output.len() > unsafe { HTTP2_COMPRESSION_BOMB_LIMIT as usize }
-                    {
+                    if output.len() > unsafe { HTTP2_COMPRESSION_BOMB_LIMIT as usize } {
                         return Err(io::Error::new(
                             io::ErrorKind::OutOfMemory,
                             "Decompression bomb detected",

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -39,13 +39,13 @@ use std::collections::VecDeque;
 use std::ffi::CString;
 use std::fmt;
 use std::io;
+use suricata_sys::sys::AppProtoEnum::ALPROTO_HTTP1;
 use suricata_sys::sys::{
     AppLayerParserState, AppProto, HttpRangeContainerBlock, SCAppLayerForceProtocolChange,
     SCAppLayerParserConfParserEnabled, SCAppLayerParserRegisterLogger,
     SCAppLayerProtoDetectConfProtoDetectionEnabled, SCFileFlowFlagsToFlags,
     SCHTTP2MimicHttp1Request,
 };
-use suricata_sys::sys::AppProtoEnum::ALPROTO_HTTP1;
 
 static mut ALPROTO_HTTP2: AppProto = ALPROTO_UNKNOWN;
 static mut ALPROTO_DOH2: AppProto = ALPROTO_UNKNOWN;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/3836

Describe changes:
- rust: format http2 files

Still TODO: base dir, dcerpc, detect, and more directories alphabetically after http2 like ike