### PR TITLE
docs: fix typos in Basic_Setup.txt

### DIFF
--- a/doc/Basic_Setup.txt
+++ b/doc/Basic_Setup.txt
@@ -56,8 +56,8 @@ the Rule_vars_section_of_the_yaml. You need to set the ip-address(es) of your
 local network at HOME_NET. It is recommended to set EXTERNAL_NET to !$HOME_NET.
 This way, every ip-address but the one set at HOME_NET will be treated as
 external. It is also possible to set EXTERNAL_NET to 'any', only the
-recommended setting is more precise and lowers the change that false positives
-will be generated. HTTP_SERVERS, SMTP_SERVERS , SQL_SERVERS , DNS_SERVERS and
+recommended setting is more precise and lowers the chance that false positives
+will be generated. HTTP_SERVERS, SMTP_SERVERS, SQL_SERVERS, DNS_SERVERS and
 TELNET_SERVERS are by default set to HOME_NET. AIM_SERVERS is by default set at
 'any'. These variables have to be set for servers on your network. All settings
 have to be set to let it have a more accurate effect.
@@ -109,7 +109,7 @@ And:
 
   tail -n 50 stats.log
 
-To make sure the information displayed is up-dated in real time, use the -f
+To make sure the information displayed is updated in real time, use the -f
 option before eve.json and stats.log:
 
   tail -f eve.json stats.log


### PR DESCRIPTION
Hi! While reading the basic setup documentation, I noticed a few minor typos that I corrected to improve readability:
- Fixed a typo where "change" was used instead of "chance" (regarding false positives).
- Removed trailing spaces before commas in the servers list.
- Corrected "up-dated" to "updated".

Have a great day!

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
