### PR TITLE
fuzz/iprep: initialize to 0 buffer buffer before writing to it

### DIFF
--- a/src/tests/fuzz/fuzz_iprep.c
+++ b/src/tests/fuzz/fuzz_iprep.c
@@ -69,7 +69,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     size_t ipreplist_len = size - split2 - 1;
 
     /* Build the full signature string */
-    char sig_buf[DETECT_MAX_RULE_SIZE];
+    char sig_buf[DETECT_MAX_RULE_SIZE] = { 0 };
     size_t sig_len = strlcat(sig_buf, "alert ip any any -> any any (iprep:", sizeof(sig_buf));
     if (sig_len + kw_len >= DETECT_MAX_RULE_SIZE) {
         return 0;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None, simple fixup for https://issues.oss-fuzz.com/issues/519820734

Describe changes:
- fuzz/iprep: initialize to 0 buffer buffer before writing to it
