### PR TITLE
af-packet: respect vlan.use-for-tracking in eBPF bypass

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2898,6 +2898,79 @@ jobs:
       # DPDK configuration checks
       - run: ./qa/live/dpdk/dpdk-testsuite.sh
 
+  ubuntu-xdp:
+    name: Ubuntu (xdp)
+    runs-on: ubuntu-latest
+    needs: [prepare-deps]
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
+      - run: sudo apt update
+      - run: |
+          sudo apt -y install \
+              autoconf \
+              automake \
+              build-essential \
+              cmake \
+              curl \
+              git \
+              hwloc \
+              libhwloc-dev \
+              jq \
+              make \
+              libpcre3 \
+              libpcre3-dbg \
+              libpcre3-dev \
+              libpcre2-dev \
+              libtool \
+              libpcap-dev \
+              libnet1-dev \
+              libyaml-0-2 \
+              libyaml-dev \
+              libcap-ng-dev \
+              libcap-ng0 \
+              libjansson-dev \
+              libjansson4 \
+              libnuma-dev \
+              liblz4-dev \
+              libssl-dev \
+              pkg-config \
+              python3 \
+              python3-yaml \
+              tcpreplay \
+              zlib1g \
+              zlib1g-dev \
+              clang \
+              libxdp-dev
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: prep
+          path: prep
+      - name: Install Rust
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $(grep rust-version rust/Cargo.toml.in|sed 's/\"//g'|awk '{print $3}') -y
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: ./autogen.sh
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
+      - run: make -j ${{ env.CPUS }}
+      - run: make check
+      - name: Running suricata-verify
+        run: python3 ./suricata-verify/run.py -q --debug-failed
+      - run: ulimit -a
+      - name: Running suricata-verify live tests
+        run: sudo python3 ./suricata-verify/run.py --live --debug-failed
+
   debian-12:
     name: Debian 12 (xdp)
     runs-on: ubuntu-latest

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2962,7 +2962,7 @@ jobs:
       - uses: ./.github/actions/install-cbindgen
       - run: tar xf prep/suricata-verify.tar.gz
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
+      - run: CFLAGS="${DEFAULT_CFLAGS} -DAFPACKET_TEST_REPLAY" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
       - run: make -j ${{ env.CPUS }}
       - run: make check
       - name: Running suricata-verify

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -595,7 +595,13 @@ static void *ParseAFPConfig(const char *iface)
         SCLogError("%s: XDP support is not built-in", iface);
 #endif
     }
-
+#ifdef AFPACKET_TEST_REPLAY
+    if ((SCConfGetChildValueIntWithDefault(if_root, if_default, "max-packets", &value)) == 1) {
+        aconf->max_packets = (uint32_t)value;
+    } else {
+        aconf->max_packets = 0;
+    }
+#endif
     if ((SCConfGetChildValueIntWithDefault(if_root, if_default, "buffer-size", &value)) == 1) {
         aconf->buffer_size = (int)value;
     } else {

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -356,6 +356,9 @@ typedef struct AFPThreadVars_
     struct ebpf_timeout_config ebpf_t_config;
 #endif
 #ifdef AFPACKET_TEST_REPLAY
+    /* Test-replay stop condition: ReceiveAFPLoop exits after this many
+     * packets. Set from AFPIfaceConfig::max_packets at thread init. A
+     * value of 0 disables the cap (loop runs until normal stop). */
     uint32_t max_packets;
 #endif
 } AFPThreadVars;
@@ -1432,7 +1435,12 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
             StatsCounterIncr(&ptv->tv->stats, ptv->capture_afp_poll_data);
             r = AFPReadFunc(ptv);
 #ifdef AFPACKET_TEST_REPLAY
-            if (ptv->max_packets > 0 && ptv->pkts >= ptv->max_packets) {
+            /* Test-replay stop condition: signal Suricata to stop after the
+             * configured number of packets so suricata-verify live tests
+             * driven by tcpreplay terminate deterministically. ptv->pkts is
+             * uint64_t; widen max_packets so the comparison is unsigned and
+             * same-width. */
+            if (ptv->max_packets > 0 && ptv->pkts >= (uint64_t)ptv->max_packets) {
                 suricata_ctl_flags |= SURICATA_STOP;
             }
 #endif

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -355,7 +355,9 @@ typedef struct AFPThreadVars_
     int ebpf_filter_fd;
     struct ebpf_timeout_config ebpf_t_config;
 #endif
-
+#ifdef AFPACKET_TEST_REPLAY
+    uint32_t max_packets;
+#endif
 } AFPThreadVars;
 
 static TmEcode ReceiveAFPThreadInit(ThreadVars *, const void *, void **);
