### PR TITLE
Add payload-only-classtypes filtering to suricata conf to filter payl…

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -134,6 +134,7 @@ Metadata::
 
         - alert:
             #payload: yes             # enable dumping payload in Base64
+            #payload-only-classtypes: [] # dump payload only for specified classtypes (empty = all)
             #payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             #payload-printable: yes   # enable dumping payload in printable (lossy) format
             #payload-length: yes      # enable dumping payload length, including the gaps

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -87,6 +87,7 @@ outputs:
       types:
         - alert:
             # payload: yes             # enable dumping payload in Base64
+            # payload-only-classtypes: [] # dump payload only for specified classtypes (empty = all)
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # payload-length: yes      # enable dumping payload length, including the gaps

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -93,6 +93,7 @@
 #include "reputation.h"
 
 #define DETECT_ENGINE_DEFAULT_INSPECTION_RECURSION_LIMIT 3000
+#define PAYLOAD_CLASSTYPE_ID_BITMAP_SIZE ((1 << 16) / 8)
 
 static int DetectEngineCtxLoadConf(DetectEngineCtx *);
 
@@ -2555,6 +2556,89 @@ error:
     DetectEngineDeReference(&de_ctx);
 }
 
+/**
+ * \brief Build the eve-log alert "payload-only-classtypes" filter.
+ *
+ * Looks up the configured classtype names in the eve-log alert config and
+ * resolves them to ids using the (already loaded) classification config. Each
+ * id sets its bit in a bitmap for O(1) lookup. The bitmap is only allocated
+ * when at least one classtype is configured.
+ *
+ * \retval uint8_t* bitmap of PAYLOAD_CLASSTYPE_ID_BITMAP_SIZE bytes, or NULL
+ *                  when not configured (meaning: no filtering).
+ */
+static uint8_t *DetectEnginePayloadClasstypeFilterBuild(DetectEngineCtx *de_ctx)
+{
+    SCConfNode *outputs = SCConfGetNode("outputs");
+    if (outputs == NULL) {
+        return NULL;
+    }
+
+    SCConfNode *alert = NULL;
+    SCConfNode *output;
+    TAILQ_FOREACH (output, &outputs->head, next) {
+        if (output->val == NULL || strcmp(output->val, "eve-log") != 0) {
+            continue;
+        }
+        SCConfNode *eve = SCConfNodeLookupChild(output, "eve-log");
+        SCConfNode *types = eve ? SCConfNodeLookupChild(eve, "types") : NULL;
+        if (types == NULL) {
+            continue;
+        }
+        SCConfNode *type;
+        TAILQ_FOREACH (type, &types->head, next) {
+            alert = SCConfNodeLookupChild(type, "alert");
+            if (alert != NULL) {
+                break;
+            }
+        }
+        if (alert != NULL) {
+            break;
+        }
+    }
+    if (alert == NULL) {
+        return NULL;
+    }
+
+    SCConfNode *list = SCConfNodeLookupChild(alert, "payload-only-classtypes");
+    if (list == NULL) {
+        return NULL;
+    }
+    if (!SCConfNodeIsSequence(list)) {
+        SCLogError("payload-only-classtypes must be a list of classtype names");
+        return NULL;
+    }
+
+    uint8_t *bitmap = NULL;
+    uint32_t count = 0;
+    SCConfNode *item;
+    TAILQ_FOREACH (item, &list->head, next) {
+        if (item->val == NULL || strlen(item->val) == 0) {
+            continue;
+        }
+        SCClassConfClasstype *ct = SCClassConfGetClasstype(item->val, de_ctx);
+        if (ct == NULL) {
+            SCLogWarning("unknown classtype \"%s\" in payload-only-classtypes", item->val);
+            continue;
+        }
+        if (bitmap == NULL) {
+            bitmap = SCCalloc(PAYLOAD_CLASSTYPE_ID_BITMAP_SIZE, sizeof(uint8_t));
+            if (bitmap == NULL) {
+                return NULL;
+            }
+        }
+        /* set bit class_id: byte (id / 8), bit (id % 8) */
+        const uint16_t id = ct->classtype_id;
+        bitmap[id / 8] |= (uint8_t)(1u << (id % 8));
+        count++;
+    }
+
+    if (bitmap != NULL) {
+        SCLogInfo("payload-only-classtypes filter enabled (%u classtype(s))", count);
+    }
+    return bitmap;
+}
+
 static DetectEngineCtx *DetectEngineCtxInitReal(
         enum DetectEngineType type, const char *prefix, uint32_t tenant_id)
 {
@@ -2643,6 +2727,8 @@ static DetectEngineCtx *DetectEngineCtxInitReal(
         if (SCRunmodeGet() == RUNMODE_CONF_TEST)
             goto error;
     }
+    /* classtypes are now loaded: resolve the eve-log payload-only-classtypes filter */
+    de_ctx->payload_classtype_filter = DetectEnginePayloadClasstypeFilterBuild(de_ctx);
 
     if (ActionInitConfig() < 0) {
         goto error;
@@ -2787,6 +2873,9 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
     DetectPortCleanupList(de_ctx, de_ctx->udp_priorityports);
 
     DetectBufferTypeFreeDetectEngine(de_ctx);
+    if (de_ctx->payload_classtype_filter != NULL) {
+        SCFree(de_ctx->payload_classtype_filter);
+    }
     SCClassConfDeinit(de_ctx);
     SCReferenceConfDeinit(de_ctx);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1165,6 +1165,9 @@ typedef struct DetectEngineCtx_ {
     pcre2_code *class_conf_regex;
     pcre2_match_data *class_conf_regex_match;
 
+    /* eve-log alert "payload-only-classtypes" filter */
+    uint8_t *payload_classtype_filter;
+
     /* reference config parsing */
 
     /* hash table used for holding the reference config info */

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -691,12 +691,37 @@ static void AlertJsonAddFirewall(SCJsonBuilder *jb, const Signature *s)
     SCJbClose(jb);
 }
 
+/**
+ * \brief Check if the alert's classtype is in the payload-only-classtypes filter of the detection engine.
+ *
+ * \param pa PacketAlert containing the signature
+ * \return true if payload should be extracted, false otherwise
+ */
+static bool ShouldDumpPayloadInAlert(const PacketAlert *pa, const uint8_t *payload_classtype_filter)
+{
+    bool dump;
+    if (payload_classtype_filter == NULL) {
+        // No filter configured = always extract based on payload flags (default behavior)
+        dump = true;
+    } else if (pa->s == NULL || pa->s->class_id == 0) {
+        // No classtype in alert, yet filtering is configured -> no extraction
+        dump = false;
+    } else {
+        // O(1) bitmap lookup: byte (id / 8), bit (id % 8)
+        const uint16_t id = pa->s->class_id;
+        dump = (payload_classtype_filter[id / 8] & (1u << (id % 8))) != 0;
+    }
+    return dump;
+}
+
 static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 {
     AlertJsonOutputCtx *json_output_ctx = aft->json_output_ctx;
 
     if (p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG))
         return TM_ECODE_OK;
+
+    DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
 
     const uint8_t final_action = p->alerts.cnt > 0 ? p->alerts.alerts[p->alerts.cnt - 1].action : 0;
     for (int i = 0; i < p->alerts.cnt; i++) {
@@ -800,9 +825,13 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             }
         }
 
+        bool should_dump_payload = ShouldDumpPayloadInAlert(
+                pa, de_ctx != NULL ? de_ctx->payload_classtype_filter : NULL);
+
         /* payload */
-        if (json_output_ctx->flags &
-                (LOG_JSON_PAYLOAD | LOG_JSON_PAYLOAD_BASE64 | LOG_JSON_PAYLOAD_LENGTH)) {
+        if (should_dump_payload &&
+                json_output_ctx->flags &
+                        (LOG_JSON_PAYLOAD | LOG_JSON_PAYLOAD_BASE64 | LOG_JSON_PAYLOAD_LENGTH)) {
             int stream = (p->proto == IPPROTO_TCP) ?
                          (pa->flags & (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_STREAM_MATCH) ?
                          1 : 0) : 0;
@@ -845,6 +874,10 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
         OutputJsonBuilderBuffer(tv, p, p->flow, jb, aft->ctx);
         SCJbFree(jb);
+    }
+
+    if (de_ctx != NULL) {
+        DetectEngineDeReference(&de_ctx);
     }
 
     if ((p->flags & PKT_HAS_TAG) && (json_output_ctx->flags &

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -186,6 +186,9 @@ outputs:
       types:
         - alert:
             # payload: yes             # enable dumping payload in Base64
+            # allows filtering payload extraction in EVE alerts based on the rule's classtype.
+            # If filtering enabled (list not empty, rules without any classtype will have payload filtered)
+            # payload-only-classtypes: ["list", "of", "classtypes"]
             # payload-buffer-size: 4 KiB  # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # payload-length: yes      # enable dumping payload length, including the gaps


### PR DESCRIPTION
…oad dump by classtype if needed

Use case is in an environment where we do not control the rules written but we do control the suricata configuration, and we want to prevent some payload extracted logged tothe clients for security reasons.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8245

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3023
SU_REPO=
SU_BRANCH=

Old version was here:

https://github.com/OISF/suricata/pull/15042