### PR TITLE
detect: guard rate filter callback registration, return bool on failure

### DIFF
--- a/examples/lib/custom/main.c
+++ b/examples/lib/custom/main.c
@@ -253,7 +253,11 @@ int main(int argc, char **argv)
      * ThreadVars will be ready. */
     SuricataInit();
 
-    SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    if (DetectEngineEnabled()) {
+        SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    } else {
+        SCLogWarning("detection engine not enabled, rate filter callback not registered");
+    }
 
     /* Spawn our worker threads. */
     pthread_t worker;

--- a/examples/lib/live/main.c
+++ b/examples/lib/live/main.c
@@ -306,7 +306,11 @@ int main(int argc, char **argv)
      * ThreadVars will be ready. */
     SuricataInit();
 
-    SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    if (DetectEngineEnabled()) {
+        SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    } else {
+        SCLogWarning("detection engine not enabled, rate filter callback not registered");
+    }
 
     /* Spawn our worker threads, one for each interface. */
     pthread_t workers[MAX_INTERFACES];

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -5203,12 +5203,17 @@ void DetectLowerSetupCallback(
     }
 }
 
-void SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc fn, void *arg)
+bool SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc fn, void *arg)
 {
     DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    if (de_ctx == NULL) {
+        SCLogError("no detection engine available for rate filter callback registration");
+        return false;
+    }
     de_ctx->RateFilterCallback = fn;
     de_ctx->rate_filter_callback_arg = arg;
     DetectEngineDeReference(&de_ctx);
+    return true;
 }
 
 int DetectEngineThreadCtxGetJsonContext(DetectEngineThreadCtx *det_ctx)

--- a/src/detect.h
+++ b/src/detect.h
@@ -1214,7 +1214,7 @@ typedef struct DetectEngineCtx_ {
  * This callback is added to the current detection engine and will be
  * copied to all future detection engines over rule reloads.
  */
-void SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc cb, void *arg);
+bool SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc cb, void *arg);
 
 /* Engine groups profiles (low, medium, high, custom) */
 enum {


### PR DESCRIPTION
## Summary

`SCDetectEngineRegisterRateFilterCallback()` calls `DetectEngineGetCurrent()` and dereferences the result unconditionally. `DetectEngineGetCurrent()` can return NULL when a plugin calls this API before the detect engine is initialized — the bundled library examples do exactly this.

**Fixes:**
- Added NULL guard with `SCLogError` and `return false` so callers can detect registration failure
- Changed return type `void` → `bool`
- Updated both bundled examples (`examples/lib/custom/main.c`, `examples/lib/live/main.c`) to check `DetectEngineEnabled()` first and log a `SCLogWarning` when detection is disabled

Flagged by Svace static analyzer and confirmed by `gcc -fanalyzer` (see #15380).

This supersedes #15380 (new PR per contribution workflow, rebased on current main, all reviewer feedback addressed).

Ticket: 8560