### PR TITLE
LLMNR protocol parser and logger v5

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -999,6 +999,118 @@ Example of a DNS answer with "grouped" format::
       }
   }
 
+Event type: LLMNR
+-----------------
+
+LLMNR (Link-Local Multicast Name Resolution, RFC 4795) is a protocol
+that allows hosts on the same local link to perform name resolution.
+It uses DNS message format, but operates on multicast (224.0.0.252 for
+IPv4, ff02::1:3 for IPv6) over UDP and TCP port 5355.
+
+Suricata logs both requests and responses as separate events. For UDP,
+queries are sent to multicast and responses come back as unicast from
+the responder's IP, resulting in separate flows.
+
+Fields
+~~~~~~
+
+Outline of fields seen in LLMNR events:
+
+* "type": Indicating LLMNR message type, can be "request" or "response"
+* "id": On-wire LLMNR transaction identifier
+* "queries": A list of query objects, each containing "rrname" and "rrtype"
+* "answers": A list of answer objects, each containing "rrname", "rrtype" with "rdata"
+* "authorities": A list of authority objects
+* "additionals": A list of additional objects
+
+Examples
+~~~~~~~~
+
+Example of an LLMNR request for the A record of "hs2011"::
+
+  "llmnr": {
+      "type": "request",
+      "tx_id": 0,
+      "id": 49985,
+      "opcode": 0,
+      "queries": [
+        {
+          "rrname": "hs2011",
+          "rrtype": "a"
+        }
+      ]
+  }
+
+Example of an LLMNR response with an A record answer::
+
+  "llmnr": {
+      "type": "response",
+      "tx_id": 0,
+      "id": 49985,
+      "opcode": 0,
+      "queries": [
+        {
+          "rrname": "hs2011",
+          "rrtype": "a"
+        }
+      ],
+      "answers": [
+        {
+          "rrname": "HS2011",
+          "a": "192.168.10.101"
+        }
+      ]
+  }
+
+Example of an LLMNR NXDOMAIN response::
+
+  "llmnr": {
+      "type": "response",
+      "tx_id": 0,
+      "id": 12345,
+      "opcode": 0,
+      "rcode": "NXDOMAIN",
+      "queries": [
+        {
+          "rrname": "unknown-host",
+          "rrtype": "a"
+        }
+      ]
+  }
+
+Example of an LLMNR response with NS authority and additional records::
+
+  "llmnr": {
+      "type": "response",
+      "tx_id": 0,
+      "id": 54321,
+      "opcode": 0,
+      "queries": [
+        {
+          "rrname": "server.local",
+          "rrtype": "a"
+        }
+      ],
+      "answers": [
+        {
+          "rrname": "server.local",
+          "a": "192.168.1.100"
+        }
+      ],
+      "authorities": [
+        {
+          "rrname": "local",
+          "ns": "ns.local"
+        }
+      ],
+      "additionals": [
+        {
+          "rrname": "ns.local",
+          "a": "192.168.1.200"
+        }
+      ]
+  }
+
 Event type: FTP
 ---------------
 

--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -16,6 +16,7 @@ Suricata Rules
    file-keywords
    dns-keywords
    mdns-keywords
+   llmnr-keywords
    tls-keywords
    ssh-keywords
    ja-keywords

--- a/doc/userguide/rules/llmnr-keywords.rst
+++ b/doc/userguide/rules/llmnr-keywords.rst
@@ -1,0 +1,105 @@
+LLMNR Keywords
+==============
+
+Suricata supports sticky buffers for matching on specific fields
+in LLMNR (Link-Local Multicast Name Resolution) messages.
+
+Note that sticky buffers are expected to be followed by one or more
+:doc:`payload-keywords`.
+
+llmnr.queries.rrname
+--------------------
+
+``llmnr.queries.rrname`` is a sticky buffer that is used to look at the
+name field in LLMNR query resource records.
+
+``llmnr.queries.rrname`` will look at both requests and responses, so
+``flow`` is recommended to confine to a specific direction.
+
+The buffer being matched on contains the complete re-assembled
+resource name, for example "workstation.local".
+
+``llmnr.queries.rrname`` supports :doc:`multi-buffer-matching`.
+
+.. container:: example-rule
+
+  alert llmnr any any -> any 5355 (msg:"LLMNR query for workstation"; \
+      flow:to_server; llmnr.queries.rrname; content:"workstation"; nocase; sid:1;)
+
+llmnr.answers.rrname
+--------------------
+
+``llmnr.answers.rrname`` is a sticky buffer that is used to look at the
+name field in LLMNR answer resource records.
+
+``llmnr.answers.rrname`` will look at both requests and responses, so
+``flow`` is recommended to confine to a specific direction.
+
+The buffer being matched on contains the complete re-assembled
+resource name, for example "server.local".
+
+``llmnr.answers.rrname`` supports :doc:`multi-buffer-matching`.
+
+.. container:: example-rule
+
+  alert llmnr any 5355 -> any any (msg:"LLMNR answer for server.local"; \
+      flow:to_client; llmnr.answers.rrname; content:"server.local"; sid:2;)
+
+llmnr.authorities.rrname
+------------------------
+
+``llmnr.authorities.rrname`` is a sticky buffer that is used to look at the
+rrname field in LLMNR authority resource records.
+
+``llmnr.authorities.rrname`` will look at both requests and responses,
+so ``flow`` is recommended to confine to a specific direction.
+
+The buffer being matched on contains the complete re-assembled
+resource name, for example "local".
+
+``llmnr.authorities.rrname`` supports :doc:`multi-buffer-matching`.
+
+.. container:: example-rule
+
+  alert llmnr any 5355 -> any any (msg:"LLMNR authority record check"; \
+      llmnr.authorities.rrname; content:"local"; sid:3;)
+
+llmnr.additionals.rrname
+------------------------
+
+``llmnr.additionals.rrname`` is a sticky buffer that is used to look at
+the rrname field in LLMNR additional resource records.
+
+``llmnr.additionals.rrname`` will look at both requests and responses,
+so ``flow`` is recommended to confine to a specific direction.
+
+The buffer being matched on contains the complete re-assembled
+resource name, for example "ns.local".
+
+``llmnr.additionals.rrname`` supports :doc:`multi-buffer-matching`.
+
+.. container:: example-rule
+
+  alert llmnr any any -> any 5355 (msg:"LLMNR additional record check"; \
+      llmnr.additionals.rrname; content:"ns.local"; sid:4;)
+
+llmnr.response.rrname
+---------------------
+
+``llmnr.response.rrname`` is a sticky buffer that is used to inspect
+all the rrname fields in a response, in the queries, answers,
+additionals and authorities. Additionally it will also inspect rdata
+fields that have the same format as an rrname (hostname).
+
+``rdata`` types that will be inspected are:
+
+* CNAME
+* PTR
+* MX
+* NS
+* SOA
+
+.. container:: example-rule
+
+  alert llmnr any 5355 -> any any (msg:"LLMNR response contains suspicious domain"; \
+      flow:to_client; llmnr.response.rrname; content:"malicious"; nocase; sid:5;)

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -44,6 +44,7 @@ Major Changes
   be ``bypass``, ``track-only`` or ``full``.
 - Default value for ``stream.reassembly.depth`` when the value is not specified in
   suricata.yaml is now 1 MiB instead of 0/unlimited.
