### PR TITLE
detect/transform: url_decode accepts an argument

### DIFF
--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -187,6 +187,11 @@ url_decode
 Decodes url-encoded data, ie replacing '+' with space and '%HH' with its value.
 This does not decode unicode '%uZZZZ' encoding
 
+This transform takes an optional argument.
+The only accepted value is ``only_decode_plus_after_query`` which limits the replacing
+of '+' with space to the part of the buffer after the first '?' character.
+This is useful for decoding HTTP query strings in compliance with RFC 1886 while leaving the path component of the URI unchanged.
+
 xor
 ---
 

--- a/rust/src/detect/transforms/urldecode.rs
+++ b/rust/src/detect/transforms/urldecode.rs
@@ -15,22 +15,65 @@
  * 02110-1301, USA.
  */
 
-use crate::detect::SIGMATCH_NOOPT;
+use crate::detect::SIGMATCH_OPTIONAL_OPT;
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, InspectionBuffer, SCDetectHelperTransformRegister,
     SCDetectSignatureAddTransform, SCInspectionBufferCheckAndExpand, SCInspectionBufferTruncate,
     SCTransformTableElmt, Signature,
 };
 
-use std::os::raw::{c_int, c_void};
-use std::ptr;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int, c_void};
 
 static mut G_TRANSFORM_URL_DECODE_ID: c_int = 0;
 
+#[repr(C)]
+#[derive(Debug, Default, PartialEq)]
+struct DetectTransformUrlDecodeData {
+    only_decode_plus_after_query: bool,
+}
+
+fn url_decode_parse_do(input: &str) -> Option<DetectTransformUrlDecodeData> {
+    let input = input.trim();
+    if input == "only_decode_plus_after_query" {
+        return Some(DetectTransformUrlDecodeData {
+            only_decode_plus_after_query: true,
+        });
+    }
+    return None;
+}
+
+unsafe fn url_decode_parse(c_arg: *const c_char) -> *mut DetectTransformUrlDecodeData {
+    if c_arg.is_null() {
+        let detect = DetectTransformUrlDecodeData::default();
+        return Box::into_raw(Box::new(detect));
+    }
+
+    if let Ok(arg) = CStr::from_ptr(c_arg).to_str() {
+        match url_decode_parse_do(arg) {
+            Some(detect) => return Box::into_raw(Box::new(detect)),
+            None => return std::ptr::null_mut(),
+        }
+    }
+    return std::ptr::null_mut();
+}
+
 unsafe extern "C" fn url_decode_setup(
-    _de: *mut DetectEngineCtx, s: *mut Signature, _opt: *const std::os::raw::c_char,
+    de: *mut DetectEngineCtx, s: *mut Signature, opt_str: *const c_char,
 ) -> c_int {
-    return SCDetectSignatureAddTransform(s, G_TRANSFORM_URL_DECODE_ID, ptr::null_mut());
+    let ctx = url_decode_parse(opt_str) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    let r = SCDetectSignatureAddTransform(s, G_TRANSFORM_URL_DECODE_ID, ctx);
+    if r != 0 {
+        url_decode_free(de, ctx);
+    }
+    return r;
+}
+
+unsafe extern "C" fn url_decode_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    std::mem::drop(Box::from_raw(ctx as *mut DetectTransformUrlDecodeData));
 }
 
 fn hex_value(i: u8) -> Option<u8> {
@@ -41,9 +84,12 @@ fn hex_value(i: u8) -> Option<u8> {
         _ => None,
     }
 }
-fn url_decode_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
+fn url_decode_transform_do(
+    input: &[u8], output: &mut [u8], ctx: &DetectTransformUrlDecodeData,
+) -> u32 {
     let mut state = (0u8, 0u8);
     let mut nb = 0;
+    let mut in_query = false;
     for &i in input.iter() {
         if state.0 > 0 {
             if let Some(v) = hex_value(i) {
@@ -68,9 +114,12 @@ fn url_decode_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
         } else if i == b'%' {
             state = (1u8, 0u8);
         } else {
-            if i == b'+' {
+            if i == b'+' && (!ctx.only_decode_plus_after_query || in_query) {
                 output[nb] = b' ';
             } else {
+                if i == b'?' {
+                    in_query = true;
+                }
                 output[nb] = i;
             }
             nb += 1;
@@ -88,7 +137,7 @@ fn url_decode_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 unsafe extern "C" fn url_decode_transform(
-    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, _ctx: *const c_void,
+    _det: *mut DetectEngineThreadCtx, buffer: *mut InspectionBuffer, ctx: *const c_void,
 ) {
     let input = (*buffer).inspect;
     let input_len = (*buffer).inspect_len;
@@ -103,10 +152,20 @@ unsafe extern "C" fn url_decode_transform(
         return;
     }
     let output = std::slice::from_raw_parts_mut(output, input_len as usize);
+    let ctx = cast_pointer!(ctx, DetectTransformUrlDecodeData);
 
-    let out_len = url_decode_transform_do(input, output);
+    let out_len = url_decode_transform_do(input, output, ctx);
 
     SCInspectionBufferTruncate(buffer, out_len);
+}
+
+unsafe extern "C" fn url_decode_id(data: *mut *const u8, length: *mut u32, ctx: *const c_void) {
+    if data.is_null() || length.is_null() || ctx.is_null() {
+        return;
+    }
+
+    *data = ctx as *const u8;
+    *length = std::mem::size_of::<DetectTransformUrlDecodeData>() as u32;
 }
 
 #[no_mangle]
@@ -117,11 +176,11 @@ pub unsafe extern "C" fn DetectTransformUrlDecodeRegister() {
             as *const libc::c_char,
         url: b"/rules/transforms.html#url-decode\0".as_ptr() as *const libc::c_char,
         Setup: Some(url_decode_setup),
-        flags: SIGMATCH_NOOPT,
+        flags: SIGMATCH_OPTIONAL_OPT,
         Transform: Some(url_decode_transform),
-        Free: None,
+        Free: Some(url_decode_free),
         TransformValidate: None,
-        TransformId: None,
+        TransformId: Some(url_decode_id),
     };
     G_TRANSFORM_URL_DECODE_ID = SCDetectHelperTransformRegister(&kw);
     if G_TRANSFORM_URL_DECODE_ID < 0 {
@@ -138,11 +197,14 @@ mod tests {
         let mut buf = Vec::new();
         buf.extend_from_slice(b"Suricata%20is+%27%61wesome%21%27%25%30%30%ZZ%4");
         let mut out = vec![0; buf.len()];
-        let nb = url_decode_transform_do(&buf, &mut out);
+        let ctx = DetectTransformUrlDecodeData {
+            only_decode_plus_after_query: false,
+        };
+        let nb = url_decode_transform_do(&buf, &mut out, &ctx);
         assert_eq!(&out[..nb as usize], b"Suricata is 'awesome!'%00%ZZ%4");
         // test in place
         let still_buf = unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) };
-        let nb = url_decode_transform_do(still_buf, &mut buf);
+        let nb = url_decode_transform_do(still_buf, &mut buf, &ctx);
         assert_eq!(&still_buf[..nb as usize], b"Suricata is 'awesome!'%00%ZZ%4");
     }
 }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8130

Describe changes:
- detect/transform: add an argument to url_decode: only_decode_plus_after_query

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3132

I guess the discussion should first go to the SV PR about the desired behavior