### PR TITLE
netflow: log applied exception policy

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -3355,6 +3355,13 @@ Fields
 * "pkts": total number of packets to client
 * "start": date of start of the flow
 * "tx_cnt": number of transactions seen in the flow (only present if flow has an application layer)
+* "exception_policy": array consisting of exception policies that have been triggered by
+  the flow:
+
+    * "target": if an exception policy was triggered, what setting exceptions
+      led to this (cf. :ref:`Exception Policy - Specific Settings<eps_settings>`).
+    * "policy": if an exception policy was triggered, what policy was applied
+      (to the flow or to any packet(s) from it).
 
 Example ::
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4821,6 +4821,21 @@
                     "type": "string",
                     "description": "Date of the end of the flow"
                 },
+                "exception_policy": {
+                    "type": "array",
+                    "properties": {
+                        "policy": {
+                            "type": "string",
+                            "description": "Which exception policy was applied"
+                        },
+                        "target": {
+                            "type": "string",
+                            "description": "What triggered the exception"
+                        }
+                    },
+                    "description":
+                            "The exception policy(ies) triggered by the flow. Not logged if none was triggered"
+                },
                 "max_ttl": {
                     "type": "integer",
                     "description": "Maximum observed Time-To-Live (TTL) value"

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -227,7 +227,7 @@ void EveAddFlow(Flow *f, SCJsonBuilder *js)
     SCJbSetString(js, "start", timebuf1);
 }
 
-static void EveExceptionPolicyLog(SCJsonBuilder *js, uint16_t flag)
+void EveExceptionPolicyLog(SCJsonBuilder *js, uint16_t flag)
 {
     if (flag & EXCEPTION_TARGET_FLAG_DEFRAG_MEMCAP) {
         SCJbStartObject(js);

--- a/src/output-json-flow.h
+++ b/src/output-json-flow.h
@@ -27,5 +27,6 @@
 void JsonFlowLogRegister(void);
 void EveAddFlow(Flow *f, SCJsonBuilder *js);
 void EveAddAppProto(Flow *f, SCJsonBuilder *js);
+void EveExceptionPolicyLog(SCJsonBuilder *js, uint16_t flag);
 
 #endif /* SURICATA_OUTPUT_JSON_FLOW_H */

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -46,6 +46,7 @@
 #include "util-logopenfile.h"
 #include "util-time.h"
 #include "output-json.h"
+#include "output-json-flow.h"
 #include "output-json-netflow.h"
 
 #include "stream-tcp-private.h"
@@ -212,6 +213,12 @@ static void NetFlowLogEveToServer(SCJsonBuilder *js, Flow *f)
         }
     }
 
+    if (f->applied_exception_policy != 0) {
+        SCJbOpenArray(js, "exception_policy");
+        EveExceptionPolicyLog(js, f->applied_exception_policy);
+        SCJbClose(js); /* close array */
+    }
+
     /* Close netflow. */
     SCJbClose(js);
 
@@ -263,6 +270,12 @@ static void NetFlowLogEveToClient(SCJsonBuilder *js, Flow *f)
         if (tx_id) {
             SCJbSetUint(js, "tx_cnt", tx_id);
         }
+    }
+
+    if (f->applied_exception_policy != 0) {
+        SCJbOpenArray(js, "exception_policy");
+        EveExceptionPolicyLog(js, f->applied_exception_policy);
+        SCJbClose(js); /* close array */
     }
 
     /* Close netflow. */


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8499

The flow logger has emitted exception_policy since the feature landed but the
netflow logger never read the same per flow state, so the field was missing from
netflow events even when a flow tripped an exception. The change exposes the
helper used by the flow logger and calls it from both the toserver and toclient
netflow records, with the schema and user guide updated in a separate
documentation commit. End to end testing with stream.midstream-policy set to
bypass confirms both events now carry the matching exception_policy entry.

Replaces #15349.

Describe changes:
- Remove the static qualifier on EveExceptionPolicyLog and declare it in
  output-json-flow.h so the netflow logger can call it.
- Emit the exception_policy array in both NetFlowLogEveToServer and
  NetFlowLogEveToClient when applied_exception_policy is non zero.
- Add the matching exception_policy entry under the netflow event in
  etc/schema.json (in the same commit as the code change).
- Document the field in the EVE format user guide.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3150
SU_REPO=
SU_BRANCH=
