### PR TITLE
detect/parse: guard HashListTableLookup results in duplicate sig check

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3390,7 +3390,12 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
             sw_tmp.s = de_ctx->sig_list;
             sw_old = HashListTableLookup(de_ctx->dup_sig_hash_table,
                                          (void *)&sw_tmp, 0);
-            /* sw_old == NULL case is impossible */
+            /* sw_old == NULL case is impossible: every sig in sig_list
+             * must have a corresponding dup_sig_hash_table entry */
+            DEBUG_VALIDATE_BUG_ON(sw_old == NULL);
+            if (unlikely(sw_old == NULL)) {
+                goto end;
+            }
             sw_old->s_prev = sig;
         }
 
@@ -3425,7 +3430,10 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
         if (sw_temp.s != NULL) {
             sw_next = HashListTableLookup(de_ctx->dup_sig_hash_table,
                                           (void *)&sw_temp, 0);
-            sw_next->s_prev = sw_dup->s_prev;
+            DEBUG_VALIDATE_BUG_ON(sw_next == NULL);
+            if (likely(sw_next != NULL)) {
+                sw_next->s_prev = sw_dup->s_prev;
+            }
         }
         SigFree(de_ctx, sw_dup->s);
     } else {
@@ -3455,7 +3463,10 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
         if (sw_temp.s != NULL) {
             sw_next = HashListTableLookup(de_ctx->dup_sig_hash_table,
                                           (void *)&sw_temp, 0);
-            sw_next->s_prev = sw_dup->s_prev;
+            DEBUG_VALIDATE_BUG_ON(sw_next == NULL);
+            if (likely(sw_next != NULL)) {
+                sw_next->s_prev = sw_dup->s_prev;
+            }
         }
         SigFree(de_ctx, sw_dup->s);
     }
@@ -3470,7 +3481,8 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
         sw_tmp.s = de_ctx->sig_list;
         SigDuplWrapper *sw_old = HashListTableLookup(de_ctx->dup_sig_hash_table,
                                                      (void *)&sw_tmp, 0);
-        if (sw_old->s != sw_dup->s) {
+        DEBUG_VALIDATE_BUG_ON(sw_old == NULL);
+        if (likely(sw_old != NULL) && sw_old->s != sw_dup->s) {
             // Link on top of the list if there was another element
             sw_old->s_prev = sig;
         }


### PR DESCRIPTION
Ticket: 8635

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8635

Describe changes:
- Guard all four `HashListTableLookup()` call sites in `DetectEngineSignatureIsDuplicate()` against a NULL return value.
- Add `DEBUG_VALIDATE_BUG_ON()` at each site to catch invariant violations in debug builds.
- Add NULL guards in production code to prevent a crash if the invariant (every `Signature` in `sig_list` has a corresponding `dup_sig_hash_table` entry) is ever broken by adjacent code.

Flagged by Svace static analyzer at detect-parse.c:3250,3253.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=