### PR TITLE
Http2 progress 8518 v1

### DIFF
--- a/doc/userguide/devguide/extending/app-layer/transactions.rst
+++ b/doc/userguide/devguide/extending/app-layer/transactions.rst
@@ -73,7 +73,7 @@ Rule Matching
 Transaction progress is also used for certain keywords to know what is the minimum state before we can expect a match: until that, Suricata won't even try to look for the patterns.
 
 As seen in ``DetectAppLayerMpmRegister`` that has ``int progress`` as parameter, and ``DetectAppLayerInspectEngineRegister``, which expects ``int tx_min_progress``, for instance. In the code snippet,
-``HTTP2StateDataClient``, ``HTTP2StateDataServer`` and ``0`` are the values passed to the functions - in the last
+``HTTP2ProgData``, ``HTTP2ProgData`` and ``0`` are the values passed to the functions - in the last
 example, for ``FTPDATA``,
 the existence of a transaction implies that a file is being transferred. Hence the ``0`` value.
 
@@ -86,14 +86,14 @@ the existence of a transaction implies that a file is being transferred. Hence t
         .
         DetectAppLayerMpmRegister("file_data", SIG_FLAG_TOSERVER, 2,
                 PrefilterMpmFiledataRegister, NULL,
-                ALPROTO_HTTP2, HTTP2StateDataClient);
+                ALPROTO_HTTP2, HTTP2ProgData);
         DetectAppLayerMpmRegister("file_data", SIG_FLAG_TOCLIENT, 2,
                 PrefilterMpmFiledataRegister, NULL,
-                ALPROTO_HTTP2, HTTP2StateDataServer);
+                ALPROTO_HTTP2, HTTP2ProgData);
         .
         .
         DetectAppLayerInspectEngineRegister("file_data",
-            ALPROTO_HTTP2, SIG_FLAG_TOCLIENT, HTTP2StateDataServer,
+            ALPROTO_HTTP2, SIG_FLAG_TOCLIENT, HTTP2ProgData,
             DetectEngineInspectFiledata, NULL);
         DetectAppLayerInspectEngineRegister(
                 "file_data", ALPROTO_FTPDATA, SIG_FLAG_TOSERVER, 0, DetectEngineInspectFiledata, NULL);

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -61,6 +61,14 @@ Logging Changes
   ``stats.app_layer.*.ftp-data`` becomes ``stats.app_layer.*.ftp_data``,
   and same for bittorrent_dht
 
+Keyword Changes
+~~~~~~~~~~~~~~~
+
+- HTTP2 keywords have now better progress defined, with the http2 transaction progress
+  being split per direction. This means that some rules should match sooner,
+  some rules will have less false negatives, and some rules will trigger once per transaction
+  instead of twice (one time for each direction)
+
 Other Changes
 ~~~~~~~~~~~~~
 - ``engine-analysis`` output has been changed for keywords that now use the generic integers framework

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -78,7 +78,7 @@ include = [
     "FtpRequestCommand",
     "FtpStateValues",
     "FtpDataStateValues",
-    "HTTP2TransactionState",
+    "HTTP2TxProgress",
     "DataRepType",
 ]
 

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -16,7 +16,7 @@
  */
 
 use super::http2::{
-    HTTP2Event, HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TransactionState,
+    HTTP2Event, HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TxProgress,
 };
 use super::parser;
 use crate::detect::uint::{
@@ -42,11 +42,16 @@ pub unsafe extern "C" fn SCHttp2TxHasFrametype(
     } else {
         &tx.frames_tc
     };
+    let eof = if direction & Direction::ToServer as u8 != 0 {
+        tx.progress_ts >= HTTP2TxProgress::HTTP2ProgComplete
+    } else {
+        tx.progress_tc >= HTTP2TxProgress::HTTP2ProgComplete
+    };
     return detect_uint_match_at_index::<HTTP2Frame, u8>(
         frames,
         ctx,
         |f| Some(f.header.ftype),
-        tx.state >= HTTP2TransactionState::HTTP2StateClosed,
+        eof,
     );
 }
 
@@ -84,12 +89,12 @@ pub unsafe extern "C" fn SCHttp2TxHasErrorCode(
     } else {
         &tx.frames_tc
     };
