### PR TITLE
output/anomaly: report unknown ethertype in decode events

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -19,6 +19,11 @@ if available. If the ``pkt_src`` value is ``stream (flow timeout)``, then the
 ``ethernet`` value will be populated with mac addresses from the flow's first
 packet with ethernet header.
 
+If ``ethertype-hex`` is set to yes, then the ``ether.ether_type`` value will
+be displayed as a hexadecimal string, e.g., ``0x0800``, matching the display
+of the anomaly event ``ether_type``. The default is ``no`` (display the value
+as a decimal value, e.g., ``2048``).
+
 If ``suricata-version`` is set to yes, then Suricata version, with its git
 revision if available, will be added to events as ``suricata_version``.
 
@@ -79,6 +84,7 @@ Output types::
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
       #ethernet: no # log ethernet header in events when available
+      #ethertype-hex: no # display ether_type values as hexadecimal strings, e.g., 0x0800
       #suricata-version: no # include suricata version. Default no.
       #redis:
       #  server: 127.0.0.1

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -176,6 +176,14 @@ Anomalies are reported by and configured by type:
 - Stream
 - Application layer
 
+Decode anomaly events for unrecognized ethertypes
+(``decoder.ethernet.unknown_ethertype``, ``decoder.vlan.unknown_type``,
+``decoder.etag.unknown_type`` and ``decoder.vntag.unknown_type``) include the
+ethertype value that could not be decoded in the ``anomaly.ether_type`` field
+as a hexadecimal string, e.g., ``0xfbb7``. With nested headers, e.g., VLAN,
+this is the innermost ethertype that could not be decoded rather than the
+ethertype of the outer header.
+
 Metadata::
 
     - anomaly:

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -18,6 +18,7 @@ outputs:
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
       #ethernet: no  # log ethernet header in events when available
