### PR TITLE
Rust fmt 3836 v5.1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -380,21 +380,7 @@ jobs:
       # especially without debug feature
       - run: cargo clippy
         working-directory: rust
-      - run: cargo fmt --check
-        working-directory: rust/suricatactl
-      - run: cargo fmt --check
-        working-directory: rust/suricatasc
-      - run: cargo fmt --check
-        working-directory: rust/sys
-      - run: cargo fmt --check
-        working-directory: rust/derive
-      - run: rustfmt --check rust/src/dns/*.rs rust/src/applayertemplate/*.rs rust/src/asn1/*.rs
-              rust/src/bittorrent_dht/*.rs rust/src/enip/*.rs rust/src/ffi/*.rs rust/src/ftp/*.rs
-              rust/src/ldap/*.rs rust/src/mime/*.rs rust/src/ntp/*.rs rust/src/quic/*.rs
-              rust/src/rfb/*.rs rust/src/ssh/*.rs rust/src/utils/*.rs rust/src/websocket/*.rs
-              rust/src/dhcp/*.rs rust/src/krb/*.rs rust/src/mdns/*.rs rust/src/pop3/*.rs
-              rust/src/http2/*.rs rust/src/ike/*.rs rust/src/modbus/*.rs rust/src/mqtt/*.rs
-              rust/src/nfs/*.rs rust/src/pgsql/*.rs
+      - run: ./scripts/rustfmt.sh
       - name: Check if Cargo.lock.in is up to date
         run: |
           cp rust/Cargo.lock rust/Cargo.lock.in
@@ -404,12 +390,6 @@ jobs:
               echo "::error ::Cargo.lock.in needs to be updated"
               exit 1
           fi
-      # does not work in other subdirectories for now
-      - run: cargo fmt --check
-        working-directory: rust/htp
-      # The ffi crate is cargo fmt clean.
-      - run: cargo fmt --check
-        working-directory: rust/ffi
 
       - run: make -j ${{ env.CPUS }} distcheck
         env:

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -609,7 +609,10 @@ mod tests {
     fn test_parse_ts_other() {
         let buf: &[u8] = &[0x03, 0x00, 0x00, 0x01, 0x00];
         let mut state = RdpState::new();
-        assert_eq!(AppLayerResult::err(), state.parse_ts(std::ptr::null_mut(), buf));
+        assert_eq!(
+            AppLayerResult::err(),
+            state.parse_ts(std::ptr::null_mut(), buf)
+        );
     }
 
     #[test]
@@ -637,7 +640,10 @@ mod tests {
     fn test_parse_tc_other() {
         let buf: &[u8] = &[0x03, 0x00, 0x00, 0x01, 0x00];
         let mut state = RdpState::new();
-        assert_eq!(AppLayerResult::err(), state.parse_tc(std::ptr::null_mut(), buf));
+        assert_eq!(
+            AppLayerResult::err(),
+            state.parse_tc(std::ptr::null_mut(), buf)
+        );
     }
 
     #[test]

--- a/rust/src/sdp/parser.rs
+++ b/rust/src/sdp/parser.rs
@@ -188,13 +188,16 @@ fn parse_origin_line(i: &[u8]) -> IResult<&[u8], String> {
     let (i, _) = tag("o=").parse(i)?;
     let (i, username) = map_res(take_while(is_token_char), std::str::from_utf8).parse(i)?;
     let (i, _) = space1.parse(i)?;
-    let (i, sess_id) = map_res(take_while(|c: u8| c.is_dec_digit()), std::str::from_utf8).parse(i)?;
+    let (i, sess_id) =
+        map_res(take_while(|c: u8| c.is_dec_digit()), std::str::from_utf8).parse(i)?;
     let (i, _) = space1.parse(i)?;
-    let (i, sess_version) = map_res(take_while(|c: u8| c.is_dec_digit()), std::str::from_utf8).parse(i)?;
+    let (i, sess_version) =
+        map_res(take_while(|c: u8| c.is_dec_digit()), std::str::from_utf8).parse(i)?;
     let (i, _) = space1.parse(i)?;
     let (i, nettype) = map_res(take_while(|c: u8| c.is_alpha()), std::str::from_utf8).parse(i)?;
     let (i, _) = space1.parse(i)?;
-    let (i, addrtype) = map_res(take_while(|c: u8| c.is_alphanum()), std::str::from_utf8).parse(i)?;
+    let (i, addrtype) =
+        map_res(take_while(|c: u8| c.is_alphanum()), std::str::from_utf8).parse(i)?;
     let (i, _) = space1.parse(i)?;
     let (i, unicast_address) = map_res(take_till(is_line_ending), std::str::from_utf8).parse(i)?;
     let (i, _) = line_ending.parse(i)?;
@@ -232,12 +235,14 @@ fn parse_connection_data(i: &[u8]) -> IResult<&[u8], String> {
     let (i, _) = tag("c=").parse(i)?;
     let (i, nettype) = map_res(take_while(|c: u8| c.is_alpha()), std::str::from_utf8).parse(i)?;
     let (i, _) = space1.parse(i)?;
-    let (i, addrtype) = map_res(take_while(|c: u8| c.is_alphanum()), std::str::from_utf8).parse(i)?;
+    let (i, addrtype) =
+        map_res(take_while(|c: u8| c.is_alphanum()), std::str::from_utf8).parse(i)?;
     let (i, _) = space1.parse(i)?;
     let (i, connection_address) = map_res(
         map_res(take_while(is_ipaddr_char), std::str::from_utf8),
         IpAddr::from_str,
-    ).parse(i)?;
+    )
+    .parse(i)?;
     let (i, first_num) = opt(preceded(char_parser('/'), parse_num)).parse(i)?;
     let (i, second_num) = opt(preceded(char_parser('/'), parse_num)).parse(i)?;
     let (i, _) = line_ending.parse(i)?;
@@ -277,7 +282,8 @@ fn parse_email(i: &[u8]) -> IResult<&[u8], String> {
     let (i, email) = preceded(
         tag("e="),
         map_res(take_till(is_line_ending), std::str::from_utf8),
-    ).parse(i)?;
+    )
+    .parse(i)?;
     let (i, _) = line_ending.parse(i)?;
     Ok((i, email.to_string()))
 }
@@ -286,7 +292,8 @@ fn parse_phone_number(i: &[u8]) -> IResult<&[u8], String> {
     let (i, phone_number) = preceded(
         tag("p="),
         map_res(take_till(is_line_ending), std::str::from_utf8),
-    ).parse(i)?;
+    )
+    .parse(i)?;
     let (i, _) = line_ending.parse(i)?;
     Ok((i, phone_number.to_string()))
 }
@@ -303,7 +310,8 @@ fn parse_bandwidth(i: &[u8]) -> IResult<&[u8], Vec<String>> {
             map_res(digit1, std::str::from_utf8),
             line_ending,
         ),
-    )).parse(i)?;
+    ))
+    .parse(i)?;
     let vec = bws.iter().map(|bw| format!("{}:{}", bw.0, bw.2)).collect();
     Ok((i, vec))
 }
@@ -322,7 +330,8 @@ fn parse_time(i: &[u8]) -> IResult<&[u8], String> {
             space1,
             map_res(digit1, std::str::from_utf8),
         ),
-    ).parse(i)?;
+    )
+    .parse(i)?;
     let (i, _) = line_ending.parse(i)?;
     let time = format!("{} {}", start_time, stop_time);
     Ok((i, time))
@@ -340,7 +349,8 @@ fn parse_repeat_times(i: &[u8]) -> IResult<&[u8], String> {
             space1,
             map_res(take_while(is_time_char), std::str::from_utf8),
         ),
-    ).parse(i)?;
+    )
+    .parse(i)?;
     let (i, _) = line_ending.parse(i)?;
     let val = format!("{} {} {} {}", d, h, m, s);
     Ok((i, val.to_string()))
@@ -358,7 +368,8 @@ fn parse_time_zone(i: &[u8]) -> IResult<&[u8], String> {
             space1,
             map_res(take_while(is_time_char), std::str::from_utf8),
         ),
-    ).parse(i)?;
+    )
+    .parse(i)?;
     let (i, _) = line_ending.parse(i)?;
     let tz = format!("{} {} {} {}", z1, z2, z3, z4);
     Ok((i, tz.to_string()))
@@ -368,7 +379,8 @@ fn parse_encryption_key(i: &[u8]) -> IResult<&[u8], String> {
     let (i, key) = preceded(
         tag("k="),
         map_res(take_till(is_line_ending), std::str::from_utf8),
-    ).parse(i)?;
+    )
+    .parse(i)?;
     let (i, _) = line_ending.parse(i)?;
     Ok((i, key.to_string()))
 }
@@ -384,7 +396,8 @@ fn parse_attributes(i: &[u8]) -> IResult<&[u8], Vec<String>> {
             )),
             line_ending,
         ),
-    )).parse(i)?;
+    ))
+    .parse(i)?;
     let vec = attrs
         .iter()
         .map(|a| {
@@ -409,26 +422,30 @@ fn parse_media_description(i: &[u8]) -> IResult<&[u8], MediaDescription> {
             tag("message"),
         )),
         |bytes: &[u8]| String::from_utf8(bytes.to_vec()),
-    ).parse(i)?;
+    )
+    .parse(i)?;
     let (i, _) = space1.parse(i)?;
 
     let (i, port) = map_res(
         take_while_m_n(1, 5, |b: u8| b.is_ascii_digit()),
         std::str::from_utf8,
-    ).parse(i)?;
+    )
+    .parse(i)?;
     let (i, number_of_ports) = opt(preceded(
         char_parser('/'),
         map_res(
             take_while_m_n(1, 5, |b: u8| b.is_ascii_digit()),
             std::str::from_utf8,
         ),
-    )).parse(i)?;
+    ))
+    .parse(i)?;
     let (i, _) = space1.parse(i)?;
 
     let (i, proto) = map_res(
         alt((tag("udp"), tag("RTP/AVP"), tag("RTP/SAVP"))),
         |bytes: &[u8]| String::from_utf8(bytes.to_vec()),
-    ).parse(i)?;
+    )
+    .parse(i)?;
 
     let (i, fmt) = many1(preceded(
         space1,
@@ -436,7 +453,8 @@ fn parse_media_description(i: &[u8]) -> IResult<&[u8], MediaDescription> {
             take_while_m_n(1, 255, |b: u8| b.is_ascii_alphanumeric()),
             std::str::from_utf8,
         ),
-    )).parse(i)?;
+    ))
+    .parse(i)?;
     let (i, _) = line_ending.parse(i)?;
 
     let (i, session_info) = opt(parse_session_info).parse(i)?;

--- a/scripts/rustfmt.sh
+++ b/scripts/rustfmt.sh
@@ -39,4 +39,4 @@ rustfmt --check rust/src/dns/*.rs rust/src/applayertemplate/*.rs rust/src/asn1/*
     rust/src/rfb/*.rs rust/src/ssh/*.rs rust/src/utils/*.rs rust/src/websocket/*.rs \
     rust/src/dhcp/*.rs rust/src/krb/*.rs rust/src/mdns/*.rs rust/src/pop3/*.rs \
     rust/src/http2/*.rs rust/src/ike/*.rs rust/src/modbus/*.rs rust/src/mqtt/*.rs \
-    rust/src/nfs/*.rs rust/src/pgsql/*.rs rust/src/rdp/*.rs
+    rust/src/nfs/*.rs rust/src/pgsql/*.rs rust/src/rdp/*.rs rust/src/sdp/*.rs

--- a/scripts/rustfmt.sh
+++ b/scripts/rustfmt.sh
@@ -39,4 +39,4 @@ rustfmt --check rust/src/dns/*.rs rust/src/applayertemplate/*.rs rust/src/asn1/*
     rust/src/rfb/*.rs rust/src/ssh/*.rs rust/src/utils/*.rs rust/src/websocket/*.rs \
     rust/src/dhcp/*.rs rust/src/krb/*.rs rust/src/mdns/*.rs rust/src/pop3/*.rs \
     rust/src/http2/*.rs rust/src/ike/*.rs rust/src/modbus/*.rs rust/src/mqtt/*.rs \
-    rust/src/nfs/*.rs rust/src/pgsql/*.rs
+    rust/src/nfs/*.rs rust/src/pgsql/*.rs rust/src/rdp/*.rs

--- a/scripts/rustfmt.sh
+++ b/scripts/rustfmt.sh
@@ -1,0 +1,42 @@
+#! /usr/bin/env bash
+# Check rust formatting, not complete yet
+
+set -e
+
+(
+cd rust/derive
+cargo fmt --check
+)
+
+(
+cd rust/htp
+cargo fmt --check
+)
+
+(
+cd rust/ffi
+cargo fmt --check
+)
+
+(
+cd rust/suricatactl
+cargo fmt --check
+)
+
+(
+cd rust/suricatasc
+cargo fmt --check
+)
+
+(
+cd rust/sys
+cargo fmt --check
+)
+
+rustfmt --check rust/src/dns/*.rs rust/src/applayertemplate/*.rs rust/src/asn1/*.rs \
+    rust/src/bittorrent_dht/*.rs rust/src/enip/*.rs rust/src/ffi/*.rs rust/src/ftp/*.rs \
+    rust/src/ldap/*.rs rust/src/mime/*.rs rust/src/ntp/*.rs rust/src/quic/*.rs \
+    rust/src/rfb/*.rs rust/src/ssh/*.rs rust/src/utils/*.rs rust/src/websocket/*.rs \
+    rust/src/dhcp/*.rs rust/src/krb/*.rs rust/src/mdns/*.rs rust/src/pop3/*.rs \
+    rust/src/http2/*.rs rust/src/ike/*.rs rust/src/modbus/*.rs rust/src/mqtt/*.rs \
+    rust/src/nfs/*.rs rust/src/pgsql/*.rs


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/3836

Describe changes:
- ci: move rustfmt to its helper script
- rust: format rdp and sdp files

https://github.com/OISF/suricata/pull/15476 next round

Still TODO: base dir, dcerpc, detect, sip, smb, snmp, telnet, tftp, x509