-    return detect_uint_match_at_index::<HTTP2Frame, u32>(
-        frames,
-        ctx,
-        http2_tx_get_errorcode,
-        tx.state >= HTTP2TransactionState::HTTP2StateClosed,
-    );
+    let eof = if direction & Direction::ToServer as u8 != 0 {
+        tx.progress_ts >= HTTP2TxProgress::HTTP2ProgComplete
+    } else {
+        tx.progress_tc >= HTTP2TxProgress::HTTP2ProgComplete
+    };
+    return detect_uint_match_at_index::<HTTP2Frame, u32>(frames, ctx, http2_tx_get_errorcode, eof);
 }
 
 #[no_mangle]
@@ -142,7 +147,11 @@ fn http2_match_priority(
     } else {
         &tx.frames_tc
     };
-    let eof = tx.state >= HTTP2TransactionState::HTTP2StateClosed;
+    let eof = if direction == Direction::ToServer {
+        tx.progress_ts >= HTTP2TxProgress::HTTP2ProgComplete
+    } else {
+        tx.progress_tc >= HTTP2TxProgress::HTTP2ProgComplete
+    };
     return detect_uint_match_at_index::<HTTP2Frame, u8>(frames, ctx, get_http2_priority, eof);
 }
 
@@ -170,7 +179,12 @@ fn http2_match_window(
     } else {
         &tx.frames_tc
     };
-    let eof = tx.state >= HTTP2TransactionState::HTTP2StateClosed;
+    // WINDOW_UPDATE frames may be sent in half-closed state
+    let eof = if direction == Direction::ToServer {
+        tx.progress_ts >= HTTP2TxProgress::HTTP2ProgComplete
+    } else {
+        tx.progress_tc >= HTTP2TxProgress::HTTP2ProgComplete
+    };
     return detect_uint_match_at_index::<HTTP2Frame, u32>(frames, ctx, get_http2_window, eof);
 }
 
@@ -999,7 +1013,7 @@ fn http2_tx_set_header(state: &mut HTTP2State, name: &[u8], input: &[u8]) {
         data: txdata,
     });
     //we do not expect more data from client
-    tx.state = HTTP2TransactionState::HTTP2StateHalfClosedClient;
+    tx.progress_ts = HTTP2TxProgress::HTTP2ProgClosed;
 }
 
 #[no_mangle]

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -747,11 +747,11 @@ impl HTTP2State {
         return sid;
     }
 