+      #ethertype-hex: no  # display ether_type values as hexadecimal strings, e.g., 0x0800
       #redis:
       #  server: 127.0.0.1
       #  port: 6379

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -57,6 +57,12 @@ Logging Changes
   E.g., previously, ``ether_type`` values were logged in host order;  an ethertype value of ``0xfbb7``
   (network order) was logged as `47099`` (``0xb7fb``). This ethertype value will be logged as ``64439``.
 
+- Anomaly events for unrecognized ethertypes
+  (``decoder.ethernet.unknown_ethertype``, ``decoder.vlan.unknown_type``,
+  ``decoder.etag.unknown_type`` and ``decoder.vntag.unknown_type``) now include
+  the ethertype value that could not be decoded in the ``anomaly.ether_type``
+  field, as a hexadecimal string, e.g., ``0xfbb7``.
+
 - Alert verdict key is changed from to ``reject-target`` to ``reject_target``
 
 - App-layer stats protocols names replace dash by underscore, meaning

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -169,6 +169,10 @@
                 "code": {
                     "type": "integer"
                 },
+                "ether_type": {
+                    "type": "string",
+                    "description": "The unknown ethertype that triggered the event, as a hexadecimal string, e.g., 0xfbb7"
+                },
                 "event": {
                     "type": "string"
                 },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1865,8 +1865,8 @@
                     }
                 },
                 "ether_type": {
-                    "type": "integer",
-                    "description": "Ethernet type value "
+                    "type": ["integer", "string"],
+                    "description": "Ethernet type value; a hexadecimal string, e.g., 0x0800, when eve-log.ethertype-hex is enabled"
                 },
                 "src_mac": {
                     "type": "string"

--- a/src/decode.h
+++ b/src/decode.h
@@ -428,6 +428,10 @@ enum PacketL2Types {
 
 struct PacketL2 {
     enum PacketL2Types type;
+    /** ethertype that could not be decoded; set on the unknown-ethertype
+     *  decode path and reported by the ethernet, VLAN, E-Tag and VN-Tag
+     *  unknown-type anomaly events */
+    uint16_t unknown_ethertype;
     union L2Hdrs {
         EthernetHdr *ethh;
     } hdrs;
@@ -1546,6 +1550,7 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
             SCLogDebug("unknown ether type: %" PRIx16 "", proto);
             StatsCounterIncr(&tv->stats, dtv->counter_ethertype_unknown);
             ENGINE_SET_EVENT(p, ETHERNET_UNKNOWN_ETHERTYPE);
+            p->l2.unknown_ethertype = proto;
             return false;
     }
     return true;

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -100,6 +100,22 @@ static void OutputAnomalyLoggerDisable(void)
         anomaly_loggers--;
 }
 
+/** \brief Does this decode event report an ethertype that could not be
+ *         decoded? Such events store the offending value in
+ *         Packet::l2.unknown_ethertype. */
+static bool DecodeEventHasUnknownEthertype(uint8_t event_code)
+{
+    switch (event_code) {
+        case ETHERNET_UNKNOWN_ETHERTYPE:
+        case VLAN_UNKNOWN_TYPE:
+        case ETAG_UNKNOWN_TYPE:
+        case VNTAG_UNKNOWN_TYPE:
+            return true;
+        default:
+            return false;
+    }
+}
+
 static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
                                   const Packet *p)
 {
@@ -131,6 +147,11 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
                 JB_SET_STRING(js, "type", "stream");
             }
             SCJbSetString(js, "event", event);
+            if (DecodeEventHasUnknownEthertype(event_code)) {
+                char ethertype[8];
+                snprintf(ethertype, sizeof(ethertype), "0x%04x", p->l2.unknown_ethertype);
+                SCJbSetString(js, "ether_type", ethertype);
+            }
         } else {
             JB_SET_STRING(js, "type", "unknown");
             SCJbSetUint(js, "code", event_code);

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -70,8 +70,8 @@
 
 static void OutputJsonDeInitCtx(OutputCtx *);
 static void CreateEveCommunityFlowId(SCJsonBuilder *js, const Flow *f, const uint16_t seed);
-static int CreateJSONEther(
-        SCJsonBuilder *parent, const Packet *p, const Flow *f, enum SCOutputJsonLogDirection dir);
+static int CreateJSONEther(SCJsonBuilder *parent, const Packet *p, const Flow *f,
+        enum SCOutputJsonLogDirection dir, bool ethertype_hex);
 
 static const char *TRAFFIC_ID_PREFIX = "traffic/id/";
 static const char *TRAFFIC_LABEL_PREFIX = "traffic/label/";
@@ -402,7 +402,7 @@ void EveAddCommonOptions(const OutputJsonCommonSettings *cfg, const Packet *p, c
         EveAddMetadata(p, f, js);
     }
     if (cfg->include_ethernet) {
-        CreateJSONEther(js, p, f, dir);
+        CreateJSONEther(js, p, f, dir, cfg->ethertype_hex);
     }
     if (cfg->include_community_id && f != NULL) {
         CreateEveCommunityFlowId(js, f, cfg->community_id_seed);
@@ -722,15 +722,21 @@ static int MacSetIterateToJSON(uint8_t *val, MacSetSide side, void *data)
     return 0;
 }
 
-static int CreateJSONEther(
-        SCJsonBuilder *js, const Packet *p, const Flow *f, enum SCOutputJsonLogDirection dir)
+static int CreateJSONEther(SCJsonBuilder *js, const Packet *p, const Flow *f,
+        enum SCOutputJsonLogDirection dir, bool ethertype_hex)
 {
     if (p != NULL) {
         /* this is a packet context, so we need to add scalar fields */
         if (PacketIsEthernet(p)) {
             const EthernetHdr *ethh = PacketGetEthernet(p);
             SCJbOpenObject(js, "ether");
-            SCJbSetUint(js, "ether_type", SCNtohs(ethh->eth_type));
+            if (ethertype_hex) {
+                char ether_type[8];
+                snprintf(ether_type, sizeof(ether_type), "0x%04x", SCNtohs(ethh->eth_type));
+                SCJbSetString(js, "ether_type", ether_type);
+            } else {
+                SCJbSetUint(js, "ether_type", SCNtohs(ethh->eth_type));
+            }
             const uint8_t *src;
             const uint8_t *dst;
             switch (dir) {
@@ -1237,6 +1243,15 @@ OutputInitResult OutputJsonInitCtx(SCConfNode *conf)
             json_ctx->cfg.include_ethernet = true;
         } else {
             json_ctx->cfg.include_ethernet = false;
+        }
+
+        /* Check if ethertype values should be displayed in hex. */
+        const SCConfNode *ethertype_hex = SCConfNodeLookupChild(conf, "ethertype-hex");
+        if (ethertype_hex && ethertype_hex->val && SCConfValIsTrue(ethertype_hex->val)) {
+            SCLogConfig("Displaying ethertype values in hexadecimal.");
+            json_ctx->cfg.ethertype_hex = true;
+        } else {
+            json_ctx->cfg.ethertype_hex = false;
         }
 
         const SCConfNode *suriver = SCConfNodeLookupChild(conf, "suricata-version");

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -63,6 +63,7 @@ typedef struct OutputJsonCommonSettings_ {
     bool include_metadata;
     bool include_community_id;
     bool include_ethernet;
+    bool ethertype_hex;
     bool compress_ipv6;
     bool include_suricata_version;
     uint16_t community_id_seed;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -115,6 +115,7 @@ outputs:
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
       #ethernet: no  # log ethernet header in events when available
+      #ethertype-hex: no  # display ether_type values as hexadecimal strings, e.g., 0x0800
       #redis:
       #  server: 127.0.0.1
       #  port: 6379


### PR DESCRIPTION
Report unknown ethertype values in anomaly events to identify the value that triggered the event.
Also, update the vlan/vntag/etag handling so the inner ethertype value is included.

The values in the anomaly events are printed as hex strings, e.g "0x8193". When `ethernet: yes` is set, ether_type values are printed as hex strings when `etherrtype-hex: yes` is set.

Link to ticket:
* https://redmine.openinfosecfoundation.org/issues/7849
* https://redmine.openinfosecfoundation.org/issues/8142

Describe changes:
- Include ethertype values with anomaly events, including those from vlang/etag/vntag frames
- Add an option to display ethertype values as hex strings when ethernet values are being logged
- Document the config option, and the inclusion of ethertype info the ethernet/vlan/etag/vntag anomaly events.

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3148