@@ -1429,6 +1431,11 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
         } else if (r > 0) {
             StatsCounterIncr(&ptv->tv->stats, ptv->capture_afp_poll_data);
             r = AFPReadFunc(ptv);
+#ifdef AFPACKET_TEST_REPLAY
+            if (ptv->max_packets > 0 && ptv->pkts >= ptv->max_packets) {
+                suricata_ctl_flags |= SURICATA_STOP;
+            }
+#endif
             switch (r) {
                 case AFP_READ_OK:
                     /* Trigger one dump of stats every second */
@@ -2600,6 +2607,9 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, const void *initdata, void **data)
     ptv->promisc = afpconfig->promisc;
     ptv->checksum_mode = afpconfig->checksum_mode;
     ptv->bpf_filter = NULL;
+#ifdef AFPACKET_TEST_REPLAY
+    ptv->max_packets = afpconfig->max_packets;
+#endif
 
     ptv->threads = 1;
 #ifdef HAVE_PACKET_FANOUT

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2297,8 +2297,8 @@ static int AFPBypassCallback(Packet *p)
         keys[0]->dst = htonl(GET_IPV4_DST_ADDR_U32(p));
         keys[0]->port16[0] = p->sp;
         keys[0]->port16[1] = p->dp;
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2322,8 +2322,8 @@ static int AFPBypassCallback(Packet *p)
         keys[1]->dst = htonl(GET_IPV4_SRC_ADDR_U32(p));
         keys[1]->port16[0] = p->dp;
         keys[1]->port16[1] = p->sp;
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
@@ -2356,8 +2356,8 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[0]->port16[0] = p->sp;
         keys[0]->port16[1] = p->dp;
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2383,8 +2383,8 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[1]->port16[0] = p->dp;
         keys[1]->port16[1] = p->sp;
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
@@ -2451,8 +2451,8 @@ static int AFPXDPBypassCallback(Packet *p)
          * (as in eBPF filter) so we need to pass from host to network order */
         keys[0]->port16[0] = htons(p->sp);
         keys[0]->port16[1] = htons(p->dp);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2475,8 +2475,8 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[1]->dst = p->src.addr_data32[0];
         keys[1]->port16[0] = htons(p->dp);
         keys[1]->port16[1] = htons(p->sp);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
@@ -2507,8 +2507,8 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         keys[0]->port16[0] = htons(p->sp);
         keys[0]->port16[1] = htons(p->dp);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2533,8 +2533,8 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         keys[1]->port16[0] = htons(p->dp);
         keys[1]->port16[1] = htons(p->sp);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -121,6 +121,9 @@ typedef struct AFPIfaceConfig_
 #ifdef HAVE_PACKET_EBPF
     struct ebpf_timeout_config ebpf_t_config;
 #endif
+#ifdef AFPACKET_TEST_REPLAY
+    uint32_t max_packets;
+#endif
     SC_ATOMIC_DECLARE(unsigned int, ref);
     void (*DerefFunc)(void *);
 } AFPIfaceConfig;

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -122,6 +122,10 @@ typedef struct AFPIfaceConfig_
     struct ebpf_timeout_config ebpf_t_config;
 #endif
 #ifdef AFPACKET_TEST_REPLAY
+    /* Stop the af-packet receive loop after this many packets. Used by
+     * suricata-verify live tests driven by tcpreplay so Suricata exits
+     * deterministically once the replay completes. A value of 0 means no
+     * cap (loop runs until the normal stop signal). */
     uint32_t max_packets;
 #endif
     SC_ATOMIC_DECLARE(unsigned int, ref);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -844,6 +844,9 @@ static void PrintBuildInfo(void)
 #ifdef HAVE_PACKET_EBPF
     strlcat(features, "EBPF ", sizeof(features));
 #endif
+#ifdef AFPACKET_TEST_REPLAY
+    strlcat(features, "AFPACKET_TEST_REPLAY ", sizeof(features));
+#endif
 #ifdef PROFILE_LOCKING
     strlcat(features, "PROFILE_LOCKING ", sizeof(features));
 #endif

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -841,6 +841,9 @@ static void PrintBuildInfo(void)
 #ifdef PROFILING
     strlcat(features, "PROFILING ", sizeof(features));
 #endif
+#ifdef HAVE_PACKET_EBPF
+    strlcat(features, "EBPF ", sizeof(features));
+#endif
 #ifdef PROFILE_LOCKING
     strlcat(features, "PROFILE_LOCKING ", sizeof(features));
 #endif


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request. Thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8242

Supersedes #15458 (opened as a fresh PR per @catenacyber's request).

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3113

## Describe changes

`AFPBypassCallback` and `AFPXDPBypassCallback` in `src/source-af-packet.c` now AND `p->vlan_id[N]` with `g_vlan_mask` before writing it into the eBPF `flow_table_v4` / `flow_table_v6` map keys, so the bypass key reflects the active `vlan.use-for-tracking` configuration instead of always including the raw VLAN id. Without this, `vlan.use-for-tracking: no` is silently ignored on the bypass path: tracked flows write keys with the VLAN id present, but the matching ingress lookup writes with the VLAN id zeroed, so the bypass never matches and the flow is reprocessed each packet.

## CI / SV coverage

This PR includes two commits from #15415, picked with @catenacyber's agreement, so SV coverage actually runs:

- `2e37d88` (catenacyber)  `ci: add new xdp build with live tests`: adds the `ubuntu-xdp` job to `.github/workflows/builds.yml` that runs `suricata-verify/run.py --live --debug-failed` (no equivalent job exists on `main` today).
- `762d2d7` (catenacyber)  `test: new afpacket max-packets feature`: adds the `AFPACKET_TEST_REPLAY` compile-time feature (all changes `#ifdef`-guarded; only the new `ubuntu-xdp` job sets `-DAFPACKET_TEST_REPLAY`, so other builds are byte-identical), used by the SV live test in suricata-verify#3113 to stop Suricata cleanly after the replay.

The matching SV PR suricata-verify#3113 that replays three VLAN-tagged UDP packets on the same 5-tuple through a dummy interface and asserts the bypass path engages with `vlan.use-for-tracking: no`.