### PR TITLE
af-packet: mask vlan id in ebpf map keys - v1

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2297,8 +2297,8 @@ static int AFPBypassCallback(Packet *p)
         keys[0]->dst = htonl(GET_IPV4_DST_ADDR_U32(p));
         keys[0]->port16[0] = p->sp;
         keys[0]->port16[1] = p->dp;
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2322,8 +2322,8 @@ static int AFPBypassCallback(Packet *p)
         keys[1]->dst = htonl(GET_IPV4_SRC_ADDR_U32(p));
         keys[1]->port16[0] = p->dp;
         keys[1]->port16[1] = p->sp;
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
@@ -2356,8 +2356,8 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[0]->port16[0] = p->sp;
         keys[0]->port16[1] = p->dp;
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2383,8 +2383,8 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[1]->port16[0] = p->dp;
         keys[1]->port16[1] = p->sp;
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
@@ -2451,8 +2451,8 @@ static int AFPXDPBypassCallback(Packet *p)
          * (as in eBPF filter) so we need to pass from host to network order */
         keys[0]->port16[0] = htons(p->sp);
         keys[0]->port16[1] = htons(p->dp);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2475,8 +2475,8 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[1]->dst = p->src.addr_data32[0];
         keys[1]->port16[0] = htons(p->dp);
         keys[1]->port16[1] = htons(p->sp);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
@@ -2507,8 +2507,8 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         keys[0]->port16[0] = htons(p->sp);
         keys[0]->port16[1] = htons(p->dp);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[0]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2533,8 +2533,8 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         keys[1]->port16[0] = htons(p->dp);
         keys[1]->port16[1] = htons(p->sp);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan0 = p->vlan_id[0] & g_vlan_mask;
+        keys[1]->vlan1 = p->vlan_id[1] & g_vlan_mask;
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8242

Describe changes:
- Userspace in `source-af-packet.c` was populating the eBPF `flow_table_v4` / `flow_table_v6` lookup keys with the raw `p->vlan_id[N]` values, while the `xdp_filter` program compiled with `VLAN_TRACKING=0` keys the maps with zeroed VLAN fields. The result was that hardware-bypass lookups never matched on VLAN traffic when `vlan.use-for-tracking` was disabled, and bypass counters stayed at 0.
- Apply the existing `g_vlan_mask` (already used by `src/flow-hash.c` for the in-kernel flow table) to both `vlan0` and `vlan1` in all eight key-population sites (IPv4 and IPv6, forward and reverse halves of the flow, EBPF and XDP paths). The mask is `0xffff` by default and `0x0000` when `vlan.use-for-tracking` is false, so userspace now produces the same key the BPF program expects.
- Adapted from a patch contributed by John Graat on the ticket. The original patch also masked a `vlan2` field that has since been removed from `struct flowv4_keys` / `flowv6_keys` in `src/util-ebpf.h`, so only `vlan0` / `vlan1` are touched here.

### Provide values to any of the below to override the defaults.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=