### PR TITLE
Rust fmt 3836 v6.1

### DIFF
--- a/rust/src/sip/parser.rs
+++ b/rust/src/sip/parser.rs
@@ -211,7 +211,12 @@ fn header_value(i: &[u8]) -> IResult<&[u8], &str> {
 
 #[inline]
 fn hcolon(i: &[u8]) -> IResult<&[u8], char> {
-    delimited(take_while(|c: u8| c.is_space()), char(':'), take_while(|c: u8| c.is_space())).parse(i)
+    delimited(
+        take_while(|c: u8| c.is_space()),
+        char(':'),
+        take_while(|c: u8| c.is_space()),
+    )
+    .parse(i)
 }
 
 fn message_header(i: &[u8]) -> IResult<&[u8], Header> {

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -157,9 +157,7 @@ impl SIPState {
         }
     }
 
-    fn parse_request_tcp(
-        &mut self, flow: *mut Flow, stream_slice: StreamSlice,
-    ) -> AppLayerResult {
+    fn parse_request_tcp(&mut self, flow: *mut Flow, stream_slice: StreamSlice) -> AppLayerResult {
         let input = stream_slice.as_slice();
         if input.is_empty() {
             return AppLayerResult::ok();
@@ -256,9 +254,7 @@ impl SIPState {
         }
     }
 
-    fn parse_response_tcp(
-        &mut self, flow: *mut Flow, stream_slice: StreamSlice,
-    ) -> AppLayerResult {
+    fn parse_response_tcp(&mut self, flow: *mut Flow, stream_slice: StreamSlice) -> AppLayerResult {
         let input = stream_slice.as_slice();
         if input.is_empty() {
             return AppLayerResult::ok();

--- a/rust/src/telnet/mod.rs
+++ b/rust/src/telnet/mod.rs
@@ -17,5 +17,5 @@
 
 //! Telnet application layer and parser module.
 
-pub mod telnet;
 mod parser;
+pub mod telnet;

--- a/rust/src/telnet/parser.rs
+++ b/rust/src/telnet/parser.rs
@@ -16,12 +16,12 @@
  */
 
 use crate::common::nom8::take_until_and_consume;
-use nom8::combinator::peek;
 use nom8::bytes::complete::take;
-use nom8::{IResult, Parser};
-use nom8::number::streaming::le_u8;
 use nom8::bytes::streaming::tag;
-use nom8::bytes::streaming::{take_until};
+use nom8::bytes::streaming::take_until;
+use nom8::combinator::peek;
+use nom8::number::streaming::le_u8;
+use nom8::{IResult, Parser};
 
 pub fn peek_message_is_ctl(i: &[u8]) -> IResult<&[u8], bool> {
     let (i, v) = peek(le_u8).parse(i)?;
@@ -33,11 +33,11 @@ pub enum TelnetMessageType<'a> {
     Data(&'a [u8]),
 }
 
-pub fn parse_ctl_suboption<'a>(i: &'a[u8], full: &'a[u8]) -> IResult<&'a[u8], &'a[u8]> {
+pub fn parse_ctl_suboption<'a>(i: &'a [u8], full: &'a [u8]) -> IResult<&'a [u8], &'a [u8]> {
     let (i, _sc) = le_u8(i)?;
     let tag: &[u8] = b"\xff\xf0";
     let (i, x) = take_until(tag).parse(i)?;
-    let o = &full[..(x.len()+3)];
+    let o = &full[..(x.len() + 3)];
     Ok((i, o))
 }
 

--- a/rust/src/telnet/telnet.rs
+++ b/rust/src/telnet/telnet.rs
@@ -15,18 +15,18 @@
  * 02110-1301, USA.
  */
 
-use std;
-use crate::core::{ALPROTO_UNKNOWN, IPPROTO_TCP};
+use super::parser;
 use crate::applayer::{self, *};
+use crate::core::{ALPROTO_UNKNOWN, IPPROTO_TCP};
 use crate::flow::Flow;
 use crate::frames::*;
-use std::ffi::CString;
 use nom8::IResult;
+use std;
+use std::ffi::CString;
 use suricata_sys::sys::{
     AppLayerParserState, AppProto, SCAppLayerParserConfParserEnabled,
     SCAppLayerParserStateIssetFlag, SCAppLayerProtoDetectConfProtoDetectionEnabled,
 };
-use super::parser;
 
 static mut ALPROTO_TELNET: AppProto = ALPROTO_UNKNOWN;
 
@@ -192,7 +192,7 @@ impl TelnetState {
                             TelnetFrameType::Data as u8,
                             None,
                         )
-                    // app-layer-frame-documentation tag end: parse_request
+                        // app-layer-frame-documentation tag end: parse_request
                     };
                     self.request_specific_frame = f;
                 }
@@ -254,7 +254,9 @@ impl TelnetState {
         return AppLayerResult::ok();
     }
 
-    fn parse_response(&mut self, flow: *mut Flow, stream_slice: &StreamSlice, input: &[u8]) -> AppLayerResult {
+    fn parse_response(
+        &mut self, flow: *mut Flow, stream_slice: &StreamSlice, input: &[u8],
+    ) -> AppLayerResult {
         // We're not interested in empty responses.
         if input.is_empty() {
             return AppLayerResult::ok();
@@ -274,14 +276,35 @@ impl TelnetState {
         let mut start = input;
         while !start.is_empty() {
             if self.response_frame.is_none() {
-                self.response_frame = Frame::new(flow, stream_slice, start, -1_i64, TelnetFrameType::Pdu as u8, None);
+                self.response_frame = Frame::new(
+                    flow,
+                    stream_slice,
+                    start,
+                    -1_i64,
+                    TelnetFrameType::Pdu as u8,
+                    None,
+                );
             }
             if self.response_specific_frame.is_none() {
                 if let Ok((_, is_ctl)) = parser::peek_message_is_ctl(start) {
                     self.response_specific_frame = if is_ctl {
-                        Frame::new(flow, stream_slice, start, -1_i64, TelnetFrameType::Ctl as u8, None)
+                        Frame::new(
+                            flow,
+                            stream_slice,
+                            start,
+                            -1_i64,
+                            TelnetFrameType::Ctl as u8,
+                            None,
+                        )
                     } else {
-                        Frame::new(flow, stream_slice, start, -1_i64, TelnetFrameType::Data as u8, None)
+                        Frame::new(
+                            flow,
+                            stream_slice,
+                            start,
+                            -1_i64,
+                            TelnetFrameType::Data as u8,
+                            None,
+                        )
                     };
                 }
             }
@@ -308,37 +331,34 @@ impl TelnetState {
 
                     if let parser::TelnetMessageType::Data(d) = response {
                         match self.state {
-                            TelnetProtocolState::Idle |
-                            TelnetProtocolState::AuthFail => {
+                            TelnetProtocolState::Idle | TelnetProtocolState::AuthFail => {
                                 self.state = TelnetProtocolState::LoginSent;
-                            },
+                            }
                             TelnetProtocolState::LoginRecv => {
                                 self.state = TelnetProtocolState::PasswdSent;
-                            },
+                            }
                             TelnetProtocolState::PasswdRecv => {
                                 if let Ok(message) = std::str::from_utf8(d) {
                                     match message {
                                         "Login incorrect" => {
                                             SCLogDebug!("LOGIN FAILED");
                                             self.state = TelnetProtocolState::AuthFail;
-                                        },
-                                        "" => {
-
-                                        },
+                                        }
+                                        "" => {}
                                         &_ => {
                                             SCLogDebug!("LOGIN OK");
                                             self.state = TelnetProtocolState::AuthOk;
-                                        },
+                                        }
                                     }
                                 }
-                            },
+                            }
                             TelnetProtocolState::AuthOk => {
                                 let _message = std::str::from_utf8(d);
                                 if let Ok(_message) = _message {
                                     SCLogDebug!("<= {}", _message);
                                 }
-                            },
-                            _ => {},
+                            }
+                            _ => {}
                         }
                     } else if let parser::TelnetMessageType::Control(_c) = response {
                         SCLogDebug!("response {:?}", _c);
@@ -382,11 +402,7 @@ fn probe(input: &[u8]) -> IResult<&[u8], ()> {
 
 /// C entry point for a probing parser.
 unsafe extern "C" fn telnet_probing_parser(
-    _flow: *const Flow,
-    _direction: u8,
-    input: *const u8,
-    input_len: u32,
-    _rdir: *mut u8
+    _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
     // Need at least 2 bytes.
     if input_len > 1 && !input.is_null() {
@@ -399,7 +415,9 @@ unsafe extern "C" fn telnet_probing_parser(
     return ALPROTO_UNKNOWN;
 }
 
-extern "C" fn telnet_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
+extern "C" fn telnet_state_new(
+    _orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto,
+) -> *mut std::os::raw::c_void {
     let state = TelnetState::new();
     let boxed = Box::new(state);
     return Box::into_raw(boxed) as *mut std::os::raw::c_void;
@@ -409,20 +427,14 @@ unsafe extern "C" fn telnet_state_free(state: *mut std::os::raw::c_void) {
     std::mem::drop(Box::from_raw(state as *mut TelnetState));
 }
 
-unsafe extern "C" fn telnet_state_tx_free(
-    state: *mut std::os::raw::c_void,
-    tx_id: u64,
-) {
+unsafe extern "C" fn telnet_state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
     let state = cast_pointer!(state, TelnetState);
     state.free_tx(tx_id);
 }
 
 unsafe extern "C" fn telnet_parse_request(
-    flow: *mut Flow,
-    state: *mut std::os::raw::c_void,
-    pstate: *mut AppLayerParserState,
-    stream_slice: StreamSlice,
-    _data: *mut std::os::raw::c_void
+    flow: *mut Flow, state: *mut std::os::raw::c_void, pstate: *mut AppLayerParserState,
+    stream_slice: StreamSlice, _data: *mut std::os::raw::c_void,
 ) -> AppLayerResult {
     let eof = SCAppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TS) > 0;
 
@@ -445,11 +457,8 @@ unsafe extern "C" fn telnet_parse_request(
 }
 
 unsafe extern "C" fn telnet_parse_response(
-    flow: *mut Flow,
-    state: *mut std::os::raw::c_void,
-    pstate: *mut AppLayerParserState,
-    stream_slice: StreamSlice,
-    _data: *mut std::os::raw::c_void
+    flow: *mut Flow, state: *mut std::os::raw::c_void, pstate: *mut AppLayerParserState,
+    stream_slice: StreamSlice, _data: *mut std::os::raw::c_void,
 ) -> AppLayerResult {
     let _eof = SCAppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TC) > 0;
     let state = cast_pointer!(state, TelnetState);
@@ -466,8 +475,7 @@ unsafe extern "C" fn telnet_parse_response(
 }
 
 unsafe extern "C" fn telnet_state_get_tx(
-    state: *mut std::os::raw::c_void,
-    tx_id: u64,
+    state: *mut std::os::raw::c_void, tx_id: u64,
 ) -> *mut std::os::raw::c_void {
     let state = cast_pointer!(state, TelnetState);
     match state.get_tx(tx_id) {
@@ -480,16 +488,13 @@ unsafe extern "C" fn telnet_state_get_tx(
     }
 }
 
-unsafe extern "C" fn telnet_state_get_tx_count(
-    state: *mut std::os::raw::c_void,
-) -> u64 {
+unsafe extern "C" fn telnet_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
     let state = cast_pointer!(state, TelnetState);
     return state.tx_id;
 }
 
 unsafe extern "C" fn telnet_tx_get_alstate_progress(
-    tx: *mut std::os::raw::c_void,
-    _direction: u8,
+    tx: *mut std::os::raw::c_void, _direction: u8,
 ) -> std::os::raw::c_int {
     let _tx = cast_pointer!(tx, TelnetTransaction);
     // TODO
@@ -524,7 +529,7 @@ pub unsafe extern "C" fn SCRegisterTelnetParser() {
         tx_comp_st_tc: 1,
         tx_get_progress: telnet_tx_get_alstate_progress,
         get_eventinfo: Some(TelnetEvent::get_event_info),
-        get_eventinfo_byid : Some(TelnetEvent::get_event_info_by_id),
+        get_eventinfo_byid: Some(TelnetEvent::get_event_info_by_id),
         localstorage_new: None,
         localstorage_free: None,
         get_tx_files: None,
@@ -537,23 +542,14 @@ pub unsafe extern "C" fn SCRegisterTelnetParser() {
         get_frame_name_by_id: Some(TelnetFrameType::ffi_name_from_id),
         get_state_id_by_name: None,
         get_state_name_by_id: None,
-
     };
 
     let ip_proto_str = CString::new("tcp").unwrap();
 
-    if SCAppLayerProtoDetectConfProtoDetectionEnabled(
-        ip_proto_str.as_ptr(),
-        parser.name,
-    ) != 0
-    {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = applayer_register_protocol_detection(&parser, 1);
         ALPROTO_TELNET = alproto;
-        if SCAppLayerParserConfParserEnabled(
-            ip_proto_str.as_ptr(),
-            parser.name,
-        ) != 0
-        {
+        if SCAppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
             let _ = AppLayerRegisterParser(&parser, alproto);
         }
         SCLogDebug!("Rust telnet parser registered.");

--- a/rust/src/tftp/mod.rs
+++ b/rust/src/tftp/mod.rs
@@ -19,5 +19,5 @@
 
 // written by Clément Galland <clement.galland@epita.fr>
 
-pub mod tftp;
 pub mod log;
+pub mod tftp;

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -17,34 +17,34 @@
 
 // written by Clément Galland <clement.galland@epita.fr>
 
-use std::str;
-use std;
+use nom8::bytes::streaming::{tag, take_while};
+use nom8::combinator::map_res;
+use nom8::number::streaming::be_u8;
 use nom8::IResult;
 use nom8::Parser;
-use nom8::combinator::map_res;
-use nom8::bytes::streaming::{tag, take_while};
-use nom8::number::streaming::be_u8;
+use std;
+use std::str;
 
-use crate::applayer::{AppLayerTxData, AppLayerStateData};
+use crate::applayer::{AppLayerStateData, AppLayerTxData};
 
-const READREQUEST:  u8 = 1;
+const READREQUEST: u8 = 1;
 const WRITEREQUEST: u8 = 2;
-const DATA:         u8 = 3;
-const ACK:          u8 = 4;
-const ERROR:        u8 = 5;
+const DATA: u8 = 3;
+const ACK: u8 = 4;
+const ERROR: u8 = 5;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct TFTPTransaction {
-    pub opcode : u8,
-    pub filename : String,
-    pub mode : String,
+    pub opcode: u8,
+    pub filename: String,
+    pub mode: String,
     id: u64,
     tx_data: AppLayerTxData,
 }
 
 pub struct TFTPState {
     state_data: AppLayerStateData,
-    pub transactions : Vec<TFTPTransaction>,
+    pub transactions: Vec<TFTPTransaction>,
     /// tx counter for assigning incrementing id's to tx's
     tx_id: u64,
 }
@@ -64,32 +64,36 @@ impl TFTPState {
 }
 
 impl TFTPTransaction {
-    pub fn new(opcode : u8, filename : String, mode : String) -> TFTPTransaction {
+    pub fn new(opcode: u8, filename: String, mode: String) -> TFTPTransaction {
         TFTPTransaction {
             opcode,
             filename,
-            mode : mode.to_lowercase(),
-            id : 0,
+            mode: mode.to_lowercase(),
+            id: 0,
             tx_data: AppLayerTxData::new(),
         }
     }
     pub fn is_mode_ok(&self) -> bool {
         match self.mode.as_str() {
             "netascii" | "mail" | "octet" => true,
-            _ => false
+            _ => false,
         }
     }
     pub fn is_opcode_ok(&self) -> bool {
         match self.opcode {
             READREQUEST | WRITEREQUEST | ACK | DATA | ERROR => true,
-            _ => false
+            _ => false,
         }
     }
 }
 
 #[no_mangle]
 pub extern "C" fn SCTftpStateAlloc() -> *mut std::os::raw::c_void {
-    let state = TFTPState { state_data: AppLayerStateData::default(), transactions : Vec::new(), tx_id: 0, };
+    let state = TFTPState {
+        state_data: AppLayerStateData::default(),
+        transactions: Vec::new(),
+        tx_id: 0,
+    };
     let boxed = Box::new(state);
     return Box::into_raw(boxed) as *mut _;
 }
@@ -100,17 +104,15 @@ pub extern "C" fn SCTftpStateFree(state: *mut std::os::raw::c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn SCTftpStateTxFree(state: &mut TFTPState,
-                                        tx_id: u64) {
+pub extern "C" fn SCTftpStateTxFree(state: &mut TFTPState, tx_id: u64) {
     state.free_tx(tx_id);
 }
 
 #[no_mangle]
-pub extern "C" fn SCTftpGetTx(state: &mut TFTPState,
-                                    tx_id: u64) -> *mut std::os::raw::c_void {
+pub extern "C" fn SCTftpGetTx(state: &mut TFTPState, tx_id: u64) -> *mut std::os::raw::c_void {
     match state.get_tx_by_id(tx_id) {
         Some(tx) => tx as *const _ as *mut _,
-        None     => std::ptr::null_mut(),
+        None => std::ptr::null_mut(),
     }
 }
 
@@ -120,10 +122,7 @@ pub extern "C" fn SCTftpGetTxCnt(state: &mut TFTPState) -> u64 {
 }
 
 fn getstr(i: &[u8]) -> IResult<&[u8], &str> {
-    map_res(
-        take_while(|c| c != 0),
-        str::from_utf8
-    ).parse(i)
+    map_res(take_while(|c| c != 0), str::from_utf8).parse(i)
 }
 
 fn tftp_request(slice: &[u8]) -> IResult<&[u8], TFTPTransaction> {
@@ -132,10 +131,10 @@ fn tftp_request(slice: &[u8]) -> IResult<&[u8], TFTPTransaction> {
     let (i, filename) = getstr(i)?;
     let (i, _) = tag(&[0u8][..]).parse(i)?;
     let (i, mode) = getstr(i)?;
-    Ok((i,
-        TFTPTransaction::new(opcode, String::from(filename), String::from(mode))
-       )
-      )
+    Ok((
+        i,
+        TFTPTransaction::new(opcode, String::from(filename), String::from(mode)),
+    ))
 }
 
 fn parse_tftp_request(input: &[u8]) -> Option<TFTPTransaction> {
@@ -156,9 +155,9 @@ fn parse_tftp_request(input: &[u8]) -> Option<TFTPTransaction> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCTftpParseRequest(state: &mut TFTPState,
-                                  input: *const u8,
-                                  len: u32) -> i64 {
+pub unsafe extern "C" fn SCTftpParseRequest(
+    state: &mut TFTPState, input: *const u8, len: u32,
+) -> i64 {
     let buf = std::slice::from_raw_parts(input, len as usize);
     match parse_tftp_request(buf) {
         Some(mut tx) => {
@@ -166,27 +165,23 @@ pub unsafe extern "C" fn SCTftpParseRequest(state: &mut TFTPState,
             tx.id = state.tx_id;
             state.transactions.push(tx);
             0
-        },
-        None => {
-           -1
         }
+        None => -1,
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SCTftpGetTxData(
-    tx: *mut std::os::raw::c_void)
-    -> *mut suricata_sys::sys::AppLayerTxData
-{
+    tx: *mut std::os::raw::c_void,
+) -> *mut suricata_sys::sys::AppLayerTxData {
     let tx = cast_pointer!(tx, TFTPTransaction);
     return &mut tx.tx_data.0;
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SCTftpGetStateData(
-    state: *mut std::os::raw::c_void)
-    -> *mut AppLayerStateData
-{
+    state: *mut std::os::raw::c_void,
+) -> *mut AppLayerStateData {
     let state = cast_pointer!(state, TFTPState);
     return &mut state.state_data;
 }
@@ -195,25 +190,28 @@ pub unsafe extern "C" fn SCTftpGetStateData(
 mod test {
     use super::*;
     static READ_REQUEST: [u8; 20] = [
-            0x00, 0x01, 0x72, 0x66, 0x63, 0x31, 0x33, 0x35, 0x30, 0x2e, 0x74, 0x78, 0x74, 0x00, 0x6f, 0x63, 0x74, 0x65, 0x74, 0x00,
+        0x00, 0x01, 0x72, 0x66, 0x63, 0x31, 0x33, 0x35, 0x30, 0x2e, 0x74, 0x78, 0x74, 0x00, 0x6f,
+        0x63, 0x74, 0x65, 0x74, 0x00,
     ];
     /* filename not terminated */
     static READ_REQUEST_INVALID_1: [u8; 20] = [
-            0x00, 0x01, 0x72, 0x66, 0x63, 0x31, 0x33, 0x35, 0x30, 0x2e, 0x74, 0x78, 0x74, 0x6e, 0x6f, 0x63, 0x74, 0x65, 0x74, 0x00,
+        0x00, 0x01, 0x72, 0x66, 0x63, 0x31, 0x33, 0x35, 0x30, 0x2e, 0x74, 0x78, 0x74, 0x6e, 0x6f,
+        0x63, 0x74, 0x65, 0x74, 0x00,
     ];
     /* garbage */
-    static READ_REQUEST_INVALID_2: [u8; 3] = [
-            0xff, 0xff, 0xff,
-    ];
+    static READ_REQUEST_INVALID_2: [u8; 3] = [0xff, 0xff, 0xff];
     static WRITE_REQUEST: [u8; 20] = [
-            0x00, 0x02, 0x72, 0x66, 0x63, 0x31, 0x33, 0x35, 0x30, 0x2e, 0x74, 0x78, 0x74, 0x00, 0x6f, 0x63, 0x74, 0x65, 0x74, 0x00,
+        0x00, 0x02, 0x72, 0x66, 0x63, 0x31, 0x33, 0x35, 0x30, 0x2e, 0x74, 0x78, 0x74, 0x00, 0x6f,
+        0x63, 0x74, 0x65, 0x74, 0x00,
     ];
     /* filename not terminated */
     static INVALID_OPCODE: [u8; 20] = [
-            0x00, 0x06, 0x72, 0x66, 0x63, 0x31, 0x33, 0x35, 0x30, 0x2e, 0x74, 0x78, 0x74, 0x6e, 0x6f, 0x63, 0x74, 0x65, 0x74, 0x00,
+        0x00, 0x06, 0x72, 0x66, 0x63, 0x31, 0x33, 0x35, 0x30, 0x2e, 0x74, 0x78, 0x74, 0x6e, 0x6f,
+        0x63, 0x74, 0x65, 0x74, 0x00,
     ];
     static INVALID_MODE: [u8; 20] = [
-            0x00, 0x01, 0x72, 0x66, 0x63, 0x31, 0x33, 0x35, 0x30, 0x2e, 0x74, 0x78, 0x74, 0x00, 0x63, 0x63, 0x63, 0x63, 0x63, 0x00,
+        0x00, 0x01, 0x72, 0x66, 0x63, 0x31, 0x33, 0x35, 0x30, 0x2e, 0x74, 0x78, 0x74, 0x00, 0x63,
+        0x63, 0x63, 0x63, 0x63, 0x00,
     ];
 
     #[test]
@@ -263,7 +261,6 @@ mod test {
 
     #[test]
     pub fn test_parse_tftp_invalid_mode() {
-
         assert_eq!(None, parse_tftp_request(&INVALID_MODE[..]));
     }
 }

--- a/rust/src/x509/mod.rs
+++ b/rust/src/x509/mod.rs
@@ -19,13 +19,13 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
+use crate::x509::GeneralName;
 use nom7::Err;
 use std;
 use std::fmt;
 use x509_parser::prelude::*;
-use crate::x509::GeneralName;
-mod time;
 mod log;
+mod time;
 
 #[repr(u32)]
 pub enum X509DecodeError {
@@ -54,7 +54,7 @@ impl fmt::Display for SCGeneralName<'_> {
             GeneralName::DNSName(s) => write!(f, "{}", s),
             GeneralName::URI(s) => write!(f, "{}", s),
             GeneralName::IPAddress(s) => write!(f, "{:?}", s),
-            _ => write!(f, "{}", self.0)
+            _ => write!(f, "{}", self.0),
         }
     }
 }
@@ -66,9 +66,7 @@ impl fmt::Display for SCGeneralName<'_> {
 /// input must be a valid buffer of at least input_len bytes
 #[no_mangle]
 pub unsafe extern "C" fn SCX509Decode(
-    input: *const u8,
-    input_len: u32,
-    err_code: *mut u32,
+    input: *const u8, input_len: u32, err_code: *mut u32,
 ) -> *mut X509 {
     let slice = std::slice::from_raw_parts(input, input_len as usize);
     let res = X509Certificate::from_der(slice);
@@ -83,7 +81,9 @@ pub unsafe extern "C" fn SCX509Decode(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCX509GetSubject(ptr: *const X509, subject_name: *mut *mut u8, subject_len: *mut u32) {
+pub unsafe extern "C" fn SCX509GetSubject(
+    ptr: *const X509, subject_name: *mut *mut u8, subject_len: *mut u32,
+) {
     if ptr.is_null() {
         *subject_len = 0;
         *subject_name = std::ptr::null_mut();
@@ -113,7 +113,9 @@ pub unsafe extern "C" fn SCX509GetSubjectAltNameLen(ptr: *const X509) -> u16 {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCX509GetSubjectAltNameAt(ptr: *const X509, idx: u16, san: *mut *mut u8, san_len: *mut u32) {
+pub unsafe extern "C" fn SCX509GetSubjectAltNameAt(
+    ptr: *const X509, idx: u16, san: *mut *mut u8, san_len: *mut u32,
+) {
     if ptr.is_null() {
         *san_len = 0;
         *san = std::ptr::null_mut();
@@ -131,7 +133,9 @@ pub unsafe extern "C" fn SCX509GetSubjectAltNameAt(ptr: *const X509, idx: u16, s
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCX509GetIssuer(ptr: *const X509, issuer_name: *mut *mut u8, issuer_len: *mut u32) {
+pub unsafe extern "C" fn SCX509GetIssuer(
+    ptr: *const X509, issuer_name: *mut *mut u8, issuer_len: *mut u32,
+) {
     if ptr.is_null() {
         *issuer_len = 0;
         *issuer_name = std::ptr::null_mut();
@@ -145,7 +149,9 @@ pub unsafe extern "C" fn SCX509GetIssuer(ptr: *const X509, issuer_name: *mut *mu
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCX509GetSerial(ptr: *const X509, serial_num: *mut *mut u8, serial_len: *mut u32) {
+pub unsafe extern "C" fn SCX509GetSerial(
+    ptr: *const X509, serial_num: *mut *mut u8, serial_len: *mut u32,
+) {
     if ptr.is_null() {
         *serial_len = 0;
         *serial_num = std::ptr::null_mut();
@@ -166,9 +172,7 @@ pub unsafe extern "C" fn SCX509GetSerial(ptr: *const X509, serial_num: *mut *mut
 /// ptr must be a valid object obtained using `SCX509Decode`
 #[no_mangle]
 pub unsafe extern "C" fn SCX509GetValidity(
-    ptr: *const X509,
-    not_before: *mut i64,
-    not_after: *mut i64,
+    ptr: *const X509, not_before: *mut i64, not_after: *mut i64,
 ) -> i32 {
     if ptr.is_null() {
         return -1;
@@ -199,7 +203,10 @@ pub unsafe extern "C" fn SCX509ArrayFree(ptr: *mut u8, len: u32) {
     if ptr.is_null() {
         return;
     }
-    drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len as usize)));
+    drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+        ptr,
+        len as usize,
+    )));
 }
 
 fn x509_parse_error_to_errcode(e: &Err<X509Error>) -> X509DecodeError {

--- a/scripts/rustfmt.sh
+++ b/scripts/rustfmt.sh
@@ -40,4 +40,4 @@ rustfmt --check rust/src/dns/*.rs rust/src/applayertemplate/*.rs rust/src/asn1/*
     rust/src/dhcp/*.rs rust/src/krb/*.rs rust/src/mdns/*.rs rust/src/pop3/*.rs \
     rust/src/http2/*.rs rust/src/ike/*.rs rust/src/modbus/*.rs rust/src/mqtt/*.rs \
     rust/src/nfs/*.rs rust/src/pgsql/*.rs rust/src/rdp/*.rs rust/src/sdp/*.rs \
-    rust/src/sip/*.rs rust/src/telnet/*.rs rust/src/x509/*.rs
+    rust/src/sip/*.rs rust/src/telnet/*.rs rust/src/tftp/*.rs rust/src/x509/*.rs

--- a/scripts/rustfmt.sh
+++ b/scripts/rustfmt.sh
@@ -40,4 +40,4 @@ rustfmt --check rust/src/dns/*.rs rust/src/applayertemplate/*.rs rust/src/asn1/*
     rust/src/dhcp/*.rs rust/src/krb/*.rs rust/src/mdns/*.rs rust/src/pop3/*.rs \
     rust/src/http2/*.rs rust/src/ike/*.rs rust/src/modbus/*.rs rust/src/mqtt/*.rs \
     rust/src/nfs/*.rs rust/src/pgsql/*.rs rust/src/rdp/*.rs rust/src/sdp/*.rs \
-    rust/src/sip/*.rs
+    rust/src/sip/*.rs rust/src/telnet/*.rs

--- a/scripts/rustfmt.sh
+++ b/scripts/rustfmt.sh
@@ -40,4 +40,4 @@ rustfmt --check rust/src/dns/*.rs rust/src/applayertemplate/*.rs rust/src/asn1/*
     rust/src/dhcp/*.rs rust/src/krb/*.rs rust/src/mdns/*.rs rust/src/pop3/*.rs \
     rust/src/http2/*.rs rust/src/ike/*.rs rust/src/modbus/*.rs rust/src/mqtt/*.rs \
     rust/src/nfs/*.rs rust/src/pgsql/*.rs rust/src/rdp/*.rs rust/src/sdp/*.rs \
-    rust/src/sip/*.rs rust/src/telnet/*.rs
+    rust/src/sip/*.rs rust/src/telnet/*.rs rust/src/x509/*.rs

--- a/scripts/rustfmt.sh
+++ b/scripts/rustfmt.sh
@@ -39,4 +39,5 @@ rustfmt --check rust/src/dns/*.rs rust/src/applayertemplate/*.rs rust/src/asn1/*
     rust/src/rfb/*.rs rust/src/ssh/*.rs rust/src/utils/*.rs rust/src/websocket/*.rs \
     rust/src/dhcp/*.rs rust/src/krb/*.rs rust/src/mdns/*.rs rust/src/pop3/*.rs \
     rust/src/http2/*.rs rust/src/ike/*.rs rust/src/modbus/*.rs rust/src/mqtt/*.rs \
-    rust/src/nfs/*.rs rust/src/pgsql/*.rs rust/src/rdp/*.rs rust/src/sdp/*.rs
+    rust/src/nfs/*.rs rust/src/pgsql/*.rs rust/src/rdp/*.rs rust/src/sdp/*.rs \
+    rust/src/sip/*.rs


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/3836

Describe changes:
- ci: move rustfmt to its helper script
- rust: format rdp and sdp files

https://github.com/OISF/suricata/pull/15510 next round

Still TODO the bigger ones: base dir, dcerpc, detect, smb, snmp