### PR TITLE
Cppcheck/v10

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -750,7 +750,7 @@ static int Setup(Flow *f, HtpState *hstate)
 
     if (NULL == htp) {
 #ifdef DEBUG_VALIDATION
-        BUG_ON(htp == NULL);
+        BUG_ON(1);
 #endif
         /* should never happen if HTPConfigure is properly invoked */
         goto error;

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1215,7 +1215,8 @@ int DetectAddressTestConfVars(void)
 {
     SCLogDebug("Testing address conf vars for any misconfigured values");
 
-    ResolvedVariablesList var_list = TAILQ_HEAD_INITIALIZER(var_list);
+    ResolvedVariablesList var_list;
+    TAILQ_INIT(&var_list);
 
     SCConfNode *address_vars_node = SCConfGetNode("vars.address-groups");
     if (address_vars_node == NULL) {

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -1059,7 +1059,8 @@ int DetectPortTestConfVars(void)
 {
     SCLogDebug("Testing port conf vars for any misconfigured values");
 
-    ResolvedVariablesList var_list = TAILQ_HEAD_INITIALIZER(var_list);
+    ResolvedVariablesList var_list;
+    TAILQ_INIT(&var_list);
 
     SCConfNode *port_vars_node = SCConfGetNode("vars.port-groups");
     if (port_vars_node == NULL) {

--- a/src/output-flow.c
+++ b/src/output-flow.c
@@ -95,9 +95,7 @@ TmEcode OutputFlowLog(ThreadVars *tv, void *thread_data, Flow *f)
     OutputFlowLogger *logger = list;
     OutputLoggerThreadStore *store = op_thread_data->store;
 
-    DEBUG_VALIDATE_BUG_ON(logger == NULL && store != NULL);
-    DEBUG_VALIDATE_BUG_ON(logger != NULL && store == NULL);
-    DEBUG_VALIDATE_BUG_ON(logger == NULL && store == NULL);
+    DEBUG_VALIDATE_BUG_ON(store == NULL);
 
     while (logger && store) {
         DEBUG_VALIDATE_BUG_ON(logger->LogFunc == NULL);

--- a/src/output-packet.c
+++ b/src/output-packet.c
@@ -94,9 +94,7 @@ static TmEcode OutputPacketLog(ThreadVars *tv, Packet *p, void *thread_data)
     OutputPacketLogger *logger = list;
     OutputLoggerThreadStore *store = op_thread_data->store;
 
-    DEBUG_VALIDATE_BUG_ON(logger == NULL && store != NULL);
-    DEBUG_VALIDATE_BUG_ON(logger != NULL && store == NULL);
-    DEBUG_VALIDATE_BUG_ON(logger == NULL && store == NULL);
+    DEBUG_VALIDATE_BUG_ON(store == NULL);
 
     while (logger && store) {
         DEBUG_VALIDATE_BUG_ON(logger->LogFunc == NULL || logger->ConditionFunc == NULL);

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -52,6 +52,9 @@ extern "C"
     void ScanBuildMarkSanitized(const void *);
 #endif
 
+#if CPPCHECK == 1
+#define __has_feature(x) 0
+#endif
 #if defined(__has_feature)
 #if __has_feature(address_sanitizer)
 #define SC_ADDRESS_SANITIZER 1

--- a/src/util-port-interval-tree.c
+++ b/src/util-port-interval-tree.c
@@ -38,6 +38,7 @@
  */
 static int SCPortIntervalCompareAndUpdate(const SCPortIntervalNode *a, SCPortIntervalNode *b)
 {
+    DEBUG_VALIDATE_BUG_ON(a == NULL); // help cppcheck
     if (a->port2 > b->max) {
         b->max = a->port2;
     }
@@ -48,6 +49,7 @@ static int SCPortIntervalCompareAndUpdate(const SCPortIntervalNode *a, SCPortInt
 }
 
 // cppcheck-suppress nullPointerRedundantCheck
+// cppcheck-suppress ctunullpointer
 IRB_GENERATE(PI, SCPortIntervalNode, irb, SCPortIntervalCompareAndUpdate);
 
 /**


### PR DESCRIPTION
Tested with cppcheck 2.19 and 2.20:
```
cppcheck --library=posix,gnu --platform=unix64 --enable=warning \
    --check-level=exhaustive \
    -q -j ${CORES} -v -f \
    -I . -Ilibhtp -I/usr/include/dpdk/ \
    --std=c11 --report-progress --error-exitcode=2 \
    \
    -DPR_SET_NAME -USELF_TEST -DHAVE_LIBLZ4 \
    -DHAVE_TPACKET_V3 -DPACKET_STATISTICS \
    \
    -D__BYTE_ORDER=1234 -D__LITTLE_ENDIAN=1234 \
    -DCPPCHECK \
    -DDEBUG_VALIDATION \
    -DFBLOCK_MUTEX -UFBLOCK_SPIN \
    -DFLOWLOCK_MUTEX -UFLOWLOCK_RWLOCK \
    -DFQLOCK_MUTEX -UFQLOCK_SPIN \
    -DHRLOCK_MUTEX -UHRLOCK_SPIN \
    -DDQLOCK_MUTEX -UDQLOCK_SPIN \
    -DDRLOCK_MUTEX -UDRLOCK_SPIN \
    -DHQLOCK_MUTEX -UHQLOCK_SPIN \
    -UUNITTESTS -UDEBUG \
    -U__cplusplus -US_SPLINT_S -URELEASE \
    -UFLOW_DEBUG_STATS -UFLOWBITS_STATS -UQUEUE_MACRO_DEBUG \
    -UPROFILE_LOCKING -UPROFILING \
    -UHAVE_MPIPE -U__tile__ -UHAVE_NAPATECH \
    -UAFLFUZZ_DECODER -UAFLFUZZ_APPLAYER -UAFLFUZZ_RULES \
    -UHELLGRIND -UHELGRIND -U__clang_analyzer__ \
    -UTM_GMTOFF -UTM_ZONE \
    --inline-suppr \
    src/*.c
```