-    fn create_global_tx(&mut self, dir: Direction) -> &mut HTTP2Transaction {
+    fn create_global_tx(&mut self, _dir: Direction) -> &mut HTTP2Transaction {
         //special transaction with only one frame
         //as it affects the global connection, there is no end to it
         let mut tx = HTTP2Transaction::new();
-        tx.tx_data = AppLayerTxData::for_direction(dir);
+        //tx.tx_data = AppLayerTxData::for_direction(dir);
         self.tx_id += 1;
         tx.tx_id = self.tx_id;
         tx.progress_tc = HTTP2TxProgress::HTTP2ProgGlobal;

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -128,19 +128,16 @@ pub enum HTTP2FrameTypeData {
 
 #[repr(u8)]
 #[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
-pub enum HTTP2TransactionState {
-    HTTP2StateIdle = 0,
-    HTTP2StateOpen = 1,
-    HTTP2StateReserved = 2,
-    HTTP2StateDataClient = 3,
-    HTTP2StateHalfClosedClient = 4,
-    HTTP2StateDataServer = 5,
-    HTTP2StateHalfClosedServer = 6,
-    HTTP2StateClosed = 7,
+pub enum HTTP2TxProgress {
+    HTTP2ProgStart = 0,
+    HTTP2ProgHeaders = 1,
+    HTTP2ProgData = 2,
+    HTTP2ProgClosed = 3,
+    HTTP2ProgComplete = 4,
     //not a RFC-defined state, used for stream 0 frames applying to the global connection
-    HTTP2StateGlobal = 8,
+    HTTP2ProgGlobal = 5,
     //not a RFC-defined state, dropping this old tx because we have too many
-    HTTP2StateTodrop = 9,
+    HTTP2ProgTodrop = 6,
 }
 
 #[derive(Debug)]
@@ -166,7 +163,8 @@ pub struct DohHttp2Tx {
 pub struct HTTP2Transaction {
     tx_id: u64,
     pub stream_id: u32,
-    pub state: HTTP2TransactionState,
+    pub progress_tc: HTTP2TxProgress,
+    pub progress_ts: HTTP2TxProgress,
     child_stream_id: u32,
 
     pub frames_tc: Vec<HTTP2Frame>,
@@ -203,7 +201,8 @@ impl HTTP2Transaction {
             tx_id: 0,
             stream_id: 0,
             child_stream_id: 0,
-            state: HTTP2TransactionState::HTTP2StateIdle,
+            progress_tc: HTTP2TxProgress::HTTP2ProgStart,
+            progress_ts: HTTP2TxProgress::HTTP2ProgStart,
             frames_tc: Vec::new(),
             frames_ts: Vec::new(),
             decoder: decompression::HTTP2Decoder::new(),
@@ -408,7 +407,9 @@ impl HTTP2Transaction {
                     if header.flags & parser::HTTP2_FLAG_HEADER_END_HEADERS == 0 {
                         self.child_stream_id = hs.stream_id;
                     }
-                    self.state = HTTP2TransactionState::HTTP2StateReserved;
+                    if self.progress_tc < HTTP2TxProgress::HTTP2ProgHeaders {
+                        self.progress_tc = HTTP2TxProgress::HTTP2ProgHeaders;
+                    }
                 }
                 r = self.handle_headers(&hs.blocks, dir);
             }
@@ -432,41 +433,30 @@ impl HTTP2Transaction {
             _ => {}
         }
         //handle closing state changes
+        let state = if dir == Direction::ToServer {
+            &mut self.progress_ts
+        } else {
+            &mut self.progress_tc
+        };
         match data {
             HTTP2FrameTypeData::HEADERS(_) | HTTP2FrameTypeData::DATA => {
                 if header.flags & parser::HTTP2_FLAG_HEADER_EOS != 0 {
-                    match self.state {
-                        HTTP2TransactionState::HTTP2StateHalfClosedClient
-                        | HTTP2TransactionState::HTTP2StateDataServer => {
-                            if dir == Direction::ToClient {
-                                self.state = HTTP2TransactionState::HTTP2StateClosed;
-                            }
-                        }
-                        HTTP2TransactionState::HTTP2StateHalfClosedServer => {
-                            if dir == Direction::ToServer {
-                                self.state = HTTP2TransactionState::HTTP2StateClosed;
-                            }
-                        }
-                        // do not revert back to a half closed state
-                        HTTP2TransactionState::HTTP2StateClosed => {}
-                        HTTP2TransactionState::HTTP2StateGlobal => {}
-                        _ => {
-                            if dir == Direction::ToClient {
-                                self.state = HTTP2TransactionState::HTTP2StateHalfClosedServer;
-                            } else {
-                                self.state = HTTP2TransactionState::HTTP2StateHalfClosedClient;
-                            }
+                    if *state < HTTP2TxProgress::HTTP2ProgClosed {
+                        *state = HTTP2TxProgress::HTTP2ProgClosed;
+                        if self.progress_ts == HTTP2TxProgress::HTTP2ProgClosed
+                            && self.progress_tc == HTTP2TxProgress::HTTP2ProgClosed
+                        {
+                            self.progress_ts = HTTP2TxProgress::HTTP2ProgComplete;
+                            self.progress_tc = HTTP2TxProgress::HTTP2ProgComplete;
                         }
                     }
                 } else if header.ftype == parser::HTTP2FrameType::Data as u8 {
                     //not end of stream
-                    if dir == Direction::ToServer {
-                        if self.state < HTTP2TransactionState::HTTP2StateDataClient {
-                            self.state = HTTP2TransactionState::HTTP2StateDataClient;
-                        }
-                    } else if self.state < HTTP2TransactionState::HTTP2StateDataServer {
-                        self.state = HTTP2TransactionState::HTTP2StateDataServer;
+                    if *state < HTTP2TxProgress::HTTP2ProgData {
+                        *state = HTTP2TxProgress::HTTP2ProgData;
                     }
+                } else if *state < HTTP2TxProgress::HTTP2ProgHeaders {
+                    *state = HTTP2TxProgress::HTTP2ProgHeaders;
                 }
             }
             _ => {}
@@ -757,13 +747,15 @@ impl HTTP2State {
         return sid;
     }
 
-    fn create_global_tx(&mut self) -> &mut HTTP2Transaction {
+    fn create_global_tx(&mut self, dir: Direction) -> &mut HTTP2Transaction {
         //special transaction with only one frame
         //as it affects the global connection, there is no end to it
         let mut tx = HTTP2Transaction::new();
+        tx.tx_data = AppLayerTxData::for_direction(dir);
         self.tx_id += 1;
         tx.tx_id = self.tx_id;
-        tx.state = HTTP2TransactionState::HTTP2StateGlobal;
+        tx.progress_tc = HTTP2TxProgress::HTTP2ProgGlobal;
+        tx.progress_ts = HTTP2TxProgress::HTTP2ProgGlobal;
         // a global tx (stream id 0) does not hold files cf RFC 9113 section 5.1.1
         self.transactions.push_back(tx);
         return self.transactions.back_mut().unwrap();
@@ -775,19 +767,20 @@ impl HTTP2State {
         if header.stream_id == 0 {
             if self.transactions.len() >= unsafe { HTTP2_MAX_STREAMS } {
                 for tx_old in &mut self.transactions {
-                    if tx_old.state == HTTP2TransactionState::HTTP2StateTodrop {
+                    if tx_old.progress_ts == HTTP2TxProgress::HTTP2ProgTodrop {
                         // loop was already run
                         break;
                     }
                     tx_old.set_event(HTTP2Event::TooManyStreams);
                     // use a distinct state, even if we do not log it
-                    tx_old.state = HTTP2TransactionState::HTTP2StateTodrop;
+                    tx_old.progress_ts = HTTP2TxProgress::HTTP2ProgTodrop;
+                    tx_old.progress_tc = HTTP2TxProgress::HTTP2ProgTodrop;
                     tx_old.tx_data.0.updated_tc = true;
                     tx_old.tx_data.0.updated_ts = true;
                 }
                 return None;
             }
-            return Some(self.create_global_tx());
+            return Some(self.create_global_tx(dir));
         }
         let sid = match data {
             //yes, the right stream_id for Suricata is not the header one
@@ -804,7 +797,9 @@ impl HTTP2State {
         };
         let index = self.find_tx_index(sid);
         if index > 0 {
-            if self.transactions[index - 1].state == HTTP2TransactionState::HTTP2StateClosed {
+            if self.transactions[index - 1].progress_tc >= HTTP2TxProgress::HTTP2ProgClosed
+                && self.transactions[index - 1].progress_ts >= HTTP2TxProgress::HTTP2ProgClosed
+            {
                 //these frames can be received in this state for a short period
                 if header.ftype != parser::HTTP2FrameType::RstStream as u8
                     && header.ftype != parser::HTTP2FrameType::WindowUpdate as u8
@@ -824,13 +819,14 @@ impl HTTP2State {
             // do not use SETTINGS_MAX_CONCURRENT_STREAMS as it can grow too much
             if self.transactions.len() >= unsafe { HTTP2_MAX_STREAMS } {
                 for tx_old in &mut self.transactions {
-                    if tx_old.state == HTTP2TransactionState::HTTP2StateTodrop {
+                    if tx_old.progress_ts == HTTP2TxProgress::HTTP2ProgTodrop {
                         // loop was already run
                         break;
                     }
                     tx_old.set_event(HTTP2Event::TooManyStreams);
                     // use a distinct state, even if we do not log it
-                    tx_old.state = HTTP2TransactionState::HTTP2StateTodrop;
+                    tx_old.progress_ts = HTTP2TxProgress::HTTP2ProgTodrop;
+                    tx_old.progress_tc = HTTP2TxProgress::HTTP2ProgTodrop;
                     tx_old.tx_data.0.updated_tc = true;
                     tx_old.tx_data.0.updated_ts = true;
                 }
@@ -840,7 +836,6 @@ impl HTTP2State {
             self.tx_id += 1;
             tx.tx_id = self.tx_id;
             tx.stream_id = sid;
-            tx.state = HTTP2TransactionState::HTTP2StateOpen;
             tx.tx_data.update_file_flags(self.state_data.file_flags);
             tx.update_file_flags(tx.tx_data.0.file_flags);
             tx.tx_data.0.file_tx = STREAM_TOSERVER | STREAM_TOCLIENT; // might hold files in both directions
@@ -1527,15 +1522,15 @@ unsafe extern "C" fn http2_state_get_tx_count(state: *mut std::os::raw::c_void) 
     return state.tx_id;
 }
 
-unsafe extern "C" fn http2_tx_get_state(tx: *mut std::os::raw::c_void) -> HTTP2TransactionState {
-    let tx = cast_pointer!(tx, HTTP2Transaction);
-    return tx.state;
-}
-
 unsafe extern "C" fn http2_tx_get_alstate_progress(
-    tx: *mut std::os::raw::c_void, _direction: u8,
+    tx: *mut std::os::raw::c_void, direction: u8,
 ) -> std::os::raw::c_int {
-    return http2_tx_get_state(tx) as i32;
+    let tx = cast_pointer!(tx, HTTP2Transaction);
+    if direction == STREAM_TOSERVER {
+        return tx.progress_ts as i32;
+    } else {
+        return tx.progress_tc as i32;
+    }
 }
 
 unsafe extern "C" fn http2_getfiles(
@@ -1579,8 +1574,8 @@ pub unsafe extern "C" fn SCRegisterHttp2Parser() {
         parse_tc: http2_parse_tc,
         get_tx_count: http2_state_get_tx_count,
         get_tx: http2_state_get_tx,
-        tx_comp_st_ts: HTTP2TransactionState::HTTP2StateClosed as i32,
-        tx_comp_st_tc: HTTP2TransactionState::HTTP2StateClosed as i32,
+        tx_comp_st_ts: HTTP2TxProgress::HTTP2ProgComplete as i32,
+        tx_comp_st_tc: HTTP2TxProgress::HTTP2ProgComplete as i32,
         tx_get_progress: http2_tx_get_alstate_progress,
         get_eventinfo: Some(HTTP2Event::get_event_info),
         get_eventinfo_byid: Some(HTTP2Event::get_event_info_by_id),

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -91,8 +91,8 @@ DetectFileHandlerProtocol_t al_protocols[ALPROTO_WITHFILES_MAX] = {
             .to_server_progress = HTP_REQUEST_PROGRESS_BODY },
     { .alproto = ALPROTO_HTTP2,
             .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT,
-            .to_client_progress = HTTP2StateDataServer,
-            .to_server_progress = HTTP2StateDataClient },
+            .to_client_progress = HTTP2ProgData,
+            .to_server_progress = HTTP2ProgData },
     { .alproto = ALPROTO_SMTP, .direction = SIG_FLAG_TOSERVER }, { .alproto = ALPROTO_UNKNOWN }
 };
 

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -112,9 +112,9 @@ void DetectHttpClientBodyRegister(void)
             PrefilterMpmHttpRequestBodyRegister, NULL, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_BODY);
 
     DetectAppLayerInspectEngineRegister("http_client_body", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectFiledata, NULL);
+            HTTP2ProgData, DetectEngineInspectFiledata, NULL);
     DetectAppLayerMpmRegister("http_client_body", SIG_FLAG_TOSERVER, 2,
-            PrefilterMpmFiledataRegister, NULL, ALPROTO_HTTP2, HTTP2StateDataClient);
+            PrefilterMpmFiledataRegister, NULL, ALPROTO_HTTP2, HTTP2ProgData);
 
     DetectBufferTypeSetDescriptionByName("http_client_body",
             "http request body");

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -120,14 +120,14 @@ void DetectHttpCookieRegister(void)
             GetResponseData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_HEADERS);
 
     DetectAppLayerInspectEngineRegister("http_cookie", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetRequestData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetRequestData2);
     DetectAppLayerInspectEngineRegister("http_cookie", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetResponseData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetResponseData2);
 
     DetectAppLayerMpmRegister("http_cookie", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetRequestData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetRequestData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
     DetectAppLayerMpmRegister("http_cookie", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetResponseData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetResponseData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_cookie",
             "http cookie header");

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -235,14 +235,14 @@ void DetectHttpHeaderNamesRegister(void)
 
     /* http2 */
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2ProgHeaders);
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME,
             BUFFER_DESC);

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -399,14 +399,14 @@ void DetectHttpHeaderRegister(void)
             0); /* not used, registered twice: HEADERS/TRAILER */
 
     DetectAppLayerInspectEngineRegister("http_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
     DetectAppLayerMpmRegister("http_header", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectAppLayerInspectEngineRegister("http_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
     DetectAppLayerMpmRegister("http_header", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_header",
             "http headers");
@@ -575,7 +575,7 @@ void DetectHttpRequestHeaderRegister(void)
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER;
 
     DetectAppLayerMultiRegister("http_request_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, GetHttp2HeaderData, 2);
+            HTTP2ProgHeaders, GetHttp2HeaderData, 2);
     DetectAppLayerMultiRegister("http_request_header", ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
             HTP_REQUEST_PROGRESS_HEADERS, GetHttp1HeaderData, 2);
 
@@ -611,7 +611,7 @@ void DetectHttpResponseHeaderRegister(void)
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER;
 
     DetectAppLayerMultiRegister("http_response_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateOpen, GetHttp2HeaderData, 2);
+            HTTP2ProgHeaders, GetHttp2HeaderData, 2);
     DetectAppLayerMultiRegister("http_response_header", ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
             HTP_RESPONSE_PROGRESS_HEADERS, GetHttp1HeaderData, 2);
 

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -198,25 +198,25 @@ static void DetectHttpHeadersRegisterStub(void)
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetRequestData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_HEADERS);
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetRequestData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetRequestData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 #endif
 #ifdef KEYWORD_TOCLIENT
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
             GetResponseData, ALPROTO_HTTP1, HTP_RESPONSE_PROGRESS_HEADERS);
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetResponseData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetResponseData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 #endif
 #ifdef KEYWORD_TOSERVER
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
             HTP_REQUEST_PROGRESS_HEADERS, DetectEngineInspectBufferGeneric, GetRequestData);
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetRequestData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetRequestData2);
 #endif
 #ifdef KEYWORD_TOCLIENT
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
             HTP_RESPONSE_PROGRESS_HEADERS, DetectEngineInspectBufferGeneric, GetResponseData);
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetResponseData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetResponseData2);
 #endif
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -116,10 +116,10 @@ void DetectHttpHHRegister(void)
             GetData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_HEADERS);
 
     DetectAppLayerInspectEngineRegister("http_host", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister("http_host", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeRegisterValidateCallback("http_host",
             DetectHttpHostValidateCallback);
@@ -155,10 +155,10 @@ void DetectHttpHHRegister(void)
             GetRawData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_HEADERS);
 
     DetectAppLayerInspectEngineRegister("http_raw_host", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetRawData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetRawData2);
 
     DetectAppLayerMpmRegister("http_raw_host", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetRawData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetRawData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_raw_host",
             "http raw host header");

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -107,10 +107,10 @@ void DetectHttpMethodRegister(void)
             GetData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_LINE);
 
     DetectAppLayerInspectEngineRegister("http_method", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister("http_method", SIG_FLAG_TOSERVER, 4, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_method",
             "http request method");

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -173,13 +173,13 @@ void DetectHttpProtocolRegister(void)
             HTP_RESPONSE_PROGRESS_LINE, DetectEngineInspectBufferGeneric, GetData);
 
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgStart);
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgStart);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME,
             BUFFER_DESC);

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -114,14 +114,14 @@ void DetectHttpRawHeaderRegister(void)
             0); /* progress handled in register */
 
     DetectAppLayerInspectEngineRegister("http_raw_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
     DetectAppLayerInspectEngineRegister("http_raw_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister("http_raw_header", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
     DetectAppLayerMpmRegister("http_raw_header", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_raw_header",
             "raw http headers");

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -117,9 +117,9 @@ void DetectHttpRequestLineRegister(void)
             PrefilterGenericMpmRegister, GetData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_LINE);
 
     DetectAppLayerInspectEngineRegister("http_request_line", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgData, DetectEngineInspectBufferGeneric, GetData2);
     DetectAppLayerMpmRegister("http_request_line", SIG_FLAG_TOSERVER, 2,
-            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2ProgData);
 
     DetectBufferTypeSetDescriptionByName("http_request_line",
             "http request line");

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -116,9 +116,9 @@ void DetectHttpResponseLineRegister(void)
             PrefilterGenericMpmRegister, GetData, ALPROTO_HTTP1, HTP_RESPONSE_PROGRESS_LINE);
 
     DetectAppLayerInspectEngineRegister("http_response_line", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgData, DetectEngineInspectBufferGeneric, GetData2);
     DetectAppLayerMpmRegister("http_response_line", SIG_FLAG_TOCLIENT, 2,
-            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2ProgData);
 
     DetectBufferTypeSetDescriptionByName("http_response_line",
             "http response line");

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -108,10 +108,10 @@ void DetectHttpStatCodeRegister (void)
             GetData, ALPROTO_HTTP1, HTP_RESPONSE_PROGRESS_LINE);
 
     DetectAppLayerInspectEngineRegister("http_stat_code", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister("http_stat_code", SIG_FLAG_TOCLIENT, 4, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_stat_code",
             "http response status code");

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -118,9 +118,9 @@ void DetectHttpStatMsgRegister (void)
             GetData, ALPROTO_HTTP1, HTP_RESPONSE_PROGRESS_LINE);
 
     DetectAppLayerInspectEngineRegister("http_stat_msg", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
     DetectAppLayerMpmRegister("http_stat_msg", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgStart);
 
     DetectBufferTypeSetDescriptionByName("http_stat_msg",
             "http response status message");

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -108,10 +108,10 @@ void DetectHttpUARegister(void)
             GetData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_HEADERS);
 
     DetectAppLayerInspectEngineRegister("http_user_agent", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister("http_user_agent", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_user_agent",
             "http user agent");

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -114,10 +114,10 @@ void DetectHttpUriRegister (void)
             GetData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_LINE);
 
     DetectAppLayerInspectEngineRegister("http_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister("http_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_uri",
             "http request uri");
@@ -152,10 +152,10 @@ void DetectHttpUriRegister (void)
 
     // no difference between raw and decoded uri for HTTP2
     DetectAppLayerInspectEngineRegister("http_raw_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister("http_raw_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateOpen);
+            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_raw_uri",
             "raw http uri");

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -95,7 +95,7 @@ void DetectHTTP2RegisterTests (void);
 
 static int g_http2_match_buffer_id = 0;
 static int g_http2_complete_buffer_id = 0;
-static int g_http2_header_name_buffer_id = 0;
+static int g_http2_header_buffer_id = 0;
 
 /**
  * \brief Registration function for HTTP2 keywords
@@ -184,14 +184,14 @@ void DetectHttp2Register(void)
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER;
 
     DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateOpen, SCHttp2TxGetHeaderName, 2);
+            HTTP2ProgHeaders, SCHttp2TxGetHeaderName, 2);
     DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, SCHttp2TxGetHeaderName, 2);
+            HTTP2ProgHeaders, SCHttp2TxGetHeaderName, 2);
 
     DetectBufferTypeSupportsMultiInstance("http2_header_name");
     DetectBufferTypeSetDescriptionByName("http2_header_name",
                                          "HTTP2 header name");
-    g_http2_header_name_buffer_id = DetectBufferTypeGetByName("http2_header_name");
+    g_http2_header_buffer_id = DetectBufferTypeGetByName("http2_header_name");
 
     DetectAppLayerInspectEngineRegister(
             "http2", ALPROTO_HTTP2, SIG_FLAG_TOSERVER, 0, DetectEngineInspectGenericList, NULL);
@@ -201,9 +201,9 @@ void DetectHttp2Register(void)
     g_http2_match_buffer_id = DetectBufferTypeRegister("http2");
 
     DetectAppLayerInspectEngineRegister("http2_complete", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateClosed, DetectEngineInspectGenericList, NULL);
+            HTTP2ProgComplete, DetectEngineInspectGenericList, NULL);
     DetectAppLayerInspectEngineRegister("http2_complete", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateClosed, DetectEngineInspectGenericList, NULL);
+            HTTP2ProgComplete, DetectEngineInspectGenericList, NULL);
 
     g_http2_complete_buffer_id = DetectBufferTypeRegister("http2_complete");
 }
@@ -244,7 +244,7 @@ static int DetectHTTP2frametypeSetup (DetectEngineCtx *de_ctx, Signature *s, con
     }
 
     if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_FRAMETYPE, (SigMatchCtx *)dua8,
-                g_http2_match_buffer_id) == NULL) {
+                g_http2_complete_buffer_id) == NULL) {
         DetectHTTP2frametypeFree(NULL, dua8);
         return -1;
     }
@@ -298,7 +298,7 @@ static int DetectHTTP2errorcodeSetup (DetectEngineCtx *de_ctx, Signature *s, con
     }
 
     if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_ERRORCODE, (SigMatchCtx *)dua32,
-                g_http2_match_buffer_id) == NULL) {
+                g_http2_complete_buffer_id) == NULL) {
         DetectHTTP2errorcodeFree(NULL, dua32);
         return -1;
     }
@@ -350,7 +350,7 @@ static int DetectHTTP2prioritySetup (DetectEngineCtx *de_ctx, Signature *s, cons
         return -1;
 
     if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_PRIORITY, (SigMatchCtx *)prio,
-                g_http2_match_buffer_id) == NULL) {
+                g_http2_complete_buffer_id) == NULL) {
         DetectHTTP2priorityFree(NULL, prio);
         return -1;
     }
@@ -455,7 +455,7 @@ static int DetectHTTP2sizeUpdateSetup (DetectEngineCtx *de_ctx, Signature *s, co
         return -1;
 
     if (SCSigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_SIZEUPDATE, (SigMatchCtx *)su,
-                g_http2_match_buffer_id) == NULL) {
+                g_http2_header_buffer_id) == NULL) {
         DetectHTTP2sizeUpdateFree(NULL, su);
         return -1;
     }
@@ -527,7 +527,7 @@ void DetectHTTP2settingsFree(DetectEngineCtx *de_ctx, void *ptr)
 
 static int DetectHTTP2headerNameSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
-    if (SCDetectBufferSetActiveList(de_ctx, s, g_http2_header_name_buffer_id) < 0)
+    if (SCDetectBufferSetActiveList(de_ctx, s, g_http2_header_buffer_id) < 0)
         return -1;
 
     if (SCDetectSignatureSetAppProto(s, ALPROTO_HTTP2) != 0)

--- a/src/output.c
+++ b/src/output.c
@@ -1090,8 +1090,8 @@ void OutputRegisterLoggers(void)
     LogHttpLogRegister();
     JsonHttpLogRegister();
     OutputRegisterTxSubModuleWithProgress(LOGGER_JSON_TX, "eve-log", "LogHttp2Log", "eve-log.http2",
-            OutputJsonLogInitSub, ALPROTO_HTTP2, JsonGenericDirFlowLogger, HTTP2StateClosed,
-            HTTP2StateClosed, JsonLogThreadInit, JsonLogThreadDeinit);
+            OutputJsonLogInitSub, ALPROTO_HTTP2, JsonGenericDirFlowLogger, HTTP2ProgClosed,
+            HTTP2ProgClosed, JsonLogThreadInit, JsonLogThreadDeinit);
     /* tls log */
     JsonTlsLogRegister();
     LogTlsStoreRegister();


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8518

Describe changes:
- http2: split progress per direction

DRAFT:
Should so-called global txs be created as unidirectional ? (meaning with `AppLayerTxData::for_direction(dir);`)

That means a rule like `alert http2 any any -> any any (http.protocol; content:"HTTP/2"; sid:35;)` will match only once (in the traffic direction) instead of twice (once per direction) for a SETTINGS frame for example (as can be seen in SV test http2-keywords2 which will require changes)