+- LLMNR protocol parser, logger and sticky buffers are implemented.
 
 Logging Changes
 ~~~~~~~~~~~~~~~

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3358,6 +3358,413 @@
                 }
             }
         },
+        "llmnr": {
+            "description": "LLMNR requests and responses",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "additionals": {
+                    "description": "LLMNR additional records",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "a": {
+                                "description": "IPv4 address",
+                                "type": "string"
+                            },
+                            "aaaa": {
+                                "description": "IPv6 address",
+                                "type": "string"
+                            },
+                            "cname": {
+                                "description": "Canonical name",
+                                "type": "string"
+                            },
+                            "mx": {
+                                "description": "Mail exchange",
+                                "type": "string"
+                            },
+                            "ns": {
+                                "description": "Name server",
+                                "type": "string"
+                            },
+                            "null": {
+                                "description": "NULL record data",
+                                "type": "string"
+                            },
+                            "opt": {
+                                "description": "EDNS OPT records",
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "code": {
+                                            "description": "EDNS option code",
+                                            "type": "integer"
+                                        },
+                                        "data": {
+                                            "description": "EDNS option data",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "ptr": {
+                                "description": "Pointer record",
+                                "type": "string"
+                            },
+                            "rrname": {
+                                "description": "Resource name of the record",
+                                "type": "string"
+                            },
+                            "rrname_truncated": {
+                                "description": "Name was truncated by Suricata due to length",
+                                "type": "boolean"
+                            },
+                            "rrtype": {
+                                "description": "Resource record type",
+                                "type": "string"
+                            },
+                            "ttl": {
+                                "description": "Time to live in seconds",
+                                "type": "integer"
+                            },
+                            "txt": {
+                                "description": "TXT record values",
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "unknown": {
+                                "description": "Unknown record type data",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "answers": {
+                    "description": "LLMNR answer records",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "a": {
+                                "description": "IPv4 address",
+                                "type": "string"
+                            },
+                            "aaaa": {
+                                "description": "IPv6 address",
+                                "type": "string"
+                            },
+                            "cname": {
+                                "description": "Canonical name",
+                                "type": "string"
+                            },
+                            "mx": {
+                                "description": "Mail exchange",
+                                "type": "string"
+                            },
+                            "ns": {
+                                "description": "Name server",
+                                "type": "string"
+                            },
+                            "null": {
+                                "description": "NULL record data",
+                                "type": "string"
+                            },
+                            "ptr": {
+                                "description": "Pointer record",
+                                "type": "string"
+                            },
+                            "rrname": {
+                                "description": "Resource name of the record",
+                                "type": "string"
+                            },
+                            "rrname_truncated": {
+                                "description": "Name was truncated by Suricata due to length",
+                                "type": "boolean"
+                            },
+                            "rrtype": {
+                                "description": "Resource record type",
+                                "type": "string"
+                            },
+                            "soa": {
+                                "description": "SOA record data",
+                                "$ref": "#/$defs/dns.soa"
+                            },
+                            "srv": {
+                                "description": "SRV record data",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "description": "Target hostname",
+                                        "type": "string"
+                                    },
+                                    "port": {
+                                        "description": "Target port",
+                                        "type": "integer"
+                                    },
+                                    "priority": {
+                                        "description": "Priority value",
+                                        "type": "integer"
+                                    },
+                                    "weight": {
+                                        "description": "Weight value",
+                                        "type": "integer"
+                                    }
+                                }
+                            },
+                            "sshfp": {
+                                "description": "SSH fingerprint record",
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "algo": {
+                                        "description": "Algorithm number",
+                                        "type": "integer"
+                                    },
+                                    "fingerprint": {
+                                        "description": "Fingerprint value",
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "description": "Fingerprint type",
+                                        "type": "integer"
+                                    }
+                                }
+                            },
+                            "ttl": {
+                                "description": "Time to live in seconds",
+                                "type": "integer"
+                            },
+                            "txt": {
+                                "description": "TXT record values",
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "unknown": {
+                                "description": "Unknown record type data",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "authorities": {
+                    "description": "LLMNR authority records",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "a": {
+                                "description": "IPv4 address",
+                                "type": "string"
+                            },
+                            "aaaa": {
+                                "description": "IPv6 address",
+                                "type": "string"
+                            },
+                            "cname": {
+                                "description": "Canonical name",
+                                "type": "string"
+                            },
+                            "mx": {
+                                "description": "Mail exchange",
+                                "type": "string"
+                            },
+                            "ns": {
+                                "description": "Name server",
+                                "type": "string"
+                            },
+                            "null": {
+                                "description": "NULL record data",
+                                "type": "string"
+                            },
+                            "ptr": {
+                                "description": "Pointer record",
+                                "type": "string"
+                            },
+                            "rrname": {
+                                "description": "Resource name of the record",
+                                "type": "string"
+                            },
+                            "rrname_truncated": {
+                                "description": "Name was truncated by Suricata due to length",
+                                "type": "boolean"
+                            },
+                            "rrtype": {
+                                "description": "Resource record type",
+                                "type": "string"
+                            },
+                            "soa": {
+                                "description": "SOA record data",
+                                "$ref": "#/$defs/dns.soa"
+                            },
+                            "ttl": {
+                                "description": "Time to live in seconds",
+                                "type": "integer"
+                            },
+                            "txt": {
+                                "description": "TXT record values",
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "unknown": {
+                                "description": "Unknown record type data",
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "flags": {
+                    "description": "LLMNR message flags",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["c", "tc", "t"]
+                    }
+                },
+                "grouped": {
+                    "description": "Grouped answer records by type",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "A": {
+                            "description": "IPv4 address records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "AAAA": {
+                            "description": "IPv6 address records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "CNAME": {
+                            "description": "Canonical name records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "MX": {
+                            "description": "Mail exchange records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "NS": {
+                            "description": "Name server records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "NULL": {
+                            "description": "NULL record data",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "PTR": {
+                            "description": "Pointer records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "SOA": {
+                            "description": "Start of authority records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "#/$defs/dns.soa"
+                            }
+                        },
+                        "TXT": {
+                            "description": "Text records",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "id": {
+                    "description": "LLMNR transaction ID",
+                    "type": "integer"
+                },
+                "opcode": {
+                    "description": "LLMNR opcode value",
+                    "type": "integer"
+                },
+                "queries": {
+                    "description": "LLMNR query records",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "rrname": {
+                                "description": "Resource name being requested",
+                                "type": "string"
+                            },
+                            "rrname_truncated": {
+                                "description": "Name was truncated by Suricata due to length",
+                                "type": "boolean"
+                            },
+                            "rrtype": {
+                                "type": "string",
+                                "description": "Type of resource being requested"
+                            }
+                        }
+                    }
+                },
+                "tx_id": {
+                    "description": "Internal transaction ID",
+                    "type": "integer"
+                },
+                "type": {
+                    "description": "Type of message, either a request or response",
+                    "type": "string",
+                    "enum": [
+                        "request",
+                        "response"
+                    ]
+                }
+            }
+        },
         "log_level": {
             "type": "string"
         },
@@ -5886,6 +6293,14 @@
                                     "description": "Errors encountered parsing LDAP/UDP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
+                                "llmnr_tcp": {
+                                    "description": "Errors encountered parsing LLMNR/TCP protocol",
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
+                                "llmnr_udp": {
+                                    "description": "Errors encountered parsing LLMNR/UDP protocol",
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
                                 "mdns": {
                                     "description": "Errors encountered parsing mDNS",
                                     "$ref": "#/$defs/stats_applayer_error"
@@ -6069,6 +6484,14 @@
                                     "type": "integer",
                                     "description": "Number of flows LDAP/UDP protocol"
                                 },
+                                "llmnr_tcp": {
+                                    "type": "integer",
+                                    "description": "Number of flows for LLMNR/TCP protocol"
+                                },
+                                "llmnr_udp": {
+                                    "type": "integer",
+                                    "description": "Number of flows for LLMNR/UDP protocol"
+                                },
                                 "mdns": {
                                     "description": "Number of flows for mDNS",
                                     "type": "integer"
@@ -6242,6 +6665,14 @@
                                 "ldap_udp": {
                                     "type": "integer",
                                     "description": "Number of transactions for LDAP/UDP protocol"
+                                },
+                                "llmnr_tcp": {
+                                    "type": "integer",
+                                    "description": "Number of transactions for LLMNR/TCP protocol"
+                                },
+                                "llmnr_udp": {
+                                    "type": "integer",
+                                    "description": "Number of transactions for LLMNR/UDP protocol"
                                 },
                                 "mdns": {
                                     "description": "Number of transactions for mDNS",

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -361,6 +361,7 @@ impl ConfigTracker {
 pub(crate) enum DnsVariant {
     Dns,
     MulticastDns,
+    Llmnr,
 }
 
 impl DnsVariant {
@@ -370,6 +371,10 @@ impl DnsVariant {
 
     pub fn is_mdns(&self) -> bool {
         matches!(self, DnsVariant::MulticastDns)
+    }
+
+    pub fn is_llmnr(&self) -> bool {
+        matches!(self, DnsVariant::Llmnr)
     }
 }
 
@@ -454,7 +459,7 @@ pub(crate) fn dns_parse_request(
                 tx.set_event(DNSEvent::ZFlagSet);
             }
 
-            if opcode >= 7 {
+            if (variant.is_llmnr() && opcode != 0) || opcode >= 7 {
                 tx.set_event(DNSEvent::InvalidOpcode);
             }
 
@@ -939,7 +944,7 @@ pub(crate) unsafe extern "C" fn parse_request(
     AppLayerResult::ok()
 }
 
-unsafe extern "C" fn parse_response(
+pub(crate) unsafe extern "C" fn parse_response(
     flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut AppLayerParserState,
     stream_slice: StreamSlice, _data: *mut std::os::raw::c_void,
 ) -> AppLayerResult {
@@ -949,7 +954,7 @@ unsafe extern "C" fn parse_response(
 }
 
 /// C binding parse a DNS request. Returns 1 on success, -1 on failure.
-unsafe extern "C" fn parse_request_tcp(
+pub(crate) unsafe extern "C" fn parse_request_tcp(
     flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut AppLayerParserState,
     stream_slice: StreamSlice, _data: *mut std::os::raw::c_void,
 ) -> AppLayerResult {
@@ -962,7 +967,7 @@ unsafe extern "C" fn parse_request_tcp(
     AppLayerResult::ok()
 }
 
-unsafe extern "C" fn parse_response_tcp(
+pub(crate) unsafe extern "C" fn parse_response_tcp(
     flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut AppLayerParserState,
     stream_slice: StreamSlice, _data: *mut std::os::raw::c_void,
 ) -> AppLayerResult {
@@ -1228,7 +1233,7 @@ pub(crate) unsafe extern "C" fn probe_udp(
     return 0;
 }
 
-unsafe extern "C" fn c_probe_tcp(
+pub(crate) unsafe extern "C" fn c_probe_tcp(
     _flow: *const Flow, direction: u8, input: *const u8, len: u32, rdir: *mut u8,
 ) -> AppProto {
     if input.is_null() || len < std::mem::size_of::<DNSHeader>() as u32 + 2 {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -140,6 +140,7 @@ pub mod sdp;
 pub mod ldap;
 pub mod flow;
 pub use suricata_ffi::direction;
+pub mod llmnr;
 
 #[allow(unused_imports)]
 pub use suricata_lua_sys;

--- a/rust/src/llmnr/llmnr.rs
+++ b/rust/src/llmnr/llmnr.rs
@@ -1,0 +1,162 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+use std;
+use std::ffi::CString;
+
+use crate::applayer::*;
+use crate::core::*;
+use crate::dns::dns;
+use crate::dns::dns::DNSHeader;
+use crate::flow::Flow;
+
+use suricata_sys::sys::{
+    AppProto, AppProtoEnum, SCAppLayerParserConfParserEnabled,
+    SCAppLayerProtoDetectConfProtoDetectionEnabled,
+};
+
+static mut ALPROTO_LLMNR: AppProto = ALPROTO_UNKNOWN;
+
+unsafe extern "C" fn probe_udp(
+    _flow: *const Flow, _dir: u8, input: *const u8, len: u32, _rdir: *mut u8,
+) -> AppProto {
+    if crate::dns::dns::probe_udp(_flow, _dir, input, len, _rdir)
+        == AppProtoEnum::ALPROTO_DNS as u16
+    {
+        return ALPROTO_LLMNR;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn probe_tcp(
+    _flow: *const Flow, _dir: u8, input: *const u8, len: u32, _rdir: *mut u8,
+) -> AppProto {
+    if crate::dns::dns::c_probe_tcp(_flow, _dir, input, len, _rdir)
+        == AppProtoEnum::ALPROTO_DNS as u16
+    {
+        return ALPROTO_LLMNR;
+    }
+    return 0;
+}
+
+pub(crate) extern "C" fn state_new(
+    _orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto,
+) -> *mut std::os::raw::c_void {
+    let state = dns::DNSState::new_variant(dns::DnsVariant::Llmnr);
+    let boxed = Box::new(state);
+    return Box::into_raw(boxed) as *mut _;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCRegisterLLMNRUdpParser() {
+    let default_port = std::ffi::CString::new("5355").unwrap();
+    let parser = RustParser {
+        name: b"llmnr\0".as_ptr() as *const std::os::raw::c_char,
+        default_port: default_port.as_ptr(),
+        ipproto: IPPROTO_UDP,
+        probe_ts: Some(probe_udp),
+        probe_tc: Some(probe_udp),
+        min_depth: 0,
+        max_depth: std::mem::size_of::<DNSHeader>() as u16,
+        state_new,
+        state_free: dns::state_free,
+        tx_free: dns::state_tx_free,
+        parse_ts: dns::parse_request,
+        parse_tc: dns::parse_response,
+        get_tx_count: dns::state_get_tx_count,
+        get_tx: dns::state_get_tx,
+        tx_comp_st_ts: 1,
+        tx_comp_st_tc: 1,
+        tx_get_progress: dns::tx_get_alstate_progress,
+        get_eventinfo: Some(dns::DNSEvent::get_event_info),
+        get_eventinfo_byid: Some(dns::DNSEvent::get_event_info_by_id),
+        localstorage_new: None,
+        localstorage_free: None,
+        get_tx_files: None,
+        get_tx_iterator: Some(
+            crate::applayer::state_get_tx_iterator::<dns::DNSState, dns::DNSTransaction>,
+        ),
+        get_tx_data: dns::state_get_tx_data,
+        get_state_data: dns::dns_get_state_data,
+        apply_tx_config: None,
+        flags: 0,
+        get_frame_id_by_name: Some(dns::DnsFrameType::ffi_id_from_name),
+        get_frame_name_by_id: Some(dns::DnsFrameType::ffi_name_from_id),
+        get_state_id_by_name: None,
+        get_state_name_by_id: None,
+    };
+
+    let ip_proto_str = CString::new("udp").unwrap();
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+        let alproto = applayer_register_protocol_detection(&parser, 1);
+        ALPROTO_LLMNR = alproto;
+        if SCAppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+            let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCRegisterLLMNRTcpParser() {
+    let default_port = std::ffi::CString::new("5355").unwrap();
+    let parser = RustParser {
+        name: b"llmnr\0".as_ptr() as *const std::os::raw::c_char,
+        default_port: default_port.as_ptr(),
+        ipproto: IPPROTO_TCP,
+        probe_ts: Some(probe_tcp),
+        probe_tc: Some(probe_tcp),
+        min_depth: 0,
+        max_depth: std::mem::size_of::<DNSHeader>() as u16 + 2,
+        state_new,
+        state_free: dns::state_free,
+        tx_free: dns::state_tx_free,
+        parse_ts: dns::parse_request_tcp,
+        parse_tc: dns::parse_response_tcp,
+        get_tx_count: dns::state_get_tx_count,
+        get_tx: dns::state_get_tx,
+        tx_comp_st_ts: 1,
+        tx_comp_st_tc: 1,
+        tx_get_progress: dns::tx_get_alstate_progress,
+        get_eventinfo: Some(dns::DNSEvent::get_event_info),
+        get_eventinfo_byid: Some(dns::DNSEvent::get_event_info_by_id),
+        localstorage_new: None,
+        localstorage_free: None,
+        get_tx_files: None,
+        get_tx_iterator: Some(
+            crate::applayer::state_get_tx_iterator::<dns::DNSState, dns::DNSTransaction>,
+        ),
+        get_tx_data: dns::state_get_tx_data,
+        get_state_data: dns::dns_get_state_data,
+        apply_tx_config: None,
+        flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+        get_frame_id_by_name: Some(dns::DnsFrameType::ffi_id_from_name),
+        get_frame_name_by_id: Some(dns::DnsFrameType::ffi_name_from_id),
+        get_state_id_by_name: None,
+        get_state_name_by_id: None,
+    };
+
+    let ip_proto_str = CString::new("tcp").unwrap();
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+        let alproto = applayer_register_protocol_detection(&parser, 1);
+        ALPROTO_LLMNR = alproto;
+        if SCAppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+            let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+    }
+}

--- a/rust/src/llmnr/log.rs
+++ b/rust/src/llmnr/log.rs
@@ -1,0 +1,168 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+use crate::dns::dns::*;
+use crate::dns::log::{
+    dns_log_opt, dns_log_soa, dns_log_srv, dns_log_sshfp, dns_print_addr, dns_rrtype_string,
+};
+use crate::jsonbuilder::{JsonBuilder, JsonError};
+
+fn llmnr_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, JsonError> {
+    let mut jsa = JsonBuilder::try_new_object()?;
+
+    jsa.set_string_from_bytes("rrname", &answer.name.value)?;
+    if answer.name.flags.contains(DNSNameFlags::TRUNCATED) {
+        jsa.set_bool("rrname_truncated", true)?;
+    }
+    let rrtype = dns_rrtype_string(answer.rrtype).to_lowercase();
+
+    match &answer.data {
+        DNSRData::A(addr) | DNSRData::AAAA(addr) => {
+            jsa.set_string(&rrtype, &dns_print_addr(addr))?;
+        }
+        DNSRData::CNAME(name) | DNSRData::MX(name) | DNSRData::NS(name) | DNSRData::PTR(name) => {
+            jsa.set_string_from_bytes(&rrtype, &name.value)?;
+            if name.flags.contains(DNSNameFlags::TRUNCATED) {
+                jsa.set_bool("rdata_truncated", true)?;
+            }
+        }
+        DNSRData::TXT(txt) => {
+            jsa.open_array(&rrtype)?;
+            for txt in txt {
+                jsa.append_string_from_bytes(txt)?;
+            }
+            jsa.close()?;
+        }
+        DNSRData::NULL(bytes) | DNSRData::Unknown(bytes) => {
+            jsa.set_string_from_bytes(&rrtype, bytes)?;
+        }
+        DNSRData::SOA(soa) => {
+            jsa.set_object(&rrtype, &dns_log_soa(soa)?)?;
+        }
+        DNSRData::SSHFP(sshfp) => {
+            jsa.set_object(&rrtype, &dns_log_sshfp(sshfp)?)?;
+        }
+        DNSRData::SRV(srv) => {
+            jsa.set_object(&rrtype, &dns_log_srv(srv)?)?;
+        }
+        DNSRData::OPT(opt) => {
+            jsa.open_array(&rrtype)?;
+            for val in opt {
+                jsa.append_object(&dns_log_opt(val)?)?;
+            }
+            jsa.close()?;
+        }
+    }
+
+    jsa.close()?;
+    return Ok(jsa);
+}
+
+fn log_json(tx: &DNSTransaction, jb: &mut JsonBuilder) -> Result<(), JsonError> {
+    jb.open_object("llmnr")?;
+
+    let message = if let Some(request) = &tx.request {
+        jb.set_string("type", "request")?;
+        request
+    } else if let Some(response) = &tx.response {
+        jb.set_string("type", "response")?;
+        response
+    } else {
+        debug_validate_fail!("unreachable");
+        return Ok(());
+    };
+
+    // The on the wire LLMNR transaction ID.
+    jb.set_uint("id", tx.tx_id() as u64)?;
+
+    let header = &message.header;
+    if header.flags & (0x0400 | 0x0200 | 0x0100) != 0 {
+        jb.open_array("flags")?;
+        if header.flags & 0x0400 != 0 {
+            jb.append_string("c")?;
+        }
+        if header.flags & 0x0200 != 0 {
+            jb.append_string("tc")?;
+        }
+        if header.flags & 0x0100 != 0 {
+            jb.append_string("t")?;
+        }
+        jb.close()?;
+    }
+
+    let opcode = ((header.flags >> 11) & 0xf) as u8;
+    jb.set_uint("opcode", opcode as u64)?;
+
+    if !message.queries.is_empty() {
+        jb.open_array("queries")?;
+        for query in &message.queries {
+            jb.start_object()?
+                .set_string_from_bytes("rrname", &query.name.value)?
+                .set_string("rrtype", &dns_rrtype_string(query.rrtype).to_lowercase())?;
+            if query.name.flags.contains(DNSNameFlags::TRUNCATED) {
+                jb.set_bool("rrname_truncated", true)?;
+            }
+            jb.close()?;
+        }
+        jb.close()?;
+    }
+
+    if !message.answers.is_empty() {
+        jb.open_array("answers")?;
+        for entry in &message.answers {
+            jb.append_object(&llmnr_log_json_answer_detail(entry)?)?;
+        }
+        jb.close()?;
+    }
+
+    if !message.authorities.is_empty() {
+        jb.open_array("authorities")?;
+        for entry in &message.authorities {
+            jb.append_object(&llmnr_log_json_answer_detail(entry)?)?;
+        }
+        jb.close()?;
+    }
+
+    if !message.additionals.is_empty() {
+        let mut is_jb_open = false;
+        for entry in &message.additionals {
+            if let DNSRData::OPT(rdata) = &entry.data {
+                if rdata.is_empty() {
+                    continue;
+                }
+            }
+            if !is_jb_open {
+                jb.open_array("additionals")?;
+                is_jb_open = true;
+            }
+            jb.append_object(&llmnr_log_json_answer_detail(entry)?)?;
+        }
+        if is_jb_open {
+            jb.close()?;
+        }
+    }
+
+    jb.close()?;
+    Ok(())
+}
+
+#[no_mangle]
+pub extern "C" fn SCLLMNRLogJson(tx: &mut DNSTransaction, jb: &mut JsonBuilder) -> bool {
+    log_json(tx, jb).is_ok()
+}

--- a/rust/src/llmnr/mod.rs
+++ b/rust/src/llmnr/mod.rs
@@ -1,0 +1,22 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! LLMNR protocol parser and logger module.
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+pub mod llmnr;

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -67,8 +67,9 @@ pub enum AppProtoEnum {
     ALPROTO_BITTORRENT_DHT = 35,
     ALPROTO_POP3 = 36,
     ALPROTO_MDNS = 37,
-    ALPROTO_HTTP = 38,
-    ALPROTO_MAX_STATIC = 39,
+    ALPROTO_LLMNR = 38,
+    ALPROTO_HTTP = 39,
+    ALPROTO_MAX_STATIC = 40,
 }
 pub type AppProto = u16;
 extern "C" {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -369,6 +369,7 @@ noinst_HEADERS = \
 	output-json-ftp.h \
 	output-json-http.h \
 	output-json-ike.h \
+	output-json-llmnr.h \
 	output-json-mdns.h \
 	output-json-metadata.h \
 	output-json-mqtt.h \
@@ -943,6 +944,7 @@ libsuricata_c_a_SOURCES = \
 	output-json-ftp.c \
 	output-json-http.c \
 	output-json-ike.c \
+	output-json-llmnr.c \
 	output-json-mdns.c \
 	output-json-metadata.c \
 	output-json-mqtt.c \

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1851,6 +1851,8 @@ void AppLayerParserRegisterProtocolParsers(void)
     RegisterHTTP2Parsers();
     SCRegisterTelnetParser();
     RegisterIMAPParsers();
+    SCRegisterLLMNRUdpParser();
+    SCRegisterLLMNRTcpParser();
 
     for (size_t i = 0; i < preregistered_callbacks_nb; i++) {
         PreRegisteredCallbacks[i]();

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -70,6 +70,7 @@ enum AppProtoEnum {
     ALPROTO_BITTORRENT_DHT,
     ALPROTO_POP3,
     ALPROTO_MDNS,
+    ALPROTO_LLMNR,
 
     // signature-only (ie not seen in flow)
     // HTTP for any version (ALPROTO_HTTP1 (version 1) or ALPROTO_HTTP2)

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1072,6 +1072,7 @@ static void AppLayerNamesSetup(void)
     AppProtoRegisterProtoString(ALPROTO_LDAP, "ldap");
     AppProtoRegisterProtoString(ALPROTO_DOH2, "doh2");
     AppProtoRegisterProtoString(ALPROTO_MDNS, "mdns");
+    AppProtoRegisterProtoString(ALPROTO_LLMNR, "llmnr");
     AppProtoRegisterProtoString(ALPROTO_TEMPLATE, "template");
     AppProtoRegisterProtoString(ALPROTO_RDP, "rdp");
     AppProtoRegisterProtoString(ALPROTO_HTTP2, "http2");

--- a/src/detect-dns-name.c
+++ b/src/detect-dns-name.c
@@ -51,6 +51,11 @@ static int mdns_answer_buffer_id = 0;
 static int mdns_authority_buffer_id = 0;
 static int mdns_additional_buffer_id = 0;
 
+static int llmnr_query_buffer_id = 0;
+static int llmnr_answer_buffer_id = 0;
+static int llmnr_authority_buffer_id = 0;
+static int llmnr_additional_buffer_id = 0;
+
 static int DetectSetupDNS(DetectEngineCtx *de_ctx, Signature *s, const char *str, int id)
 {
     if (SCDetectBufferSetActiveList(de_ctx, s, id) < 0) {
@@ -69,6 +74,18 @@ static int DetectSetupMDNS(DetectEngineCtx *de_ctx, Signature *s, const char *st
         return -1;
     }
     if (SCDetectSignatureSetAppProto(s, ALPROTO_MDNS) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int DetectSetupLLMNR(DetectEngineCtx *de_ctx, Signature *s, const char *str, int id)
+{
+    if (SCDetectBufferSetActiveList(de_ctx, s, id) < 0) {
+        return -1;
+    }
+    if (SCDetectSignatureSetAppProto(s, ALPROTO_LLMNR) < 0) {
         return -1;
     }
 
@@ -113,6 +130,26 @@ static int SetupAdditionalsBufferMdns(DetectEngineCtx *de_ctx, Signature *s, con
 static int SetupAuthoritiesBufferMdns(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     return DetectSetupMDNS(de_ctx, s, str, mdns_authority_buffer_id);
+}
+
+static int SetupQueryBufferLlmnr(DetectEngineCtx *de_ctx, Signature *s, const char *str)
+{
+    return DetectSetupLLMNR(de_ctx, s, str, llmnr_query_buffer_id);
+}
+
+static int SetupAnswerBufferLlmnr(DetectEngineCtx *de_ctx, Signature *s, const char *str)
+{
+    return DetectSetupLLMNR(de_ctx, s, str, llmnr_answer_buffer_id);
+}
+
+static int SetupAdditionalsBufferLlmnr(DetectEngineCtx *de_ctx, Signature *s, const char *str)
+{
+    return DetectSetupLLMNR(de_ctx, s, str, llmnr_additional_buffer_id);
+}
+
+static int SetupAuthoritiesBufferLlmnr(DetectEngineCtx *de_ctx, Signature *s, const char *str)
+{
+    return DetectSetupLLMNR(de_ctx, s, str, llmnr_authority_buffer_id);
 }
 
 static int Register(const char *keyword, const char *desc, const char *doc,
@@ -166,4 +203,19 @@ void DetectDnsNameRegister(void)
             Register("mdns.authorities.rrname", "mDNS authorities rrname sticky buffer",
                     "/rules/mdns-keywords.html#mdns-authorities-rrname", SetupAuthoritiesBufferMdns,
                     SCDnsTxGetAuthorityName, ALPROTO_MDNS);
+
+    llmnr_query_buffer_id = Register("llmnr.queries.rrname", "LLMNR query rrname sticky buffer",
+            "/rules/llmnr-keywords.html#llmnr-queries-rrname", SetupQueryBufferLlmnr,
+            SCDnsTxGetQueryName, ALPROTO_LLMNR);
+    llmnr_answer_buffer_id = Register("llmnr.answers.rrname", "LLMNR answer rrname sticky buffer",
+            "/rules/llmnr-keywords.html#llmnr-answers-rrname", SetupAnswerBufferLlmnr,
+            SCDnsTxGetAnswerName, ALPROTO_LLMNR);
+    llmnr_additional_buffer_id =
+            Register("llmnr.additionals.rrname", "LLMNR additionals rrname sticky buffer",
+                    "/rules/llmnr-keywords.html#llmnr-additionals-rrname",
+                    SetupAdditionalsBufferLlmnr, SCDnsTxGetAdditionalName, ALPROTO_LLMNR);
+    llmnr_authority_buffer_id =
+            Register("llmnr.authorities.rrname", "LLMNR authorities rrname sticky buffer",
+                    "/rules/llmnr-keywords.html#llmnr-authorities-rrname",
+                    SetupAuthoritiesBufferLlmnr, SCDnsTxGetAuthorityName, ALPROTO_LLMNR);
 }

--- a/src/detect-dns-response.c
+++ b/src/detect-dns-response.c
@@ -35,6 +35,7 @@
 
 static int detect_buffer_id = 0;
 static int mdns_detect_buffer_id = 0;
+static int llmnr_detect_buffer_id = 0;
 
 typedef struct PrefilterMpm {
     int list_id;
@@ -76,6 +77,18 @@ static int MdnsDetectSetup(DetectEngineCtx *de_ctx, Signature *s, const char *st
         return -1;
     }
     if (SCDetectSignatureSetAppProto(s, ALPROTO_MDNS) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int LlmnrDetectSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)
+{
+    if (SCDetectBufferSetActiveList(de_ctx, s, llmnr_detect_buffer_id) < 0) {
+        return -1;
+    }
+    if (SCDetectSignatureSetAppProto(s, ALPROTO_LLMNR) < 0) {
         return -1;
     }
 
@@ -349,6 +362,28 @@ static void SCDetectMdnsResponseRrnameRegister(void)
     mdns_detect_buffer_id = DetectBufferTypeGetByName(keyword);
 }
 
+static void SCDetectLlmnrResponseRrnameRegister(void)
+{
+    static const char *keyword = "llmnr.response.rrname";
+    int keyword_id = SCDetectHelperNewKeywordId();
+    sigmatch_table[keyword_id].name = keyword;
+    sigmatch_table[keyword_id].desc = "LLMNR response rrname buffer";
+    sigmatch_table[keyword_id].url = "/rules/llmnr-keywords.html#llmnr-response-rrname";
+    sigmatch_table[keyword_id].Setup = LlmnrDetectSetup;
+    sigmatch_table[keyword_id].flags |= SIGMATCH_NOOPT;
+    sigmatch_table[keyword_id].flags |= SIGMATCH_INFO_STICKY_BUFFER;
+
+    DetectAppLayerInspectEngineRegister(
+            keyword, ALPROTO_LLMNR, SIG_FLAG_TOCLIENT, 1, DetectEngineInspectCb, NULL);
+    DetectAppLayerMpmRegister(keyword, SIG_FLAG_TOCLIENT, 2, DetectDnsResponsePrefilterMpmRegister,
+            NULL, ALPROTO_LLMNR, 1);
+
+    DetectBufferTypeSetDescriptionByName(keyword, "llmnr response rdata");
+    DetectBufferTypeSupportsMultiInstance(keyword);
+
+    llmnr_detect_buffer_id = DetectBufferTypeGetByName(keyword);
+}
+
 void DetectDnsResponseRegister(void)
 {
     static const char *keyword = "dns.response.rrname";
@@ -371,4 +406,5 @@ void DetectDnsResponseRegister(void)
     detect_buffer_id = DetectBufferTypeGetByName(keyword);
 
     SCDetectMdnsResponseRrnameRegister();
+    SCDetectLlmnrResponseRrnameRegister();
 }

--- a/src/output-json-llmnr.c
+++ b/src/output-json-llmnr.c
@@ -1,0 +1,161 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+#include "suricata-common.h"
+#include "conf.h"
+
+#include "threadvars.h"
+
+#include "util-byte.h"
+#include "util-debug.h"
+#include "util-mem.h"
+#include "app-layer-parser.h"
+#include "output.h"
+
+#include "output-json.h"
+#include "output-json-llmnr.h"
+#include "rust.h"
+
+typedef struct SCLLMNRLogFileCtx_ {
+    uint64_t flags; /** Store mode */
+    OutputJsonCtx *eve_ctx;
+} SCLLMNRLogFileCtx;
+
+typedef struct LogLLMNRLogThread_ {
+    SCLLMNRLogFileCtx *llmnrlog_ctx;
+    OutputJsonThreadCtx *ctx;
+} SCLLMNRLogThread;
+
+bool AlertJsonLLMNR(void *txptr, SCJsonBuilder *js)
+{
+    return SCLLMNRLogJson(txptr, js);
+}
+
+static int JsonLLMNRLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f,
+        void *alstate, void *txptr, uint64_t tx_id)
+{
+    SCLLMNRLogThread *td = (SCLLMNRLogThread *)thread_data;
+    SCLLMNRLogFileCtx *llmnrlog_ctx = td->llmnrlog_ctx;
+
+    SCJsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "llmnr", NULL, llmnrlog_ctx->eve_ctx);
+    if (unlikely(jb == NULL)) {
+        return TM_ECODE_OK;
+    }
+
+    if (SCLLMNRLogJson(txptr, jb)) {
+        OutputJsonBuilderBuffer(tv, p, p->flow, jb, td->ctx);
+    }
+    SCJbFree(jb);
+
+    return TM_ECODE_OK;
+}
+
+static TmEcode SCLLMNRLogThreadInit(ThreadVars *t, const void *initdata, void **data)
+{
+    SCLLMNRLogThread *aft = SCCalloc(1, sizeof(SCLLMNRLogThread));
+    if (unlikely(aft == NULL))
+        return TM_ECODE_FAILED;
+
+    if (initdata == NULL) {
+        SCLogDebug("Error getting context for EveLogLLMNR.  \"initdata\" argument NULL");
+        goto error_exit;
+    }
+
+    /* Use the Output Context (file pointer and mutex) */
+    aft->llmnrlog_ctx = ((OutputCtx *)initdata)->data;
+    aft->ctx = CreateEveThreadCtx(t, aft->llmnrlog_ctx->eve_ctx);
+    if (!aft->ctx) {
+        goto error_exit;
+    }
+
+    *data = (void *)aft;
+    return TM_ECODE_OK;
+
+error_exit:
+    SCFree(aft);
+    return TM_ECODE_FAILED;
+}
+
+static TmEcode SCLLMNRLogThreadDeinit(ThreadVars *t, void *data)
+{
+    SCLLMNRLogThread *aft = (SCLLMNRLogThread *)data;
+    if (aft == NULL) {
+        return TM_ECODE_OK;
+    }
+    FreeEveThreadCtx(aft->ctx);
+
+    /* clear memory */
+    memset(aft, 0, sizeof(SCLLMNRLogThread));
+
+    SCFree(aft);
+    return TM_ECODE_OK;
+}
+
+static void SCLLMNRLogDeInitCtxSub(OutputCtx *output_ctx)
+{
+    SCLogDebug("cleaning up sub output_ctx %p", output_ctx);
+    SCLLMNRLogFileCtx *llmnrlog_ctx = (SCLLMNRLogFileCtx *)output_ctx->data;
+    SCFree(llmnrlog_ctx);
+    SCFree(output_ctx);
+}
+
+static OutputInitResult JsonLLMNRLogInitCtxSub(SCConfNode *conf, OutputCtx *parent_ctx)
+{
+    OutputInitResult result = { NULL, false };
+    const char *enabled = SCConfNodeLookupChildValue(conf, "enabled");
+    if (enabled != NULL && !SCConfValIsTrue(enabled)) {
+        result.ok = true;
+        return result;
+    }
+
+    OutputJsonCtx *ojc = parent_ctx->data;
+
+    SCLLMNRLogFileCtx *llmnrlog_ctx = SCCalloc(1, sizeof(SCLLMNRLogFileCtx));
+    if (unlikely(llmnrlog_ctx == NULL)) {
+        return result;
+    }
+
+    llmnrlog_ctx->eve_ctx = ojc;
+    llmnrlog_ctx->flags = ~0ULL;
+
+    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
+    if (unlikely(output_ctx == NULL)) {
+        SCFree(llmnrlog_ctx);
+        return result;
+    }
+
+    output_ctx->data = llmnrlog_ctx;
+    output_ctx->DeInit = SCLLMNRLogDeInitCtxSub;
+
+    SCLogDebug("LLMNR log sub-module initialized");
+
+    SCAppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_LLMNR);
+    SCAppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_LLMNR);
+
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
+}
+
+void JsonLLMNRLogRegister(void)
+{
+    OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", "JsonLLMNRLog", "eve-log.llmnr",
+            JsonLLMNRLogInitCtxSub, ALPROTO_LLMNR, JsonLLMNRLogger, SCLLMNRLogThreadInit,
+            SCLLMNRLogThreadDeinit);
+}

--- a/src/output-json-llmnr.h
+++ b/src/output-json-llmnr.h
@@ -15,9 +15,12 @@
  * 02110-1301, USA.
  */
 
-//! LLMNR protocol parser and logger module.
-
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
-pub mod llmnr;
-pub mod log;
+#ifndef SURICATA_OUTPUT_JSON_LLMNR_H
+#define SURICATA_OUTPUT_JSON_LLMNR_H
+
+void JsonLLMNRLogRegister(void);
+bool AlertJsonLLMNR(void *txptr, SCJsonBuilder *js);
+
+#endif /* SURICATA_OUTPUT_JSON_LLMNR_H */

--- a/src/output.c
+++ b/src/output.c
@@ -83,6 +83,7 @@
 #include "app-layer-parser.h"
 #include "output-filestore.h"
 #include "output-json-arp.h"
+#include "output-json-llmnr.h"
 
 typedef struct RootLogger_ {
     OutputLogFunc LogFunc;
@@ -948,6 +949,7 @@ void OutputRegisterRootLoggers(void)
     // ALPROTO_DCERPC special: uses state
     RegisterSimpleJsonApplayerLogger(ALPROTO_DNS, (EveJsonSimpleTxLogFunc)AlertJsonDns, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_MDNS, (EveJsonSimpleTxLogFunc)AlertJsonMdns, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_LLMNR, (EveJsonSimpleTxLogFunc)AlertJsonLLMNR, NULL);
     // either need a cast here or in rust for ModbusTransaction, done here
     RegisterSimpleJsonApplayerLogger(ALPROTO_MODBUS, (EveJsonSimpleTxLogFunc)SCModbusToJson, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_ENIP, (EveJsonSimpleTxLogFunc)SCEnipLoggerLog, NULL);
@@ -1225,6 +1227,8 @@ void OutputRegisterLoggers(void)
     }
     /* ARP JSON logger */
     JsonArpLogRegister();
+    /* LLMNR JSON logger */
+    JsonLLMNRLogRegister();
 
     for (size_t i = 0; i < preregistered_loggers_nb; i++) {
         OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", preregistered_loggers[i].logname,

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -345,6 +345,7 @@ outputs:
         - quic
         - ldap
         - pop3
+        - llmnr
         #- modbus
         - arp:
             enabled: no        # Many events can be logged. Disabled by default

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1296,6 +1296,12 @@ app-layer:
     mdns:
       enabled: yes
 
+    llmnr:
+      enabled: yes
+      detection-ports:
+        dp: 5355
+        sp: 5355
+
 # Limit for the maximum number of asn1 frames to decode (default 256)
 asn1-max-frames: 256
 


### PR DESCRIPTION
Changes:
- Added sticky buffers
- Removed unused functions
- Added more SV tests (invalid opcode, hostname matching, sticky buffers and LLMNR metadata in alert)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8366

Previous PR: https://github.com/OISF/suricata/pull/15483

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3047