### PR TITLE
dcerpc: mimic gap behavior for invalid data

### DIFF
--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -798,45 +798,71 @@ impl DCERPCState {
         }
     }
 
-    pub fn handle_input_data(
-        &mut self, stream_slice: StreamSlice, direction: Direction,
-    ) -> AppLayerResult {
-        let mut cur_i = stream_slice.as_slice();
-        let mut consumed = 0u32;
+    /// Common function to handle gap or mimic a gap like situation.
+    ///
+    /// Arguments:
+    /// * `i`: input bytes.
+    /// * `direction`: direction that is currently being dealt with.
+    /// * `skip_error_record`: true if a record is to be skipped and treated like
+    ///   a gap. false if a record is actually meant to be handled like a gap.
+    ///
+    /// Return value: Tuple - (parsed, retval)
+    /// * parsed : Number of bytes successfully parsed/skipped.
+    /// * retval: -1 in case the parsed bytes should be skipped, 0 otherwise.
+    fn handle_gap (&mut self, i: &[u8], direction: Direction, skip_error_record: bool) -> (u32, i8) {
+        let mut consumed;
 
+        if !skip_error_record && ((!self.tc_gap && direction == Direction::ToClient) || (!self.ts_gap && direction == Direction::ToServer)) {
+            return (0, 0);
+        }
         // Skip the record since this means that its in the middle of a known length record
-        if (self.ts_gap && direction == Direction::ToServer)
-            || (self.tc_gap && direction == Direction::ToClient)
-        {
-            SCLogDebug!("Trying to catch up after GAP (input {})", cur_i.len());
-            match self.search_dcerpc_record(cur_i) {
-                Ok((_, pg)) => {
-                    SCLogDebug!("DCERPC record found");
-                    let offset = cur_i.len() - pg.len();
-                    cur_i = &cur_i[offset..];
-                    consumed = offset as u32;
+        SCLogDebug!("Trying to catch up after GAP (input {})", i.len());
+        match self.search_dcerpc_record(i) {
+            Ok((_, pg)) => {
+                SCLogDebug!("DCERPC record found");
+                let offset = i.len() - pg.len();
+                consumed = offset as u32;
+                if !skip_error_record {
                     match direction {
                         Direction::ToServer => {
                             self.ts_gap = false;
-                        }
+                        },
                         Direction::ToClient => {
                             self.tc_gap = false;
                         }
                     }
                 }
-                _ => {
-                    consumed = cur_i.len() as u32;
-                    // At least 2 bytes are required to know if a new record is beginning
-                    if consumed < 2 {
-                        consumed = 0;
-                    } else {
-                        consumed -= 1;
-                    }
-                    SCLogDebug!("DCERPC record NOT found");
-                    return AppLayerResult::incomplete(consumed, 2);
+            },
+            _ => {
+                consumed = i.len() as u32;
+                // At least 2 bytes are required to know if a new record is beginning
+                if consumed < 2 {
+                    consumed = 0;
+                } else {
+                    consumed -= 1;
                 }
-            }
+                SCLogDebug!("DCERPC record NOT found");
+                return (consumed, -1);
+            },
         }
+
+        (consumed, 0)
+    }
+
+    pub fn handle_input_data(
+        &mut self, stream_slice: StreamSlice, direction: Direction,
+    ) -> AppLayerResult {
+        let mut cur_i = stream_slice.as_slice();
+        let mut rem = cur_i.len() as u32;
+
+        SCLogDebug!("ts_gap: {:?}; direction: {:?}; tc_gap: {:?}", self.ts_gap, direction, self.tc_gap);
+        let (nb, ret) = self.handle_gap(cur_i, direction, false /* handling the actual gap */);
+        let mut consumed = nb;
+        if ret == -1 {
+            return AppLayerResult::incomplete(consumed, 2);
+        }
+        cur_i = &cur_i[consumed as usize..];
+        rem -= consumed;
 
         let mut flow = std::ptr::null_mut();
         if let Some(f) = self.flow {
@@ -856,7 +882,11 @@ impl DCERPCState {
                         header.rpc_vers,
                         header.rpc_vers_minor
                     );
-                        return AppLayerResult::err();
+                        SCLogDebug!("mimicing gap for invalid header");
+                        let (nb, _ret) = self.handle_gap(cur_i, direction, true /* mimicing a gap */);
+                        consumed += nb;
+                        /* no need to update rem/cur_i as it won't be used anymore */
+                        return AppLayerResult::incomplete(consumed, rem - consumed);
                     }
                     header
                 }


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/14890

Changes since v7:
- rebased on top of latest main

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7251

One more try to get the PCAPs.