### PR TITLE
detect: ban keywords from firewall rules / firewall mode - v1

### DIFF
--- a/doc/userguide/rules/bypass-keyword.rst
+++ b/doc/userguide/rules/bypass-keyword.rst
@@ -11,6 +11,11 @@ The ``bypass`` keyword is useful in cases where there is a large flow expected
 
 The ``bypass`` keyword is considered a post-match keyword.
 
+.. note::
+
+   ``bypass`` cannot be used in firewall mode, not even with Threat Detection
+   rules, as this could lead to bypassing the firewall altogether.
+
 bypass
 ------
 

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -912,6 +912,9 @@ the reassembled stream.
 The checksums will be recalculated by Suricata and changed after the
 replace keyword is being used.
 
+.. note:: ``replace`` cannot be used in firewall rules, nor in firewall mode,
+   even if only in Threat Detection rules.
+
 .. _pcre:
 
 pcre (Perl Compatible Regular Expressions)

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -64,7 +64,7 @@ void DetectBypassRegister(void)
     sigmatch_table[DETECT_BYPASS].Match = DetectBypassMatch;
     sigmatch_table[DETECT_BYPASS].Setup = DetectBypassSetup;
     sigmatch_table[DETECT_BYPASS].Free  = NULL;
-    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT;
+    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_BAN_FIREWALL_MODE;
 }
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -331,6 +331,12 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
         DEBUG_VALIDATE_BUG_ON(flags & (SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT |
                                               SIGMATCH_INFO_BITFLAGS_UINT));
     }
+    if (flags & SIGMATCH_BAN_FIREWALL_RULE) {
+        if (prev == 1)
+            printf("%c", sep);
+        printf("banned from firewall rules");
+        prev = 1;
+    }
     if (e->Transform) {
         if (prev == 1)
             printf("%c", sep);

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -337,6 +337,12 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
         printf("banned from firewall rules");
         prev = 1;
     }
+    if (flags & SIGMATCH_BAN_FIREWALL_MODE) {
+        if (prev == 1)
+            printf("%c", sep);
+        printf("banned from firewall mode");
+        prev = 1;
+    }
     if (e->Transform) {
         if (prev == 1)
             printf("%c", sep);

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -350,6 +350,8 @@ extern int DETECT_TBLSIZE_IDX;
 #define SIGMATCH_INFO_ENUM_UINT (1UL << (19))
 /** keyword is an uint with bitflags */
 #define SIGMATCH_INFO_BITFLAGS_UINT (1UL << (20))
+/** keyword cannot be used in firewall rules */
+#define SIGMATCH_BAN_FIREWALL_RULE (1UL << (21))
 
 int SigTableList(const char *keyword);
 void SigTableCleanup(void);

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -352,6 +352,8 @@ extern int DETECT_TBLSIZE_IDX;
 #define SIGMATCH_INFO_BITFLAGS_UINT (1UL << (20))
 /** keyword cannot be used in firewall rules */
 #define SIGMATCH_BAN_FIREWALL_RULE (1UL << (21))
+/** keyword cannot be used in firewall mode */
+#define SIGMATCH_BAN_FIREWALL_MODE (1UL << (22))
 
 int SigTableList(const char *keyword);
 void SigTableCleanup(void);

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -968,6 +968,11 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 #undef URL
     }
 
+    if (s->init_data->firewall_rule && (st->flags & SIGMATCH_BAN_FIREWALL_RULE) != 0) {
+        SCLogError("keyword \'%s\' is not allowed with firewall rules", optname);
+        goto error;
+    }
+
     int setup_ret = 0;
 
     /* Validate double quoting, trimming trailing white space along the way. */
@@ -985,6 +990,12 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
         if (ovlen == 0) {
             SCLogError("invalid formatting or malformed option to %s keyword: \'%s\'", optname,
                     optstr);
+            goto error;
+        }
+
+        /** error with firewall rule ban before firewall untested warning */
+        if (s->init_data->firewall_rule && (st->flags & SIGMATCH_BAN_FIREWALL_RULE) != 0) {
+            SCLogError("keyword \'%s\' is not allowed with firewall rules", optname);
             goto error;
         }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -973,6 +973,11 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
         goto error;
     }
 
+    if (EngineModeIsFirewall() && (st->flags & SIGMATCH_BAN_FIREWALL_MODE) != 0) {
+        SCLogError("keyword \'%s\' is not allowed in firewall mode", optname);
+        goto error;
+    }
+
     int setup_ret = 0;
 
     /* Validate double quoting, trimming trailing white space along the way. */
@@ -990,12 +995,6 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
         if (ovlen == 0) {
             SCLogError("invalid formatting or malformed option to %s keyword: \'%s\'", optname,
                     optstr);
-            goto error;
-        }
-
-        /** error with firewall rule ban before firewall untested warning */
-        if (s->init_data->firewall_rule && (st->flags & SIGMATCH_BAN_FIREWALL_RULE) != 0) {
-            SCLogError("keyword \'%s\' is not allowed with firewall rules", optname);
             goto error;
         }
 

--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -58,14 +58,18 @@ static int DetectReplacePostMatch(DetectEngineThreadCtx *det_ctx,
 void DetectReplaceRegister (void)
 {
     sigmatch_table[DETECT_REPLACE].name = "replace";
-    sigmatch_table[DETECT_REPLACE].desc = "only to be used in IPS-mode. Change the following content into another";
+    sigmatch_table[DETECT_REPLACE].desc =
+            "only to be used in IPS-mode. Banned from firewall rules & firewall mode usage. Change "
+            "the following content into another";
     sigmatch_table[DETECT_REPLACE].url = "/rules/payload-keywords.html#replace";
     sigmatch_table[DETECT_REPLACE].Match = DetectReplacePostMatch;
     sigmatch_table[DETECT_REPLACE].Setup = DetectReplaceSetup;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_REPLACE].RegisterTests = DetectReplaceRegisterTests;
 #endif
-    sigmatch_table[DETECT_REPLACE].flags = (SIGMATCH_QUOTES_MANDATORY|SIGMATCH_HANDLE_NEGATION);
+    sigmatch_table[DETECT_REPLACE].flags =
+            (SIGMATCH_QUOTES_MANDATORY | SIGMATCH_HANDLE_NEGATION | SIGMATCH_BAN_FIREWALL_RULE |
+                    SIGMATCH_BAN_FIREWALL_MODE);
 }
 
 static int DetectReplacePostMatch(DetectEngineThreadCtx *det_ctx,


### PR DESCRIPTION

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/8551 (mainly)

Wasn't sure which ticket to refer in the `bypass` case. We have https://redmine.openinfosecfoundation.org/issues/8459 but it's actually to support it...

Describe changes:
- add flags to allow banning rule keywords from firewall rules or from firewall mode altogether
- apply both flags to `replace` keyword
- apply firewall mode ban to `bypass` keyword

I'm not sure I understand the need for banning `replace` from both, tbh, since firewall mode ban will prevent it from existing in any ruleset. Can probably keep just that one 🤔 

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3122