### PR TITLE
Stack 8001 v16.5

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -2032,7 +2032,7 @@ AppLayerProtoDetectThreadCtx *AppLayerProtoDetectGetCtxThread(void)
         for (j = 0; j < 2; j++) {
             mpm_ctx = &alpd_ctx.ctx_ipp[i].ctx_pm[j].mpm_ctx;
             mpm_tctx = &alpd_tctx->mpm_tctx[i][j];
-            MpmInitThreadCtx(mpm_tctx, mpm_ctx->mpm_type);
+            MpmInitThreadCtx(mpm_tctx, mpm_ctx, mpm_ctx->mpm_type);
         }
     }
 

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -197,7 +197,7 @@ static void *FTPLocalStorageAlloc(void)
     if (unlikely(td->ftp_mpm_thread_ctx == NULL)) {
         exit(EXIT_FAILURE);
     }
-    MpmInitThreadCtx(td->ftp_mpm_thread_ctx, FTP_MPM);
+    MpmInitThreadCtx(td->ftp_mpm_thread_ctx, ftp_mpm_ctx, FTP_MPM);
     return td;
 }
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1556,7 +1556,7 @@ static void *SMTPLocalStorageAlloc(void)
     if (unlikely(td->smtp_mpm_thread_ctx == NULL)) {
         exit(EXIT_FAILURE);
     }
-    MpmInitThreadCtx(td->smtp_mpm_thread_ctx, SMTP_MPM);
+    MpmInitThreadCtx(td->smtp_mpm_thread_ctx, smtp_mpm_ctx, SMTP_MPM);
     return td;
 }
 

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -965,10 +965,23 @@ void PatternMatchThreadDestroy(MpmThreadCtx *mpm_thread_ctx, uint16_t mpm_matche
     SCLogDebug("mpm_thread_ctx %p, mpm_matcher %"PRIu16"", mpm_thread_ctx, mpm_matcher);
     MpmDestroyThreadCtx(mpm_thread_ctx, mpm_matcher);
 }
