### PR TITLE
detect: guard rate filter callback registration against NULL engine

### DIFF
--- a/examples/lib/custom/main.c
+++ b/examples/lib/custom/main.c
@@ -253,7 +253,11 @@ int main(int argc, char **argv)
      * ThreadVars will be ready. */
     SuricataInit();
 
-    SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    if (DetectEngineEnabled()) {
+        SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    } else {
+        SCLogWarning("detection engine not enabled, rate filter callback not registered");
+    }
 
     /* Spawn our worker threads. */
     pthread_t worker;

--- a/examples/lib/live/main.c
+++ b/examples/lib/live/main.c
@@ -306,7 +306,11 @@ int main(int argc, char **argv)
      * ThreadVars will be ready. */
     SuricataInit();
 
-    SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    if (DetectEngineEnabled()) {
+        SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+    } else {
+        SCLogWarning("detection engine not enabled, rate filter callback not registered");
+    }
 
     /* Spawn our worker threads, one for each interface. */
     pthread_t workers[MAX_INTERFACES];

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -5206,6 +5206,10 @@ void DetectLowerSetupCallback(
 void SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc fn, void *arg)
 {
     DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    if (de_ctx == NULL) {
+        SCLogError("no detection engine available for rate filter callback registration");
+        return;
+    }
     de_ctx->RateFilterCallback = fn;
     de_ctx->rate_filter_callback_arg = arg;
     DetectEngineDeReference(&de_ctx);


### PR DESCRIPTION
Ticket: 8560

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8560

Describe changes:
- Add NULL guard with `SCLogError` and early return in `SCDetectEngineRegisterRateFilterCallback()` when `DetectEngineGetCurrent()` returns NULL. Return type remains `void`.
- Update both bundled library examples to check `DetectEngineEnabled()` before calling the registration function, and log a `SCLogWarning` when detection is disabled.

Flagged by Svace static analyzer and confirmed by `gcc -fanalyzer`. Supersedes #15553.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=