### PR TITLE
firewall: mostly minor doc updates - v1

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2810,10 +2810,10 @@ Suricata as a Firewall options (experimental)
 
 It is possible to run Suricata as a firewall.
 Please read :ref:`Firewall Mode Design <firewall mode design>` before using this.
-The existing yaml configuration options are listed below. If the engine is run
-in firewall mode, dedicated stats counters will be added to the stats logs.
+The existing yaml configuration options are listed below. For more examples on default policy configuration by app-layer hook, check :ref:`firewall examples-default policies-http`.
 
-To see the stats reported for the firewall mode, refer to :ref:`firewall mode stats`.
+If the engine is run in firewall mode, dedicated stats counters will be added to
+the stats logs. To see the stats reported for the firewall mode, refer to :ref:`firewall mode stats`.
 
 ::
 
@@ -2829,6 +2829,18 @@ To see the stats reported for the firewall mode, refer to :ref:`firewall mode st
      #rule-files:
      #  - firewall.rules
 
+     # Default policies
+     #
+     # Choose a default policy for each firewall hook.
+     # It is also possible to specify policies by app-layer protocol.
+     # DNS example: Drop and alert on all DNS requests that are not allowed in firewall.rules, accept all responses.
+     #
+     #policies:
+     #  packet-filter: ["drop:packet"]
+     #  dns:
+     #    request-started: ["accept:hook"]
+     #    request-complete: ["drop:flow", "alert"]
+     #    response-started: ["accept:tx"]
 
 Engine analysis and profiling
 -----------------------------

--- a/doc/userguide/firewall/firewall-example.rst
+++ b/doc/userguide/firewall/firewall-example.rst
@@ -55,8 +55,13 @@ The HTTP rules need to ``accept`` each state::
 
 Each state needs an ``accept`` rule. Each state is evaluated at least once.
 
+.. _firewall examples-default policies-http:
+
 HTTP example with partially using default policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the example below: the config auto accepts various hooks, leaving just ``http1:request_line``,
+``http1:request_headers`` and ``http1:response_line`` for the ruleset to accept.
 
 ::
 
@@ -108,9 +113,6 @@ HTTP example with partially using default policies
     # allow the 200 ok stat code.
     accept:hook http1:response_line any any -> any any ( \
             http.stat_code; content:"200"; sid:201;)
-
-Explanation: the config auto accepts various hooks, leaving just ``http1:request_line``,
-``http1:request_headers`` and ``http1:response_line`` for the ruleset to accept.
 
 
 TLS SNI with complex TCP rules

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -2372,6 +2372,20 @@ firewall:
   # in order and rules are applied in that order (per state, see docs)
   #rule-files:
   #  - firewall.rules
+  #
+
+  # Default policies
+  #
+  # Choose a default policy for each firewall hook.
+  # It is also possible to specify policies by app-layer protocol.
+  # DNS example: Drop and alert on all DNS requests that are not allowed in firewall.rules, accept all responses.
+  #
+  #policies:
+  #  packet-filter: ["drop:packet"]
+  #  dns:
+  #    request-started: ["accept:hook"]
+  #    request-complete: ["drop:flow", "alert"]
+  #    response-started: ["accept:tx"]
 
 ##
 ## Include other configs


### PR DESCRIPTION
Just some follow-ups from discussions on https://github.com/OISF/suricata/pull/15464/

Describe changes:
- update suricata.yaml.in to include default policies example and minor explanation
- adjust the suricata-yaml firewall docs to include said default policies, and a link to more examples
- minor restructure of the HTTP firewall example section, to bring the explanation before the example itself