-void PatternMatchThreadPrepare(MpmThreadCtx *mpm_thread_ctx, uint16_t mpm_matcher)
+void PatternMatchThreadPrepare(MpmThreadCtx *mpm_thread_ctx, DetectEngineCtx *de_ctx)
 {
-    SCLogDebug("mpm_thread_ctx %p, type %"PRIu16, mpm_thread_ctx, mpm_matcher);
-    MpmInitThreadCtx(mpm_thread_ctx, mpm_matcher);
+    SCLogDebug("mpm_thread_ctx %p, type %" PRIu16, mpm_thread_ctx, de_ctx->mpm_matcher);
+    MpmCtx cum_mpm_ctx = { 0 };
+    for (HashListTableBucket *htb = HashListTableGetListHead(de_ctx->mpm_hash_table); htb != NULL;
+            htb = HashListTableGetListNext(htb)) {
+        // iterate all de_ctx mpms to merge one MpmCtx with max pattern_cnt and max max_pat_id
+        const MpmStore *ms = (MpmStore *)HashListTableGetListData(htb);
+        if (ms == NULL || ms->mpm_ctx == NULL) {
+            continue;
+        }
+        if (ms->mpm_ctx->pattern_cnt > cum_mpm_ctx.pattern_cnt)
+            cum_mpm_ctx.pattern_cnt = ms->mpm_ctx->pattern_cnt;
+        if (ms->mpm_ctx->max_pat_id > cum_mpm_ctx.max_pat_id)
+            cum_mpm_ctx.max_pat_id = ms->mpm_ctx->max_pat_id;
+    }
+    MpmInitThreadCtx(mpm_thread_ctx, &cum_mpm_ctx, de_ctx->mpm_matcher);
 }
 
 /** \brief Predict a strength value for patterns

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -41,7 +41,7 @@ uint32_t PatternStrength(uint8_t *, uint16_t);
 uint8_t PatternMatchDefaultMatcher(void);
 
 void PatternMatchPrepare(MpmCtx *, uint16_t);
-void PatternMatchThreadPrepare(MpmThreadCtx *, uint16_t type);
+void PatternMatchThreadPrepare(MpmThreadCtx *, DetectEngineCtx *);
 
 void PatternMatchDestroy(MpmCtx *, uint16_t);
 void PatternMatchThreadDestroy(MpmThreadCtx *mpm_thread_ctx, uint16_t);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3288,7 +3288,7 @@ error:
  */
 static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx)
 {
-    PatternMatchThreadPrepare(&det_ctx->mtc, de_ctx->mpm_matcher);
+    PatternMatchThreadPrepare(&det_ctx->mtc, de_ctx);
 
     PmqSetup(&det_ctx->pmq);
 

--- a/src/util-mpm-ac-ks-small.c
+++ b/src/util-mpm-ac-ks-small.c
@@ -48,8 +48,8 @@ uint32_t FUNC_NAME(const SCACTileSearchCtx *ctx, MpmThreadCtx *mpm_thread_ctx,
     uint32_t i = 0;
     int matches = 0;
 
-    uint8_t mpm_bitarray[ctx->mpm_bitarray_size];
-    memset(mpm_bitarray, 0, ctx->mpm_bitarray_size);
+    uint8_t *mpm_bitarray = (uint8_t *)mpm_thread_ctx->ctx;
+    memset(mpm_bitarray, 0, mpm_thread_ctx->memory_size);
 
     const uint8_t* restrict xlate = ctx->translate_table;
     STYPE *state_table = (STYPE*)ctx->state_table;

--- a/src/util-mpm-ac-ks.c
+++ b/src/util-mpm-ac-ks.c
@@ -1138,8 +1138,8 @@ uint32_t SCACTileSearchLarge(const SCACTileSearchCtx *ctx, MpmThreadCtx *mpm_thr
     uint32_t i = 0;
     int matches = 0;
 
-    uint8_t mpm_bitarray[ctx->mpm_bitarray_size];
-    memset(mpm_bitarray, 0, ctx->mpm_bitarray_size);
+    uint8_t *mpm_bitarray = (uint8_t *)mpm_thread_ctx->ctx;
+    memset(mpm_bitarray, 0, mpm_thread_ctx->memory_size);
 
     const uint8_t* restrict xlate = ctx->translate_table;
     register int state = 0;
@@ -1337,6 +1337,33 @@ void SCACTilePrintInfo(MpmCtx *mpm_ctx)
     printf("\n");
 }
 
+/**
+ * \brief Init the mpm thread context.
+ *
+ * \param mpm_ctx        Pointer to the mpm context.
+ * \param mpm_thread_ctx Pointer to the mpm thread context.
+ */
+static void SCACTileInitThreadCtx(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx)
+{
+    size_t size = (mpm_ctx->pattern_cnt + 7) / 8;
+
+    uint8_t *bitarray = SCCalloc(size, sizeof(uint8_t));
+    if (bitarray == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    mpm_thread_ctx->ctx = bitarray;
+    mpm_thread_ctx->memory_cnt = 1;
+    mpm_thread_ctx->memory_size = size;
+}
+
+static void SCACTileDestroyThreadCtx(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx)
+{
+    mpm_thread_ctx->memory_cnt = 0;
+    mpm_thread_ctx->memory_size = 0;
+    SCFree(mpm_thread_ctx->ctx);
+    mpm_thread_ctx->ctx = NULL;
+}
+
 /************************** Mpm Registration ***************************/
 
 /**
@@ -1357,6 +1384,8 @@ void MpmACTileRegister(void)
     mpm_table[MPM_AC_KS].CacheRuleset = NULL;
     mpm_table[MPM_AC_KS].Search = SCACTileSearch;
     mpm_table[MPM_AC_KS].PrintCtx = SCACTilePrintInfo;
+    mpm_table[MPM_AC_KS].InitThreadCtx = SCACTileInitThreadCtx;
+    mpm_table[MPM_AC_KS].DestroyThreadCtx = SCACTileDestroyThreadCtx;
 #ifdef UNITTESTS
     mpm_table[MPM_AC_KS].RegisterUnittests = SCACTileRegisterTests;
 #endif
@@ -1385,6 +1414,7 @@ static int SCACTileTest01(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghjiklmnopqrstuvwxyz";
 
@@ -1397,6 +1427,7 @@ static int SCACTileTest01(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1417,6 +1448,7 @@ static int SCACTileTest02(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghjiklmnopqrstuvwxyz";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1428,6 +1460,7 @@ static int SCACTileTest02(void)
         printf("0 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1452,6 +1485,7 @@ static int SCACTileTest03(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghjiklmnopqrstuvwxyz";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1463,6 +1497,7 @@ static int SCACTileTest03(void)
         printf("3 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1484,6 +1519,7 @@ static int SCACTileTest04(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghjiklmnopqrstuvwxyz";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1495,6 +1531,7 @@ static int SCACTileTest04(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1516,6 +1553,7 @@ static int SCACTileTest05(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghjiklmnopqrstuvwxyz";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1527,6 +1565,7 @@ static int SCACTileTest05(void)
         printf("3 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1546,6 +1585,7 @@ static int SCACTileTest06(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcd";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1557,6 +1597,7 @@ static int SCACTileTest06(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1588,6 +1629,7 @@ static int SCACTileTest07(void)
     /* total matches: 135: 6 unique */
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1595,6 +1637,7 @@ static int SCACTileTest07(void)
     FAIL_IF_NOT(cnt == 6);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     PASS;
 }
@@ -1615,6 +1658,7 @@ static int SCACTileTest08(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
                                   (uint8_t *)"a", 1);
@@ -1625,6 +1669,7 @@ static int SCACTileTest08(void)
         printf("0 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1645,6 +1690,7 @@ static int SCACTileTest09(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
                                   (uint8_t *)"ab", 2);
@@ -1655,6 +1701,7 @@ static int SCACTileTest09(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1675,6 +1722,7 @@ static int SCACTileTest10(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "01234567890123456789012345678901234567890123456789"
                 "01234567890123456789012345678901234567890123456789"
@@ -1690,6 +1738,7 @@ static int SCACTileTest10(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1717,6 +1766,7 @@ static int SCACTileTest11(void)
 
     if (SCACTilePreparePatterns(NULL, &mpm_ctx) == -1)
         goto end;
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     result = 1;
 
@@ -1735,6 +1785,7 @@ static int SCACTileTest11(void)
 
  end:
      SCACTileDestroyCtx(&mpm_ctx);
+     SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
      PmqFree(&pmq);
      return result;
 }
@@ -1757,6 +1808,7 @@ static int SCACTileTest12(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyz";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1768,6 +1820,7 @@ static int SCACTileTest12(void)
         printf("2 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1789,6 +1842,7 @@ static int SCACTileTest13(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyzABCD";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1800,6 +1854,7 @@ static int SCACTileTest13(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1821,6 +1876,7 @@ static int SCACTileTest14(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyzABCDE";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1832,6 +1888,7 @@ static int SCACTileTest14(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1853,6 +1910,7 @@ static int SCACTileTest15(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyzABCDEF";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1864,6 +1922,7 @@ static int SCACTileTest15(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1885,6 +1944,7 @@ static int SCACTileTest16(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyzABC";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1896,6 +1956,7 @@ static int SCACTileTest16(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1917,6 +1978,7 @@ static int SCACTileTest17(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyzAB";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1928,6 +1990,7 @@ static int SCACTileTest17(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1954,6 +2017,7 @@ static int SCACTileTest18(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcde""fghij""klmno""pqrst""uvwxy""z";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1965,6 +2029,7 @@ static int SCACTileTest18(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1986,6 +2051,7 @@ static int SCACTileTest19(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1997,6 +2063,7 @@ static int SCACTileTest19(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -2024,6 +2091,7 @@ static int SCACTileTest20(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AA";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -2035,6 +2103,7 @@ static int SCACTileTest20(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -2055,6 +2124,7 @@ static int SCACTileTest21(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
                                   (uint8_t *)"AA", 2);
@@ -2065,6 +2135,7 @@ static int SCACTileTest21(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -2087,6 +2158,7 @@ static int SCACTileTest22(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyz";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -2098,6 +2170,7 @@ static int SCACTileTest22(void)
         printf("2 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -2118,6 +2191,7 @@ static int SCACTileTest23(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
                                   (uint8_t *)"aa", 2);
@@ -2128,6 +2202,7 @@ static int SCACTileTest23(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -2148,6 +2223,7 @@ static int SCACTileTest24(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
                                   (uint8_t *)"aa", 2);
@@ -2158,6 +2234,7 @@ static int SCACTileTest24(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -2179,6 +2256,7 @@ static int SCACTileTest25(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -2190,6 +2268,7 @@ static int SCACTileTest25(void)
         printf("3 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -2210,6 +2289,7 @@ static int SCACTileTest26(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "works";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -2221,6 +2301,7 @@ static int SCACTileTest26(void)
         printf("3 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -2241,6 +2322,7 @@ static int SCACTileTest27(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "tone";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -2252,6 +2334,7 @@ static int SCACTileTest27(void)
         printf("0 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -2272,6 +2355,7 @@ static int SCACTileTest28(void)
     PmqSetup(&pmq);
 
     SCACTilePreparePatterns(NULL, &mpm_ctx);
+    SCACTileInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "tONE";
     uint32_t cnt = SCACTileSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -2283,6 +2367,7 @@ static int SCACTileTest28(void)
         printf("0 != %" PRIu32 " ",cnt);
 
     SCACTileDestroyCtx(&mpm_ctx);
+    SCACTileDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -861,9 +861,8 @@ uint32_t SCACSearch(const MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
      * to dig deeper */
     /* \todo Change it for stateful MPM.  Supply the state using mpm_thread_ctx */
     const SCACPatternList *pid_pat_list = ctx->pid_pat_list;
-
-    uint8_t bitarray[ctx->pattern_id_bitarray_size];
-    memset(bitarray, 0, ctx->pattern_id_bitarray_size);
+    uint8_t *bitarray = (uint8_t *)mpm_thread_ctx->ctx;
+    memset(bitarray, 0, mpm_thread_ctx->memory_size);
 
     if (ctx->state_count < 32767) {
         register SC_AC_STATE_TYPE_U16 state = 0;
@@ -1029,6 +1028,32 @@ void SCACPrintInfo(MpmCtx *mpm_ctx)
     printf("\n");
 }
 
+/**
+ * \brief Init the mpm thread context.
+ *
+ * \param mpm_ctx        Pointer to the mpm context.
+ * \param mpm_thread_ctx Pointer to the mpm thread context.
+ */
+static void SCACInitThreadCtx(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx)
+{
+    size_t size = (mpm_ctx->max_pat_id / 8) + 1;
+
+    uint8_t *bitarray = SCCalloc(size, sizeof(uint8_t));
+    if (bitarray == NULL) {
+        exit(EXIT_FAILURE);
+    }
+    mpm_thread_ctx->ctx = bitarray;
+    mpm_thread_ctx->memory_cnt = 1;
+    mpm_thread_ctx->memory_size = size;
+}
+
+static void SCACDestroyThreadCtx(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx)
+{
+    mpm_thread_ctx->memory_cnt = 0;
+    mpm_thread_ctx->memory_size = 0;
+    SCFree(mpm_thread_ctx->ctx);
+    mpm_thread_ctx->ctx = NULL;
+}
 
 /************************** Mpm Registration ***************************/
 
@@ -1049,6 +1074,8 @@ void MpmACRegister(void)
     mpm_table[MPM_AC].CacheRuleset = NULL;
     mpm_table[MPM_AC].Search = SCACSearch;
     mpm_table[MPM_AC].PrintCtx = SCACPrintInfo;
+    mpm_table[MPM_AC].InitThreadCtx = SCACInitThreadCtx;
+    mpm_table[MPM_AC].DestroyThreadCtx = SCACDestroyThreadCtx;
 #ifdef UNITTESTS
     mpm_table[MPM_AC].RegisterUnittests = SCACRegisterTests;
 #endif
@@ -1076,6 +1103,7 @@ static int SCACTest01(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghjiklmnopqrstuvwxyz";
 
@@ -1088,6 +1116,7 @@ static int SCACTest01(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1108,6 +1137,7 @@ static int SCACTest02(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghjiklmnopqrstuvwxyz";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1119,6 +1149,7 @@ static int SCACTest02(void)
         printf("0 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1143,6 +1174,7 @@ static int SCACTest03(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghjiklmnopqrstuvwxyz";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1154,6 +1186,7 @@ static int SCACTest03(void)
         printf("3 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1175,6 +1208,7 @@ static int SCACTest04(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghjiklmnopqrstuvwxyz";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1186,6 +1220,7 @@ static int SCACTest04(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1207,6 +1242,7 @@ static int SCACTest05(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghjiklmnopqrstuvwxyz";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1218,6 +1254,7 @@ static int SCACTest05(void)
         printf("3 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1237,6 +1274,7 @@ static int SCACTest06(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcd";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1248,6 +1286,7 @@ static int SCACTest06(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1279,6 +1318,7 @@ static int SCACTest07(void)
     /* total matches: 135: unique matches: 6 */
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1286,6 +1326,7 @@ static int SCACTest07(void)
     FAIL_IF_NOT(cnt == 6);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     PASS;
 }
@@ -1306,6 +1347,7 @@ static int SCACTest08(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
                                (uint8_t *)"a", 1);
@@ -1316,6 +1358,7 @@ static int SCACTest08(void)
         printf("0 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1336,6 +1379,7 @@ static int SCACTest09(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
                                (uint8_t *)"ab", 2);
@@ -1346,6 +1390,7 @@ static int SCACTest09(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1366,6 +1411,7 @@ static int SCACTest10(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "01234567890123456789012345678901234567890123456789"
                 "01234567890123456789012345678901234567890123456789"
@@ -1381,6 +1427,7 @@ static int SCACTest10(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1409,6 +1456,8 @@ static int SCACTest11(void)
     if (SCACPreparePatterns(NULL, &mpm_ctx) == -1)
         goto end;
 
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
+
     result = 1;
 
     const char *buf = "he";
@@ -1426,6 +1475,7 @@ static int SCACTest11(void)
 
  end:
      SCACDestroyCtx(&mpm_ctx);
+     SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
      PmqFree(&pmq);
      return result;
 }
@@ -1448,6 +1498,7 @@ static int SCACTest12(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyz";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1459,6 +1510,7 @@ static int SCACTest12(void)
         printf("2 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1480,6 +1532,7 @@ static int SCACTest13(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyzABCD";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1491,6 +1544,7 @@ static int SCACTest13(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1512,6 +1566,7 @@ static int SCACTest14(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyzABCDE";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1523,6 +1578,7 @@ static int SCACTest14(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1544,6 +1600,7 @@ static int SCACTest15(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyzABCDEF";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1555,6 +1612,7 @@ static int SCACTest15(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1576,6 +1634,7 @@ static int SCACTest16(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyzABC";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1587,6 +1646,7 @@ static int SCACTest16(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1608,6 +1668,7 @@ static int SCACTest17(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyzAB";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1619,6 +1680,7 @@ static int SCACTest17(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1645,6 +1707,7 @@ static int SCACTest18(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcde""fghij""klmno""pqrst""uvwxy""z";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1656,6 +1719,7 @@ static int SCACTest18(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1677,6 +1741,7 @@ static int SCACTest19(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1688,6 +1753,7 @@ static int SCACTest19(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1715,6 +1781,7 @@ static int SCACTest20(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AAAAA""AA";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1726,6 +1793,7 @@ static int SCACTest20(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1746,6 +1814,7 @@ static int SCACTest21(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
                               (uint8_t *)"AA", 2);
@@ -1756,6 +1825,7 @@ static int SCACTest21(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1778,6 +1848,7 @@ static int SCACTest22(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "abcdefghijklmnopqrstuvwxyz";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1789,6 +1860,7 @@ static int SCACTest22(void)
         printf("2 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1809,6 +1881,7 @@ static int SCACTest23(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
                               (uint8_t *)"aa", 2);
@@ -1819,6 +1892,7 @@ static int SCACTest23(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1839,6 +1913,7 @@ static int SCACTest24(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
                               (uint8_t *)"aa", 2);
@@ -1849,6 +1924,7 @@ static int SCACTest24(void)
         printf("1 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1870,6 +1946,7 @@ static int SCACTest25(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1881,6 +1958,7 @@ static int SCACTest25(void)
         printf("3 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1901,6 +1979,7 @@ static int SCACTest26(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "works";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1912,6 +1991,7 @@ static int SCACTest26(void)
         printf("3 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1932,6 +2012,7 @@ static int SCACTest27(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "tone";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1943,6 +2024,7 @@ static int SCACTest27(void)
         printf("0 != %" PRIu32 " ",cnt);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     return result;
 }
@@ -1962,6 +2044,7 @@ static int SCACTest28(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf = "tONE";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq,
@@ -1969,6 +2052,7 @@ static int SCACTest28(void)
     FAIL_IF_NOT(cnt == 0);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     PASS;
 }
@@ -2030,6 +2114,7 @@ static int SCACTest30(void)
     PmqSetup(&pmq);
 
     SCACPreparePatterns(NULL, &mpm_ctx);
+    SCACInitThreadCtx(&mpm_ctx, &mpm_thread_ctx);
 
     const char *buf1 = "abcdefghijklmnopqrstuvwxyz";
     uint32_t cnt = SCACSearch(&mpm_ctx, &mpm_thread_ctx, &pmq, (uint8_t *)buf1, strlen(buf1));
@@ -2039,6 +2124,7 @@ static int SCACTest30(void)
     FAIL_IF_NOT(cnt == 0);
 
     SCACDestroyCtx(&mpm_ctx);
+    SCACDestroyThreadCtx(&mpm_ctx, &mpm_thread_ctx);
     PmqFree(&pmq);
     PASS;
 }

--- a/src/util-mpm.c
+++ b/src/util-mpm.c
@@ -192,10 +192,10 @@ void MpmFactoryDeRegisterAllMpmCtxProfiles(DetectEngineCtx *de_ctx)
     de_ctx->mpm_ctx_factory_container = NULL;
 }
 
-void MpmInitThreadCtx(MpmThreadCtx *mpm_thread_ctx, uint16_t matcher)
+void MpmInitThreadCtx(MpmThreadCtx *mpm_thread_ctx, MpmCtx *mpm_ctx, uint16_t matcher)
 {
     if (mpm_table[matcher].InitThreadCtx != NULL) {
-        mpm_table[matcher].InitThreadCtx(NULL, mpm_thread_ctx);
+        mpm_table[matcher].InitThreadCtx(mpm_ctx, mpm_thread_ctx);
     }
 }
 

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -208,7 +208,7 @@ void MpmTableSetup(void);
 void MpmRegisterTests(void);
 
 void MpmInitCtx(MpmCtx *mpm_ctx, uint8_t matcher);
-void MpmInitThreadCtx(MpmThreadCtx *mpm_thread_ctx, uint16_t);
+void MpmInitThreadCtx(MpmThreadCtx *mpm_thread_ctx, MpmCtx *mpm_ctx, uint16_t);
 void MpmDestroyThreadCtx(MpmThreadCtx *mpm_thread_ctx, const uint16_t matcher);
 
 int MpmAddPatternCS(struct MpmCtx_ *mpm_ctx, uint8_t *pat, uint16_t patlen,

--- a/src/util-spm-mm.c
+++ b/src/util-spm-mm.c
@@ -37,11 +37,11 @@
  *  Convert haystack data to lowercase before inspecting it with
  *  `memmem`. Do this in a sliding window manner. */
 static const uint8_t *SCMemimem(const uint8_t *haystack, uint32_t haystack_len,
-        const uint8_t *needle, const uint32_t needle_len)
+        const uint8_t *needle, const uint16_t needle_len)
 {
     if (needle_len > haystack_len)
         return NULL;
-    uint32_t slice_size = MAX(MIN(haystack_len, 128), needle_len * 3);
+    uint32_t slice_size = MAX(MIN(haystack_len, 128), (uint32_t)needle_len * 3);
     uint8_t slice[slice_size];
     uint32_t o = 0;
     do {

--- a/src/util-spm-mm.h
+++ b/src/util-spm-mm.h
@@ -26,7 +26,7 @@
 #ifdef HAVE_MEMMEM
 
 typedef struct SpmMmCtx_ {
-    uint32_t needle_len;
+    uint16_t needle_len;
     int nocase;
     uint8_t needle[];
 } SpmMmCtx;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/8001

Describe changes: improve stack allocations

https://github.com/OISF/suricata/pull/15075 next version without global atomics, but computing a dummy MpmCtx out of all the ones in a DetectEngineCtx to get the maximum number of patterns

Still todo after : 
- Allocate arrays on the heap instead of the stack when the size comes from `buffer_type_id` which is a legit u32
