### PR TITLE
Fw backports/v6.1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2443,7 +2443,7 @@ jobs:
       # using leading to random crashes: https://github.com/actions/runner-images/issues/9491
         run: sudo sysctl vm.mmap_rnd_bits=28
       - run: ./autogen.sh
-      - run: ./configure --enable-warnings --enable-debug-validation
+      - run: ./configure --enable-warnings --enable-debug-validation --enable-qa-simulation
         env:
           CFLAGS: "${{ env.DEFAULT_CFLAGS }} -Wshadow -fsanitize=address -fno-omit-frame-pointer"
           LDFLAGS: "-fsanitize=address" 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1995,6 +1995,7 @@ jobs:
       - run: llvm-profdata-19 merge -o nfq-fw-netns-route.profdata /tmp/nfq-fw-netns-route.profraw
 
       - run: llvm-profdata-19 merge -o combined.profdata nfq-fw-netns-route.profdata
+
       - run: llvm-cov-19 export ./src/suricata -instr-profile=combined.profdata -format=lcov --ignore-filename-regex="^(/github/home/.cargo/.*|/usr/.*|/rustc/.*)" --skip-branches > coverage.lcov
       - name: Upload coverage.lcov artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -27,9 +27,9 @@ jobs:
 
   # Checking for correct formatting of branch for C code changes
   check-formatting:
-    name: Formatting Check (clang 14)
-    runs-on: ubuntu-22.04
-    container: ubuntu:22.04
+    name: Formatting Check (clang 17)
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
     continue-on-error: false
     steps:
 
@@ -50,7 +50,7 @@ jobs:
                 automake \
                 cargo \
                 cbindgen \
-                clang-format-14 \
+                clang-format-17 \
                 git \
                 libtool \
                 libpcap-dev \

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2785,6 +2785,31 @@ use of.
     vista: []
     windows2k3: []
 
+Suricata as a Firewall options (experimental)
+---------------------------------------------
+
+It is possible to run Suricata as a firewall.
+Please read :ref:`Firewall Mode Design <firewall mode design>` before using this.
+The existing yaml configuration options are listed below. If the engine is run
+in firewall mode, dedicated stats counters will be added to the stats logs.
+
+To see the stats counters reported for the firewall, refer to :ref:`firewall mode stats`.
+
+::
+
+   firewall:
+     # toggle to enable firewall mode
+     #enabled: no
+     # Firewall rule file are in their own path and are not managed
+     # by Suricata-Update.
+     #rule-path: /etc/suricata/firewall/
+
+     # List of files with firewall rules. Order matters, files are loaded
+     # in order and rules are applied in that order (per state, see docs)
+     #rule-files:
+     #  - firewall.rules
+
+
 Engine analysis and profiling
 -----------------------------
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2793,7 +2793,7 @@ Please read :ref:`Firewall Mode Design <firewall mode design>` before using this
 The existing yaml configuration options are listed below. If the engine is run
 in firewall mode, dedicated stats counters will be added to the stats logs.
 
-To see the stats counters reported for the firewall, refer to :ref:`firewall mode stats`.
+To see the stats reported for the firewall mode, refer to :ref:`firewall mode stats`.
 
 ::
 

--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -48,11 +48,11 @@ Rules categorized in the following tables apply to all packets.
     +-----------------------+--------------------------------------------------------------------+----------------+--------------------------------+
     |          Table        |                             Description                            | Default Policy |           Rule Order           |
     +=======================+====================================================================+================+================================+
-    | ``packet:pre_flow``   | Firewall rules to be evaluated before flow is created/updated      | ``drop:packet``|   As appears in the rule file  |
+    | ``packet:pre_flow``   | Firewall rules to be evaluated before flow is created/updated      | ``accept:hook``| As appears in the rule file    |
     +-----------------------+--------------------------------------------------------------------+----------------+--------------------------------+
-    | ``packet:pre_stream`` | Firewall rules to be evaluated before stream is updated            | ``drop:packet``|   As appears in the rule file  |
+    | ``packet:pre_stream`` | Firewall rules to be evaluated before stream is updated            | ``accept:hook``| As appears in the rule file    |
     +-----------------------+--------------------------------------------------------------------+----------------+--------------------------------+
-    | ``packet:filter``     | Firewall rules to be evaluated against every packet after decoding | ``drop:packet``|   As appears in the rule file  |
+    | ``packet:filter``     | Firewall rules to be evaluated against every packet after decoding | ``drop:packet``| As appears in the rule file    |
     +-----------------------+--------------------------------------------------------------------+----------------+--------------------------------+
     | ``packet:td``         | Generic IDS/IPS threat detection rules                             | ``accept:hook``| Internal IDS/IPS rule ordering |
     +-----------------------+--------------------------------------------------------------------+----------------+--------------------------------+
@@ -70,9 +70,9 @@ application layer are per app layer protocol and per protocol state. e.g. ``http
     +----------------+--------------------------------------------------------------------------+----------------+--------------------------------+
     |      Table     |                                Description                               | Default Policy |           Rule Order           |
     +================+==========================================================================+================+================================+
-    | ``app:filter`` | Firewall rules to be evaluated per applayer protocol and state           | ``drop:flow``  |   As appears in the rule file  |
+    | ``app:filter`` | Firewall rules to be evaluated per applayer protocol and state           | ``drop:flow``  | As appears in the rule file    |
     +----------------+--------------------------------------------------------------------------+----------------+--------------------------------+
-    | ``app:td``     | Generic IDS/IPS threat detection rules                                   | ``accept:hook``| Internal IDS/IPS rule ordering |
+    | ``app:td``     | App-layer IDS/IPS threat detection rules                                 | ``accept:hook``| Internal IDS/IPS rule ordering |
     +----------------+--------------------------------------------------------------------------+----------------+--------------------------------+
 
 

--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -244,6 +244,23 @@ ssh
 
 Available states are listed in :ref:`ssh-hooks`.
 
+Auto-accept prior states
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To avoid creating lots of boilerplate ``accept`` rules there is a special notation to have
+a rule accept not just the hook it matches in, but also the hooks before it.
+
+Example::
+
+    accept:flow tls:<client_hello_done ... tls.sni; content:"suricata.io"; ...
+
+The main matching logic here is in the ``tls:client_hello_done`` hook. The state before it,
+``tls:client_in_progress`` is also accepted, as if the ruleset was actually::
+
+    accept:hook tls:client_in_progress ...
+    accept:flow tls:client_hello_done ... tls.sni; content:"suricata.io"; ...
+
+This logic only applies to the ``app:filter`` table.
 
 Firewall pipeline
 -----------------

--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -18,6 +18,19 @@ properties than the default "threat detection" rulesets:
 Concepts
 ========
 
+Firewall vs Threat Detection (TD)
+---------------------------------
+
+The interaction between firewall and TD is concepualized as if they are 2 seperate
+instances, where the firewall instance runs first, and it passes along to the TD
+instance what is accepted by the firewall.
+
+This is reflected in the stats, where a packet accepted by the firewall is counted
+as ``firewall.accepted``. If it was also allowed by TD, it will additionally be
+counted as ``ips.accepted``. If it was dropped by firewall, only ``firewall.blocked``
+will be incremented. No ``ips.*`` counter will be updated as conceptually the TD
+instance won't have seen the packet.
+
 Tables
 ------
 
@@ -93,8 +106,38 @@ drop
 * ``packet`` drop this packet directly, don't eval any further rules
 * ``flow`` drop this packet as with ``packet`` and drop all future packets in this flow
 
-.. note:: the action ``pass`` is not available in firewall rules due to ambiguity around
-   the existing meaning for threat detection rules.
+.. note:: unlike in threat detection mode rules, a ``drop`` in a firewall rule does not
+   imply alert
+
+pass
+~~~~
+
+``pass`` is not available as a primary firewall action, but can be used as a secondary
+action in firewall rules. The effect of the action will only apply to threat detection rules.
+
+alert
+~~~~~
+
+``alert`` is not available as a primary firewall action, but can be used as a secondary
+action in firewall rules. The effect will be the creation of an alert event when the
+firewall rule matches.
+
+Multi action rules
+~~~~~~~~~~~~~~~~~~
+
+In firewall rules, multiple actions can be specified: a primary firewall action, followed
+by one or more secondary actions.
+
+Example::
+
+    accept:flow,pass:flow,alert tls:client_hello_done ... tls.sni; ...
+
+In this example the first action ``accept:flow`` is the primary firewall action. When the
+rule matches, the flow will be accepted. The secondary actions ``pass:flow`` and ``alert`` are
+evaluated in the context of the threat detection engine.
+
+.. note:: the secondary actions are only evaluated if the primary firewall action is accepted.
+   This is different from the behavior of the ``pass`` action in threat detection mode.
 
 .. _rule-hooks:
 
@@ -263,3 +306,32 @@ One can optionally, also load firewall rules exclusively from commandline using 
 
 Firewall rules are available in the file ``firewall.json`` as a part of the output
 of :ref:`engine analysis<config:engine-analysis>`.
+
+Default policies
+================
+
+Each hook has a default policy. By default ``packet:filter`` enforces a ``drop:packet`` policy and the
+``app:filter`` hooks applies ``drop:flow``.
+
+The policies can be configured in ``firewall`` block in the config.
+
+Example for ``packet:filter``, to use reject instead of drop::
+
+    firewall:
+      policies:
+        packet-filter: [ "reject:packet" ]
+
+
+Example for DNS::
+
+    firewall:
+      policies:
+        dns:
+          request-started: ["accept:hook"]
+
+          # Drop and alert on all DNS requests that are not allowed in
+          # firewall.rules.
+          request-complete: ["drop:flow", "alert"]
+
+          # Accept all responses.
+          response-started: ["accept:tx"]

--- a/doc/userguide/firewall/firewall-example.rst
+++ b/doc/userguide/firewall/firewall-example.rst
@@ -55,10 +55,68 @@ The HTTP rules need to ``accept`` each state::
 
 Each state needs an ``accept`` rule. Each state is evaluated at least once.
 
+HTTP example with partially using default policies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    firewall:
+      policies:
+        http:
+          request-started:
+            - "accept:hook"
+          request-line:
+            - "drop:flow"
+            - "alert"
+          request-headers:
+            - "drop:flow"
+            - "alert"
+          request-body:
+            - "accept:hook"
+          request-trailer:
+            - "accept:hook"
+          request-complete:
+            - "accept:hook"
+
+          response-started:
+            - "accept:hook"
+          response-line:
+            - "drop:flow"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+          response-body:
+            - "accept:hook"
+          response-trailer:
+            - "accept:hook"
+          response-complete:
+            - "accept:hook"
+
+
+::
+
+    # allow GET
+    accept:hook http1:request_line any any -> any any ( \
+            http.method; content:"GET"; sid:101;)
+    # or allow POST
+    accept:hook http1:request_line any any -> any any ( \
+            http.method; content:"POST"; sid:102;)
+    # allow User-Agent curl
+    accept:hook http1:request_headers any any -> any any ( \
+            http.user_agent; content:"curl"; sid:103;)
+
+    # allow the 200 ok stat code.
+    accept:hook http1:response_line any any -> any any ( \
+            http.stat_code; content:"200"; sid:201;)
+
+Explanation: the config auto accepts various hooks, leaving just ``http1:request_line``,
+``http1:request_headers`` and ``http1:response_line`` for the ruleset to accept.
+
+
 TLS SNI with complex TCP rules
 ------------------------------
 
-In this example the ``packet_filter`` rules will be more opinionated about the traffic::
+In this example the ``packet:filter`` rules will be more opinionated about the traffic::
 
     # allow 3-way handshake
     accept:hook tcp:all $HOME_NET any -> $EXTERNAL_NET 443 (flags:S; \
@@ -91,3 +149,27 @@ there be additional constraints::
     accept:hook tls:server_handshake_done $EXTERNAL_NET any -> $HOME_NET any (sid:204;)
     accept:hook tls:server_finished $EXTERNAL_NET any -> $HOME_NET any (sid:205;)
 
+TLS SNI with auto-accept logic
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Rule that has the same effect as the 11 TLS rules above::
+
+    accept:flow tls:<client_hello_done $HOME_NET any -> $EXTERNAL_NET any (tls.sni; \
+            pcre:"/^(suricata.io|oisf.net)$/; sid:101;)
+
+Explanation: ``accept:flow`` accepts all of the TLS flow from the moment the rule
+has matched. The ``tls:client_in_progress`` hook is auto-accepted by the use of the
+``<`` modifier in the hook ``tls:<client_hello_done``.
+
+TLS SNI with auto-accept logic, plus disabling TD matching
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To allow-list a connection to a specific SNI, w/o threat detection rules
+matching on this flow either, the example above can be extended by adding ``pass:flow``
+as a secondary action::
+
+    accept:flow,pass:flow tls:<client_hello_done $HOME_NET any -> $EXTERNAL_NET any \
+        (tls.sni; pcre:"/^(suricata.io|oisf.net)$/; sid:101;)
+
+Explanation: as soon as this rule fully matches at the ``tls:client_hello_done`` hook,
+a ``pass`` is applied to the flow effectively bypassing the threat detection engine.

--- a/doc/userguide/firewall/firewall-stats.rst
+++ b/doc/userguide/firewall/firewall-stats.rst
@@ -1,0 +1,34 @@
+.. _firewall mode stats:
+
+Firewall Mode Stats
+*******************
+
+Statistics counters for the firewall mode cover:
+
+    - drop reasons: ``stats.firewall.drop_reason``
+    - discarded alerts: ``stats.firewall.discarded_alerts``
+    - blocked packets: ``stats.firewall.blocked``
+    - accepted packets: ``stats.firewall.accepted``
+    - rejected packets: ``stats.firewall.rejected``
+
+These will be present in the stats logs if the engine is run in firewall mode,
+only.
+
+Drop reasons
+============
+
+If a drop was caused by the firewall, the corresponding counter will be incremented. The existing ones are:
+
+    - ``rules``: a firewall rule triggered the drop
+    - ``default_packet_policy``: drop caused by the default fail closed firewall behavior, on the packet hook level
+    - ``default_app_policy``: drop caused by the default fail close firewall behavior, on the app-layer hook level
+    - ``pre_flow_hook``: drop caused by the pre-flow hook
+    - ``pre_stream_hook``: drop caused by the pre-stream hook
+    - ``flow_drop``: the whole flow was dropped after a firewall action.
+
+Discarded alerts
+================
+
+In Firewall mode, alerts generated *after* a drop are discarded.
+These are reported with the counter ``stats.firewall.discarded_alerts``.
+Note that the drop may be caused by non-firewall rules.

--- a/doc/userguide/firewall/firewall-stats.rst
+++ b/doc/userguide/firewall/firewall-stats.rst
@@ -29,6 +29,9 @@ If a drop was caused by the firewall, the corresponding counter will be incremen
 Discarded alerts
 ================
 
-In Firewall mode, alerts generated *after* a drop are discarded.
+When the alert queue is full for a firewall rule match, the alert is discarded.
 These are reported with the counter ``stats.firewall.discarded_alerts``.
 Note that the drop may be caused by non-firewall rules.
+
+The rule's primary action as well as other secondary actions will be applied to
+the traffic as normal.

--- a/doc/userguide/firewall/index.rst
+++ b/doc/userguide/firewall/index.rst
@@ -5,3 +5,4 @@ Firewall Mode
 
    firewall-design
    firewall-example
+   firewall-stats

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1999,6 +1999,16 @@
                 }
             }
         },
+        "firewall": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hook": {
+                    "type": "string",
+                    "description": "Firewall hook for the match"
+                }
+            }
+        },
         "flow": {
             "type": "object",
             "additionalProperties": false,

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -7212,7 +7212,7 @@
                         },
                         "alert_queue_overflow": {
                             "type": "integer",
-                            "description": "Count of alerts discarded due to alert queue overflow or a drop in firewall mode"
+                            "description": "Count of alerts discarded due to alert queue overflow"
                         },
                         "alerts_suppressed": {
                             "type": "integer",
@@ -7356,6 +7356,56 @@
                         },
                         "open_files_max_hit": {
                             "type": "integer"
+                        }
+                    }
+                },
+                "firewall": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "accepted": {
+                            "type": "integer",
+                            "description": "Count of accepted packets due to firewall policies"
+                        },
+                        "blocked": {
+                            "type": "integer",
+                            "description": "Count of blocked packets due to firewall policies"
+                        },
+                        "discarded_alerts": {
+                            "type": "integer",
+                            "description": "Count of alerts discarded due to a drop while in firewall mode"
+                        },
+                        "drop_reason": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "default_app_policy": {
+                                    "type": "integer",
+                                    "description":
+                                            "Number of packets dropped due to firewall's mode default app policy"
+                                },
+                                "default_packet_policy": {
+                                    "type": "integer",
+                                    "description":
+                                            "Number of packets dropped due to firewall's mode default packet policy"
+                                },
+                                "pre_flow_hook": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to pre-flow hook"
+                                },
+                                "pre_stream_hook": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to pre-stream hook"
+                                },
+                                "rules": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to firewall rules"
+                                }
+                            }
+                        },
+                        "rejected": {
+                            "type": "integer",
+                            "description": "Count of packets rejected due to firewall policies"
                         }
                     }
                 },
@@ -7768,16 +7818,6 @@
                                     "description":
                                             "Number of packets dropped due to decoding errors"
                                 },
-                                "default_app_policy": {
-                                    "type": "integer",
-                                    "description":
-                                            "Number of packets dropped due to default app policy"
-                                },
-                                "default_packet_policy": {
-                                    "type": "integer",
-                                    "description":
-                                            "Number of packets dropped due to default packet policy"
-                                },
                                 "defrag_error": {
                                     "type": "integer",
                                     "description":
@@ -7800,16 +7840,6 @@
                                 "nfq_error": {
                                     "type": "integer",
                                     "description": "Number of packets dropped due to no NFQ verdict"
-                                },
-                                "pre_flow_hook": {
-                                    "description":
-                                            "Number of packets dropped in the pre_flow hook ",
-                                    "type": "integer"
-                                },
-                                "pre_stream_hook": {
-                                    "description":
-                                            "Number of packets dropped in the pre_stream hook ",
-                                    "type": "integer"
                                 },
                                 "rules": {
                                     "type": "integer",

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -7387,7 +7387,7 @@
                         },
                         "discarded_alerts": {
                             "type": "integer",
-                            "description": "Count of alerts discarded due to a drop while in firewall mode"
+                            "description": "Count of alerts discarded due max alerts reached"
                         },
                         "drop_reason": {
                             "type": "object",

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -7382,24 +7382,28 @@
                                 "default_app_policy": {
                                     "type": "integer",
                                     "description":
-                                            "Number of packets dropped due to firewall's mode default app policy"
+                                        "Count of packets dropped due to firewall's mode default app policy"
                                 },
                                 "default_packet_policy": {
                                     "type": "integer",
                                     "description":
-                                            "Number of packets dropped due to firewall's mode default packet policy"
+                                        "Count of packets dropped due to firewall's mode default packet policy"
+                                },
+                                "flow_drop": {
+                                    "type": "integer",
+                                    "description": "Count of packets dropped due to a firewall policy that led to flow drop"
                                 },
                                 "pre_flow_hook": {
                                     "type": "integer",
-                                    "description": "Number of packets dropped due to pre-flow hook"
+                                    "description": "Count of packets dropped due to pre-flow hook"
                                 },
                                 "pre_stream_hook": {
                                     "type": "integer",
-                                    "description": "Number of packets dropped due to pre-stream hook"
+                                    "description": "Count of packets dropped due to pre-stream hook"
                                 },
                                 "rules": {
                                     "type": "integer",
-                                    "description": "Number of packets dropped due to firewall rules"
+                                    "description": "Count of packets dropped due to firewall rules"
                                 }
                             }
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2006,6 +2006,10 @@
                 "hook": {
                     "type": "string",
                     "description": "Firewall hook for the match"
+                },
+                "policy": {
+                    "type": "string",
+                    "description": "Firewall actions for the match (from rule or default policy)"
                 }
             }
         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -7832,6 +7832,10 @@
                                     "description":
                                             "Number of packets dropped due to defrag memcap exception policy"
                                 },
+                                "exception_policy_flow_drop": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to an exception policy flow dropping"
+                                },
                                 "flow_drop": {
                                     "type": "integer",
                                     "description": "Number of packets dropped due to dropped flows"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -7889,7 +7889,7 @@
                         },
                         "replaced": {
                             "type": "integer",
-                            "description": "Number of replaced packets"
+                            "description": "Number of packets replaced by the stream engine or based on a match of the 'replaced' keyword."
                         }
                     }
                 },

--- a/qa/live/netns/firewall2.rules
+++ b/qa/live/netns/firewall2.rules
@@ -1,0 +1,15 @@
+accept:packet arp:all any any -> any any (alert; sid:200;)
+
+# allow session setup
+accept:hook tcp:all any any <> any 80 (flow:not_established; alert; sid:1021;)
+
+# pass rest of the flow to 
+accept:hook tcp:all any any <> any 80 (flow:established; alert; sid:1023;)
+#accept:hook ip:all any any <> any any (alert; sid:1024;)
+
+# default drop
+
+accept:hook http1:request_started any any -> any any (alert; sid:100;)
+accept:hook http1:request_line any any -> any any (http.method; bsize:3; urilen:>1; sid:201; alert;)
+accept:tx http1:request_headers any any -> any any (http.user_agent; pcre:"/wget/i"; sid:202; alert;)
+

--- a/qa/live/netns/nfq-fw-netns-route.sh
+++ b/qa/live/netns/nfq-fw-netns-route.sh
@@ -268,8 +268,8 @@ SID201=$(jq -c 'select(.alert.signature_id==201)' ./eve.json | wc -l)
 SID202=$(jq -c 'select(.alert.signature_id==202)' ./eve.json | wc -l)
 echo "SID201 $SID201 SID202 $SID202"
 
-ACCEPTED=$(jq -c 'select(.event_type == "stats")' ./eve.json | tail -n1 | jq '.stats.ips.accepted')
-BLOCKED=$(jq -c 'select(.event_type == "stats")' ./eve.json | tail -n1 | jq '.stats.ips.blocked')
+ACCEPTED=$(jq -c 'select(.event_type == "stats")' ./eve.json | tail -n1 | jq '.stats.firewall.accepted')
+BLOCKED=$(jq -c 'select(.event_type == "stats")' ./eve.json | tail -n1 | jq '.stats.firewall.blocked')
 echo "ACCEPTED $ACCEPTED BLOCKED $BLOCKED"
 
 if [ $ACCEPTED -eq 0 ]; then
@@ -317,6 +317,7 @@ fi
 
 echo "* dumping some stats..."
 cat ./eve.json | jq -c 'select(.http)'|tail -n1|jq
+cat ./eve.json | jq -c 'select(.stats)|.stats.firewall'|tail -n1|jq
 cat ./eve.json | jq -c 'select(.stats)|.stats.ips'|tail -n1|jq
 echo "* dumping some stats... done"
 

--- a/rules/README.md
+++ b/rules/README.md
@@ -8,6 +8,7 @@ signature IDs.
 | Component         | Start   | End     |
 | ----------------- | ------- | ------- |
 | Decoder           | 2200000 | 2200999 |
+| Firewall          | 2201000 | 2201999 |
 | Stream            | 2210000 | 2210999 |
 | Generic App-Layer | 2260000 | 2260999 |
 

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -560,9 +560,13 @@ SetTopLevelDir
 
 RequireProgram GIT git
 # ubuntu uses clang-format-{version} name for newer versions. fedora not.
-RequireProgram GIT_CLANG_FORMAT git-clang-format-14 git-clang-format-11 git-clang-format-10 git-clang-format-9 git-clang-format
+RequireProgram GIT_CLANG_FORMAT git-clang-format-17 git-clang-format-14 git-clang-format-11 git-clang-format-10 git-clang-format-9 git-clang-format
 GIT_CLANG_FORMAT_BINARY=clang-format
-if [[ $GIT_CLANG_FORMAT =~ .*git-clang-format-14$ ]]; then
+if [[ $GIT_CLANG_FORMAT =~ .*git-clang-format-17$ ]]; then
+    # default binary is clang-format, specify the correct version.
+    # Alternative: git config clangformat.binary "clang-format-17"
+    GIT_CLANG_FORMAT_BINARY="clang-format-17"
+elif [[ $GIT_CLANG_FORMAT =~ .*git-clang-format-14$ ]]; then
     # default binary is clang-format, specify the correct version.
     # Alternative: git config clangformat.binary "clang-format-14"
     GIT_CLANG_FORMAT_BINARY="clang-format-14"

--- a/src/decode.c
+++ b/src/decode.c
@@ -949,6 +949,8 @@ const char *PacketDropReasonToString(enum PacketDropReason r)
             return "firewall pre stream hook";
         case PKT_DROP_REASON_FW_FLOW_PRE_HOOK:
             return "firewall pre flow hook";
+        case PKT_DROP_REASON_FW_FLOW_DROP:
+            return "firewall flow drop";
         case PKT_DROP_REASON_NOT_SET:
         case PKT_DROP_REASON_MAX:
             return NULL;
@@ -997,6 +999,8 @@ static const char *PacketDropReasonToJsonString(enum PacketDropReason r)
             return "firewall.drop_reason.pre_stream_hook";
         case PKT_DROP_REASON_FW_FLOW_PRE_HOOK:
             return "firewall.drop_reason.pre_flow_hook";
+        case PKT_DROP_REASON_FW_FLOW_DROP:
+            return "firewall.drop_reason.flow_drop";
         case PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY:
             return "firewall.drop_reason.default_packet_policy";
         case PKT_DROP_REASON_FW_DEFAULT_APP_POLICY:
@@ -1039,6 +1043,7 @@ void CaptureStatsUpdate(ThreadVars *tv, const Packet *p)
         return;
 
     CaptureStats *s = &t_capture_stats;
+
     if (EngineModeIsFirewall()) {
         /** The firewall mode and its stats counters should work as when there are two different
          * devices for the firewall control and the IPS control.

--- a/src/decode.c
+++ b/src/decode.c
@@ -917,6 +917,8 @@ const char *PacketDropReasonToString(enum PacketDropReason r)
             return "flow memcap";
         case PKT_DROP_REASON_FLOW_DROP:
             return "flow drop";
+        case PKT_DROP_REASON_EP_FLOW_DROP:
+            return "exception policy flow drop";
         case PKT_DROP_REASON_STREAM_ERROR:
             return "stream error";
         case PKT_DROP_REASON_STREAM_MEMCAP:
@@ -971,6 +973,8 @@ static const char *PacketDropReasonToJsonString(enum PacketDropReason r)
             return "ips.drop_reason.flow_memcap";
         case PKT_DROP_REASON_FLOW_DROP:
             return "ips.drop_reason.flow_drop";
+        case PKT_DROP_REASON_EP_FLOW_DROP:
+            return "ips.drop_reason.exception_policy_flow_drop";
         case PKT_DROP_REASON_STREAM_ERROR:
             return "ips.drop_reason.stream_error";
         case PKT_DROP_REASON_STREAM_MEMCAP:

--- a/src/decode.c
+++ b/src/decode.c
@@ -939,14 +939,16 @@ const char *PacketDropReasonToString(enum PacketDropReason r)
             return "nfq error";
         case PKT_DROP_REASON_INNER_PACKET:
             return "tunnel packet drop";
-        case PKT_DROP_REASON_DEFAULT_PACKET_POLICY:
-            return "default packet policy";
-        case PKT_DROP_REASON_DEFAULT_APP_POLICY:
-            return "default app policy";
-        case PKT_DROP_REASON_STREAM_PRE_HOOK:
-            return "pre stream hook";
-        case PKT_DROP_REASON_FLOW_PRE_HOOK:
-            return "pre flow hook";
+        case PKT_DROP_REASON_FW_RULES:
+            return "firewall rules";
+        case PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY:
+            return "firewall default packet policy";
+        case PKT_DROP_REASON_FW_DEFAULT_APP_POLICY:
+            return "firewall default app policy";
+        case PKT_DROP_REASON_FW_STREAM_PRE_HOOK:
+            return "firewall pre stream hook";
+        case PKT_DROP_REASON_FW_FLOW_PRE_HOOK:
+            return "firewall pre flow hook";
         case PKT_DROP_REASON_NOT_SET:
         case PKT_DROP_REASON_MAX:
             return NULL;
@@ -989,14 +991,16 @@ static const char *PacketDropReasonToJsonString(enum PacketDropReason r)
             return "ips.drop_reason.nfq_error";
         case PKT_DROP_REASON_INNER_PACKET:
             return "ips.drop_reason.tunnel_packet_drop";
-        case PKT_DROP_REASON_DEFAULT_PACKET_POLICY:
-            return "ips.drop_reason.default_packet_policy";
-        case PKT_DROP_REASON_DEFAULT_APP_POLICY:
-            return "ips.drop_reason.default_app_policy";
-        case PKT_DROP_REASON_STREAM_PRE_HOOK:
-            return "ips.drop_reason.pre_stream_hook";
-        case PKT_DROP_REASON_FLOW_PRE_HOOK:
-            return "ips.drop_reason.pre_flow_hook";
+        case PKT_DROP_REASON_FW_RULES:
+            return "firewall.drop_reason.rules";
+        case PKT_DROP_REASON_FW_STREAM_PRE_HOOK:
+            return "firewall.drop_reason.pre_stream_hook";
+        case PKT_DROP_REASON_FW_FLOW_PRE_HOOK:
+            return "firewall.drop_reason.pre_flow_hook";
+        case PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY:
+            return "firewall.drop_reason.default_packet_policy";
+        case PKT_DROP_REASON_FW_DEFAULT_APP_POLICY:
+            return "firewall.drop_reason.default_app_policy";
         case PKT_DROP_REASON_NOT_SET:
         case PKT_DROP_REASON_MAX:
             return NULL;
@@ -1009,11 +1013,25 @@ typedef struct CaptureStats_ {
     uint16_t counter_ips_blocked;
     uint16_t counter_ips_rejected;
     uint16_t counter_ips_replaced;
+    uint16_t counter_fw_accepted;
+    uint16_t counter_fw_blocked;
+    uint16_t counter_fw_rejected;
 
     uint16_t counter_drop_reason[PKT_DROP_REASON_MAX];
 } CaptureStats;
 
 thread_local CaptureStats t_capture_stats;
+
+static bool VerdictByFirewall(const Packet *p)
+{
+    if (!EngineModeIsFirewall()) {
+        return false;
+    }
+    if (p->drop_reason >= PKT_DROP_REASON_FW_RULES) {
+        return true;
+    }
+    return false;
+}
 
 void CaptureStatsUpdate(ThreadVars *tv, const Packet *p)
 {
@@ -1021,15 +1039,46 @@ void CaptureStatsUpdate(ThreadVars *tv, const Packet *p)
         return;
 
     CaptureStats *s = &t_capture_stats;
-    if (unlikely(PacketCheckAction(p, ACTION_REJECT_ANY))) {
-        StatsIncr(tv, s->counter_ips_rejected);
-    } else if (unlikely(PacketCheckAction(p, ACTION_DROP))) {
-        StatsIncr(tv, s->counter_ips_blocked);
-    } else if (unlikely(p->flags & PKT_STREAM_MODIFIED)) {
-        StatsIncr(tv, s->counter_ips_replaced);
+    if (EngineModeIsFirewall()) {
+        /** The firewall mode and its stats counters should work as when there are two different
+         * devices for the firewall control and the IPS control.
+         * As such, if the firewall blocks a packet, it won't reach the IPS level of evaluation,
+         * so won't be counted in either stats.
+         * When the firewall accepts a packet, it can still be blocked, rejected or accepted by
+         * IPS rules and policies.
+         */
+        if (unlikely(PacketCheckAction(p, ACTION_REJECT_ANY))) {
+            if (VerdictByFirewall(p)) {
+                StatsIncr(tv, s->counter_fw_rejected);
+            } else {
+                StatsIncr(tv, s->counter_fw_accepted);
+                StatsIncr(tv, s->counter_ips_rejected);
+            }
+        } else if (PacketCheckAction(p, ACTION_DROP)) {
+            if (VerdictByFirewall(p)) {
+                StatsIncr(tv, s->counter_fw_blocked);
+            } else {
+                /* If a packet was dropped by IPS, it had to first be accepted by the firewall, to
+                 * reach the IPS flow control */
+                StatsIncr(tv, s->counter_fw_accepted);
+                StatsIncr(tv, s->counter_ips_blocked);
+            }
+        } else if (PacketCheckAction(p, ACTION_ACCEPT)) {
+            StatsIncr(tv, s->counter_fw_accepted);
+            StatsIncr(tv, s->counter_ips_accepted);
+        }
     } else {
-        StatsIncr(tv, s->counter_ips_accepted);
+        if (unlikely(PacketCheckAction(p, ACTION_REJECT_ANY))) {
+            StatsIncr(tv, s->counter_ips_rejected);
+        } else if (unlikely(PacketCheckAction(p, ACTION_DROP))) {
+            StatsIncr(tv, s->counter_ips_blocked);
+        } else if (unlikely(p->flags & PKT_STREAM_MODIFIED)) {
+            StatsIncr(tv, s->counter_ips_replaced);
+        } else {
+            StatsIncr(tv, s->counter_ips_accepted);
+        }
     }
+
     if (p->drop_reason != PKT_DROP_REASON_NOT_SET) {
         StatsIncr(tv, s->counter_drop_reason[p->drop_reason]);
     }
@@ -1043,10 +1092,20 @@ void CaptureStatsSetup(ThreadVars *tv)
         s->counter_ips_blocked = StatsRegisterCounter("ips.blocked", tv);
         s->counter_ips_rejected = StatsRegisterCounter("ips.rejected", tv);
         s->counter_ips_replaced = StatsRegisterCounter("ips.replaced", tv);
-        for (int i = PKT_DROP_REASON_NOT_SET; i < PKT_DROP_REASON_MAX; i++) {
+        for (int i = PKT_DROP_REASON_NOT_SET; i <= PKT_DROP_REASON_NON_FW_MAX; i++) {
             const char *name = PacketDropReasonToJsonString(i);
             if (name != NULL)
                 s->counter_drop_reason[i] = StatsRegisterCounter(name, tv);
+        }
+        if (EngineModeIsFirewall()) {
+            s->counter_fw_accepted = StatsRegisterCounter("firewall.accepted", tv);
+            s->counter_fw_blocked = StatsRegisterCounter("firewall.blocked", tv);
+            s->counter_fw_rejected = StatsRegisterCounter("firewall.rejected", tv);
+            for (int i = PKT_DROP_REASON_FW_RULES; i < PKT_DROP_REASON_MAX; i++) {
+                const char *name = PacketDropReasonToJsonString(i);
+                if (name != NULL)
+                    s->counter_drop_reason[i] = StatsRegisterCounter(name, tv);
+            }
         }
     }
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -396,10 +396,11 @@ enum PacketDropReason {
     PKT_DROP_REASON_STREAM_URG,
     PKT_DROP_REASON_NFQ_ERROR,    /**< no nfq verdict, must be error */
     PKT_DROP_REASON_INNER_PACKET, /**< drop issued by inner (tunnel) packet */
+    PKT_DROP_REASON_EP_FLOW_DROP,
 /** If more non-firewall drop reasons are added, make sure not to "break" PKT_DROP_REASON_NON_FW_MAX
  */
 /* Limiter for non-firewall drop reasons. */
-#define PKT_DROP_REASON_NON_FW_MAX PKT_DROP_REASON_INNER_PACKET
+#define PKT_DROP_REASON_NON_FW_MAX PKT_DROP_REASON_EP_FLOW_DROP
     /** Firewall-related reasons only */
     PKT_DROP_REASON_FW_RULES,
     PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY, /**< drop issued by default packet policy */

--- a/src/decode.h
+++ b/src/decode.h
@@ -247,7 +247,7 @@ struct PacketContextData {
  * found in this packet */
 typedef struct PacketAlert_ {
     SigIntId iid;   /* Internal ID, used for sorting */
-    uint8_t action; /* Internal num, used for thresholding */
+    uint8_t action; /* Rule or threshold action to be applied to packet */
     uint8_t flags;
     const struct Signature_ *s;
     uint64_t tx_id; /* Used for sorting */
@@ -287,6 +287,7 @@ typedef struct PacketAlerts_ {
     uint16_t cnt;
     uint16_t discarded;
     uint16_t suppressed;
+    uint16_t firewall_discarded; /* alerts discarded after a drop, in fw mode*/
     PacketAlert *alerts;
     /* single pa used when we're dropping,
      * so we can log it out in the drop log. */
@@ -393,12 +394,18 @@ enum PacketDropReason {
     PKT_DROP_REASON_STREAM_MIDSTREAM,
     PKT_DROP_REASON_STREAM_REASSEMBLY,
     PKT_DROP_REASON_STREAM_URG,
-    PKT_DROP_REASON_NFQ_ERROR,             /**< no nfq verdict, must be error */
-    PKT_DROP_REASON_INNER_PACKET,          /**< drop issued by inner (tunnel) packet */
-    PKT_DROP_REASON_DEFAULT_PACKET_POLICY, /**< drop issued by default packet policy */
-    PKT_DROP_REASON_DEFAULT_APP_POLICY,    /**< drop issued by default app policy */
-    PKT_DROP_REASON_STREAM_PRE_HOOK,       /**< drop issued in the pre_stream hook */
-    PKT_DROP_REASON_FLOW_PRE_HOOK,         /**< drop issued in the pre_flow hook */
+    PKT_DROP_REASON_NFQ_ERROR,    /**< no nfq verdict, must be error */
+    PKT_DROP_REASON_INNER_PACKET, /**< drop issued by inner (tunnel) packet */
+/** If more non-firewall drop reasons are added, make sure not to "break" PKT_DROP_REASON_NON_FW_MAX
+ */
+/* Limiter for non-firewall drop reasons. */
+#define PKT_DROP_REASON_NON_FW_MAX PKT_DROP_REASON_INNER_PACKET
+    /** Firewall-related reasons only */
+    PKT_DROP_REASON_FW_RULES,
+    PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY, /**< drop issued by default packet policy */
+    PKT_DROP_REASON_FW_DEFAULT_APP_POLICY,    /**< drop issued by default app policy */
+    PKT_DROP_REASON_FW_STREAM_PRE_HOOK,       /**< drop issued in the pre_stream hook */
+    PKT_DROP_REASON_FW_FLOW_PRE_HOOK,         /**< drop issued in the pre_flow hook */
     PKT_DROP_REASON_MAX,
 };
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -406,6 +406,7 @@ enum PacketDropReason {
     PKT_DROP_REASON_FW_DEFAULT_APP_POLICY,    /**< drop issued by default app policy */
     PKT_DROP_REASON_FW_STREAM_PRE_HOOK,       /**< drop issued in the pre_stream hook */
     PKT_DROP_REASON_FW_FLOW_PRE_HOOK,         /**< drop issued in the pre_flow hook */
+    PKT_DROP_REASON_FW_FLOW_DROP,
     PKT_DROP_REASON_MAX,
 };
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -160,8 +160,20 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f)
         SCLogDebug("setting flow action pass");
     }
 
-    // TODO pass and accept could be set at the same time?
-    if (action & (ACTION_DROP | ACTION_REJECT_ANY | ACTION_PASS)) {
+    /* pass:flow can be set if accept:flow is present */
+    if (action & ACTION_PASS) {
+        if (f->flags & (FLOW_ACTION_DROP | FLOW_ACTION_PASS)) {
+            /* drop or pass already set. First to set wins. */
+            SCLogDebug("not setting %s flow already set to %s",
+                    (action & ACTION_PASS) ? "pass" : "drop",
+                    (f->flags & FLOW_ACTION_DROP) ? "drop" : "pass");
+        } else {
+            f->flags |= FLOW_ACTION_PASS;
+            SCLogDebug("setting flow action pass");
+        }
+
+        // TODO firewall drop:flow should override FLOW_ACTION_PASS
+    } else if (action & (ACTION_DROP | ACTION_REJECT_ANY)) {
         if (f->flags & (FLOW_ACTION_DROP | FLOW_ACTION_PASS | FLOW_ACTION_ACCEPT)) {
             /* drop or pass already set. First to set wins. */
             SCLogDebug("not setting %s flow already set to %s",
@@ -171,10 +183,6 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f)
             if (action & (ACTION_DROP | ACTION_REJECT_ANY)) {
                 f->flags |= FLOW_ACTION_DROP;
                 SCLogDebug("setting flow action drop");
-            }
-            if (action & ACTION_PASS) {
-                f->flags |= FLOW_ACTION_PASS;
-                SCLogDebug("setting flow action pass");
             }
         }
     }
@@ -217,10 +225,7 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const Pac
 
         DEBUG_VALIDATE_BUG_ON(!PacketCheckAction(p, ACTION_DROP));
     } else {
-        if (pa->action & ACTION_PASS) {
-            SCLogDebug("[packet %p][PASS sid %u]", p, s->id);
-            // nothing to set in the packet
-        } else if (pa->action & ACTION_ACCEPT) {
+        if (pa->action & ACTION_ACCEPT) {
             const enum ActionScope as = pa->s->action_scope;
             SCLogDebug("packet %" PRIu64 ": ACCEPT %u as:%u flags:%02x", p->pcap_cnt, s->id, as,
                     pa->flags);
@@ -230,6 +235,9 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const Pac
                 p->action |= ACTION_ACCEPT;
             }
         } else if (pa->action & (ACTION_ALERT | ACTION_CONFIG)) {
+            // nothing to set in the packet
+        } else if (pa->action & ACTION_PASS) {
+            SCLogDebug("[packet %p][PASS sid %u]", p, s->id);
             // nothing to set in the packet
         } else if (pa->action != 0) {
             DEBUG_VALIDATE_BUG_ON(1); // should be unreachable

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -592,14 +592,12 @@ static inline void PacketAlertFinalizeProcessQueue(
                 skip_td = true;
                 continue;
             }
-
-            // TODO we can also drop if alert is suppressed, right?
-            if (s->action & ACTION_DROP) {
-                SCLogDebug("sid:%u led to a drop that will skip any firewall alerts", s->id);
-                dropped = true;
-            }
         } else {
             p->alerts.discarded++;
+        }
+
+        if (s->action & ACTION_DROP) {
+            dropped = true;
         }
     }
 }

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -633,8 +633,7 @@ static inline void PacketAlertFinalizeProcessQueue(
             }
 
             if (dropped) {
-                SCLogDebug("Skippig firewall signature after a drop.");
-                p->alerts.firewall_discarded++;
+                SCLogDebug("Skipping firewall signature after a drop.");
                 continue;
             }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -153,7 +153,7 @@ int PacketAlertCheck(Packet *p, uint32_t sid)
 }
 #endif
 
-static inline void RuleActionToFlow(const uint8_t action, Flow *f)
+static inline void RuleActionToFlow(const uint8_t action, Flow *f, const bool fw_rule)
 {
     if (action & ACTION_ACCEPT) {
         f->flags |= FLOW_ACTION_ACCEPT;
@@ -185,6 +185,10 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f)
                 SCLogDebug("setting flow action drop");
             }
         }
+    }
+
+    if (fw_rule) {
+        f->aux_flags |= FLOW_AUX_ACTION_BY_FIREWALL;
     }
 }
 
@@ -222,7 +226,7 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const Pac
             p->alerts.drop.s = (Signature *)s;
         }
         if ((p->flow != NULL) && (pa->flags & PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)) {
-            RuleActionToFlow(pa->action, p->flow);
+            RuleActionToFlow(pa->action, p->flow, is_fw_rule);
         }
 
         DEBUG_VALIDATE_BUG_ON(!PacketCheckAction(p, ACTION_DROP));
@@ -247,7 +251,7 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const Pac
 
         if ((pa->action & (ACTION_PASS | ACTION_ACCEPT)) && (p->flow != NULL) &&
                 (pa->flags & PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)) {
-            RuleActionToFlow(pa->action, p->flow);
+            RuleActionToFlow(pa->action, p->flow, is_fw_rule);
         }
     }
 }

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -188,10 +188,8 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f, const bool fw
                     (action & ACTION_PASS) ? "pass" : "drop",
                     (f->flags & FLOW_ACTION_DROP) ? "drop" : "pass");
         } else {
-            if (action & (ACTION_DROP | ACTION_REJECT_ANY)) {
-                f->flags |= FLOW_ACTION_DROP;
-                SCLogDebug("setting flow action drop");
-            }
+            f->flags |= FLOW_ACTION_DROP;
+            SCLogDebug("setting flow action drop");
         }
     }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -175,7 +175,14 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f, const bool fw
 
         // TODO firewall drop:flow should override FLOW_ACTION_PASS
     } else if (action & (ACTION_DROP | ACTION_REJECT_ANY)) {
-        if (f->flags & (FLOW_ACTION_DROP | FLOW_ACTION_PASS | FLOW_ACTION_ACCEPT)) {
+        /* drop:flow from TD rules will override a accept:flow from
+         * firewall rules. */
+        if (f->flags & FLOW_ACTION_ACCEPT) {
+            f->flags &= ~FLOW_ACTION_ACCEPT;
+            f->flags |= FLOW_ACTION_DROP;
+            SCLogDebug("replaced FLOW_ACTION_ACCEPT with FLOW_ACTION_DROP");
+        }
+        if (f->flags & (FLOW_ACTION_DROP | FLOW_ACTION_PASS)) {
             /* drop or pass already set. First to set wins. */
             SCLogDebug("not setting %s flow already set to %s",
                     (action & ACTION_PASS) ? "pass" : "drop",

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -198,15 +198,17 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const Pac
     SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x", p->pcap_cnt, s->id,
             pa->action, pa->flags);
 
+    const bool is_fw_rule = s->flags & SIG_FLAG_FIREWALL ? true : false;
     /* REJECT also sets ACTION_DROP, just make it more visible with this check */
     if (pa->action & ACTION_DROP_REJECT) {
-        uint8_t drop_reason = PKT_DROP_REASON_RULES;
-        if (s->detect_table == DETECT_TABLE_PACKET_PRE_STREAM) {
-            drop_reason = PKT_DROP_REASON_STREAM_PRE_HOOK;
-        } else if (s->detect_table == DETECT_TABLE_PACKET_PRE_FLOW) {
-            drop_reason = PKT_DROP_REASON_FLOW_PRE_HOOK;
+        uint8_t drop_reason = is_fw_rule ? PKT_DROP_REASON_FW_RULES : PKT_DROP_REASON_RULES;
+        if (is_fw_rule) {
+            if (s->detect_table == DETECT_TABLE_PACKET_PRE_STREAM) {
+                drop_reason = PKT_DROP_REASON_FW_STREAM_PRE_HOOK;
+            } else if (s->detect_table == DETECT_TABLE_PACKET_PRE_FLOW) {
+                drop_reason = PKT_DROP_REASON_FW_FLOW_PRE_HOOK;
+            }
         }
-
         /* PacketDrop will update the packet action, too */
         PacketDrop(p, pa->action,
                 (pa->flags & PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED)
@@ -544,9 +546,10 @@ static inline void PacketAlertFinalizeProcessQueue(
             }
         }
 
-        /* skip firewall sigs following a drop: IDS mode still shows alerts after an alert. */
+        /* skip firewall sigs following a drop: IDS mode still shows alerts after a drop. */
         if ((s->flags & SIG_FLAG_FIREWALL) && dropped) {
-            p->alerts.discarded++;
+            SCLogDebug("Skippig firewall signature after a drop.");
+            p->alerts.firewall_discarded++;
 
             /* Thresholding removes this alert */
         } else if (res == 0 || res == 2 || (s->action & (ACTION_ALERT | ACTION_PASS)) == 0) {
@@ -581,6 +584,7 @@ static inline void PacketAlertFinalizeProcessQueue(
 
             // TODO we can also drop if alert is suppressed, right?
             if (s->action & ACTION_DROP) {
+                SCLogDebug("sid:%u led to a drop that will skip any firewall alerts", s->id);
                 dropped = true;
             }
         } else {

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -19,6 +19,7 @@
 #include "suricata.h"
 
 #include "detect.h"
+#include "detect-parse.h"
 #include "detect-engine-alert.h"
 #include "detect-engine-threshold.h"
 #include "detect-engine-tag.h"
@@ -157,7 +158,7 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f, const bool fw
 {
     if (action & ACTION_ACCEPT) {
         f->flags |= FLOW_ACTION_ACCEPT;
-        SCLogDebug("setting flow action pass");
+        SCLogDebug("setting flow action accept");
     }
 
     /* pass:flow can be set if accept:flow is present */
@@ -199,7 +200,7 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f, const bool fw
  *  \param pa packet alert struct -- match, including actions after thresholding (rate_filter) */
 static void PacketApplySignatureActions(Packet *p, const Signature *s, const PacketAlert *pa)
 {
-    SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x", p->pcap_cnt, s->id,
+    SCLogDebug("packet %" PRIu64 ", sid %u: action %02x alert_flags %02x", p->pcap_cnt, s->id,
             pa->action, pa->flags);
 
     const bool is_fw_rule = s->flags & SIG_FLAG_FIREWALL ? true : false;
@@ -386,7 +387,7 @@ void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet
     /* we do that even before inserting into the queue, so we save it even if appending fails */
     if (p->alerts.drop.action == 0 && s->action & ACTION_DROP) {
         p->alerts.drop = PacketAlertSet(det_ctx, s, tx_id, alert_flags);
-        SCLogDebug("Set PacketAlert drop action. s->iid %" PRIu32 "", s->iid);
+        SCLogDebug("sid %u: set PacketAlert drop action. s->iid %" PRIu32 "", s->id, s->iid);
     }
 
     uint16_t pos = det_ctx->alert_queue_size;
@@ -400,7 +401,8 @@ void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet
     }
     det_ctx->alert_queue[pos] = PacketAlertSet(det_ctx, s, tx_id, alert_flags);
 
-    SCLogDebug("Appending sid %" PRIu32 ", s->iid %" PRIu32 " to alert queue", s->id, s->iid);
+    SCLogDebug("packet %" PRIu64 ": appending sid %" PRIu32 ", s->iid %" PRIu32 " to alert queue",
+            p->pcap_cnt, s->id, s->iid);
     det_ctx->alert_queue_size++;
 }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -157,7 +157,9 @@ int PacketAlertCheck(Packet *p, uint32_t sid)
 static inline void RuleActionToFlow(const uint8_t action, Flow *f, const bool fw_rule)
 {
     if (action & ACTION_ACCEPT) {
+        DEBUG_VALIDATE_BUG_ON(!fw_rule);
         f->flags |= FLOW_ACTION_ACCEPT;
+        f->aux_flags |= FLOW_AUX_ACTION_BY_FIREWALL;
         SCLogDebug("setting flow action accept");
     }
 
@@ -179,7 +181,10 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f, const bool fw
          * firewall rules. */
         if (f->flags & FLOW_ACTION_ACCEPT) {
             f->flags &= ~FLOW_ACTION_ACCEPT;
+            f->aux_flags &= ~FLOW_AUX_ACTION_BY_FIREWALL;
             f->flags |= FLOW_ACTION_DROP;
+            if (fw_rule)
+                f->aux_flags |= FLOW_AUX_ACTION_BY_FIREWALL;
             SCLogDebug("replaced FLOW_ACTION_ACCEPT with FLOW_ACTION_DROP");
         }
         if (f->flags & (FLOW_ACTION_DROP | FLOW_ACTION_PASS)) {
@@ -490,6 +495,98 @@ static inline void FlowApplySignatureActions(
     }
 }
 
+/** \internal
+ * \brief handle immediate actions for a firewall rule match
+ *
+ * Delayed action (accept) is handled after TD has also run, as TD drop
+ * can overrule a FW accept. So returning `accept` here means "will accept if TD agrees".
+ *
+ * \retval pol firewall policy with action that is (drop) or should possibly be (accept)
+ * applied to the packet and flow.
+ */
+static struct DetectFirewallPolicy HandleFirewallRule(
+        const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p, PacketAlert *pa)
+{
+    const Signature *s = pa->s;
+    struct DetectFirewallPolicy pol = { .action = 0, .action_scope = 0 };
+    int res = PacketAlertHandle(de_ctx, det_ctx, s, p, pa);
+    SCLogDebug("packet %" PRIu64 ": fw sid %u: res %d", p->pcap_cnt, s->id, res);
+    if (res > 0) {
+        /* Now, if we have an alert, we have to check if we want
+         * to tag this session or src/dst host */
+        if (s->sm_arrays[DETECT_SM_LIST_TMATCH] != NULL) {
+            KEYWORD_PROFILING_SET_LIST(det_ctx, DETECT_SM_LIST_TMATCH);
+            SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_TMATCH];
+            while (1) {
+                /* tags are set only for alerts */
+                KEYWORD_PROFILING_START;
+                sigmatch_table[smd->type].Match(det_ctx, p, (Signature *)s, smd->ctx);
+                KEYWORD_PROFILING_END(det_ctx, smd->type, 1);
+                if (smd->is_last)
+                    break;
+                smd++;
+            }
+        }
+        /* if this is a terminating action, pass the action to the caller. */
+        if (s->action_scope != ACTION_SCOPE_HOOK ||
+                pa->flags & PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET) {
+            pol.action = s->action;
+            pol.action_scope = s->action_scope;
+            if (pol.action & ACTION_DROP) {
+                uint8_t drop_reason = PKT_DROP_REASON_FW_RULES;
+                if (s->detect_table == DETECT_TABLE_PACKET_PRE_STREAM) {
+                    drop_reason = PKT_DROP_REASON_FW_STREAM_PRE_HOOK;
+                } else if (s->detect_table == DETECT_TABLE_PACKET_PRE_FLOW) {
+                    drop_reason = PKT_DROP_REASON_FW_FLOW_PRE_HOOK;
+                }
+                PacketDrop(p, pol.action, drop_reason);
+                if (p->flow && pol.action_scope == ACTION_SCOPE_FLOW) {
+                    p->flow->flags |= FLOW_ACTION_DROP;
+                    p->flow->aux_flags |= FLOW_AUX_ACTION_BY_FIREWALL;
+                    SCLogDebug("packet %" PRIu64 ": FLOW_ACTION_DROP set by firewall by sid %u",
+                            p->pcap_cnt, s->id);
+                }
+            }
+            if (pol.action & ACTION_PASS) {
+                if (p->flow && pol.action_scope == ACTION_SCOPE_FLOW) {
+                    p->flow->flags |= FLOW_ACTION_PASS;
+                    SCLogDebug("packet %" PRIu64 ": FLOW_ACTION_PASS set by firewall by sid %u",
+                            p->pcap_cnt, s->id);
+                }
+            }
+        }
+        /* add the alert for logging if required. */
+        if (s->action & ACTION_ALERT) {
+            if (p->alerts.cnt < packet_alert_max) {
+                p->alerts.alerts[p->alerts.cnt++] = *pa;
+            } else {
+                p->alerts.firewall_discarded++;
+            }
+        }
+    }
+    return pol;
+}
+
+/*
+ * Queue order after sorting:
+ *
+ * Firewall use case: rules are sorted by Signature::detect_table, Signature::iid (which reflects
+ * order in the rule file(s)) This means:
+ * - pre_flow
+ * - pre_stream
+ * - packet:filter (firewall)
+ * - packet:td (IDS/IPS rules)
+ * - app:filter (firewall)
+ * - app:td (IDS/IPS rules)
+ *
+ * Firewall DROPs are immediate.
+ * Firewall ACCEPTs depend on TD not dropping.
+ * Firewall rules are not affected by PASS.
+ * TD rules are affected by PASS, both set by Firewall and TD rules.
+ *
+ * Non-Firewall use case: rules are sorted by Signature::iid (which reflect order based on flowbits,
+ * action-order, priority, etc)
+ */
 static inline void PacketAlertFinalizeProcessQueue(
         const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p)
 {
@@ -503,17 +600,82 @@ static inline void PacketAlertFinalizeProcessQueue(
 
     bool dropped = false;
     bool skip_td = false;
+    bool skip_fw = false;
+    bool fw_accept_packet = false; // same as skip_fw?
+    bool fw_accept_flow = false;
+
+#ifdef DEBUG
+    SCLogDebug("packet %" PRIu64 ": starting alert event queue", p->pcap_cnt);
+    for (uint16_t x = 0; x < det_ctx->alert_queue_size; x++) {
+        const PacketAlert *pa = &det_ctx->alert_queue[x];
+        const Signature *s = pa->s;
+        SCLogDebug("(list) %s sid %u: action %02x scope %u iid %u detect_table %u",
+                (s->flags & SIG_FLAG_FIREWALL) ? "fw" : "td", s->id, s->action, s->action_scope,
+                s->iid, s->detect_table);
+    }
+#endif /* DEBUG */
+    uint8_t skip_table_id = 0;
+    bool skip_table = false;
     for (uint16_t i = 0; i < det_ctx->alert_queue_size; i++) {
         PacketAlert *pa = &det_ctx->alert_queue[i];
         const Signature *s = pa->s;
 
+        if (s->flags & SIG_FLAG_FIREWALL) {
+            if (skip_fw) {
+                continue;
+            }
+            /* skip for this table, but not for later. Mostly for showing
+             * alerts for both packet:filter and app:filter together. */
+            if (skip_table) {
+                if (s->detect_table <= skip_table_id)
+                    continue;
+                skip_table = false;
+            }
+
+            if (dropped) {
+                SCLogDebug("Skippig firewall signature after a drop.");
+                p->alerts.firewall_discarded++;
+                continue;
+            }
+
+            struct DetectFirewallPolicy pol = HandleFirewallRule(de_ctx, det_ctx, p, pa);
+            /* drop is immediate */
+            if (pol.action & ACTION_DROP) {
+                dropped = true;
+            } else if (pol.action & ACTION_ACCEPT) {
+                SCLogDebug("fw sid %u setting skip_fw for action %02x scope %s", s->id, pol.action,
+                        ActionScopeToString(pol.action_scope));
+                /* see if we want to skip other alerts for this table */
+                if (pol.action_scope == ACTION_SCOPE_HOOK) {
+                    skip_table_id = s->detect_table;
+                    skip_table = true;
+                } else {
+                    skip_fw = true;
+                }
+                fw_accept_packet = true;
+                if (pol.action_scope == ACTION_SCOPE_FLOW)
+                    fw_accept_flow = true;
+            }
+            if (pol.action & ACTION_PASS) {
+                skip_td = true;
+            }
+            if (dropped)
+                goto fw_dropped;
+
+            continue;
+        }
+
+        SCLogDebug("sid: %u, action %02x, firewall? %s", s->id, pa->action,
+                BOOL2STR(s->flags & SIG_FLAG_FIREWALL));
+
         /* if a firewall rule told us to skip, we don't count the skipped
          * alerts. */
-        if (have_fw_rules && skip_td && (s->flags & SIG_FLAG_FIREWALL) == 0) {
+        if (have_fw_rules && skip_td) {
             continue;
         }
 
         int res = PacketAlertHandle(de_ctx, det_ctx, s, p, pa);
+        SCLogDebug("sid %u: res %d", pa->s->id, res);
         if (res > 0) {
             /* Now, if we have an alert, we have to check if we want
              * to tag this session or src/dst host */
@@ -549,7 +711,7 @@ static inline void PacketAlertFinalizeProcessQueue(
                 /* set actions on the flow */
                 FlowApplySignatureActions(p, pa, s, pa->flags);
 
-                SCLogDebug("det_ctx->alert_queue[i].action %02x (DROP %s, PASS %s)", pa->action,
+                SCLogDebug("sid %u: action %02x (DROP %s, PASS %s)", pa->s->id, pa->action,
                         BOOL2STR(pa->action & ACTION_DROP), BOOL2STR(pa->action & ACTION_PASS));
 
                 /* set actions on packet */
@@ -557,13 +719,8 @@ static inline void PacketAlertFinalizeProcessQueue(
             }
         }
 
-        /* skip firewall sigs following a drop: IDS mode still shows alerts after a drop. */
-        if ((s->flags & SIG_FLAG_FIREWALL) && dropped) {
-            SCLogDebug("Skippig firewall signature after a drop.");
-            p->alerts.firewall_discarded++;
-
-            /* Thresholding removes this alert */
-        } else if (res == 0 || res == 2 || (s->action & (ACTION_ALERT | ACTION_PASS)) == 0) {
+        /* Thresholding removes this alert */
+        if (res == 0 || res == 2 || (s->action & (ACTION_ALERT | ACTION_PASS)) == 0) {
             SCLogDebug("sid:%u: skipping alert because of thresholding (res=%d) or NOALERT (%02x)",
                     s->id, res, s->action);
             /* we will not copy this to the AlertQueue */
@@ -598,6 +755,21 @@ static inline void PacketAlertFinalizeProcessQueue(
 
         if (s->action & ACTION_DROP) {
             dropped = true;
+        }
+    }
+
+fw_dropped:
+    /* after threat detection has been handled, see if the fw intended to accept (drop is handled
+     * immediately by the fw), as fw accept can be overruled by td drop. */
+    if (have_fw_rules) {
+        if (p->action & ACTION_DROP) {
+            SCLogDebug("packet %" PRIu64 ": dropped by TD", p->pcap_cnt);
+        } else if (fw_accept_packet) {
+            p->action |= ACTION_ACCEPT;
+            if (p->flow && fw_accept_flow) {
+                p->flow->flags |= FLOW_ACTION_ACCEPT;
+                SCLogDebug("packet %" PRIu64 ": FLOW_ACTION_ACCEPT set from firewall", p->pcap_cnt);
+            }
         }
     }
 }

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -2063,6 +2063,11 @@ static void FirewallAddRulesForState(const DetectEngineCtx *de_ctx, const AppPro
             }
         }
 
+        if ((s->flags & SIG_FLAG_FW_HOOK_LTE) && state < s->app_progress_hook) {
+            SCJbAppendString(ctx->js, s->sig_str);
+            accept_rules += ((s->action & ACTION_ACCEPT) != 0);
+        }
+
         if (s->app_progress_hook == state) {
             SCJbAppendString(ctx->js, s->sig_str);
             accept_rules += ((s->action & ACTION_ACCEPT) != 0);

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1980,11 +1980,70 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
 
 #include "app-layer-parser.h"
 
+static const char *ActionScopeToString(enum ActionScope s)
+{
+    switch (s) {
+        case ACTION_SCOPE_PACKET:
+            return "packet";
+        case ACTION_SCOPE_FLOW:
+            return "flow";
+            break;
+        case ACTION_SCOPE_HOOK:
+            return "hook";
+        case ACTION_SCOPE_TX:
+            return "tx";
+        case ACTION_SCOPE_AUTO:
+            return "auto";
+    }
+    DEBUG_VALIDATE_BUG_ON(1);
+    return "unknown";
+}
+
+static void AddPolicy(const DetectEngineCtx *de_ctx, RuleAnalyzer *ctx, const AppProto a,
+        const uint8_t state, const uint8_t direction)
+{
+    char policy_string[64] = "";
+    const struct DetectFirewallPolicy *p = NULL;
+    const struct DetectFirewallPolicies *fw_policies = de_ctx->fw_policies;
+    if (direction == STREAM_TOSERVER) {
+        p = &fw_policies->app[a].ts[state];
+    } else {
+        p = &fw_policies->app[a].tc[state];
+    }
+    const char *as = ActionScopeToString(p->action_scope);
+    DEBUG_VALIDATE_BUG_ON(as == NULL);
+    if (as == NULL)
+        return;
+    if (p->action & ACTION_REJECT_ANY) {
+        if (p->action & ACTION_REJECT_DST) {
+            snprintf(policy_string, sizeof(policy_string), "rejectdst:%s", as);
+        } else if (p->action & ACTION_REJECT_BOTH) {
+            snprintf(policy_string, sizeof(policy_string), "rejectboth:%s", as);
+        } else {
+            snprintf(policy_string, sizeof(policy_string), "rejectsrc:%s", as);
+        }
+    } else if (p->action & ACTION_DROP) {
+        snprintf(policy_string, sizeof(policy_string), "drop:%s", as);
+    } else if (p->action & ACTION_ACCEPT) {
+        snprintf(policy_string, sizeof(policy_string), "accept:%s", as);
+    } else {
+        DEBUG_VALIDATE_BUG_ON(1);
+    }
+    if (p->action & ACTION_PASS) {
+        if (p->action_scope == ACTION_SCOPE_FLOW) {
+            strlcat(policy_string, ",pass:flow", sizeof(policy_string));
+        } else {
+            DEBUG_VALIDATE_BUG_ON(1);
+        }
+    }
+    SCJbSetString(ctx->js, "policy", policy_string);
+}
+
 static void FirewallAddRulesForState(const DetectEngineCtx *de_ctx, const AppProto a,
         const uint8_t state, const uint8_t direction, RuleAnalyzer *ctx)
 {
     uint32_t accept_rules = 0;
-    SCJbSetString(ctx->js, "policy", "drop:flow");
+    AddPolicy(de_ctx, ctx, a, state, direction);
     SCJbOpenArray(ctx->js, "rules");
     for (Signature *s = de_ctx->sig_list; s != NULL; s = s->next) {
         if ((s->flags & SIG_FLAG_FIREWALL) == 0)

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1980,25 +1980,6 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
 
 #include "app-layer-parser.h"
 
-static const char *ActionScopeToString(enum ActionScope s)
-{
-    switch (s) {
-        case ACTION_SCOPE_PACKET:
-            return "packet";
-        case ACTION_SCOPE_FLOW:
-            return "flow";
-            break;
-        case ACTION_SCOPE_HOOK:
-            return "hook";
-        case ACTION_SCOPE_TX:
-            return "tx";
-        case ACTION_SCOPE_AUTO:
-            return "auto";
-    }
-    DEBUG_VALIDATE_BUG_ON(1);
-    return "unknown";
-}
-
 static void AddPolicy(const DetectEngineCtx *de_ctx, RuleAnalyzer *ctx, const AppProto a,
         const uint8_t state, const uint8_t direction)
 {

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -2117,17 +2117,21 @@ int FirewallAnalyzer(const DetectEngineCtx *de_ctx)
         if (!AppProtoIsValid(a))
             continue;
 
-        // HACK not all protocols have named states yet
-        const char *hack = AppLayerParserGetStateNameById(IPPROTO_TCP, a, 0, STREAM_TOSERVER);
-        if (!hack)
-            continue;
-
-        SCJbOpenObject(ctx.js, AppProtoToString(a));
         const uint8_t complete_state_ts =
                 (const uint8_t)AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOSERVER);
-        for (uint8_t state = 0; state < complete_state_ts; state++) {
+        SCJbOpenObject(ctx.js, AppProtoToString(a));
+        for (uint8_t state = 0; state <= complete_state_ts; state++) {
             const char *name =
                     AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOSERVER);
+            if (name == NULL) {
+                if (state == 0)
+                    name = "request-started";
+                else if (state == complete_state_ts)
+                    name = "request-complete";
+                else
+                    name = "unknown";
+            }
+
             char table_name[128];
             snprintf(table_name, sizeof(table_name), "app:%s:%s", AppProtoToString(a), name);
             SCJbOpenObject(ctx.js, table_name);
@@ -2142,9 +2146,17 @@ int FirewallAnalyzer(const DetectEngineCtx *de_ctx)
         }
         const uint8_t complete_state_tc =
                 (const uint8_t)AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOCLIENT);
-        for (uint8_t state = 0; state < complete_state_tc; state++) {
+        for (uint8_t state = 0; state <= complete_state_tc; state++) {
             const char *name =
                     AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOCLIENT);
+            if (name == NULL) {
+                if (state == 0)
+                    name = "response-started";
+                else if (state == complete_state_tc)
+                    name = "response-complete";
+                else
+                    name = "unknown";
+            }
             char table_name[128];
             snprintf(table_name, sizeof(table_name), "app:%s:%s", AppProtoToString(a), name);
             SCJbOpenObject(ctx.js, table_name);

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -50,6 +50,8 @@
 #include <glob.h>
 #endif
 
+#include "app-layer-parser.h"
+
 extern int rule_reload;
 extern int engine_analysis;
 static bool fp_engine_analysis_set = false;
@@ -294,6 +296,15 @@ static int ProcessSigFiles(DetectEngineCtx *de_ctx, char *pattern, SigFileLoader
 
 static int LoadFirewallRuleFiles(DetectEngineCtx *de_ctx)
 {
+    if (DetectFirewallInitDefaultPolicies(de_ctx) < 0) {
+        SCLogError("initializing firewall policies failed");
+        return -1;
+    }
+    if (DetectFirewallLoadDefaultPolicies(de_ctx) < 0) {
+        SCLogError("loading firewall policies failed");
+        return -1;
+    }
+
     if (de_ctx->firewall_rule_file_exclusive) {
         int32_t good_sigs = 0;
         int32_t bad_sigs = 0;
@@ -393,7 +404,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, bool sig_file_exc
 
     if (EngineModeIsFirewall() || de_ctx->firewall_rule_file_exclusive) {
         if (LoadFirewallRuleFiles(de_ctx) < 0) {
-            if (de_ctx->failure_fatal) {
+            if (de_ctx->fw_policies == NULL || de_ctx->failure_fatal) {
                 exit(EXIT_FAILURE);
             }
             ret = -1;

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -936,6 +936,28 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
             continue; // done for this sig
         }
 
+        /* special case: insert sigs at hook before Signature::app_progress_hook for the HOOK_LTE
+         * case: we need a addition per hook to make sure that the sig is called when needed. For
+         * hook 0 it could have a preceding rule that makes sure this sig isn't triggered, but then
+         * for hook 1 we would need to be called. */
+        if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+            for (uint8_t state = 0; state < s->app_progress_hook; state++) {
+                SCLogDebug("handle HOOK %u LTE", state);
+                const int dir = (s->flags & SIG_FLAG_TOSERVER) ? 0 : 1;
+                const char *pname = AppLayerParserGetStateNameById(IPPROTO_TCP, // TODO
+                        s->alproto, state, dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT);
+                if (pname == NULL)
+                    goto error;
+                const int sm_list = DetectEngineAppHookToSmlist(
+                        s->alproto, state, dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT);
+                if (TxNonPFAddSig(de_ctx, tx_engines_hash, s->alproto, dir, (int16_t)state, sm_list,
+                            pname, s) != 0) {
+                    goto error;
+                }
+                tx_non_pf = true;
+            }
+        }
+
         for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
             const int list_id = s->init_data->buffers[x].id;
             const DetectBufferType *buf = DetectEngineBufferTypeGetById(de_ctx, list_id);

--- a/src/detect-engine-prefilter.h
+++ b/src/detect-engine-prefilter.h
@@ -42,6 +42,7 @@ typedef struct DetectTransaction_ {
 
     const uint8_t tx_progress;
     const uint8_t tx_end_state;
+    bool is_last; /* is this the last tx? */
 } DetectTransaction;
 
 typedef struct PrefilterStore_ {

--- a/src/detect-engine-prefilter.h
+++ b/src/detect-engine-prefilter.h
@@ -40,8 +40,8 @@ typedef struct DetectTransaction_ {
     /* original value to track changes. */
     const uint8_t detect_progress_orig;
 
-    const int tx_progress;
-    const int tx_end_state;
+    const uint8_t tx_progress;
+    const uint8_t tx_end_state;
 } DetectTransaction;
 
 typedef struct PrefilterStore_ {

--- a/src/detect-engine-profile.c
+++ b/src/detect-engine-profile.c
@@ -35,6 +35,9 @@ void RulesDumpTxMatchArray(const DetectEngineThreadCtx *det_ctx, const SigGroupH
         const Packet *p, const uint64_t tx_id, const uint32_t rule_cnt,
         const uint32_t pkt_prefilter_cnt)
 {
+    if (sgh == NULL)
+        return;
+
     SCJsonBuilder *js =
             CreateEveHeaderWithTxId(p, LOG_DIR_PACKET, "inspectedrules", NULL, tx_id, NULL);
     if (js == NULL)
@@ -78,6 +81,9 @@ void RulesDumpTxMatchArray(const DetectEngineThreadCtx *det_ctx, const SigGroupH
 void RulesDumpMatchArray(const DetectEngineThreadCtx *det_ctx,
         const SigGroupHead *sgh, const Packet *p)
 {
+    if (sgh == NULL)
+        return;
+
     SCJsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "inspectedrules", NULL, NULL);
     if (js == NULL)
         return;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2808,6 +2808,12 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
         HashTableFree(de_ctx->non_pf_engine_names);
     }
     if (de_ctx->fw_policies) {
+        for (uint32_t i = 0; i < DETECT_FIREWALL_POLICY_SIZE; i++) {
+            if (de_ctx->fw_policies->pkt_policy_signatures[i]) {
+                SCFree(de_ctx->fw_policies->pkt_policy_signatures[i]->msg);
+                SCFree(de_ctx->fw_policies->pkt_policy_signatures[i]);
+            }
+        }
         HashTableFree(de_ctx->fw_policies->policy_signatures);
     }
     SCFree(de_ctx->fw_policies);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2746,6 +2746,7 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
     if (de_ctx->non_pf_engine_names) {
         HashTableFree(de_ctx->non_pf_engine_names);
     }
+    SCFree(de_ctx->fw_policies);
     SCFree(de_ctx);
     //DetectAddressGroupPrintMemory();
     //DetectSigGroupPrintMemory();

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2807,6 +2807,9 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
     if (de_ctx->non_pf_engine_names) {
         HashTableFree(de_ctx->non_pf_engine_names);
     }
+    if (de_ctx->fw_policies) {
+        HashTableFree(de_ctx->fw_policies->policy_signatures);
+    }
     SCFree(de_ctx->fw_policies);
     SCFree(de_ctx);
     //DetectAddressGroupPrintMemory();

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3420,6 +3420,10 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
     det_ctx->counter_alerts = StatsRegisterCounter("detect.alert", tv);
     det_ctx->counter_alerts_overflow = StatsRegisterCounter("detect.alert_queue_overflow", tv);
     det_ctx->counter_alerts_suppressed = StatsRegisterCounter("detect.alerts_suppressed", tv);
+    if (EngineModeIsFirewall()) {
+        det_ctx->counter_firewall_discarded_alerts =
+                StatsRegisterCounter("firewall.discarded_alerts", tv);
+    }
 
     /* Register counter for Lua rule errors. */
     det_ctx->lua_rule_errors = StatsRegisterCounter("detect.lua.errors", tv);
@@ -3500,6 +3504,10 @@ DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
     det_ctx->counter_alerts = StatsRegisterCounter("detect.alert", tv);
     det_ctx->counter_alerts_overflow = StatsRegisterCounter("detect.alert_queue_overflow", tv);
     det_ctx->counter_alerts_suppressed = StatsRegisterCounter("detect.alerts_suppressed", tv);
+    if (EngineModeIsFirewall()) {
+        det_ctx->counter_firewall_discarded_alerts =
+                StatsRegisterCounter("firewall.discarded_alerts", tv);
+    }
 #ifdef PROFILING
     det_ctx->counter_mpm_list = StatsRegisterAvgCounter("detect.mpm_list", tv);
     det_ctx->counter_match_list = StatsRegisterAvgCounter("detect.match_list", tv);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -794,6 +794,32 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
     s->init_data->init_flags |= SIG_FLAG_INIT_STATE_MATCH;
 }
 
+/** \brief get the sm_list for a app hook */
+int DetectEngineAppHookToSmlist(const AppProto p, const uint8_t state, const int direction)
+{
+    const char *app_proto = AppProtoToString(p);
+    if (app_proto == NULL) {
+        SCLogError("unknown app_proto %u", p);
+        return -1;
+    }
+    if (strcmp(app_proto, "http") == 0)
+        app_proto = "http1";
+
+    const char *name = AppLayerParserGetStateNameById(
+            IPPROTO_TCP, p, state, direction & (STREAM_TOSERVER | STREAM_TOCLIENT));
+    if (name == NULL)
+        return -1;
+
+    char generic_hook_name[256];
+    snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", app_proto, name);
+    int list = DetectBufferTypeGetByName(generic_hook_name);
+    if (list < 0) {
+        SCLogError("no list registered as %s for %s hook %s", generic_hook_name, app_proto, name);
+        return -1;
+    }
+    return list;
+}
+
 /**
  *  \note for the file inspect engine, the id DE_STATE_ID_FILE_INSPECT
  *        is assigned.
@@ -805,6 +831,41 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
     bool head_is_mpm = false;
     uint8_t last_id = DE_STATE_FLAG_BASE;
     SCLogDebug("%u: setup app inspect engines. %u buffers", s->id, s->init_data->buffer_index);
+
+    if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+        SCLogDebug("need an inspect engine per state, range 0-%u", s->app_progress_hook);
+        for (uint8_t state = 0; state < s->app_progress_hook; state++) {
+            uint8_t dir = 0;
+            int direction = 0;
+            BUG_ON((s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)) ==
+                    (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT));
+            BUG_ON((s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)) == 0);
+            if (s->flags & SIG_FLAG_TOSERVER) {
+                direction = STREAM_TOSERVER;
+                dir = 0;
+            } else if (s->flags & SIG_FLAG_TOCLIENT) {
+                direction = STREAM_TOCLIENT;
+                dir = 1;
+            }
+
+            int sm_list =
+                    DetectEngineAppHookToSmlist(s->init_data->hook.t.app.alproto, 0, direction);
+            if (sm_list < 0)
+                return -1;
+
+            DetectEngineAppInspectionEngine t = {
+                .alproto = s->init_data->hook.t.app.alproto,
+                .progress = (uint16_t)state,
+                .sm_list = (uint16_t)sm_list,
+                .sm_list_base = (uint16_t)sm_list,
+                .dir = dir,
+            };
+            AppendAppInspectEngine(de_ctx, &t, s, NULL, mpm_list, files_id, &last_id, &head_is_mpm);
+            SCLogDebug("sid %u: appended pass-tru engine at hook:%u sm_list:%d for "
+                       "SIG_FLAG_INIT_HOOK_LTE",
+                    s->id, state, sm_list);
+        }
+    }
 
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
         SigMatchData *smd = SigMatchList2DataArray(s->init_data->buffers[x].head);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -209,4 +209,6 @@ bool DetectMd5ValidateCallback(
 
 void DeStateRegisterTests(void);
 
+int DetectEngineAppHookToSmlist(const AppProto p, const uint8_t state, const int direction);
+
 #endif /* SURICATA_DETECT_ENGINE_H */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1315,6 +1315,7 @@ static SignatureHook SetAppHook(const AppProto alproto, int progress)
  */
 static int SigParseProtoHookApp(Signature *s, const char *proto_hook, const char *p, const char *h)
 {
+    SCLogDebug("h:'%s'", h);
     if (strcmp(h, "request_started") == 0) {
         s->flags |= SIG_FLAG_TOSERVER;
         s->init_data->hook =
@@ -1349,7 +1350,7 @@ static int SigParseProtoHookApp(Signature *s, const char *proto_hook, const char
     }
 
     char generic_hook_name[64];
-    snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:generic", proto_hook);
+    snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", p, h);
     int list = DetectBufferTypeGetByName(generic_hook_name);
     if (list < 0) {
         SCLogError("no list registered as %s for hook %s", generic_hook_name, proto_hook);
@@ -1410,6 +1411,13 @@ static int SigParseProto(Signature *s, const char *protostr)
             AppLayerProtoDetectSupportedIpprotos(s->alproto, s->proto.proto);
 
             if (h) {
+                /* FW hook LTE mode */
+                SCLogDebug("hook '%s'", h);
+                if (*h == '<') {
+                    h++;
+                    SCLogDebug("hook and prior hooks: '%s'", h);
+                    s->flags |= SIG_FLAG_FW_HOOK_LTE;
+                }
                 if (SigParseProtoHookApp(s, protostr, p, h) < 0) {
                     SCLogError("protocol \"%s\" does not support hook \"%s\"", p, h);
                     SCReturnInt(-1);
@@ -2435,6 +2443,11 @@ static void SigSetupPrefilter(DetectEngineCtx *de_ctx, Signature *s)
     SCEnter();
     SCLogDebug("s %u: set up prefilter/mpm", s->id);
     DEBUG_VALIDATE_BUG_ON(s->init_data->mpm_sm != NULL);
+
+    if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+        SCLogDebug("no prefilter for SIG_FLAG_FW_HOOK_LTE sig");
+        SCReturn;
+    }
 
     if (s->init_data->prefilter_sm != NULL) {
         if (s->init_data->prefilter_sm->type == DETECT_CONTENT) {

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3709,6 +3709,122 @@ void DetectSetupParseRegexes(const char *parse_str, DetectParseRegex *detect_par
     }
 }
 
+static uint32_t PolicySignatureHashFunc(HashTable *ht, void *data, uint16_t datalen)
+{
+    const Signature *s = data;
+    const int dir = 1 + (s->flags & SIG_FLAG_TOSERVER) != 0; // 2 for ts, 1 for tc
+    uint32_t hash = s->alproto * s->app_progress_hook * dir;
+    hash = hash % ht->array_size;
+    return hash;
+}
+
+static char PolicySignatureCompareFunc(
+        void *data1, uint16_t datalen1, void *data2, uint16_t datalen2)
+{
+    const Signature *s1 = data1;
+    const Signature *s2 = data2;
+
+    if (s1 == NULL || s2 == NULL)
+        return 0;
+
+    return s1->flags == s2->flags && s1->alproto == s2->alproto &&
+           s1->app_progress_hook == s2->app_progress_hook;
+}
+
+static void PolicySignatureHashFree(void *data)
+{
+    Signature *s = data;
+    SCFree(s->msg);
+    SCFree(s);
+}
+
+const char *ActionScopeToString(enum ActionScope s)
+{
+    switch (s) {
+        case ACTION_SCOPE_PACKET:
+            return "packet";
+        case ACTION_SCOPE_FLOW:
+            return "flow";
+        case ACTION_SCOPE_HOOK:
+            return "hook";
+        case ACTION_SCOPE_TX:
+            return "tx";
+        case ACTION_SCOPE_AUTO:
+            return "auto";
+    }
+    DEBUG_VALIDATE_BUG_ON(1);
+    return "unknown";
+}
+
+void DetectFirewallPolicyToString(const struct DetectFirewallPolicy *p, char *out, size_t out_size)
+{
+    const char *as = ActionScopeToString(p->action_scope);
+    DEBUG_VALIDATE_BUG_ON(as == NULL);
+    if (as == NULL)
+        return;
+    if (p->action & ACTION_REJECT_ANY) {
+        if (p->action & ACTION_REJECT_DST) {
+            snprintf(out, out_size, "rejectdst:%s", as);
+        } else if (p->action & ACTION_REJECT_BOTH) {
+            snprintf(out, out_size, "rejectboth:%s", as);
+        } else {
+            snprintf(out, out_size, "rejectsrc:%s", as);
+        }
+    } else if (p->action & ACTION_DROP) {
+        snprintf(out, out_size, "drop:%s", as);
+    } else if (p->action & ACTION_ACCEPT) {
+        snprintf(out, out_size, "accept:%s", as);
+    } else {
+        DEBUG_VALIDATE_BUG_ON(1);
+    }
+    if (p->action & ACTION_PASS) {
+        if (p->action_scope == ACTION_SCOPE_FLOW) {
+            strlcat(out, ",pass:flow", out_size);
+        } else {
+            DEBUG_VALIDATE_BUG_ON(1);
+        }
+    }
+    if (p->action & ACTION_ALERT) {
+        strlcat(out, ",alert", out_size);
+    }
+}
+
+static int AddAppPolicySignature(HashTable *ht, const int direction, const AppProto alproto,
+        const char *app_name, const uint8_t hook, const char *hookname,
+        struct DetectFirewallPolicy *pol)
+{
+    Signature *s = SCCalloc(1, sizeof(*s)); // SigAlloc does way more than we need
+    if (s == NULL)
+        return -1;
+    char msg[256];
+    snprintf(msg, sizeof(msg), "SURICATA FW default app policy");
+    s->msg = SCStrdup(msg);
+    if (s->msg == NULL) {
+        SCFree(s);
+        return -1;
+    }
+    s->app_progress_hook = hook;
+    s->action = pol->action;
+    s->action_scope = pol->action_scope;
+    s->alproto = alproto;
+    s->flags = (direction == STREAM_TOSERVER) ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;
+    s->flags |= SIG_FLAG_FIREWALL;
+    s->type = SIG_TYPE_APP_TX;
+    s->detect_table = DETECT_TABLE_APP_FILTER;
+    s->id = 2201001;
+    s->rev = 1;
+    s->gid = 1;
+    s->prio = 3;
+
+    if (HashTableAdd(ht, s, 0) != 0) {
+        SCFree(s->msg);
+        SCFree(s);
+        return -1;
+    }
+    SCLogDebug("added to hash");
+    return 0;
+}
+
 static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *pol)
 {
     SCConfNode *policy_actions = SCConfGetNode(policy_name);
@@ -3734,7 +3850,7 @@ static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *p
 
 static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const char *hookname,
         const uint8_t state, const uint8_t complete_state, const int direction,
-        struct DetectFirewallAppPolicy *app_fw_policies)
+        struct DetectFirewallPolicies *fw_policies, struct DetectFirewallAppPolicy *app_fw_policies)
 {
     char policy_name[256];
     const char *in_name = hookname;
@@ -3768,10 +3884,12 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
         FatalError("internal error: failed to assemble firewall policy config string");
     }
 
+    struct DetectFirewallPolicy *pol;
     if (direction == STREAM_TOSERVER)
-        r = DoParsePolicy(policy_name, &app_fw_policies[app_proto].ts[state]);
+        pol = &app_fw_policies[app_proto].ts[state];
     else
-        r = DoParsePolicy(policy_name, &app_fw_policies[app_proto].tc[state]);
+        pol = &app_fw_policies[app_proto].tc[state];
+    r = DoParsePolicy(policy_name, pol);
     if (r == 0 && in_name != NULL) {
         if (state == 0) {
             if (direction == STREAM_TOSERVER)
@@ -3791,10 +3909,14 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
             FatalError("internal error: failed to assemble firewall policy config string");
         }
 
-        if (direction == STREAM_TOSERVER)
-            return DoParsePolicy(policy_name, &app_fw_policies[app_proto].ts[state]);
-        else
-            return DoParsePolicy(policy_name, &app_fw_policies[app_proto].tc[state]);
+        r = DoParsePolicy(policy_name, pol);
+    }
+
+    /* for policies with an alert action, create a policy sig */
+    if (r == 1 && pol->action & ACTION_ALERT) {
+        SCLogDebug("adding policy signature");
+        return AddAppPolicySignature(fw_policies->policy_signatures, direction, app_proto, app_name,
+                state, hookname, pol);
     }
     return r;
 }
@@ -3808,6 +3930,10 @@ int DetectFirewallInitDefaultPolicies(DetectEngineCtx *de_ctx)
         return -1;
     struct DetectFirewallAppPolicy *app_fw_policies = fw_policies->app;
     if (app_fw_policies == NULL)
+        goto error;
+    fw_policies->policy_signatures = HashTableInit(
+            512, PolicySignatureHashFunc, PolicySignatureCompareFunc, PolicySignatureHashFree);
+    if (fw_policies->policy_signatures == NULL)
         goto error;
 
     fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER].action = ACTION_DROP;
@@ -3885,7 +4011,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
             const char *name =
                     AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOSERVER);
             if (DoParseAppPolicy(prefix, a, name, state, complete_state_ts, STREAM_TOSERVER,
-                        app_fw_policies) < 0)
+                        fw_policies, app_fw_policies) < 0)
                 return -1;
         }
 
@@ -3895,12 +4021,28 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
             const char *name =
                     AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOCLIENT);
             if (DoParseAppPolicy(prefix, a, name, state, complete_state_tc, STREAM_TOCLIENT,
-                        app_fw_policies) < 0)
+                        fw_policies, app_fw_policies) < 0)
                 return -1;
         }
     }
 
     return 0;
+}
+
+Signature *DetectFirewallGetPolicySignature(struct DetectFirewallPolicies *fw_policies,
+        const AppProto alproto, const int direction, const uint8_t hook)
+{
+    if (fw_policies != NULL && fw_policies->policy_signatures != NULL) {
+        Signature lookup;
+        lookup.alproto = alproto;
+        lookup.flags = SIG_FLAG_FIREWALL |
+                       (direction == STREAM_TOSERVER ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT);
+        lookup.app_progress_hook = hook;
+
+        Signature *s = HashTableLookup(fw_policies->policy_signatures, &lookup, 0);
+        return s;
+    }
+    return NULL;
 }
 
 /*

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3698,7 +3698,7 @@ static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *p
     int idx = 0;
     SCConfNode *paction = NULL;
     TAILQ_FOREACH (paction, &policy_actions->head, next) {
-        SCLogNotice("fw: %s => %s", policy_name, paction->val);
+        SCLogDebug("fw: %s => %s", policy_name, paction->val);
         if (SigParseActionDo(paction->val, idx, true, &action, &action_scope) < 0)
             return -1;
         idx++;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1553,7 +1553,7 @@ static uint8_t ActionStringToFlags(const char *action)
  *            Signature.
  * \retval -1 On failure.
  */
-static int SigParseAction(Signature *s, const char *action_in)
+static int SigParseActionDo(Signature *s, const char *action_in, const int idx)
 {
     char action[32];
     strlcpy(action, action_in, sizeof(action));
@@ -1576,6 +1576,23 @@ static int SigParseAction(Signature *s, const char *action_in)
     if (flags == 0)
         return -1;
 
+    if (s->init_data->firewall_rule) {
+        if (idx == 0 &&
+                !(flags & (ACTION_ACCEPT | ACTION_DROP | ACTION_REJECT_ANY | ACTION_CONFIG))) {
+            SCLogError("only accept, config, drop and reject actions allowed as primary action "
+                       "firewall "
+                       "rules");
+            return -1;
+        }
+        if (idx > 0 &&
+                (flags & (ACTION_ACCEPT | ACTION_DROP | ACTION_REJECT_ANY | ACTION_CONFIG))) {
+            SCLogError("accept, config, drop and reject actions not allowed as secondary action "
+                       "firewall "
+                       "rules");
+            return -1;
+        }
+    }
+
     /* parse scope, if any */
     if (o) {
         uint8_t scope_flags = 0;
@@ -1590,7 +1607,6 @@ static int SigParseAction(Signature *s, const char *action_in)
                         o, action_in);
                 return -1;
             }
-            s->action_scope = scope_flags;
         } else if (flags & (ACTION_ACCEPT)) {
             if (strcmp(o, "packet") == 0) {
                 scope_flags = (uint8_t)ACTION_SCOPE_PACKET;
@@ -1607,7 +1623,6 @@ static int SigParseAction(Signature *s, const char *action_in)
                         o, action_in);
                 return -1;
             }
-            s->action_scope = scope_flags;
         } else if (flags & (ACTION_CONFIG)) {
             if (strcmp(o, "packet") == 0) {
                 scope_flags = (uint8_t)ACTION_SCOPE_PACKET;
@@ -1616,13 +1631,17 @@ static int SigParseAction(Signature *s, const char *action_in)
                         action_in);
                 return -1;
             }
-            s->action_scope = scope_flags;
         } else {
             SCLogError("invalid action scope '%s' in action '%s': scope only supported for actions "
                        "'drop', 'pass' and 'reject'",
                     o, action_in);
             return -1;
         }
+        if (s->action_scope != 0 && s->action_scope != scope_flags) {
+            SCLogError("multi-action rules cannot use different action scopes");
+            return -1;
+        }
+        s->action_scope = scope_flags;
     }
 
     /* require explicit action scope for fw rules */
@@ -1635,14 +1654,37 @@ static int SigParseAction(Signature *s, const char *action_in)
         SCLogError("'accept' action only supported for firewall rules");
         return -1;
     }
+    s->action |= flags;
+    return 0;
+}
 
-    if (s->init_data->firewall_rule && (flags & ACTION_PASS)) {
-        SCLogError("'pass' action not supported for firewall rules");
-        return -1;
+static int SigParseAction(Signature *s, const char *action_in)
+{
+    /* multi-action rules are only supported for firewall rules at this time. */
+    if (!s->init_data->firewall_rule)
+        return SigParseActionDo(s, action_in, 0);
+
+    int r = 0;
+    char *copy = SCStrdup(action_in);
+    if (copy == NULL)
+        FatalError("could not duplicate opt string");
+
+    int i = 0;
+    char *xsaveptr = NULL;
+    char *a = strtok_r(copy, ",", &xsaveptr);
+    while (a != NULL) {
+        if (SigParseActionDo(s, a, i) < 0) {
+            r = -1;
+            break;
+        }
+        a = strtok_r(NULL, ",", &xsaveptr);
+        i++;
     }
 
-    s->action = flags;
-    return 0;
+    SCFree(copy);
+
+    SCLogDebug("s->action %02x", s->action);
+    return r;
 }
 
 /**

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2559,6 +2559,17 @@ static bool DetectFirewallRuleValidate(const DetectEngineCtx *de_ctx, const Sign
                 break;
         }
     }
+    if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+        if (!(((s->action & ACTION_ACCEPT) != 0) &&
+                    (s->action_scope == ACTION_SCOPE_FLOW || s->action_scope == ACTION_SCOPE_TX ||
+                            s->action_scope == ACTION_SCOPE_HOOK))) {
+            SCLogError("rule %u: auto-accept notation (<hook) can only be used with accept:flow, "
+                       "accept:tx and accept:hook",
+                    s->id);
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3789,6 +3789,44 @@ void DetectFirewallPolicyToString(const struct DetectFirewallPolicy *p, char *ou
     }
 }
 
+static int AddPktPolicySignature(struct DetectFirewallPolicies *fw_policies,
+        struct DetectFirewallPolicy *pol, enum DetectFirewallPacketPolicies pkt_pol)
+{
+    Signature *s = SCCalloc(1, sizeof(*s)); // SigAlloc does way more than we need
+    if (s == NULL)
+        return -1;
+    char msg[256];
+    switch (pkt_pol) {
+        case DETECT_FIREWALL_POLICY_PACKET_FILTER:
+            s->detect_table = DETECT_TABLE_PACKET_FILTER;
+            break;
+        case DETECT_FIREWALL_POLICY_PRE_FLOW:
+            s->detect_table = DETECT_TABLE_PACKET_PRE_FLOW;
+            break;
+        case DETECT_FIREWALL_POLICY_PRE_STREAM:
+            s->detect_table = DETECT_TABLE_PACKET_PRE_STREAM;
+            break;
+    }
+    snprintf(msg, sizeof(msg), "SURICATA FW default packet policy");
+    s->msg = SCStrdup(msg);
+    if (s->msg == NULL) {
+        SCFree(s);
+        return -1;
+    }
+    s->action = pol->action;
+    s->action_scope = pol->action_scope;
+    s->flags = SIG_FLAG_FIREWALL;
+    s->type = SIG_TYPE_PKT;
+    s->id = 2201000;
+    s->rev = 1;
+    s->gid = 1;
+    s->prio = 3;
+
+    fw_policies->pkt_policy_signatures[pkt_pol] = s;
+    SCLogDebug("added to array");
+    return 0;
+}
+
 static int AddAppPolicySignature(HashTable *ht, const int direction, const AppProto alproto,
         const char *app_name, const uint8_t hook, const char *hookname,
         struct DetectFirewallPolicy *pol)
@@ -3984,6 +4022,11 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
     r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER]);
     if (r < 0)
         return -1;
+    if (fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER].action & ACTION_ALERT)
+        if (AddPktPolicySignature(fw_policies,
+                    &fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER],
+                    DETECT_FIREWALL_POLICY_PACKET_FILTER) < 0)
+            return -1;
 
     r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-flow", prefix);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
@@ -3992,6 +4035,10 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
     r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW]);
     if (r < 0)
         return -1;
+    if (fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW].action & ACTION_ALERT)
+        if (AddPktPolicySignature(fw_policies, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW],
+                    DETECT_FIREWALL_POLICY_PRE_FLOW) < 0)
+            return -1;
 
     r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-stream", prefix);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
@@ -4000,6 +4047,10 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
     r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM]);
     if (r < 0)
         return -1;
+    if (fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM].action & ACTION_ALERT)
+        if (AddPktPolicySignature(fw_policies, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM],
+                    DETECT_FIREWALL_POLICY_PRE_STREAM) < 0)
+            return -1;
 
     for (AppProto a = 0; a < g_alproto_max; a++) {
         if (!AppProtoIsValid(a))

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2484,6 +2484,25 @@ static bool DetectFirewallRuleValidate(const DetectEngineCtx *de_ctx, const Sign
                 s->id);
         return false;
     }
+    if (s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {
+        switch (s->action_scope) {
+            case ACTION_SCOPE_PACKET:
+                if (!(DetectProtoContainsProto(&s->proto, IPPROTO_UDP))) {
+                    if (s->action & (ACTION_ACCEPT | ACTION_DROP)) {
+                        SCLogError("rule %u uses action scope \"packet\" for an non-UDP app hook",
+                                s->id);
+                        return false;
+                    }
+                }
+                break;
+            case ACTION_SCOPE_FLOW:
+            case ACTION_SCOPE_AUTO:
+            case ACTION_SCOPE_TX:
+            case ACTION_SCOPE_HOOK:
+                // supported for app hooks
+                break;
+        }
+    }
     return true;
 }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1547,13 +1547,14 @@ static uint8_t ActionStringToFlags(const char *action)
  *        to its Signature instance.
  *
  * \param s      Pointer to the Signature instance to which the action belongs.
- * \param action Pointer to the action string used by the Signature.
+ * \param action_in Pointer to the action string used by the Signature.
  *
  * \retval  0 On successfully parsing the action string and adding it to the
  *            Signature.
  * \retval -1 On failure.
  */
-static int SigParseActionDo(Signature *s, const char *action_in, const int idx)
+static int SigParseActionDo(const char *action_in, const int idx, const bool fw_rule,
+        uint8_t *action_out, uint8_t *scope_out)
 {
     char action[32];
     strlcpy(action, action_in, sizeof(action));
@@ -1576,7 +1577,7 @@ static int SigParseActionDo(Signature *s, const char *action_in, const int idx)
     if (flags == 0)
         return -1;
 
-    if (s->init_data->firewall_rule) {
+    if (fw_rule) {
         if (idx == 0 &&
                 !(flags & (ACTION_ACCEPT | ACTION_DROP | ACTION_REJECT_ANY | ACTION_CONFIG))) {
             SCLogError("only accept, config, drop and reject actions allowed as primary action "
@@ -1637,24 +1638,24 @@ static int SigParseActionDo(Signature *s, const char *action_in, const int idx)
                     o, action_in);
             return -1;
         }
-        if (s->action_scope != 0 && s->action_scope != scope_flags) {
+        if (*scope_out != 0 && *scope_out != scope_flags) {
             SCLogError("multi-action rules cannot use different action scopes");
             return -1;
         }
-        s->action_scope = scope_flags;
+        *scope_out = scope_flags;
     }
 
     /* require explicit action scope for fw rules */
-    if (s->init_data->firewall_rule && s->action_scope == 0) {
+    if (fw_rule && *scope_out == 0) {
         SCLogError("firewall rules require setting an explicit action scope");
         return -1;
     }
 
-    if (!s->init_data->firewall_rule && (flags & ACTION_ACCEPT)) {
+    if (!fw_rule && (flags & ACTION_ACCEPT)) {
         SCLogError("'accept' action only supported for firewall rules");
         return -1;
     }
-    s->action |= flags;
+    *action_out |= flags;
     return 0;
 }
 
@@ -1662,7 +1663,7 @@ static int SigParseAction(Signature *s, const char *action_in)
 {
     /* multi-action rules are only supported for firewall rules at this time. */
     if (!s->init_data->firewall_rule)
-        return SigParseActionDo(s, action_in, 0);
+        return SigParseActionDo(action_in, 0, false, &s->action, &s->action_scope);
 
     int r = 0;
     char *copy = SCStrdup(action_in);
@@ -1673,7 +1674,7 @@ static int SigParseAction(Signature *s, const char *action_in)
     char *xsaveptr = NULL;
     char *a = strtok_r(copy, ",", &xsaveptr);
     while (a != NULL) {
-        if (SigParseActionDo(s, a, i) < 0) {
+        if (SigParseActionDo(a, i, true, &s->action, &s->action_scope) < 0) {
             r = -1;
             break;
         }
@@ -3682,6 +3683,200 @@ void DetectSetupParseRegexes(const char *parse_str, DetectParseRegex *detect_par
     if (!DetectSetupParseRegexesOpts(parse_str, detect_parse, 0)) {
         FatalError("pcre compile and study failed");
     }
+}
+
+static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *pol)
+{
+    SCConfNode *policy_actions = SCConfGetNode(policy_name);
+    if (policy_actions == NULL) {
+        SCLogDebug("fw: no policy at %s", policy_name);
+        return 0;
+    }
+
+    uint8_t action = 0;
+    uint8_t action_scope = 0;
+    int idx = 0;
+    SCConfNode *paction = NULL;
+    TAILQ_FOREACH (paction, &policy_actions->head, next) {
+        SCLogNotice("fw: %s => %s", policy_name, paction->val);
+        if (SigParseActionDo(paction->val, idx, true, &action, &action_scope) < 0)
+            return -1;
+        idx++;
+    }
+    pol->action = action;
+    pol->action_scope = action_scope;
+    return 1;
+}
+
+static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const char *hookname,
+        const uint8_t state, const uint8_t complete_state, const int direction,
+        struct DetectFirewallAppPolicy *app_fw_policies)
+{
+    char policy_name[256];
+    const char *in_name = hookname;
+    if (hookname == NULL) {
+        if (state == 0) {
+            if (direction == STREAM_TOSERVER)
+                hookname = "request-started";
+            else
+                hookname = "response-started";
+        } else if (state == complete_state) {
+            if (direction == STREAM_TOSERVER)
+                hookname = "request-complete";
+            else
+                hookname = "response-complete";
+        }
+        if (hookname == NULL)
+            return 0;
+    }
+    char *nname = SCStrdup(hookname);
+    if (nname == NULL)
+        return -1;
+    for (int i = 0; nname[i] != '\0'; i++) {
+        if (nname[i] == '_')
+            nname[i] = '-';
+    }
+
+    const char *app_name = AppProtoToString(app_proto);
+    int r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s", prefix, app_name, nname);
+    SCFree(nname);
+    if (r < 0 || (size_t)r >= sizeof(policy_name)) {
+        FatalError("internal error: failed to assemble firewall policy config string");
+    }
+
+    if (direction == STREAM_TOSERVER)
+        r = DoParsePolicy(policy_name, &app_fw_policies[app_proto].ts[state]);
+    else
+        r = DoParsePolicy(policy_name, &app_fw_policies[app_proto].tc[state]);
+    if (r == 0 && in_name != NULL) {
+        if (state == 0) {
+            if (direction == STREAM_TOSERVER)
+                hookname = "request-started";
+            else
+                hookname = "response-started";
+        } else if (state == complete_state) {
+            if (direction == STREAM_TOSERVER)
+                hookname = "request-complete";
+            else
+                hookname = "response-complete";
+        }
+        if (hookname == NULL)
+            return 0;
+        r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s", prefix, app_name, hookname);
+        if (r < 0 || (size_t)r >= sizeof(policy_name)) {
+            FatalError("internal error: failed to assemble firewall policy config string");
+        }
+
+        if (direction == STREAM_TOSERVER)
+            return DoParsePolicy(policy_name, &app_fw_policies[app_proto].ts[state]);
+        else
+            return DoParsePolicy(policy_name, &app_fw_policies[app_proto].tc[state]);
+    }
+    return r;
+}
+
+/** \brief allocate and initialize to default values the policies table */
+int DetectFirewallInitDefaultPolicies(DetectEngineCtx *de_ctx)
+{
+    struct DetectFirewallPolicies *fw_policies = SCCalloc(
+            1, sizeof(*fw_policies) + g_alproto_max * sizeof(struct DetectFirewallAppPolicy));
+    if (fw_policies == NULL)
+        return -1;
+    struct DetectFirewallAppPolicy *app_fw_policies = fw_policies->app;
+    if (app_fw_policies == NULL)
+        goto error;
+
+    fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER].action = ACTION_DROP;
+    fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER].action_scope = ACTION_SCOPE_PACKET;
+
+    fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW].action = ACTION_ACCEPT;
+    fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW].action_scope = ACTION_SCOPE_HOOK;
+
+    fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM].action = ACTION_ACCEPT;
+    fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM].action_scope = ACTION_SCOPE_HOOK;
+
+    for (AppProto a = 0; a < g_alproto_max; a++) {
+        for (int i = 0; i < 48; i++) {
+            app_fw_policies[a].ts[i].action = ACTION_DROP;
+            app_fw_policies[a].ts[i].action_scope = ACTION_SCOPE_FLOW;
+            app_fw_policies[a].tc[i].action = ACTION_DROP;
+            app_fw_policies[a].tc[i].action_scope = ACTION_SCOPE_FLOW;
+        }
+    }
+    de_ctx->fw_policies = fw_policies;
+    return 0;
+
+error:
+    SCFree(fw_policies);
+    return -1;
+}
+
+int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
+{
+    int r;
+    char policy_name[256];
+    char prefix[96] = "firewall.policies";
+    if (strlen(de_ctx->config_prefix) > 0) {
+        snprintf(prefix, sizeof(prefix), "%s.firewall.policies", de_ctx->config_prefix);
+    }
+
+    struct DetectFirewallPolicies *fw_policies = de_ctx->fw_policies;
+    if (fw_policies == NULL)
+        return -1;
+    struct DetectFirewallAppPolicy *app_fw_policies = fw_policies->app;
+    if (app_fw_policies == NULL)
+        return -1;
+
+    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-filter", prefix);
+    if (r < 0 || (size_t)r >= sizeof(policy_name)) {
+        FatalError("internal error: failed to assemble firewall policy config string");
+    }
+    r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER]);
+    if (r < 0)
+        return -1;
+
+    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-flow", prefix);
+    if (r < 0 || (size_t)r >= sizeof(policy_name)) {
+        FatalError("internal error: failed to assemble firewall policy config string");
+    }
+    r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW]);
+    if (r < 0)
+        return -1;
+
+    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-stream", prefix);
+    if (r < 0 || (size_t)r >= sizeof(policy_name)) {
+        FatalError("internal error: failed to assemble firewall policy config string");
+    }
+    r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM]);
+    if (r < 0)
+        return -1;
+
+    for (AppProto a = 0; a < g_alproto_max; a++) {
+        if (!AppProtoIsValid(a))
+            continue;
+
+        const uint8_t complete_state_ts =
+                (const uint8_t)AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOSERVER);
+        for (uint8_t state = 0; state <= complete_state_ts; state++) {
+            const char *name =
+                    AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOSERVER);
+            if (DoParseAppPolicy(prefix, a, name, state, complete_state_ts, STREAM_TOSERVER,
+                        app_fw_policies) < 0)
+                return -1;
+        }
+
+        const uint8_t complete_state_tc =
+                (const uint8_t)AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOCLIENT);
+        for (uint8_t state = 0; state <= complete_state_tc; state++) {
+            const char *name =
+                    AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOCLIENT);
+            if (DoParseAppPolicy(prefix, a, name, state, complete_state_tc, STREAM_TOCLIENT,
+                        app_fw_policies) < 0)
+                return -1;
+        }
+    }
+
+    return 0;
 }
 
 /*

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1586,6 +1586,12 @@ static int SigParseActionDo(const char *action_in, const int idx, const bool fw_
         return -1;
 
     if (fw_rule) {
+        /* in firewall mode, drop is just drop. Whereas in IDS/IPS mode, drop is drop+alert.
+         * Same for reject which includes ACTION_DROP. */
+        if (flags & ACTION_DROP) {
+            flags &= ~ACTION_ALERT;
+        }
+
         if (idx == 0 &&
                 !(flags & (ACTION_ACCEPT | ACTION_DROP | ACTION_REJECT_ANY | ACTION_CONFIG))) {
             SCLogError("only accept, config, drop and reject actions allowed as primary action "

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -114,4 +114,7 @@ int SC_Pcre2SubstringGet(pcre2_match_data *match_data, uint32_t number, PCRE2_UC
 
 void DetectRegisterAppLayerHookLists(void);
 
+int DetectFirewallInitDefaultPolicies(DetectEngineCtx *);
+int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *);
+
 #endif /* SURICATA_DETECT_PARSE_H */

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -24,6 +24,7 @@
 #ifndef SURICATA_DETECT_PARSE_H
 #define SURICATA_DETECT_PARSE_H
 
+#include "action-globals.h"
 #include "app-layer-protos.h"
 #include "detect-engine-register.h"
 // types from detect.h with only forward declarations for bindgen
@@ -32,6 +33,7 @@ typedef struct Signature_ Signature;
 typedef struct SigMatchCtx_ SigMatchCtx;
 typedef struct SigMatch_ SigMatch;
 typedef struct SigMatchData_ SigMatchData;
+struct DetectFirewallPolicies;
 
 /** Flags to indicate if the Signature parsing must be done
 *   switching the source and dest (for ip addresses and ports)
@@ -114,7 +116,13 @@ int SC_Pcre2SubstringGet(pcre2_match_data *match_data, uint32_t number, PCRE2_UC
 
 void DetectRegisterAppLayerHookLists(void);
 
+const char *ActionScopeToString(enum ActionScope s);
+
+struct DetectFirewallPolicy;
+void DetectFirewallPolicyToString(const struct DetectFirewallPolicy *p, char *out, size_t out_size);
 int DetectFirewallInitDefaultPolicies(DetectEngineCtx *);
 int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *);
+Signature *DetectFirewallGetPolicySignature(struct DetectFirewallPolicies *fw_policies,
+        const AppProto alproto, const int direction, const uint8_t hook);
 
 #endif /* SURICATA_DETECT_PARSE_H */

--- a/src/detect.c
+++ b/src/detect.c
@@ -70,20 +70,14 @@ typedef struct DetectRunScratchpad {
     const AppProto alproto;
     const uint8_t flow_flags; /* flow/state flags: STREAM_* */
     const bool app_decoder_events;
-    /**
-     *  Either ACTION_DROP (drop:packet) or ACTION_ACCEPT (accept:hook)
-     *
-     *  ACTION_DROP means the default policy of drop:packet is applied
-     *  ACTION_ACCEPT means the default policy of accept:hook is applied
-     */
-    const uint8_t default_action;
+    const enum DetectFirewallPacketPolicies fw_pkt_policy;
     const SigGroupHead *sgh;
 } DetectRunScratchpad;
 
 /* prototypes */
 static DetectRunScratchpad DetectRunSetup(const DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, Packet *const p, Flow *const pflow,
-        const uint8_t default_action);
+        const enum DetectFirewallPacketPolicies fw_pkt_policy);
 static void DetectRunInspectIPOnly(ThreadVars *tv, const DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, Flow * const pflow, Packet * const p);
 static inline void DetectRunGetRuleGroup(const DetectEngineCtx *de_ctx,
@@ -121,7 +115,8 @@ static void DetectRun(ThreadVars *th_v,
      * Mark as a constant pointer, although the flow itself can change. */
     Flow * const pflow = p->flow;
 
-    DetectRunScratchpad scratch = DetectRunSetup(de_ctx, det_ctx, p, pflow, ACTION_DROP);
+    DetectRunScratchpad scratch =
+            DetectRunSetup(de_ctx, det_ctx, p, pflow, DETECT_FIREWALL_POLICY_PACKET_FILTER);
 
     /* run the IPonly engine */
     DetectRunInspectIPOnly(th_v, de_ctx, det_ctx, pflow, p);
@@ -131,17 +126,21 @@ static void DetectRun(ThreadVars *th_v,
     /* if we didn't get a sig group head, we
      * have nothing to do.... */
     if (scratch.sgh == NULL) {
-        SCLogDebug("no sgh for this packet, nothing to match against");
-        goto end;
+        if (!EngineModeIsFirewall()) {
+            SCLogDebug("no sgh for this packet, nothing to match against");
+            goto end;
+        }
+        SCLogDebug("packet %" PRIu64 ": no sgh, need to apply default policies", p->pcap_cnt);
+    } else {
+        /* run the prefilters for packets */
+        DetectRunPrefilterPkt(th_v, de_ctx, det_ctx, p, &scratch);
     }
-
-    /* run the prefilters for packets */
-    DetectRunPrefilterPkt(th_v, de_ctx, det_ctx, p, &scratch);
-
     PACKET_PROFILING_DETECT_START(p, PROF_DETECT_RULES);
     /* inspect the rules against the packet */
     const uint8_t pkt_policy = DetectRulePacketRules(th_v, de_ctx, det_ctx, p, pflow, &scratch);
     PACKET_PROFILING_DETECT_END(p, PROF_DETECT_RULES);
+    SCLogDebug("packet %" PRIu64 ": pkt_policy %02x (p->action %02x)", p->pcap_cnt, pkt_policy,
+            p->action);
 
     /* Only FW rules will already have set the action, IDS rules go through PacketAlertFinalize
      *
@@ -209,7 +208,8 @@ end:
 /** \internal
  */
 static void DetectRunPacketHook(ThreadVars *th_v, const DetectEngineCtx *de_ctx,
-        DetectEngineThreadCtx *det_ctx, const SigGroupHead *sgh, Packet *p)
+        DetectEngineThreadCtx *det_ctx, const SigGroupHead *sgh, Packet *p,
+        enum DetectFirewallPacketPolicies fw_pkt_policy)
 {
     SCEnter();
     SCLogDebug("p->pcap_cnt %" PRIu64 " direction %s pkt_src %s", p->pcap_cnt,
@@ -221,7 +221,7 @@ static void DetectRunPacketHook(ThreadVars *th_v, const DetectEngineCtx *de_ctx,
      * Mark as a constant pointer, although the flow itself can change. */
     Flow *const pflow = p->flow;
 
-    DetectRunScratchpad scratch = DetectRunSetup(de_ctx, det_ctx, p, pflow, ACTION_ACCEPT);
+    DetectRunScratchpad scratch = DetectRunSetup(de_ctx, det_ctx, p, pflow, fw_pkt_policy);
     scratch.sgh = sgh;
 
     /* if we didn't get a sig group head, we
@@ -658,6 +658,54 @@ static inline bool SkipFwRules(const Packet *p)
     return false;
 }
 
+/**
+ * \internal
+ * \brief apply packet default policy
+ * \param[in] de_ctx detect engine, for looking up the policy
+ * \param[in] policy policy to apply
+ * \param[in] p packet to apply policy to
+ * \param[in] final see if we need to apply accept:hook to the packet
+ * \retval action action to immediately apply, accept:hook will not set this unless final is true
+ *
+ * If this is run from the post-match final check, we need to apply a
+ * packet:filter accept:hook to the packet as well.
+ */
+static uint8_t DetectRunApplyPacketPolicy(const DetectEngineCtx *de_ctx,
+        const enum DetectFirewallPacketPolicies policy, Packet *p, const bool final)
+{
+    DEBUG_VALIDATE_BUG_ON(de_ctx->fw_policies == NULL);
+    const struct DetectFirewallPolicy *pol = &de_ctx->fw_policies->pkt[policy];
+    if (pol->action & ACTION_DROP) {
+        SCLogDebug("packet %" PRIu64 ": drop PKT_DROP_REASON_DEFAULT_PACKET_POLICY", p->pcap_cnt);
+        PacketDrop(p, pol->action, PKT_DROP_REASON_DEFAULT_PACKET_POLICY);
+    } else if (pol->action & ACTION_ACCEPT) {
+        SCLogDebug("packet %" PRIu64 ": accept", p->pcap_cnt);
+        if (pol->action_scope == ACTION_SCOPE_PACKET) {
+            p->action |= pol->action;
+            SCLogDebug("packet %" PRIu64 ": accept scope packet", p->pcap_cnt);
+        } else if (pol->action_scope == ACTION_SCOPE_HOOK) {
+            SCLogDebug("packet %" PRIu64 ": accept scope hook", p->pcap_cnt);
+            if (final) {
+                p->action |= pol->action;
+                SCLogDebug("packet %" PRIu64 ": accept scope hook upgraded to packet", p->pcap_cnt);
+            }
+        } else if (pol->action_scope == ACTION_SCOPE_FLOW) {
+            p->action |= pol->action;
+            SCLogDebug("packet %" PRIu64 ": accept scope flow", p->pcap_cnt);
+            if (p->flow) {
+                p->flow->flags |= FLOW_ACTION_ACCEPT;
+            }
+        } else {
+            /* should be unreachable */
+            DEBUG_VALIDATE_BUG_ON(1);
+        }
+    } else {
+        /* should be unreachable */
+        DEBUG_VALIDATE_BUG_ON(1);
+    }
+    return p->action;
+}
+
 static inline uint8_t DetectRulePacketRules(ThreadVars *const tv,
         const DetectEngineCtx *const de_ctx, DetectEngineThreadCtx *const det_ctx, Packet *const p,
         Flow *const pflow, const DetectRunScratchpad *scratch)
@@ -905,28 +953,25 @@ next:
     /* if no rule told us to accept, and no rule explicitly dropped, we invoke the default drop
      * policy
      */
-    if (have_fw_rules && scratch->default_action == ACTION_DROP) {
-        if (!skip_fw && !fw_verdict) {
-            DEBUG_VALIDATE_BUG_ON(action & ACTION_DROP);
-            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_PACKET_POLICY);
-            action |= ACTION_DROP;
-        } else {
+    if (have_fw_rules) {
+        if (skip_fw || fw_verdict) {
             /* apply fw action */
             p->action |= action;
+        } else {
+            DEBUG_VALIDATE_BUG_ON(action & ACTION_DROP);
+            /* non-final call as we may have to consider app-layer still */
+            action |= DetectRunApplyPacketPolicy(de_ctx, scratch->fw_pkt_policy, p, false);
         }
     }
     return action;
 }
 
 /** \internal
- *  \param default_action either ACTION_DROP (drop:packet) or ACTION_ACCEPT (accept:hook)
- *
- *  ACTION_DROP means the default policy of drop:packet is applied
- *  ACTION_ACCEPT means the default policy of accept:hook is applied
+ *  \param fw_pkt_policy policy to apply to packet rules
  */
 static DetectRunScratchpad DetectRunSetup(const DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, Packet *const p, Flow *const pflow,
-        const uint8_t default_action)
+        const enum DetectFirewallPacketPolicies fw_pkt_policy)
 {
     AppProto alproto = ALPROTO_UNKNOWN;
     uint8_t flow_flags = 0; /* flow/state flags */
@@ -1019,7 +1064,7 @@ static DetectRunScratchpad DetectRunSetup(const DetectEngineCtx *de_ctx,
         app_decoder_events = AppLayerParserHasDecoderEvents(pflow->alparser);
     }
 
-    DetectRunScratchpad pad = { alproto, flow_flags, app_decoder_events, default_action, NULL };
+    DetectRunScratchpad pad = { alproto, flow_flags, app_decoder_events, fw_pkt_policy, NULL };
     PACKET_PROFILING_DETECT_END(p, PROF_DETECT_SETUP);
     return pad;
 }
@@ -1048,11 +1093,12 @@ static inline void DetectRunPostRules(ThreadVars *tv, const DetectEngineCtx *de_
     /* firewall: "fail" closed if we don't have an ACCEPT. This can happen
      * if there was no rule group. */
     // TODO review packet src types here
-    if (EngineModeIsFirewall() && !(p->action & ACTION_ACCEPT) && p->pkt_src == PKT_SRC_WIRE &&
-            scratch->default_action == ACTION_DROP) {
-        SCLogDebug("packet %" PRIu64 ": droppit as no ACCEPT set %02x (pkt %s)", p->pcap_cnt,
-                p->action, PktSrcToString(p->pkt_src));
-        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_PACKET_POLICY);
+    if (EngineModeIsFirewall() && ((p->action & (ACTION_ACCEPT | ACTION_DROP)) == 0) &&
+            p->pkt_src == PKT_SRC_WIRE) {
+        SCLogDebug("packet %" PRIu64 ": default action as no verdict set %02x (pkt %s)",
+                p->pcap_cnt, p->action, PktSrcToString(p->pkt_src));
+        (void)DetectRunApplyPacketPolicy(de_ctx, scratch->fw_pkt_policy, p, true);
+        DEBUG_VALIDATE_BUG_ON((p->action & (ACTION_DROP | ACTION_ACCEPT)) == 0);
     }
 }
 
@@ -1548,6 +1594,16 @@ static inline void RuleMatchCandidateMergeStateRules(
     // and come before any other element later in the list
 }
 
+struct DetectFirewallAppTxState {
+    bool fw_skip_app_filter;
+    bool tx_fw_verdict;
+    bool skip_fw_hook;
+    uint8_t skip_before_progress;
+    bool fw_last_for_progress;
+    bool fw_next_progress_missing;
+    bool last_fw_rule; /**< processing the last fw rule, so we need to eval all hooks after it. */
+};
+
 /** \internal
  *  \brief apply default policy
  *  \param p packet to apply policy to
@@ -1557,11 +1613,91 @@ static inline void RuleMatchCandidateMergeStateRules(
  *  \note alproto and progress are unused right now, will be used
  *        to look up configurable default policies later
  */
-static void DetectFirewallApplyDefaultPolicy(
-        Packet *p, const AppProto alproto, const uint8_t progress)
+static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
+        const struct DetectFirewallAppPolicy *policies, Packet *p, const AppProto alproto,
+        const uint8_t direction, const uint8_t progress)
 {
-    PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_APP_POLICY);
-    p->flow->flags |= FLOW_ACTION_DROP;
+    const struct DetectFirewallPolicy *policy;
+    if (direction & STREAM_TOSERVER) {
+        policy = &policies[alproto].ts[progress];
+        SCLogDebug("packet %" PRIu64 ", hook:%u, toserver, policy: action %02x scope %u",
+                p->pcap_cnt, progress, policy->action, policy->action_scope);
+    } else {
+        policy = &policies[alproto].tc[progress];
+        SCLogDebug("packet %" PRIu64 ", hook:%u, toclient, policy: action %02x scope %u",
+                p->pcap_cnt, progress, policy->action, policy->action_scope);
+    }
+
+    if (policy->action & ACTION_DROP) {
+        SCLogDebug("dropping packet PKT_DROP_REASON_DEFAULT_APP_POLICY");
+        PacketDrop(p, policy->action, PKT_DROP_REASON_DEFAULT_APP_POLICY);
+        if (policy->action_scope == ACTION_SCOPE_FLOW) {
+            SCLogDebug("dropping flow");
+            p->flow->flags |= FLOW_ACTION_DROP;
+        }
+    } else if (policy->action & ACTION_ACCEPT) {
+        if (policy->action_scope == ACTION_SCOPE_FLOW) {
+            p->flow->flags |= FLOW_ACTION_ACCEPT;
+        }
+        SCLogDebug("packet %" PRIu64 " hook %u default policy ACCEPT", p->pcap_cnt, progress);
+    } else {
+        /* should be unreachable */
+        DEBUG_VALIDATE_BUG_ON(1);
+    }
+    return policy;
+}
+
+/** \internal
+ *  \brief run default policies for hook(s)
+ *
+ *  For a range of hooks look up the policy and apply it.
+ *
+ *  \param is_last is this tx the last we have? Used to check if an action needs to be applied to
+ * the packet.
+ *
+ *  \retval DETECT_TX_FW_FC_BREAK rest of rules shouldn't be inspected
+ *  \retval DETECT_TX_FW_FC_SKIP skip current firewall rule
+ *  \retval DETECT_TX_FW_FC_OK no action needed
+ */
+static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
+        DetectEngineThreadCtx *det_ctx, const struct DetectFirewallAppPolicy *policies,
+        DetectTransaction *tx, Packet *p, const AppProto alproto, const uint8_t direction,
+        const uint8_t start_hook, const uint8_t end_hook, const bool is_last)
+{
+    uint8_t actions = 0;
+    for (uint8_t hook = start_hook; hook <= end_hook; hook++) {
+        SCLogDebug("%" PRIu64 ": %s default policy for hook %u", p->pcap_cnt,
+                direction & STREAM_TOSERVER ? "toserver" : "toclient", hook);
+
+        const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
+                det_ctx->de_ctx->fw_policies->app, p, alproto, direction, hook);
+        SCLogDebug("fw: hook:%u policy:%02x", hook, policy->action);
+        actions |= policy->action;
+        if (policy->action & ACTION_DROP) {
+            SCLogDebug("fw: action %02x", policy->action);
+            return DETECT_TX_FW_FC_BREAK;
+        } else if (policy->action == ACTION_ACCEPT) {
+            SCLogDebug("fw: accept hook %u", hook);
+
+            /* accepting flow, so skip rest of the fw rules */
+            if (policy->action_scope == ACTION_SCOPE_FLOW) {
+                DetectRunAppendDefaultAccept(det_ctx, p);
+                return DETECT_TX_FW_FC_SKIP;
+            } else if (policy->action_scope == ACTION_SCOPE_TX) {
+                tx->tx_data_ptr->flags |= APP_LAYER_TX_ACCEPT;
+                SCLogDebug("ACTION_SCOPE_TX, setting APP_LAYER_TX_ACCEPT");
+                if (is_last) {
+                    DetectRunAppendDefaultAccept(det_ctx, p);
+                    SCLogDebug("DetectRunAppendDefaultAccept for last tx");
+                }
+                return DETECT_TX_FW_FC_SKIP;
+            }
+        }
+    }
+    if ((is_last && (actions & (ACTION_ACCEPT | ACTION_DROP)) == ACTION_ACCEPT)) {
+        DetectRunAppendDefaultAccept(det_ctx, p);
+    }
+    return DETECT_TX_FW_FC_OK;
 }
 
 /** \internal
@@ -1576,12 +1712,13 @@ static void DetectFirewallApplyDefaultPolicy(
  * \retval DETECT_TX_FW_FC_SKIP skip this rule
  */
 static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
-        DetectEngineThreadCtx *det_ctx, Packet *p, DetectTransaction *tx, const Signature *s,
-        const uint32_t can_idx, bool *tx_fw_verdict, const bool last_tx)
+        DetectEngineThreadCtx *det_ctx, Packet *p, DetectTransaction *tx, const uint8_t direction,
+        const Signature *s, const uint32_t can_idx, struct DetectFirewallAppTxState *fw_state,
+        const bool last_tx)
 {
     if (p->flow->flags & FLOW_ACTION_ACCEPT) {
-        if ((*tx_fw_verdict) == false) {
-            *tx_fw_verdict = true;
+        if (fw_state->tx_fw_verdict == false) {
+            fw_state->tx_fw_verdict = true;
             DetectRunAppendDefaultAccept(det_ctx, p);
         }
         if (s->flags & SIG_FLAG_FIREWALL) {
@@ -1592,13 +1729,13 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
     if (tx->tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
         /* append a blank accept:packet action for the APP_LAYER_TX_ACCEPT,
          * if this is the last tx */
-        if (!*tx_fw_verdict) {
+        if (!fw_state->tx_fw_verdict) {
             const bool accept_tx_applies_to_packet = last_tx;
             if (accept_tx_applies_to_packet) {
                 SCLogDebug("accept:(tx|hook): should be applied to the packet");
                 DetectRunAppendDefaultAccept(det_ctx, p);
             }
-            *tx_fw_verdict = true;
+            fw_state->tx_fw_verdict = true;
         }
 
         if (s->flags & SIG_FLAG_FIREWALL) {
@@ -1608,18 +1745,22 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
 
         /* threat detect rules will be inspected */
     } else if (s->flags & SIG_FLAG_FIREWALL) {
+        fw_state->fw_next_progress_missing = false;
+        fw_state->fw_last_for_progress = false;
+
         /* if our first rule is beyond the starting state, we need to check if
          * there are rules missing for states in between. */
+        // TODO detect_progress_orig already is +1?
         if (s->app_progress_hook > tx->detect_progress_orig && can_idx == 0) {
             SCLogDebug("missing fw rules at list start: sid %u, progress %u (%u:%u)", s->id,
                     s->app_progress_hook, tx->detect_progress, tx->detect_progress_orig);
-
             /* if this rule was after the state we expected meaning that there are
-             * no rules for that state. Invoke the default drop policy. */
-            DetectFirewallApplyDefaultPolicy(p, s->alproto, tx->detect_progress_orig);
-            *tx_fw_verdict = true;
-            SCLogDebug("default app drop");
-            return DETECT_TX_FW_FC_BREAK;
+             * no rules for that state. Invoke the default policies. */
+            enum DetectTxFirewallFlowControl r = DetectFirewallApplyDefaultPolicies(det_ctx,
+                    det_ctx->de_ctx->fw_policies->app, tx, p, s->alproto, direction,
+                    tx->detect_progress_orig, s->app_progress_hook - 1, last_tx);
+            fw_state->tx_fw_verdict = true;
+            return r;
         }
     }
     return DETECT_TX_FW_FC_OK;
@@ -1647,9 +1788,8 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
  */
 static enum DetectTxFirewallFlowControl DetectRunTxCheckFirewallPolicy(
         DetectEngineThreadCtx *det_ctx, Packet *p, Flow *f, DetectTransaction *tx,
-        const Signature *s, const uint32_t can_idx, const uint32_t can_size, bool *skip_fw_hook,
-        const uint8_t skip_before_progress, bool *fw_last_for_progress,
-        bool *fw_next_progress_missing)
+        const Signature *s, const uint32_t can_idx, const uint32_t can_size,
+        struct DetectFirewallAppTxState *fw_state)
 {
     if (s->flags & SIG_FLAG_FIREWALL) {
         /* check if the next sig is on the same progress hook. If not, we need to apply our
@@ -1668,32 +1808,34 @@ static enum DetectTxFirewallFlowControl DetectRunTxCheckFirewallPolicy(
                     SCLogDebug("peek: next sid progress %u != current progress %u, so current "
                                "is last for progress",
                             next_s->app_progress_hook, s->app_progress_hook);
-                    *fw_last_for_progress = true;
+                    fw_state->fw_last_for_progress = true;
 
                     if (next_s->app_progress_hook - s->app_progress_hook > 1) {
                         SCLogDebug("peek: missing progress, so we'll drop that unless we get a "
                                    "sweeping accept first");
-                        *fw_next_progress_missing = true;
+                        fw_state->fw_next_progress_missing = true;
                     }
                 }
             } else {
                 SCLogDebug("peek: next sid not a fw rule, so current is last for progress");
-                *fw_last_for_progress = true;
+                fw_state->fw_last_for_progress = true;
+                fw_state->last_fw_rule = true;
             }
         } else {
             SCLogDebug("peek: no peek beyond last rule");
             if (s->app_progress_hook < tx->tx_progress) {
                 SCLogDebug("peek: there are no rules to allow the state after this rule");
-                *fw_next_progress_missing = true;
+                fw_state->fw_next_progress_missing = true;
             }
-            *fw_last_for_progress = true;
+            fw_state->fw_last_for_progress = true;
+            fw_state->last_fw_rule = true;
         }
 
-        if ((*skip_fw_hook) == true) {
-            if (s->app_progress_hook <= skip_before_progress) {
+        if (fw_state->skip_fw_hook == true) {
+            if (s->app_progress_hook <= fw_state->skip_before_progress) {
                 return DETECT_TX_FW_FC_SKIP;
             }
-            *skip_fw_hook = false;
+            fw_state->skip_fw_hook = false;
         }
     } else {
         /* fw mode, we skip anything after the fw rules if:
@@ -1756,41 +1898,111 @@ static inline bool ApplyAcceptToPacket(
 
 /** \internal
  * \retval bool true: break_out_of_app_filter, false: don't break out */
-static bool ApplyAccept(Packet *p, const uint8_t flow_flags, const Signature *s,
-        DetectTransaction *tx, const int tx_end_state, const bool fw_next_progress_missing,
-        bool *tx_fw_verdict, bool *skip_fw_hook, uint8_t *skip_before_progress)
+static bool ApplyAccept(DetectEngineThreadCtx *det_ctx, Packet *p, const uint8_t direction,
+        const Signature *s, DetectTransaction *tx, const int tx_end_state, const bool is_last,
+        struct DetectFirewallAppTxState *fw_state)
 {
-    *tx_fw_verdict = true;
+    fw_state->tx_fw_verdict = true;
 
     const enum ActionScope as = s->action_scope;
     /* accept:hook: jump to first rule of next state.
      * Implemented as skip until the first rule of next state. */
     if (as == ACTION_SCOPE_HOOK) {
-        *skip_fw_hook = true;
-        *skip_before_progress = s->app_progress_hook;
+        fw_state->skip_fw_hook = true;
+        fw_state->skip_before_progress = s->app_progress_hook;
 
+        SCLogDebug("fw match sid:%u hook:%u", s->id, s->app_progress_hook);
+        SCLogDebug("fw fw_skip_app_filter:%s tx_fw_verdict:%s skip_fw_hook:%s "
+                   "skip_before_progress:%u fw_last_for_progress:%s fw_next_progress_missing:%s",
+                BOOL2STR(fw_state->fw_skip_app_filter), BOOL2STR(fw_state->tx_fw_verdict),
+                BOOL2STR(fw_state->skip_fw_hook), fw_state->skip_before_progress,
+                BOOL2STR(fw_state->fw_last_for_progress),
+                BOOL2STR(fw_state->fw_next_progress_missing));
         /* if there is no fw rule for the next progress value,
-         * we invoke the default drop policy. */
-        if (fw_next_progress_missing) {
-            SCLogDebug("%" PRIu64 ": %s default drop for progress", p->pcap_cnt,
-                    flow_flags & STREAM_TOSERVER ? "toserver" : "toclient");
-            DetectFirewallApplyDefaultPolicy(p, s->alproto, s->app_progress_hook + 1);
-            return true;
+         * we invoke the defaul policies for the remaining available hooks. */
+        if (fw_state->fw_next_progress_missing) {
+            const uint8_t last_hook =
+                    fw_state->last_fw_rule
+                            ? (uint8_t)tx_end_state
+                            : MIN((uint8_t)tx_end_state, s->app_progress_hook + (uint8_t)1);
+            enum DetectTxFirewallFlowControl r = DetectFirewallApplyDefaultPolicies(det_ctx,
+                    det_ctx->de_ctx->fw_policies->app, tx, p, s->alproto, direction,
+                    s->app_progress_hook + 1, last_hook, is_last);
+            if (r == DETECT_TX_FW_FC_BREAK)
+                return true;
         }
         return false;
     } else if (as == ACTION_SCOPE_TX) {
         tx->tx_data_ptr->flags |= APP_LAYER_TX_ACCEPT;
-        *skip_fw_hook = true;
-        *skip_before_progress = (uint8_t)tx_end_state + 1; // skip all hooks
-        SCLogDebug(
-                "accept:tx applied, skip_fw_hook, skip_before_progress %u", *skip_before_progress);
+        fw_state->skip_fw_hook = true;
+        fw_state->skip_before_progress = (uint8_t)tx_end_state + 1; // skip all hooks
+        SCLogDebug("accept:tx applied, skip_fw_hook, skip_before_progress %u",
+                fw_state->skip_before_progress);
         return false;
     } else if (as == ACTION_SCOPE_PACKET) {
         return true;
     } else if (as == ACTION_SCOPE_FLOW) {
+        SCLogDebug("ACTION_ACCEPT with ACTION_SCOPE_FLOW");
         return true;
     }
     return false;
+}
+
+/**
+ * \internal
+ * \brief check if there are no (fw) rules, and apply the default policies if so
+ *
+ * \retval 3 policies handled, continue with inspection
+ * \retval 2 continue with next tx
+ * \retval 1 done with inspection
+ * \retval 0 ok, continue as normal. No policies applied.
+ */
+static int DetectTxFirewallNoRulesApplyPolicies(DetectEngineThreadCtx *det_ctx, Packet *p, Flow *f,
+        DetectTransaction *tx, const AppProto alproto, const uint8_t flow_flags, const int rule_cnt,
+        const bool last_tx)
+{
+    /* if there are no rules / rule candidates, handling invoking the default
+     * policy. */
+    if (rule_cnt == 0 || (det_ctx->tx_candidates[0].s->flags & SIG_FLAG_FIREWALL) == 0) {
+        /* if there are no rules, make sure to handle accept:flow and accept:tx */
+        if (rule_cnt == 0) {
+            if (f->flags & FLOW_ACTION_ACCEPT) {
+                DetectRunAppendDefaultAccept(det_ctx, p);
+                return 1;
+            }
+            if (tx->tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
+                /* current tx is the last we have, append a blank accept:packet */
+                if (last_tx) {
+                    DetectRunAppendDefaultAccept(det_ctx, p);
+                    return 1;
+                }
+                return 2;
+            }
+        }
+
+        /* if there are no fw rules, handle default policies */
+        if ((f->flags & FLOW_ACTION_ACCEPT) == 0 &&
+                (tx->tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) == 0) {
+            /* No rules to eval, so we need to see if there are default policies to apply.
+             * Start at last inspected progress and check each hook. If all hooks accepted,
+             * apply the accept to the packet. */
+            SCLogDebug("tx.detect_progress_orig %u tx.tx_progress %u", tx->detect_progress_orig,
+                    tx->tx_progress);
+            enum DetectTxFirewallFlowControl r =
+                    DetectFirewallApplyDefaultPolicies(det_ctx, det_ctx->de_ctx->fw_policies->app,
+                            tx, p, alproto, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT),
+                            tx->detect_progress_orig, (const uint8_t)tx->tx_progress, last_tx);
+            SCLogDebug("r %u", r);
+            if (r == DETECT_TX_FW_FC_BREAK)
+                return 1;
+            if (r == DETECT_TX_FW_FC_SKIP)
+                return 2;
+            /* continue with TD rules */
+            SCLogDebug("continue with TD rules");
+            return 3;
+        }
+    }
+    return 0;
 }
 
 static void DetectRunTx(ThreadVars *tv,
@@ -1849,7 +2061,7 @@ static void DetectRunTx(ThreadVars *tv,
         total_rules += (tx.de_state ? tx.de_state->cnt : 0);
 
         /* run prefilter engines and merge results into a candidates array */
-        if (sgh->tx_engines) {
+        if (sgh && sgh->tx_engines) {
             PACKET_PROFILING_DETECT_START(p, PROF_DETECT_PF_TX);
             DetectRunPrefilterTx(det_ctx, sgh, p, ipproto, flow_flags, alproto,
                     alstate, &tx);
@@ -1943,9 +2155,16 @@ static void DetectRunTx(ThreadVars *tv,
             SCLogDebug("%u: sid %u flags %p", i, s->id, can->flags);
         }
 #endif
-        bool skip_fw_hook = false;
-        uint8_t skip_before_progress = 0;
-        bool fw_next_progress_missing = false;
+
+        struct DetectFirewallAppTxState fw_state = {
+            false,
+            false,
+            false,
+            0,
+            false,
+            false,
+            false,
+        };
 
         SCLogDebug("%s: tx_progress %u tx %p have_fw_rules %s array_idx %u detect_progress_orig %u "
                    "cur detect_progress %u",
@@ -1953,33 +2172,21 @@ static void DetectRunTx(ThreadVars *tv,
                 tx.tx_data_ptr, BOOL2STR(have_fw_rules), array_idx, tx.detect_progress_orig,
                 tx.detect_progress);
 
-        /* if there are no rules / rule candidates, handling invoking the default
-         * policy. */
-        if (have_fw_rules && array_idx == 0) {
-            if (f->flags & FLOW_ACTION_ACCEPT) {
+        if (have_fw_rules) {
+            /* if there are no firewall rules to consider, handle invoking the default
+             * policies. */
+            const int r = DetectTxFirewallNoRulesApplyPolicies(
+                    det_ctx, p, f, &tx, alproto, flow_flags, array_idx, last_tx);
+            if (r != 0) {
                 fw_verdicted++;
-                DetectRunAppendDefaultAccept(det_ctx, p);
-                return;
-            }
-            if (tx.tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
-                fw_verdicted++;
-
-                /* current tx is the last we have, append a blank accept:packet */
-                if (last_tx) {
-                    DetectRunAppendDefaultAccept(det_ctx, p);
+                if (r == 1) {
+                    SCLogDebug("done");
                     return;
-                }
-                goto next;
-            } else {
-                /* use last inspected progress */
-                DetectFirewallApplyDefaultPolicy(p, alproto, tx.detect_progress_orig);
-                fw_verdicted++;
-                break;
+                } else if (r == 2)
+                    goto next_tx_fw; /* next tx */
             }
         }
 
-        bool fw_skip_app_filter = false; /**< skip the rest of the app filter (fw) rules */
-        bool tx_fw_verdict = false;
         /* run rules: inspect the match candidates */
         for (uint32_t i = 0; i < array_idx; i++) {
             RuleMatchCandidateTx *can = &det_ctx->tx_candidates[i];
@@ -1991,14 +2198,24 @@ static void DetectRunTx(ThreadVars *tv,
                     tx.detect_progress, tx.detect_progress_orig, s->app_progress_hook);
 
             if (have_fw_rules) {
-                if ((s->flags & SIG_FLAG_FIREWALL) != 0 && fw_skip_app_filter)
+                if ((s->flags & SIG_FLAG_FIREWALL) != 0 && fw_state.fw_skip_app_filter) {
                     continue;
+                }
                 const enum DetectTxFirewallFlowControl fw_r = DetectRunTxPreCheckFirewallPolicy(
-                        det_ctx, p, &tx, s, i, &tx_fw_verdict, last_tx);
-                if (fw_r == DETECT_TX_FW_FC_SKIP)
+                        det_ctx, p, &tx, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT), s, i,
+                        &fw_state, last_tx);
+                SCLogDebug("fw fw_skip_app_filter:%s tx_fw_verdict:%s skip_fw_hook:%s "
+                           "skip_before_progress:%u fw_last_for_progress:%s "
+                           "fw_next_progress_missing:%s",
+                        BOOL2STR(fw_state.fw_skip_app_filter), BOOL2STR(fw_state.tx_fw_verdict),
+                        BOOL2STR(fw_state.skip_fw_hook), fw_state.skip_before_progress,
+                        BOOL2STR(fw_state.fw_last_for_progress),
+                        BOOL2STR(fw_state.fw_next_progress_missing));
+                if (fw_r == DETECT_TX_FW_FC_SKIP) {
                     continue;
-                else if (fw_r == DETECT_TX_FW_FC_BREAK)
+                } else if (fw_r == DETECT_TX_FW_FC_BREAK) {
                     break;
+                }
             }
 
             /* deduplicate: rules_array is sorted, but not deduplicated:
@@ -2027,9 +2244,8 @@ static void DetectRunTx(ThreadVars *tv,
                     if (have_fw_rules && (s->flags & SIG_FLAG_FIREWALL) &&
                             (s->action & ACTION_ACCEPT) && s->app_progress_hook == tx.tx_progress) {
                         const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
-                        fw_skip_app_filter = ApplyAccept(p, flow_flags, s, &tx, tx_end_state,
-                                fw_next_progress_missing, &tx_fw_verdict, &skip_fw_hook,
-                                &skip_before_progress);
+                        fw_state.fw_skip_app_filter = ApplyAccept(
+                                det_ctx, p, flow_flags, s, &tx, tx_end_state, last_tx, &fw_state);
                         if (fw_accept_to_packet)
                             DetectRunAppendDefaultAccept(det_ctx, p);
                     }
@@ -2049,11 +2265,16 @@ static void DetectRunTx(ThreadVars *tv,
                 SCLogDebug("%p/%"PRIu64" Start sid %u", tx.tx_ptr, tx.tx_id, s->id);
             }
 
-            bool fw_last_for_progress = false;
             if (have_fw_rules) {
                 const enum DetectTxFirewallFlowControl fw_r = DetectRunTxCheckFirewallPolicy(
-                        det_ctx, p, f, &tx, s, i, array_idx, &skip_fw_hook, skip_before_progress,
-                        &fw_last_for_progress, &fw_next_progress_missing);
+                        det_ctx, p, f, &tx, s, i, array_idx, &fw_state);
+                SCLogDebug("fw fw_skip_app_filter:%s tx_fw_verdict:%s skip_fw_hook:%s "
+                           "skip_before_progress:%u fw_last_for_progress:%s "
+                           "fw_next_progress_missing:%s",
+                        BOOL2STR(fw_state.fw_skip_app_filter), BOOL2STR(fw_state.tx_fw_verdict),
+                        BOOL2STR(fw_state.skip_fw_hook), fw_state.skip_before_progress,
+                        BOOL2STR(fw_state.fw_last_for_progress),
+                        BOOL2STR(fw_state.fw_next_progress_missing));
                 if (fw_r == DETECT_TX_FW_FC_SKIP)
                     continue;
                 else if (fw_r == DETECT_TX_FW_FC_BREAK)
@@ -2072,34 +2293,59 @@ static void DetectRunTx(ThreadVars *tv,
                 SCLogDebug(
                         "%p/%" PRIu64 " sig %u (%u) matched", tx.tx_ptr, tx.tx_id, s->id, s->iid);
 
-                if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT)) {
-                    fw_skip_app_filter = ApplyAccept(p, flow_flags, s, &tx, tx_end_state,
-                            fw_next_progress_missing, &tx_fw_verdict, &skip_fw_hook,
-                            &skip_before_progress);
-                    /* see if we need to apply tx/hook accept to the packet. This can be needed when
-                     * we've completed the inspection so far for an incomplete tx, and an accept:tx
-                     * or accept:hook is the last match.*/
-                    const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
-                    if (fw_accept_to_packet) {
-                        SCLogDebug("accept:(tx|hook): should be applied to the packet");
-                        alert_flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET;
+                if (s->flags & SIG_FLAG_FIREWALL) {
+                    if (s->action & ACTION_ACCEPT) {
+                        fw_state.fw_skip_app_filter = ApplyAccept(
+                                det_ctx, p, flow_flags, s, &tx, tx_end_state, last_tx, &fw_state);
+                        fw_state.fw_next_progress_missing = false; // reset
+                        /* see if we need to apply tx/hook accept to the packet. This can be needed
+                         * when we've completed the inspection so far for an incomplete tx, and an
+                         * accept:tx or accept:hook is the last match.*/
+                        const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
+                        if (fw_accept_to_packet) {
+                            SCLogDebug("accept:(tx|hook): should be applied to the packet");
+                            alert_flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET;
+                        }
+                    } else if (s->action & ACTION_DROP) {
+                        SCLogDebug("drop packet because of rule with drop action");
+                        PacketDrop(p, s->action, PKT_DROP_REASON_RULES);
+                        if (s->action_scope == ACTION_SCOPE_FLOW) {
+                            SCLogDebug("drop flow because of rule with drop action");
+                            f->flags |= FLOW_ACTION_DROP;
+                        }
                     }
                 }
                 AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
 
-            } else if (fw_last_for_progress) {
-                SCLogDebug("sid %u: not a match: %s rule, fw_last_for_progress %s", s->id,
-                        (s->flags & SIG_FLAG_FIREWALL) ? "firewall" : "regular",
-                        BOOL2STR(fw_last_for_progress));
-                if (s->flags & SIG_FLAG_FIREWALL) {
-                    SCLogDebug("%" PRIu64 ": %s default drop for progress", p->pcap_cnt,
-                            flow_flags & STREAM_TOSERVER ? "toserver" : "toclient");
-                    /* if this rule was the last for our progress state, and it didn't match,
-                     * we have to invoke the default drop policy. */
-                    DetectFirewallApplyDefaultPolicy(p, s->alproto, s->app_progress_hook);
-                    fw_skip_app_filter = true;
-                    tx_fw_verdict = true;
+            } else if (fw_state.fw_last_for_progress && (s->flags & SIG_FLAG_FIREWALL)) {
+                SCLogDebug("%" PRIu64 ": %s default policy for progress %u", p->pcap_cnt,
+                        flow_flags & STREAM_TOSERVER ? "toserver" : "toclient",
+                        s->app_progress_hook);
+                /* if this rule was the last for our progress state, and it didn't match,
+                 * we have to invoke the default policy. We only check the current rule hook. */
+                const struct DetectFirewallPolicy *policy =
+                        DetectFirewallApplyDefaultAppPolicy(det_ctx->de_ctx->fw_policies->app, p,
+                                s->alproto, flow_flags, s->app_progress_hook);
+                SCLogDebug("fw_last_for_progress policy %02x", policy->action);
+                if (policy->action & ACTION_DROP) {
+                    fw_state.fw_skip_app_filter = true;
+                    SCLogDebug("packet %02x", p->action);
+                } else if (policy->action == ACTION_ACCEPT) {
+                    SCLogDebug("accept hook(s)? current hook %u (tx.detect_progress %u) max %u",
+                            s->app_progress_hook, tx.detect_progress, tx.tx_progress);
+
+                    /* accepting flow, so skip rest of the fw rules */
+                    if (policy->action_scope == ACTION_SCOPE_FLOW) {
+                        fw_state.fw_skip_app_filter = true;
+                    }
+
+                    /* if this is also the last fw rule we'll inspect we have to issue a default
+                     * accept to the packet */
+                    if (s->app_progress_hook == tx.tx_progress) {
+                        DetectRunAppendDefaultAccept(det_ctx, p);
+                    }
                 }
+                fw_state.tx_fw_verdict = true;
             }
             DetectVarProcessList(det_ctx, p->flow, p);
             RULE_PROFILING_END(det_ctx, s, r, p);
@@ -2136,7 +2382,7 @@ static void DetectRunTx(ThreadVars *tv,
                 PMQ_RESET(&det_ctx->pmq);
             }
         }
-        if (tx_fw_verdict)
+        if (fw_state.tx_fw_verdict)
             fw_verdicted++;
 
         det_ctx->tx_id = 0;
@@ -2167,7 +2413,7 @@ static void DetectRunTx(ThreadVars *tv,
 
             StoreDetectProgress(&tx, flow_flags, tx.detect_progress);
         }
-
+    next_tx_fw:
         InspectionBufferClean(det_ctx);
 
     next:
@@ -2175,17 +2421,8 @@ static void DetectRunTx(ThreadVars *tv,
             break;
     }
 
-    /* apply default policy if there were txs to inspect, we have fw rules and non of the rules
-     * applied a policy. */
     SCLogDebug("packet %" PRIu64 ": tx_inspected %u fw_verdicted %u", p->pcap_cnt, tx_inspected,
             fw_verdicted);
-    if (tx_inspected && have_fw_rules && tx_inspected != fw_verdicted) {
-        SCLogDebug("%" PRIu64 ": %s default drop", p->pcap_cnt,
-                flow_flags & STREAM_TOSERVER ? "toserver" : "toclient");
-        DetectFirewallApplyDefaultPolicy(
-                p, ALPROTO_UNKNOWN, 0); // TODO can we assign this to a hook?
-        return;
-    }
     /* if all tables have been bypassed, we accept:packet */
     if (tx_inspected == 0 && fw_verdicted == 0 && have_fw_rules) {
         DetectRunAppendDefaultAccept(det_ctx, p);
@@ -2402,7 +2639,7 @@ uint8_t DetectPreFlow(ThreadVars *tv, DetectEngineThreadCtx *det_ctx, Packet *p)
     const SigGroupHead *sgh = de_ctx->pre_flow_sgh;
 
     SCLogDebug("thread id: %u, packet %" PRIu64 ", sgh %p", tv->id, p->pcap_cnt, sgh);
-    DetectRunPacketHook(tv, de_ctx, det_ctx, sgh, p);
+    DetectRunPacketHook(tv, de_ctx, det_ctx, sgh, p, DETECT_FIREWALL_POLICY_PRE_FLOW);
     return p->action;
 }
 
@@ -2413,7 +2650,7 @@ uint8_t DetectPreStream(ThreadVars *tv, DetectEngineThreadCtx *det_ctx, Packet *
     const SigGroupHead *sgh = de_ctx->pre_stream_sgh[direction];
 
     SCLogDebug("thread id: %u, packet %" PRIu64 ", sgh %p", tv->id, p->pcap_cnt, sgh);
-    DetectRunPacketHook(tv, de_ctx, det_ctx, sgh, p);
+    DetectRunPacketHook(tv, de_ctx, det_ctx, sgh, p, DETECT_FIREWALL_POLICY_PRE_STREAM);
     return p->action;
 }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -1486,7 +1486,7 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
 
 #define NO_TX                                                                                      \
     {                                                                                              \
-        NULL, 0, NULL, NULL, 0, 0, 0, 0,                                                           \
+        NULL, 0, NULL, NULL, 0, 0, 0, 0, false,                                                    \
     }
 
 /** \internal
@@ -1540,6 +1540,7 @@ static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alpro
         .detect_progress_orig = detect_progress,
         .tx_progress = (uint8_t)tx_progress,
         .tx_end_state = (uint8_t)tx_end_state,
+        .is_last = false,
     };
     return tx;
 }
@@ -1665,7 +1666,7 @@ static inline void DetectRunAppendDefaultAppPolicyAlert(DetectEngineThreadCtx *d
 static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
         DetectEngineThreadCtx *det_ctx, const struct DetectFirewallAppPolicy *policies,
         const DetectTransaction *tx, Packet *p, const AppProto alproto, const uint8_t direction,
-        const uint8_t progress, const bool last_tx)
+        const uint8_t progress)
 {
     const struct DetectFirewallPolicy *policy;
     if (direction & STREAM_TOSERVER) {
@@ -1706,10 +1707,10 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
                 break;
             case ACTION_SCOPE_TX:
                 tx->tx_data_ptr->flags |= APP_LAYER_TX_ACCEPT;
-                apply_to_packet = last_tx;
+                apply_to_packet = tx->is_last;
                 break;
             case ACTION_SCOPE_HOOK:
-                apply_to_packet = last_tx && last_hook;
+                apply_to_packet = tx->is_last && last_hook;
                 break;
             default:
                 /* should be unreachable */
@@ -1749,25 +1750,26 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
 static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
         DetectEngineThreadCtx *det_ctx, const struct DetectFirewallAppPolicy *policies,
         DetectTransaction *tx, Packet *p, const AppProto alproto, const uint8_t direction,
-        const uint8_t start_hook, const uint8_t end_hook, const bool is_last)
+        const uint8_t start_hook, const uint8_t end_hook)
 {
     DEBUG_VALIDATE_BUG_ON(start_hook > end_hook);
 
     const bool need_verdict =
-            is_last && (end_hook == tx->tx_end_state || end_hook == tx->tx_progress);
+            tx->is_last && (end_hook == tx->tx_end_state || end_hook == tx->tx_progress);
     SCLogDebug("need_verdict:%s is_last:%s end_hook:%u tx->tx_end_state:%u tx->progress: %u",
-            BOOL2STR(need_verdict), BOOL2STR(is_last), end_hook, tx->tx_end_state, tx->tx_progress);
+            BOOL2STR(need_verdict), BOOL2STR(tx->is_last), end_hook, tx->tx_end_state,
+            tx->tx_progress);
 
     for (uint8_t hook = start_hook; hook <= end_hook; hook++) {
         const bool apply_to_packet =
-                is_last && (hook == tx->tx_end_state || hook == tx->tx_progress);
+                tx->is_last && (hook == tx->tx_end_state || hook == tx->tx_progress);
 
         SCLogDebug("%" PRIu64 ": %s default policy for hook %u, apply_to_packet %s", p->pcap_cnt,
                 direction & STREAM_TOSERVER ? "toserver" : "toclient", hook,
                 BOOL2STR(apply_to_packet));
 
-        const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(det_ctx,
-                det_ctx->de_ctx->fw_policies->app, tx, p, alproto, direction, hook, is_last);
+        const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
+                det_ctx, det_ctx->de_ctx->fw_policies->app, tx, p, alproto, direction, hook);
         SCLogDebug("fw: hook:%u policy:%02x apply_to_packet:%s", hook, policy->action,
                 BOOL2STR(apply_to_packet));
         if (policy->action & ACTION_DROP) {
@@ -1826,8 +1828,7 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
  */
 static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         DetectEngineThreadCtx *det_ctx, Packet *p, DetectTransaction *tx, const uint8_t direction,
-        const Signature *s, const uint32_t can_idx, struct DetectFirewallAppTxState *fw_state,
-        const bool last_tx)
+        const Signature *s, const uint32_t can_idx, struct DetectFirewallAppTxState *fw_state)
 {
     SCLogDebug("packet %" PRIu64 ": running pre-checks before sid %u", p->pcap_cnt, s->id);
 
@@ -1856,7 +1857,7 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         /* append a blank accept:packet action for the APP_LAYER_TX_ACCEPT,
          * if this is the last tx */
         fw_state->fw_skip_app_filter = true;
-        const bool accept_tx_applies_to_packet = last_tx;
+        const bool accept_tx_applies_to_packet = tx->is_last;
         if (accept_tx_applies_to_packet) {
             SCLogDebug("accept:tx: should be applied to the packet");
             DetectRunAppendDefaultAccept(det_ctx, p);
@@ -1885,7 +1886,7 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
          * no rules for that state. Invoke the default policies. */
         enum DetectTxFirewallFlowControl r = DetectFirewallApplyDefaultPolicies(det_ctx,
                 det_ctx->de_ctx->fw_policies->app, tx, p, s->alproto, direction,
-                tx->detect_progress_orig, s->app_progress_hook - 1, last_tx);
+                tx->detect_progress_orig, s->app_progress_hook - 1);
         if (r != DETECT_TX_FW_FC_OK) {
             /* both SKIP and BREAK mean: no more fw rules to inspect.
              * SKIP applies to just this TX.
@@ -1988,8 +1989,7 @@ static void DetectRunAppendDefaultAccept(DetectEngineThreadCtx *det_ctx, Packet 
 /** \internal
  * \brief see if the accept rule needs to apply to the packet
  */
-static inline bool ApplyAcceptToPacket(
-        const bool last_tx, const DetectTransaction *tx, const Signature *s)
+static inline bool ApplyAcceptToPacket(const DetectTransaction *tx, const Signature *s)
 {
     if ((s->flags & SIG_FLAG_FIREWALL) == 0) {
         return false;
@@ -2002,7 +2002,7 @@ static inline bool ApplyAcceptToPacket(
      * - packet will only be accepted if this is set on the last tx
      */
     if (s->action_scope == ACTION_SCOPE_TX) {
-        if (last_tx) {
+        if (tx->is_last) {
             return true;
         }
     }
@@ -2010,7 +2010,7 @@ static inline bool ApplyAcceptToPacket(
      * - packet will only be accepted if this is set on the last tx
      * - the hook accepted should be the last progress available. */
     if (s->action_scope == ACTION_SCOPE_HOOK) {
-        if (last_tx && (s->app_progress_hook == tx->tx_progress)) {
+        if (tx->is_last && (s->app_progress_hook == tx->tx_progress)) {
             return true;
         }
     }
@@ -2024,7 +2024,7 @@ static inline bool ApplyAcceptToPacket(
  *
  * */
 static void DetectRunTxFirewallApplyAccept(DetectEngineThreadCtx *det_ctx, Packet *p,
-        const uint8_t direction, const Signature *s, DetectTransaction *tx, const bool is_last,
+        const uint8_t direction, const Signature *s, DetectTransaction *tx,
         struct DetectFirewallAppTxState *fw_state)
 {
     const enum ActionScope as = s->action_scope;
@@ -2046,9 +2046,9 @@ static void DetectRunTxFirewallApplyAccept(DetectEngineThreadCtx *det_ctx, Packe
             const uint8_t last_hook = fw_state->last_fw_rule
                                               ? tx->tx_end_state
                                               : MIN(tx->tx_end_state, s->app_progress_hook + 1);
-            enum DetectTxFirewallFlowControl r = DetectFirewallApplyDefaultPolicies(det_ctx,
-                    det_ctx->de_ctx->fw_policies->app, tx, p, s->alproto, direction,
-                    s->app_progress_hook + 1, last_hook, is_last);
+            enum DetectTxFirewallFlowControl r =
+                    DetectFirewallApplyDefaultPolicies(det_ctx, det_ctx->de_ctx->fw_policies->app,
+                            tx, p, s->alproto, direction, s->app_progress_hook + 1, last_hook);
             if (r == DETECT_TX_FW_FC_BREAK) {
                 fw_state->fw_skip_app_filter = true;
                 return;
@@ -2078,8 +2078,7 @@ static void DetectRunTxFirewallApplyAccept(DetectEngineThreadCtx *det_ctx, Packe
  * \retval 0 ok, continue as normal. No policies applied.
  */
 static int DetectTxFirewallNoRulesApplyPolicies(DetectEngineThreadCtx *det_ctx, Packet *p, Flow *f,
-        DetectTransaction *tx, const AppProto alproto, const uint8_t flow_flags, const int rule_cnt,
-        const bool last_tx)
+        DetectTransaction *tx, const AppProto alproto, const uint8_t flow_flags, const int rule_cnt)
 {
     /* if there are no rules / rule candidates, handling invoking the default
      * policy. */
@@ -2093,7 +2092,7 @@ static int DetectTxFirewallNoRulesApplyPolicies(DetectEngineThreadCtx *det_ctx, 
             }
             if (tx->tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
                 /* current tx is the last we have, append a blank accept:packet */
-                if (last_tx) {
+                if (tx->is_last) {
                     SCLogDebug("default accept:tx: no rules");
                     DetectRunAppendDefaultAccept(det_ctx, p);
                     return 1;
@@ -2113,7 +2112,7 @@ static int DetectTxFirewallNoRulesApplyPolicies(DetectEngineThreadCtx *det_ctx, 
             enum DetectTxFirewallFlowControl r =
                     DetectFirewallApplyDefaultPolicies(det_ctx, det_ctx->de_ctx->fw_policies->app,
                             tx, p, alproto, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT),
-                            tx->detect_progress_orig, tx->tx_progress, last_tx);
+                            tx->detect_progress_orig, tx->tx_progress);
             SCLogDebug("r %u", r);
             if (r == DETECT_TX_FW_FC_BREAK)
                 return 1;
@@ -2136,14 +2135,14 @@ static int DetectTxFirewallNoRulesApplyPolicies(DetectEngineThreadCtx *det_ctx, 
  */
 static void DetectRunTxFirewallRuleFullMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         DetectTransaction *tx, struct DetectFirewallAppTxState *fw_state, Flow *f, Packet *p,
-        const uint8_t flow_flags, const bool last_tx)
+        const uint8_t flow_flags)
 {
     uint8_t alert_flags = (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_TX);
     if (s->action & ACTION_ACCEPT) {
         /* see if we need to apply tx/hook accept to the packet. This can be needed
          * when we've completed the inspection so far for an incomplete tx, and an
          * accept:tx or accept:hook is the last match.*/
-        const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, tx, s);
+        const bool fw_accept_to_packet = ApplyAcceptToPacket(tx, s);
         if (fw_accept_to_packet) {
             SCLogDebug("packet %" PRIu64 ": apply accept to packet", p->pcap_cnt);
             SCLogDebug("accept:(tx|hook): should be applied to the packet");
@@ -2155,7 +2154,7 @@ static void DetectRunTxFirewallRuleFullMatch(DetectEngineThreadCtx *det_ctx, con
          * policy matches that could add alerts. */
         AlertQueueAppend(det_ctx, s, p, tx->tx_id, alert_flags);
 
-        DetectRunTxFirewallApplyAccept(det_ctx, p, flow_flags, s, tx, last_tx, fw_state);
+        DetectRunTxFirewallApplyAccept(det_ctx, p, flow_flags, s, tx, fw_state);
     } else if (s->action & ACTION_DROP) {
         SCLogDebug("drop packet because of rule with drop action");
         PacketDrop(p, s->action, PKT_DROP_REASON_FW_RULES);
@@ -2184,12 +2183,12 @@ static void DetectRunTxFirewallRuleFullMatch(DetectEngineThreadCtx *det_ctx, con
  * \retval 0 ok, caller must continue as normal
  */
 static int DetectRunTxFirewallRulePartialMatch(
-        DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, const bool last_tx)
+        DetectEngineThreadCtx *det_ctx, const Signature *s, const DetectTransaction *tx, Packet *p)
 {
     if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT)) {
         /* partial match always uses ACTION_SCOPE_HOOK. Final action only on the full
          * match */
-        if (last_tx) {
+        if (tx->is_last) {
             SCLogDebug("need to apply accept to packet");
             DetectRunAppendDefaultAccept(det_ctx, p);
         }
@@ -2215,7 +2214,7 @@ static int DetectRunTxFirewallRulePartialMatch(
  */
 static int DetectRunTxFirewallRuleNoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         DetectTransaction *tx, struct DetectFirewallAppTxState *fw_state, Packet *p,
-        const uint8_t flow_flags, const bool last_tx)
+        const uint8_t flow_flags)
 {
     if (fw_state->fw_last_for_progress && (s->flags & SIG_FLAG_FIREWALL)) {
         SCLogDebug("%" PRIu64 ": %s default policy for progress %u", p->pcap_cnt,
@@ -2226,7 +2225,7 @@ static int DetectRunTxFirewallRuleNoMatch(DetectEngineThreadCtx *det_ctx, const 
          * the DetectRunTxPreCheckFirewallPolicy function for the next rule. */
         const struct DetectFirewallPolicy *policy =
                 DetectFirewallApplyDefaultAppPolicy(det_ctx, det_ctx->de_ctx->fw_policies->app, tx,
-                        p, s->alproto, flow_flags, s->app_progress_hook, last_tx);
+                        p, s->alproto, flow_flags, s->app_progress_hook);
         SCLogDebug("fw_last_for_progress policy %02x", policy->action);
         if (policy->action & ACTION_DROP) {
             return 1;
@@ -2243,14 +2242,14 @@ static int DetectRunTxFirewallRuleNoMatch(DetectEngineThreadCtx *det_ctx, const 
  */
 static void DetectRunTxFirewallRuleStatefulReApplyMatch(DetectEngineThreadCtx *det_ctx,
         const Signature *s, DetectTransaction *tx, struct DetectFirewallAppTxState *fw_state,
-        Packet *p, const uint8_t flow_flags, const bool last_tx)
+        Packet *p, const uint8_t flow_flags)
 {
     /* if we're still in the same progress state as an earlier full
      * match, we need to apply the same accept */
     if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT) &&
             s->app_progress_hook == tx->tx_progress) {
-        const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, tx, s);
-        DetectRunTxFirewallApplyAccept(det_ctx, p, flow_flags, s, tx, last_tx, fw_state);
+        const bool fw_accept_to_packet = ApplyAcceptToPacket(tx, s);
+        DetectRunTxFirewallApplyAccept(det_ctx, p, flow_flags, s, tx, fw_state);
         if (fw_accept_to_packet) {
             SCLogDebug("packet %" PRIu64 ": apply accept to packet", p->pcap_cnt);
             DetectRunAppendDefaultAccept(det_ctx, p);
@@ -2300,9 +2299,9 @@ static void DetectRunTx(ThreadVars *tv,
             tx_id_min++; // next (if any) run look for +1
             goto next;
         }
+        tx.is_last = (total_txs == tx.tx_id + 1);
         tx_id_min = tx.tx_id + 1; // next look for cur + 1
         tx_inspected++;
-        const bool last_tx = (total_txs == tx.tx_id + 1);
 
         SCLogDebug("%p/%" PRIu64 " txd flags %02x", tx.tx_ptr, tx.tx_id, tx.tx_data_ptr->flags);
 
@@ -2430,7 +2429,7 @@ static void DetectRunTx(ThreadVars *tv,
             /* if there are no firewall rules to consider, handle invoking the default
              * policies. */
             const int r = DetectTxFirewallNoRulesApplyPolicies(
-                    det_ctx, p, f, &tx, alproto, flow_flags, array_idx, last_tx);
+                    det_ctx, p, f, &tx, alproto, flow_flags, array_idx);
             if (r == 1) {
                 SCLogDebug("done");
                 return;
@@ -2450,9 +2449,9 @@ static void DetectRunTx(ThreadVars *tv,
                     tx.detect_progress, tx.detect_progress_orig, s->app_progress_hook);
 
             if (have_fw_rules) {
-                const enum DetectTxFirewallFlowControl fw_r = DetectRunTxPreCheckFirewallPolicy(
-                        det_ctx, p, &tx, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT), s, i,
-                        &fw_state, last_tx);
+                const enum DetectTxFirewallFlowControl fw_r =
+                        DetectRunTxPreCheckFirewallPolicy(det_ctx, p, &tx,
+                                flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT), s, i, &fw_state);
                 SCLogDebug("fw fw_skip_app_filter:%s skip_fw_hook:%s "
                            "skip_before_progress:%u fw_last_for_progress:%s "
                            "fw_next_progress_missing:%s",
@@ -2494,7 +2493,7 @@ static void DetectRunTx(ThreadVars *tv,
                      * match, we need to apply the same accept */
                     if (have_fw_rules) {
                         DetectRunTxFirewallRuleStatefulReApplyMatch(
-                                det_ctx, s, &tx, &fw_state, p, flow_flags, last_tx);
+                                det_ctx, s, &tx, &fw_state, p, flow_flags);
                     }
                     continue;
                 }
@@ -2544,17 +2543,16 @@ static void DetectRunTx(ThreadVars *tv,
                     AlertQueueAppend(det_ctx, s, p, tx.tx_id,
                             (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_TX));
                 } else {
-                    DetectRunTxFirewallRuleFullMatch(
-                            det_ctx, s, &tx, &fw_state, f, p, flow_flags, last_tx);
+                    DetectRunTxFirewallRuleFullMatch(det_ctx, s, &tx, &fw_state, f, p, flow_flags);
                 }
             } else if (r == 0) {
                 SCLogDebug("sid %u partial match", s->id);
-                if (DetectRunTxFirewallRulePartialMatch(det_ctx, s, p, last_tx) == 1) {
+                if (DetectRunTxFirewallRulePartialMatch(det_ctx, s, &tx, p) == 1) {
                     break;
                 }
             } else {
-                if (DetectRunTxFirewallRuleNoMatch(
-                            det_ctx, s, &tx, &fw_state, p, flow_flags, last_tx) == 1) {
+                if (DetectRunTxFirewallRuleNoMatch(det_ctx, s, &tx, &fw_state, p, flow_flags) ==
+                        1) {
                     return;
                 }
             }

--- a/src/detect.c
+++ b/src/detect.c
@@ -2148,7 +2148,6 @@ static void DetectRunTx(ThreadVars *tv,
     AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(ipproto, alproto);
     AppLayerGetTxIterState state = { 0 };
 
-    uint32_t fw_verdicted = 0;
     uint32_t tx_inspected = 0;
     const bool have_fw_rules = EngineModeIsFirewall();
 
@@ -2304,7 +2303,6 @@ static void DetectRunTx(ThreadVars *tv,
             const int r = DetectTxFirewallNoRulesApplyPolicies(
                     det_ctx, p, f, &tx, alproto, flow_flags, array_idx, last_tx);
             if (r != 0) {
-                fw_verdicted++;
                 if (r == 1) {
                     SCLogDebug("done");
                     return;
@@ -2530,8 +2528,6 @@ static void DetectRunTx(ThreadVars *tv,
                 PMQ_RESET(&det_ctx->pmq);
             }
         }
-        if (fw_state.tx_fw_verdict)
-            fw_verdicted++;
 
         det_ctx->tx_id = 0;
         det_ctx->tx_id_set = false;
@@ -2569,10 +2565,9 @@ static void DetectRunTx(ThreadVars *tv,
             break;
     }
 
-    SCLogDebug("packet %" PRIu64 ": tx_inspected %u fw_verdicted %u", p->pcap_cnt, tx_inspected,
-            fw_verdicted);
+    SCLogDebug("packet %" PRIu64 ": tx_inspected %u", p->pcap_cnt, tx_inspected);
     /* if all tables have been bypassed, we accept:packet */
-    if (tx_inspected == 0 && fw_verdicted == 0 && have_fw_rules) {
+    if (tx_inspected == 0 && have_fw_rules) {
         SCLogDebug("default accept: no app inspect performed");
         DetectRunAppendDefaultAccept(det_ctx, p);
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1618,7 +1618,8 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
  * \param skip_before_progress progress value to skip rules before.
  * Only used if `skip_fw_hook` is set.
  *
- * \param last_for_progress[out] set to true if this is the last rule for a progress value
+ * \param fw_last_for_progress[out] set to true if this is the last firewall rule for a progress
+ * value
  *
  * \param fw_next_progress_missing[out] set to true if the next fw rule does not target the next
  * progress value, or there is no fw rule for that value.
@@ -1630,7 +1631,8 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
 static enum DetectTxFirewallFlowControl DetectRunTxCheckFirewallPolicy(
         DetectEngineThreadCtx *det_ctx, Packet *p, Flow *f, DetectTransaction *tx,
         const Signature *s, const uint32_t can_idx, const uint32_t can_size, bool *skip_fw_hook,
-        const uint8_t skip_before_progress, bool *last_for_progress, bool *fw_next_progress_missing)
+        const uint8_t skip_before_progress, bool *fw_last_for_progress,
+        bool *fw_next_progress_missing)
 {
     if (s->flags & SIG_FLAG_FIREWALL) {
         /* check if the next sig is on the same progress hook. If not, we need to apply our
@@ -1649,7 +1651,7 @@ static enum DetectTxFirewallFlowControl DetectRunTxCheckFirewallPolicy(
                     SCLogDebug("peek: next sid progress %u != current progress %u, so current "
                                "is last for progress",
                             next_s->app_progress_hook, s->app_progress_hook);
-                    *last_for_progress = true;
+                    *fw_last_for_progress = true;
 
                     if (next_s->app_progress_hook - s->app_progress_hook > 1) {
                         SCLogDebug("peek: missing progress, so we'll drop that unless we get a "
@@ -1659,7 +1661,7 @@ static enum DetectTxFirewallFlowControl DetectRunTxCheckFirewallPolicy(
                 }
             } else {
                 SCLogDebug("peek: next sid not a fw rule, so current is last for progress");
-                *last_for_progress = true;
+                *fw_last_for_progress = true;
             }
         } else {
             SCLogDebug("peek: no peek beyond last rule");
@@ -1667,7 +1669,7 @@ static enum DetectTxFirewallFlowControl DetectRunTxCheckFirewallPolicy(
                 SCLogDebug("peek: there are no rules to allow the state after this rule");
                 *fw_next_progress_missing = true;
             }
-            *last_for_progress = true;
+            *fw_last_for_progress = true;
         }
 
         if ((*skip_fw_hook) == true) {
@@ -2025,11 +2027,11 @@ static void DetectRunTx(ThreadVars *tv,
                 SCLogDebug("%p/%"PRIu64" Start sid %u", tx.tx_ptr, tx.tx_id, s->id);
             }
 
-            bool last_for_progress = false;
+            bool fw_last_for_progress = false;
             if (have_fw_rules) {
                 const enum DetectTxFirewallFlowControl fw_r = DetectRunTxCheckFirewallPolicy(
                         det_ctx, p, f, &tx, s, i, array_idx, &skip_fw_hook, skip_before_progress,
-                        &last_for_progress, &fw_next_progress_missing);
+                        &fw_last_for_progress, &fw_next_progress_missing);
                 if (fw_r == DETECT_TX_FW_FC_SKIP)
                     continue;
                 else if (fw_r == DETECT_TX_FW_FC_BREAK)
@@ -2063,10 +2065,10 @@ static void DetectRunTx(ThreadVars *tv,
                 }
                 AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
 
-            } else if (last_for_progress) {
-                SCLogDebug("sid %u: not a match: %s rule, last_for_progress %s", s->id,
+            } else if (fw_last_for_progress) {
+                SCLogDebug("sid %u: not a match: %s rule, fw_last_for_progress %s", s->id,
                         (s->flags & SIG_FLAG_FIREWALL) ? "firewall" : "regular",
-                        BOOL2STR(last_for_progress));
+                        BOOL2STR(fw_last_for_progress));
                 if (s->flags & SIG_FLAG_FIREWALL) {
                     SCLogDebug("%" PRIu64 ": %s default drop for progress", p->pcap_cnt,
                             flow_flags & STREAM_TOSERVER ? "toserver" : "toclient");

--- a/src/detect.c
+++ b/src/detect.c
@@ -1868,9 +1868,6 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
     }
 
     /* handle missing rules case */
-    fw_state->fw_next_progress_missing = false;
-    fw_state->fw_last_for_progress = false;
-
     if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
         SCLogDebug("SIG_FLAG_FW_HOOK_LTE");
         return DETECT_TX_FW_FC_OK; // TODO check for other cases
@@ -2343,6 +2340,9 @@ static void DetectRunTx(ThreadVars *tv,
                 } else if (fw_r == DETECT_TX_FW_FC_BREAK) {
                     break;
                 }
+
+                fw_state.fw_last_for_progress = false;
+                fw_state.fw_next_progress_missing = false; // reset
             }
 
             /* deduplicate: rules_array is sorted, but not deduplicated:
@@ -2443,7 +2443,6 @@ static void DetectRunTx(ThreadVars *tv,
 
                         fw_state.fw_skip_app_filter = ApplyAccept(
                                 det_ctx, p, flow_flags, s, &tx, tx_end_state, last_tx, &fw_state);
-                        fw_state.fw_next_progress_missing = false; // reset
                     } else if (s->action & ACTION_DROP) {
                         SCLogDebug("drop packet because of rule with drop action");
                         PacketDrop(p, s->action, PKT_DROP_REASON_FW_RULES);

--- a/src/detect.c
+++ b/src/detect.c
@@ -1897,34 +1897,22 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
  * \internal
  * \brief Check and update firewall rules state.
  *
- * \param skip_fw_hook bool to indicate firewall rules skips
- * For state `skip_before_progress` should be skipped.
- *
- * \param skip_before_progress progress value to skip rules before.* Only used if `skip_fw_hook` is
- * set.
- *
- * \param fw_last_for_progress[out] set to true if this is  firewall rule for a progress
- * value
- *
- * \param fw_next_progress_missing[out] set to true if the next fw rule does not target the next
- * progress value, or there is no fw rule for that value.
+ * \param fw_state pointer to flow control state
  *
  * \retval DETECT_TX_FW_FC_OK no action needed
  * \retval DETECT_TX_FW_FC_BREAK rest of rules shouldn't inspected
  * \retval DETECT_TX_FW_FC_SKIP skip this rule
  */
-static enum DetectTxFirewallFlowControl DetectRunTxCheckFirewallPolicy(
-        DetectEngineThreadCtx *det_ctx, Packet *p, Flow *f, DetectTransaction *tx,
-        const Signature *s, const uint32_t can_idx, const uint32_t can_size,
-        struct DetectFirewallAppTxState *fw_state)
+static enum DetectTxFirewallFlowControl DetectRunTxCheckRuleState(DetectEngineThreadCtx *det_ctx,
+        Packet *p, Flow *f, DetectTransaction *tx, const Signature *s, const uint32_t can_idx,
+        const uint32_t can_size, struct DetectFirewallAppTxState *fw_state)
 {
     if (s->flags & SIG_FLAG_FIREWALL) {
         /* check if the next sig is on the same progress hook. If not, we need to apply our
          * default policy in case the current sig doesn't apply one. If the next sig has a
          * progress beyond our progress + 1, it means the next progress has no rules and needs
          * the default policy applied. But only after we evaluate the current rule first, as
-         * that may override it.
-         * TODO should we do this after dedup below? */
+         * that may override it. */
 
         if (can_idx + 1 < can_size) {
             const Signature *next_s = det_ctx->tx_candidates[can_idx + 1].s;
@@ -2395,8 +2383,9 @@ static void DetectRunTx(ThreadVars *tv,
             }
 
             if (have_fw_rules) {
-                const enum DetectTxFirewallFlowControl fw_r = DetectRunTxCheckFirewallPolicy(
-                        det_ctx, p, f, &tx, s, i, array_idx, &fw_state);
+                /* check if we should run this rule and update the firewall flow state */
+                const enum DetectTxFirewallFlowControl fw_r =
+                        DetectRunTxCheckRuleState(det_ctx, p, f, &tx, s, i, array_idx, &fw_state);
                 SCLogDebug("fw fw_skip_app_filter:%s skip_fw_hook:%s "
                            "skip_before_progress:%u fw_last_for_progress:%s "
                            "fw_next_progress_missing:%s",

--- a/src/detect.c
+++ b/src/detect.c
@@ -676,8 +676,9 @@ static uint8_t DetectRunApplyPacketPolicy(const DetectEngineCtx *de_ctx,
     DEBUG_VALIDATE_BUG_ON(de_ctx->fw_policies == NULL);
     const struct DetectFirewallPolicy *pol = &de_ctx->fw_policies->pkt[policy];
     if (pol->action & ACTION_DROP) {
-        SCLogDebug("packet %" PRIu64 ": drop PKT_DROP_REASON_DEFAULT_PACKET_POLICY", p->pcap_cnt);
-        PacketDrop(p, pol->action, PKT_DROP_REASON_DEFAULT_PACKET_POLICY);
+        SCLogDebug(
+                "packet %" PRIu64 ": drop PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY", p->pcap_cnt);
+        PacketDrop(p, pol->action, PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY);
     } else if (pol->action & ACTION_ACCEPT) {
         SCLogDebug("packet %" PRIu64 ": accept", p->pcap_cnt);
         if (pol->action_scope == ACTION_SCOPE_PACKET) {
@@ -994,6 +995,7 @@ static DetectRunScratchpad DetectRunSetup(const DetectEngineCtx *de_ctx,
 
     det_ctx->alert_queue_size = 0;
     p->alerts.drop.action = 0;
+    p->alerts.firewall_discarded = 0;
 
 #ifdef DEBUG
     if (p->flags & PKT_STREAM_ADD) {
@@ -1084,6 +1086,10 @@ static inline void DetectRunPostRules(ThreadVars *tv, const DetectEngineCtx *de_
     }
     if (p->alerts.discarded > 0) {
         StatsAddUI64(tv, det_ctx->counter_alerts_overflow, (uint64_t)p->alerts.discarded);
+    }
+    if (p->alerts.firewall_discarded > 0) {
+        StatsAddUI64(tv, det_ctx->counter_firewall_discarded_alerts,
+                (uint64_t)p->alerts.firewall_discarded);
     }
     if (p->alerts.suppressed > 0) {
         StatsAddUI64(tv, det_ctx->counter_alerts_suppressed, (uint64_t)p->alerts.suppressed);
@@ -1629,8 +1635,8 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
     }
 
     if (policy->action & ACTION_DROP) {
-        SCLogDebug("dropping packet PKT_DROP_REASON_DEFAULT_APP_POLICY");
-        PacketDrop(p, policy->action, PKT_DROP_REASON_DEFAULT_APP_POLICY);
+        SCLogDebug("dropping packet PKT_DROP_REASON_FW_DEFAULT_APP_POLICY");
+        PacketDrop(p, policy->action, PKT_DROP_REASON_FW_DEFAULT_APP_POLICY);
         if (policy->action_scope == ACTION_SCOPE_FLOW) {
             SCLogDebug("dropping flow");
             p->flow->flags |= FLOW_ACTION_DROP;
@@ -2311,7 +2317,7 @@ static void DetectRunTx(ThreadVars *tv,
                         }
                     } else if (s->action & ACTION_DROP) {
                         SCLogDebug("drop packet because of rule with drop action");
-                        PacketDrop(p, s->action, PKT_DROP_REASON_RULES);
+                        PacketDrop(p, s->action, PKT_DROP_REASON_FW_RULES);
                         if (s->action_scope == ACTION_SCOPE_FLOW) {
                             SCLogDebug("drop flow because of rule with drop action");
                             f->flags |= FLOW_ACTION_DROP;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1928,17 +1928,30 @@ static void DetectRunTx(ThreadVars *tv,
         uint8_t skip_before_progress = 0;
         bool fw_next_progress_missing = false;
 
-        /* if there are no rules / rule candidates, make sure we don't
-         * invoke the default drop */
-        if (have_fw_rules && array_idx == 0 && (tx.tx_data_ptr->flags & APP_LAYER_TX_ACCEPT)) {
-            fw_verdicted++;
+        SCLogDebug("%s: tx_progress %u tx %p have_fw_rules %s array_idx %u detect_progress_orig %u "
+                   "cur detect_progress %u",
+                flow_flags & STREAM_TOSERVER ? "toserver" : "toclient", tx.tx_progress,
+                tx.tx_data_ptr, BOOL2STR(have_fw_rules), array_idx, tx.detect_progress_orig,
+                tx.detect_progress);
 
-            /* current tx is the last we have, append a blank accept:packet */
-            if (last_tx) {
-                DetectRunAppendDefaultAccept(det_ctx, p);
-                return;
+        /* if there are no rules / rule candidates, handling invoking the default
+         * policy. */
+        if (have_fw_rules && array_idx == 0) {
+            if (tx.tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
+                fw_verdicted++;
+
+                /* current tx is the last we have, append a blank accept:packet */
+                if (last_tx) {
+                    DetectRunAppendDefaultAccept(det_ctx, p);
+                    return;
+                }
+                goto next;
+            } else {
+                /* use last inspected progress */
+                DetectFirewallApplyDefaultPolicy(p, alproto, tx.detect_progress_orig);
+                fw_verdicted++;
+                break;
             }
-            goto next;
         }
 
         bool tx_fw_verdict = false;

--- a/src/detect.c
+++ b/src/detect.c
@@ -2458,7 +2458,7 @@ static void DetectRunTx(ThreadVars *tv,
                         DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, true, flow_flags, tx.tx_id,
                                 alproto, s->app_progress_hook);
                     }
-                } else if (policy->action == ACTION_ACCEPT) {
+                } else if (policy->action & ACTION_ACCEPT) {
                     SCLogDebug("accept hook(s)? current hook %u (tx.detect_progress %u) max %u",
                             s->app_progress_hook, tx.detect_progress, tx.tx_progress);
 
@@ -2469,9 +2469,16 @@ static void DetectRunTx(ThreadVars *tv,
 
                     /* if this is also the last fw rule we'll inspect we have to issue a default
                      * accept to the packet */
-                    if (last_tx && s->app_progress_hook == tx.tx_progress) {
-                        SCLogDebug("default accept: last_tx");
-                        DetectRunAppendDefaultAccept(det_ctx, p);
+                    if (s->app_progress_hook == tx.tx_progress ||
+                            policy->action_scope == ACTION_SCOPE_TX) {
+                        if (policy->action & ACTION_ALERT) {
+                            SCLogDebug("policy alert, do the append");
+                            DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, last_tx, flow_flags,
+                                    tx.tx_id, alproto, s->app_progress_hook);
+                        } else if (last_tx) {
+                            SCLogDebug("default accept: last_tx");
+                            DetectRunAppendDefaultAccept(det_ctx, p);
+                        }
                     }
                 }
                 fw_state.tx_fw_verdict = true;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1723,6 +1723,10 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
         actions |= policy->action;
         if (policy->action & ACTION_DROP) {
             SCLogDebug("fw: action %02x", policy->action);
+            if (policy->action & ACTION_ALERT) {
+                DetectRunAppendDefaultAppPolicyAlert(
+                        det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
+            }
             return DETECT_TX_FW_FC_BREAK;
 
         } else if (policy->action & ACTION_ACCEPT) {
@@ -2438,6 +2442,10 @@ static void DetectRunTx(ThreadVars *tv,
                 if (policy->action & ACTION_DROP) {
                     fw_state.fw_skip_app_filter = true;
                     SCLogDebug("packet %02x", p->action);
+                    if (policy->action & ACTION_ALERT) {
+                        DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, true, flow_flags, tx.tx_id,
+                                alproto, s->app_progress_hook);
+                    }
                 } else if (policy->action == ACTION_ACCEPT) {
                     SCLogDebug("accept hook(s)? current hook %u (tx.detect_progress %u) max %u",
                             s->app_progress_hook, tx.detect_progress, tx.tx_progress);

--- a/src/detect.c
+++ b/src/detect.c
@@ -2352,7 +2352,7 @@ static void DetectRunTx(ThreadVars *tv,
 
                     /* if this is also the last fw rule we'll inspect we have to issue a default
                      * accept to the packet */
-                    if (s->app_progress_hook == tx.tx_progress) {
+                    if (last_tx && s->app_progress_hook == tx.tx_progress) {
                         DetectRunAppendDefaultAccept(det_ctx, p);
                     }
                 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1628,7 +1628,6 @@ static inline void RuleMatchCandidateMergeStateRules(
 
 struct DetectFirewallAppTxState {
     bool fw_skip_app_filter;
-    bool tx_fw_verdict;
     bool skip_fw_hook;
     uint8_t skip_before_progress;
     bool fw_last_for_progress;
@@ -1826,15 +1825,24 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         const Signature *s, const uint32_t can_idx, struct DetectFirewallAppTxState *fw_state,
         const bool last_tx)
 {
-    if ((s->flags & SIG_FLAG_FIREWALL) != 0 && fw_state->fw_skip_app_filter) {
-        return DETECT_TX_FW_FC_SKIP;
+    SCLogDebug("packet %" PRIu64 ": running pre-checks before sid %u", p->pcap_cnt, s->id);
+
+    /* enforce skip app filter. If a prior rule caused a fw_skip_app_filter set, we will skip
+     * each fw rule from now. Non-FW rules will just be inspected. Non-FW need to hit this
+     * path to help put into effect the FLOW_ACTION_ACCEPT/APP_LAYER_TX_ACCEPT and call
+     * the default policy enforcement. */
+    if (fw_state->fw_skip_app_filter) {
+        if ((s->flags & SIG_FLAG_FIREWALL) != 0) {
+            return DETECT_TX_FW_FC_SKIP;
+        } else {
+            return DETECT_TX_FW_FC_OK;
+        }
     }
     if (p->flow->flags & FLOW_ACTION_ACCEPT) {
-        if (fw_state->tx_fw_verdict == false) {
-            fw_state->tx_fw_verdict = true;
-            SCLogDebug("default accept due to flow accept");
-            DetectRunAppendDefaultAccept(det_ctx, p);
-        }
+        fw_state->fw_skip_app_filter = true;
+        SCLogDebug("default accept due to flow accept");
+        DetectRunAppendDefaultAccept(det_ctx, p);
+
         if (s->flags & SIG_FLAG_FIREWALL) {
             return DETECT_TX_FW_FC_SKIP;
         }
@@ -1843,13 +1851,11 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
     if (tx->tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
         /* append a blank accept:packet action for the APP_LAYER_TX_ACCEPT,
          * if this is the last tx */
-        if (!fw_state->tx_fw_verdict) {
-            const bool accept_tx_applies_to_packet = last_tx;
-            if (accept_tx_applies_to_packet) {
-                SCLogDebug("accept:tx: should be applied to the packet");
-                DetectRunAppendDefaultAccept(det_ctx, p);
-            }
-            fw_state->tx_fw_verdict = true;
+        fw_state->fw_skip_app_filter = true;
+        const bool accept_tx_applies_to_packet = last_tx;
+        if (accept_tx_applies_to_packet) {
+            SCLogDebug("accept:tx: should be applied to the packet");
+            DetectRunAppendDefaultAccept(det_ctx, p);
         }
 
         if (s->flags & SIG_FLAG_FIREWALL) {
@@ -1858,29 +1864,34 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         }
 
         /* threat detect rules will be inspected */
-    } else if (s->flags & SIG_FLAG_FIREWALL) {
-        fw_state->fw_next_progress_missing = false;
-        fw_state->fw_last_for_progress = false;
+        return DETECT_TX_FW_FC_OK;
+    }
 
-        if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
-            SCLogDebug("SIG_FLAG_FW_HOOK_LTE");
-            return DETECT_TX_FW_FC_OK; // TODO check for other cases
+    /* handle missing rules case */
+    fw_state->fw_next_progress_missing = false;
+    fw_state->fw_last_for_progress = false;
+
+    if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+        SCLogDebug("SIG_FLAG_FW_HOOK_LTE");
+        return DETECT_TX_FW_FC_OK; // TODO check for other cases
+    }
+    /* if our first rule is beyond the starting state, we need to check if
+     * there are rules missing for states in between. */
+    if (s->app_progress_hook > tx->detect_progress_orig && can_idx == 0) {
+        SCLogDebug("missing fw rules at list start: sid %u, progress %u (%u:%u)", s->id,
+                s->app_progress_hook, tx->detect_progress, tx->detect_progress_orig);
+        /* if this rule was after the state we expected meaning that there are
+         * no rules for that state. Invoke the default policies. */
+        enum DetectTxFirewallFlowControl r = DetectFirewallApplyDefaultPolicies(det_ctx,
+                det_ctx->de_ctx->fw_policies->app, tx, p, s->alproto, direction,
+                tx->detect_progress_orig, s->app_progress_hook - 1, last_tx);
+        if (r != DETECT_TX_FW_FC_OK) {
+            /* both SKIP and BREAK mean: no more fw rules to inspect.
+             * SKIP applies to just this TX.
+             * DROP applies to everything. */
+            fw_state->fw_skip_app_filter = true;
         }
-        /* if our first rule is beyond the starting state, we need to check if
-         * there are rules missing for states in between. */
-        if (s->app_progress_hook > tx->detect_progress_orig && can_idx == 0) {
-            SCLogDebug("missing fw rules at list start: sid %u, progress %u (%u:%u)", s->id,
-                    s->app_progress_hook, tx->detect_progress, tx->detect_progress_orig);
-            /* if this rule was after the state we expected meaning that there are
-             * no rules for that state. Invoke the default policies. */
-            enum DetectTxFirewallFlowControl r = DetectFirewallApplyDefaultPolicies(det_ctx,
-                    det_ctx->de_ctx->fw_policies->app, tx, p, s->alproto, direction,
-                    tx->detect_progress_orig, s->app_progress_hook - 1, last_tx);
-            if (r != DETECT_TX_FW_FC_OK) {
-                fw_state->tx_fw_verdict = true;
-            }
-            return r;
-        }
+        return r;
     }
     return DETECT_TX_FW_FC_OK;
 }
@@ -2023,8 +2034,6 @@ static bool ApplyAccept(DetectEngineThreadCtx *det_ctx, Packet *p, const uint8_t
         const Signature *s, DetectTransaction *tx, const int tx_end_state, const bool is_last,
         struct DetectFirewallAppTxState *fw_state)
 {
-    fw_state->tx_fw_verdict = true;
-
     const enum ActionScope as = s->action_scope;
     /* accept:hook: jump to first rule of next state.
      * Implemented as skip until the first rule of next state. */
@@ -2033,11 +2042,10 @@ static bool ApplyAccept(DetectEngineThreadCtx *det_ctx, Packet *p, const uint8_t
         fw_state->skip_before_progress = s->app_progress_hook;
 
         SCLogDebug("fw match sid:%u hook:%u", s->id, s->app_progress_hook);
-        SCLogDebug("fw fw_skip_app_filter:%s tx_fw_verdict:%s skip_fw_hook:%s "
+        SCLogDebug("fw fw_skip_app_filter:%s skip_fw_hook:%s "
                    "skip_before_progress:%u fw_last_for_progress:%s fw_next_progress_missing:%s",
-                BOOL2STR(fw_state->fw_skip_app_filter), BOOL2STR(fw_state->tx_fw_verdict),
-                BOOL2STR(fw_state->skip_fw_hook), fw_state->skip_before_progress,
-                BOOL2STR(fw_state->fw_last_for_progress),
+                BOOL2STR(fw_state->fw_skip_app_filter), BOOL2STR(fw_state->skip_fw_hook),
+                fw_state->skip_before_progress, BOOL2STR(fw_state->fw_last_for_progress),
                 BOOL2STR(fw_state->fw_next_progress_missing));
         /* if there is no fw rule for the next progress value,
          * we invoke the defaul policies for the remaining available hooks. */
@@ -2284,7 +2292,6 @@ static void DetectRunTx(ThreadVars *tv,
         struct DetectFirewallAppTxState fw_state = {
             false,
             false,
-            false,
             0,
             false,
             false,
@@ -2325,12 +2332,11 @@ static void DetectRunTx(ThreadVars *tv,
                 const enum DetectTxFirewallFlowControl fw_r = DetectRunTxPreCheckFirewallPolicy(
                         det_ctx, p, &tx, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT), s, i,
                         &fw_state, last_tx);
-                SCLogDebug("fw fw_skip_app_filter:%s tx_fw_verdict:%s skip_fw_hook:%s "
+                SCLogDebug("fw fw_skip_app_filter:%s skip_fw_hook:%s "
                            "skip_before_progress:%u fw_last_for_progress:%s "
                            "fw_next_progress_missing:%s",
-                        BOOL2STR(fw_state.fw_skip_app_filter), BOOL2STR(fw_state.tx_fw_verdict),
-                        BOOL2STR(fw_state.skip_fw_hook), fw_state.skip_before_progress,
-                        BOOL2STR(fw_state.fw_last_for_progress),
+                        BOOL2STR(fw_state.fw_skip_app_filter), BOOL2STR(fw_state.skip_fw_hook),
+                        fw_state.skip_before_progress, BOOL2STR(fw_state.fw_last_for_progress),
                         BOOL2STR(fw_state.fw_next_progress_missing));
                 if (fw_r == DETECT_TX_FW_FC_SKIP) {
                     continue;
@@ -2391,12 +2397,11 @@ static void DetectRunTx(ThreadVars *tv,
             if (have_fw_rules) {
                 const enum DetectTxFirewallFlowControl fw_r = DetectRunTxCheckFirewallPolicy(
                         det_ctx, p, f, &tx, s, i, array_idx, &fw_state);
-                SCLogDebug("fw fw_skip_app_filter:%s tx_fw_verdict:%s skip_fw_hook:%s "
+                SCLogDebug("fw fw_skip_app_filter:%s skip_fw_hook:%s "
                            "skip_before_progress:%u fw_last_for_progress:%s "
                            "fw_next_progress_missing:%s",
-                        BOOL2STR(fw_state.fw_skip_app_filter), BOOL2STR(fw_state.tx_fw_verdict),
-                        BOOL2STR(fw_state.skip_fw_hook), fw_state.skip_before_progress,
-                        BOOL2STR(fw_state.fw_last_for_progress),
+                        BOOL2STR(fw_state.fw_skip_app_filter), BOOL2STR(fw_state.skip_fw_hook),
+                        fw_state.skip_before_progress, BOOL2STR(fw_state.fw_last_for_progress),
                         BOOL2STR(fw_state.fw_next_progress_missing));
                 if (fw_r == DETECT_TX_FW_FC_SKIP)
                     continue;
@@ -2491,7 +2496,6 @@ static void DetectRunTx(ThreadVars *tv,
                         fw_state.fw_skip_app_filter = true;
                     }
                 }
-                fw_state.tx_fw_verdict = true;
             }
             DetectVarProcessList(det_ctx, p->flow, p);
             RULE_PROFILING_END(det_ctx, s, r, p);

--- a/src/detect.c
+++ b/src/detect.c
@@ -35,6 +35,7 @@
 #include "app-layer-frames.h"
 
 #include "detect.h"
+#include "detect-parse.h"
 #include "detect-dsize.h"
 #include "detect-engine.h"
 #include "detect-engine-build.h"
@@ -1621,6 +1622,20 @@ struct DetectFirewallAppTxState {
     bool last_fw_rule; /**< processing the last fw rule, so we need to eval all hooks after it. */
 };
 
+static inline void DetectRunAppendDefaultAppPolicyAlert(DetectEngineThreadCtx *det_ctx, Packet *p,
+        const bool apply_to_packet, const int direction, const uint64_t tx_id,
+        const AppProto alproto, const uint8_t hook)
+{
+    if (EngineModeIsFirewall()) {
+        Signature *s = DetectFirewallGetPolicySignature(
+                det_ctx->de_ctx->fw_policies, alproto, direction, hook);
+        BUG_ON(s == NULL);
+        uint8_t alert_flags = apply_to_packet ? PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET : 0;
+        alert_flags |= PACKET_ALERT_FLAG_TX;
+        AlertQueueAppend(det_ctx, s, p, tx_id, alert_flags);
+    }
+}
+
 /** \internal
  *  \brief apply default policy
  *  \param p packet to apply policy to
@@ -1631,8 +1646,8 @@ struct DetectFirewallAppTxState {
  *        to look up configurable default policies later
  */
 static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
-        const struct DetectFirewallAppPolicy *policies, Packet *p, const AppProto alproto,
-        const uint8_t direction, const uint8_t progress)
+        DetectEngineThreadCtx *det_ctx, const struct DetectFirewallAppPolicy *policies, Packet *p,
+        const AppProto alproto, const uint8_t direction, const uint8_t progress)
 {
     const struct DetectFirewallPolicy *policy;
     if (direction & STREAM_TOSERVER) {
@@ -1688,30 +1703,55 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
                 direction & STREAM_TOSERVER ? "toserver" : "toclient", hook);
 
         const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
-                det_ctx->de_ctx->fw_policies->app, p, alproto, direction, hook);
-        SCLogDebug("fw: hook:%u policy:%02x", hook, policy->action);
+                det_ctx, det_ctx->de_ctx->fw_policies->app, p, alproto, direction, hook);
+        SCLogDebug("fw: hook:%u policy:%02x is_last:%s", hook, policy->action, BOOL2STR(is_last));
         actions |= policy->action;
         if (policy->action & ACTION_DROP) {
             SCLogDebug("fw: action %02x", policy->action);
             return DETECT_TX_FW_FC_BREAK;
-        } else if (policy->action == ACTION_ACCEPT) {
-            SCLogDebug("fw: accept hook %u", hook);
+
+        } else if (policy->action & ACTION_ACCEPT) {
+            SCLogDebug("fw: accept hook %u action %02x", hook, policy->action);
 
             /* accepting flow, so skip rest of the fw rules */
             if (policy->action_scope == ACTION_SCOPE_FLOW) {
-                DetectRunAppendDefaultAccept(det_ctx, p);
+                if (policy->action & ACTION_ALERT) {
+                    DetectRunAppendDefaultAppPolicyAlert(
+                            det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
+                } else {
+                    DetectRunAppendDefaultAccept(det_ctx, p);
+                }
                 return DETECT_TX_FW_FC_SKIP;
+
             } else if (policy->action_scope == ACTION_SCOPE_TX) {
                 tx->tx_data_ptr->flags |= APP_LAYER_TX_ACCEPT;
                 SCLogDebug("ACTION_SCOPE_TX, setting APP_LAYER_TX_ACCEPT");
-                if (is_last) {
+                if (policy->action & ACTION_ALERT) {
+                    DetectRunAppendDefaultAppPolicyAlert(
+                            det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
+                } else if (is_last) {
                     DetectRunAppendDefaultAccept(det_ctx, p);
                     SCLogDebug("DetectRunAppendDefaultAccept for last tx");
                 }
                 return DETECT_TX_FW_FC_SKIP;
+
+            } else if (policy->action_scope == ACTION_SCOPE_HOOK) {
+                if (policy->action & ACTION_ALERT) {
+                    DetectRunAppendDefaultAppPolicyAlert(
+                            det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
+                } else if (is_last) {
+                    DetectRunAppendDefaultAccept(det_ctx, p);
+                    SCLogDebug("DetectRunAppendDefaultAccept for last tx");
+                }
+            }
+        } else {
+            if (policy->action & ACTION_ALERT) {
+                DetectRunAppendDefaultAppPolicyAlert(
+                        det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
             }
         }
     }
+
     if ((is_last && (actions & (ACTION_ACCEPT | ACTION_DROP)) == ACTION_ACCEPT)) {
         DetectRunAppendDefaultAccept(det_ctx, p);
     }
@@ -2364,9 +2404,9 @@ static void DetectRunTx(ThreadVars *tv,
                         s->app_progress_hook);
                 /* if this rule was the last for our progress state, and it didn't match,
                  * we have to invoke the default policy. We only check the current rule hook. */
-                const struct DetectFirewallPolicy *policy =
-                        DetectFirewallApplyDefaultAppPolicy(det_ctx->de_ctx->fw_policies->app, p,
-                                s->alproto, flow_flags, s->app_progress_hook);
+                const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
+                        det_ctx, det_ctx->de_ctx->fw_policies->app, p, s->alproto, flow_flags,
+                        s->app_progress_hook);
                 SCLogDebug("fw_last_for_progress policy %02x", policy->action);
                 if (policy->action & ACTION_DROP) {
                     fw_state.fw_skip_app_filter = true;

--- a/src/detect.c
+++ b/src/detect.c
@@ -2467,22 +2467,15 @@ static void DetectRunTx(ThreadVars *tv,
                         flow_flags & STREAM_TOSERVER ? "toserver" : "toclient",
                         s->app_progress_hook);
                 /* if this rule was the last for our progress state, and it didn't match,
-                 * we have to invoke the default policy. We only check the current rule hook. */
+                 * we have to invoke the default policy. We only check the current rule hook.
+                 * DROP is immediate, flow control for various accept options is handled by
+                 * the DetectRunTxPreCheckFirewallPolicy function for the next rule. */
                 const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
                         det_ctx, det_ctx->de_ctx->fw_policies->app, &tx, p, s->alproto, flow_flags,
                         s->app_progress_hook, last_tx);
                 SCLogDebug("fw_last_for_progress policy %02x", policy->action);
                 if (policy->action & ACTION_DROP) {
-                    fw_state.fw_skip_app_filter = true;
-                    SCLogDebug("packet %02x", p->action);
-                } else if (policy->action & ACTION_ACCEPT) {
-                    SCLogDebug("accept hook(s)? current hook %u (tx.detect_progress %u) max %u",
-                            s->app_progress_hook, tx.detect_progress, tx.tx_progress);
-
-                    /* accepting flow, so skip rest of the fw rules */
-                    if (policy->action_scope == ACTION_SCOPE_FLOW) {
-                        fw_state.fw_skip_app_filter = true;
-                    }
+                    return;
                 }
             }
             DetectVarProcessList(det_ctx, p->flow, p);

--- a/src/detect.c
+++ b/src/detect.c
@@ -1066,6 +1066,12 @@ static void DetectRunCleanup(DetectEngineThreadCtx *det_ctx,
     SCReturn;
 }
 
+enum DetectTxFirewallFlowControl {
+    DETECT_TX_FW_FC_OK = 0,    /**< continue to next rule */
+    DETECT_TX_FW_FC_SKIP = 1,  /**< skip this rule, continue to next */
+    DETECT_TX_FW_FC_BREAK = 2, /**< break rule loop */
+};
+
 void RuleMatchCandidateTxArrayInit(DetectEngineThreadCtx *det_ctx, uint32_t size)
 {
     DEBUG_VALIDATE_BUG_ON(det_ctx->tx_candidates);
@@ -1549,14 +1555,14 @@ static inline void RuleMatchCandidateMergeStateRules(
  * \param fw_next_progress_missing[out] set to true if the next fw rule does not target the next
  * progress value, or there is no fw rule for that value.
  *
- * \retval 0 no action needed
- * \retval 1 rest of rules shouldn't inspected
- * \retval -1 skip this rule
+ * \retval DETECT_TX_FW_FC_OK no action needed
+ * \retval DETECT_TX_FW_FC_BREAK rest of rules shouldn't inspected
+ * \retval DETECT_TX_FW_FC_SKIP skip this rule
  */
-static int DetectRunTxCheckFirewallPolicy(DetectEngineThreadCtx *det_ctx, Packet *p, Flow *f,
-        DetectTransaction *tx, const Signature *s, const uint32_t can_idx, const uint32_t can_size,
-        bool *skip_fw_hook, const uint8_t skip_before_progress, bool *last_for_progress,
-        bool *fw_next_progress_missing)
+static enum DetectTxFirewallFlowControl DetectRunTxCheckFirewallPolicy(
+        DetectEngineThreadCtx *det_ctx, Packet *p, Flow *f, DetectTransaction *tx,
+        const Signature *s, const uint32_t can_idx, const uint32_t can_size, bool *skip_fw_hook,
+        const uint8_t skip_before_progress, bool *last_for_progress, bool *fw_next_progress_missing)
 {
     if (s->flags & SIG_FLAG_FIREWALL) {
         /* check if the next sig is on the same progress hook. If not, we need to apply our
@@ -1598,7 +1604,7 @@ static int DetectRunTxCheckFirewallPolicy(DetectEngineThreadCtx *det_ctx, Packet
 
         if ((*skip_fw_hook) == true) {
             if (s->app_progress_hook <= skip_before_progress) {
-                return -1;
+                return DETECT_TX_FW_FC_SKIP;
             }
             *skip_fw_hook = false;
         }
@@ -1608,10 +1614,10 @@ static int DetectRunTxCheckFirewallPolicy(DetectEngineThreadCtx *det_ctx, Packet
          * - packet pass (e.g. exception policy) */
         if (p->flags & PKT_NOPACKET_INSPECTION || (f->flags & (FLOW_ACTION_PASS))) {
             SCLogDebug("skipping firewall rule %u", s->id);
-            return 1;
+            return DETECT_TX_FW_FC_BREAK;
         }
     }
-    return 0;
+    return DETECT_TX_FW_FC_OK;
 }
 
 // TODO move into det_ctx?
@@ -1955,12 +1961,12 @@ static void DetectRunTx(ThreadVars *tv,
 
             bool last_for_progress = false;
             if (have_fw_rules) {
-                int fw_r = DetectRunTxCheckFirewallPolicy(det_ctx, p, f, &tx, s, i, array_idx,
-                        &skip_fw_hook, skip_before_progress, &last_for_progress,
-                        &fw_next_progress_missing);
-                if (fw_r == -1)
+                const enum DetectTxFirewallFlowControl fw_r = DetectRunTxCheckFirewallPolicy(
+                        det_ctx, p, f, &tx, s, i, array_idx, &skip_fw_hook, skip_before_progress,
+                        &last_for_progress, &fw_next_progress_missing);
+                if (fw_r == DETECT_TX_FW_FC_SKIP)
                     continue;
-                if (fw_r == 1)
+                else if (fw_r == DETECT_TX_FW_FC_BREAK)
                     break;
             }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -2428,12 +2428,11 @@ static void DetectRunTx(ThreadVars *tv,
              * policies. */
             const int r = DetectTxFirewallNoRulesApplyPolicies(
                     det_ctx, p, f, &tx, alproto, flow_flags, array_idx, last_tx);
-            if (r != 0) {
-                if (r == 1) {
-                    SCLogDebug("done");
-                    return;
-                } else if (r == 2)
-                    goto next_tx_fw; /* next tx */
+            if (r == 1) {
+                SCLogDebug("done");
+                return;
+            } else if (r == 2) {
+                goto next_tx_fw; /* next tx, need to clean up buffers */
             }
         }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -1779,6 +1779,9 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         const Signature *s, const uint32_t can_idx, struct DetectFirewallAppTxState *fw_state,
         const bool last_tx)
 {
+    if ((s->flags & SIG_FLAG_FIREWALL) != 0 && fw_state->fw_skip_app_filter) {
+        return DETECT_TX_FW_FC_SKIP;
+    }
     if (p->flow->flags & FLOW_ACTION_ACCEPT) {
         if (fw_state->tx_fw_verdict == false) {
             fw_state->tx_fw_verdict = true;
@@ -2268,9 +2271,6 @@ static void DetectRunTx(ThreadVars *tv,
                     tx.detect_progress, tx.detect_progress_orig, s->app_progress_hook);
 
             if (have_fw_rules) {
-                if ((s->flags & SIG_FLAG_FIREWALL) != 0 && fw_state.fw_skip_app_filter) {
-                    continue;
-                }
                 const enum DetectTxFirewallFlowControl fw_r = DetectRunTxPreCheckFirewallPolicy(
                         det_ctx, p, &tx, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT), s, i,
                         &fw_state, last_tx);

--- a/src/detect.c
+++ b/src/detect.c
@@ -650,6 +650,14 @@ static int SortHelper(const void *a, const void *b)
     return sa->iid > sb->iid ? 1 : -1;
 }
 
+static inline bool SkipFwRules(const Packet *p)
+{
+    if (p->flow != NULL) {
+        return (p->flow->flags & FLOW_ACTION_ACCEPT) != 0;
+    }
+    return false;
+}
+
 static inline uint8_t DetectRulePacketRules(ThreadVars *const tv,
         const DetectEngineCtx *const de_ctx, DetectEngineThreadCtx *const det_ctx, Packet *const p,
         Flow *const pflow, const DetectRunScratchpad *scratch)
@@ -676,7 +684,7 @@ static inline uint8_t DetectRulePacketRules(ThreadVars *const tv,
         RulesDumpMatchArray(det_ctx, scratch->sgh, p);
 #endif
 
-    bool skip_fw = false;
+    bool skip_fw = SkipFwRules(p);
     uint32_t sflags, next_sflags = 0;
     if (match_cnt) {
         next_s = *match_array++;
@@ -863,12 +871,12 @@ static inline uint8_t DetectRulePacketRules(ThreadVars *const tv,
                 } else if (as == ACTION_SCOPE_PACKET) {
                     /* accept:packet: break loop, return accept */
                     action |= s->action;
-                    break_out_of_packet_filter = true;
+                    skip_fw = true;
 
                 } else if (as == ACTION_SCOPE_FLOW) {
                     /* accept:flow: break loop, return accept */
                     action |= s->action;
-                    break_out_of_packet_filter = true;
+                    skip_fw = true;
 
                     /* set immediately, as we're in hook "packet_filter" */
                     if (pflow) {
@@ -887,7 +895,7 @@ next:
         DetectReplaceFree(det_ctx);
         RULE_PROFILING_END(det_ctx, s, smatch, p);
 
-        /* fw accept:packet or accept:flow means we're done here */
+        /* fw drop means we're done here */
         if (break_out_of_packet_filter)
             break;
 
@@ -898,7 +906,7 @@ next:
      * policy
      */
     if (have_fw_rules && scratch->default_action == ACTION_DROP) {
-        if (!fw_verdict) {
+        if (!skip_fw && !fw_verdict) {
             DEBUG_VALIDATE_BUG_ON(action & ACTION_DROP);
             PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_PACKET_POLICY);
             action |= ACTION_DROP;
@@ -1571,6 +1579,15 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         DetectEngineThreadCtx *det_ctx, Packet *p, DetectTransaction *tx, const Signature *s,
         const uint32_t can_idx, bool *tx_fw_verdict, const bool last_tx)
 {
+    if (p->flow->flags & FLOW_ACTION_ACCEPT) {
+        if ((*tx_fw_verdict) == false) {
+            *tx_fw_verdict = true;
+            DetectRunAppendDefaultAccept(det_ctx, p);
+        }
+        if (s->flags & SIG_FLAG_FIREWALL) {
+            return DETECT_TX_FW_FC_SKIP;
+        }
+    }
     /* skip fw rules if we're in accept:tx mode */
     if (tx->tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
         /* append a blank accept:packet action for the APP_LAYER_TX_ACCEPT,
@@ -1939,6 +1956,11 @@ static void DetectRunTx(ThreadVars *tv,
         /* if there are no rules / rule candidates, handling invoking the default
          * policy. */
         if (have_fw_rules && array_idx == 0) {
+            if (f->flags & FLOW_ACTION_ACCEPT) {
+                fw_verdicted++;
+                DetectRunAppendDefaultAccept(det_ctx, p);
+                return;
+            }
             if (tx.tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
                 fw_verdicted++;
 
@@ -1956,19 +1978,21 @@ static void DetectRunTx(ThreadVars *tv,
             }
         }
 
+        bool fw_skip_app_filter = false; /**< skip the rest of the app filter (fw) rules */
         bool tx_fw_verdict = false;
         /* run rules: inspect the match candidates */
         for (uint32_t i = 0; i < array_idx; i++) {
             RuleMatchCandidateTx *can = &det_ctx->tx_candidates[i];
             const Signature *s = det_ctx->tx_candidates[i].s;
             uint32_t *inspect_flags = det_ctx->tx_candidates[i].flags;
-            bool break_out_of_app_filter = false;
 
             SCLogDebug("%" PRIu64 ": sid:%u: %s tx %u/%u/%u sig %u", p->pcap_cnt, s->id,
                     flow_flags & STREAM_TOSERVER ? "toserver" : "toclient", tx.tx_progress,
                     tx.detect_progress, tx.detect_progress_orig, s->app_progress_hook);
 
             if (have_fw_rules) {
+                if ((s->flags & SIG_FLAG_FIREWALL) != 0 && fw_skip_app_filter)
+                    continue;
                 const enum DetectTxFirewallFlowControl fw_r = DetectRunTxPreCheckFirewallPolicy(
                         det_ctx, p, &tx, s, i, &tx_fw_verdict, last_tx);
                 if (fw_r == DETECT_TX_FW_FC_SKIP)
@@ -2003,13 +2027,11 @@ static void DetectRunTx(ThreadVars *tv,
                     if (have_fw_rules && (s->flags & SIG_FLAG_FIREWALL) &&
                             (s->action & ACTION_ACCEPT) && s->app_progress_hook == tx.tx_progress) {
                         const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
-                        break_out_of_app_filter = ApplyAccept(p, flow_flags, s, &tx, tx_end_state,
+                        fw_skip_app_filter = ApplyAccept(p, flow_flags, s, &tx, tx_end_state,
                                 fw_next_progress_missing, &tx_fw_verdict, &skip_fw_hook,
                                 &skip_before_progress);
                         if (fw_accept_to_packet)
                             DetectRunAppendDefaultAccept(det_ctx, p);
-                        if (break_out_of_app_filter)
-                            break;
                     }
                     continue;
                 }
@@ -2051,7 +2073,7 @@ static void DetectRunTx(ThreadVars *tv,
                         "%p/%" PRIu64 " sig %u (%u) matched", tx.tx_ptr, tx.tx_id, s->id, s->iid);
 
                 if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT)) {
-                    break_out_of_app_filter = ApplyAccept(p, flow_flags, s, &tx, tx_end_state,
+                    fw_skip_app_filter = ApplyAccept(p, flow_flags, s, &tx, tx_end_state,
                             fw_next_progress_missing, &tx_fw_verdict, &skip_fw_hook,
                             &skip_before_progress);
                     /* see if we need to apply tx/hook accept to the packet. This can be needed when
@@ -2075,7 +2097,7 @@ static void DetectRunTx(ThreadVars *tv,
                     /* if this rule was the last for our progress state, and it didn't match,
                      * we have to invoke the default drop policy. */
                     DetectFirewallApplyDefaultPolicy(p, s->alproto, s->app_progress_hook);
-                    break_out_of_app_filter = true;
+                    fw_skip_app_filter = true;
                     tx_fw_verdict = true;
                 }
             }
@@ -2113,9 +2135,6 @@ static void DetectRunTx(ThreadVars *tv,
                 det_ctx->post_rule_work_queue.len = 0;
                 PMQ_RESET(&det_ctx->pmq);
             }
-
-            if (break_out_of_app_filter)
-                break;
         }
         if (tx_fw_verdict)
             fw_verdicted++;
@@ -2334,12 +2353,9 @@ static void DetectFlow(ThreadVars *tv,
     }
 
     /* in firewall mode, we still need to run the fw rulesets even for exception policy pass */
-    bool skip = false;
-    if (EngineModeIsFirewall()) {
-        skip = (f->flags & (FLOW_ACTION_ACCEPT));
-
-    } else {
-        skip = (p->flags & PKT_NOPACKET_INSPECTION || f->flags & (FLOW_ACTION_PASS));
+    bool skip = (p->flags & PKT_NOPACKET_INSPECTION || f->flags & (FLOW_ACTION_PASS));
+    if (EngineModeIsFirewall() && (f->flags & FLOW_ACTION_ACCEPT) == 0) {
+        skip = false;
     }
     if (skip) {
         /* enfore prior accept:flow */

--- a/src/detect.c
+++ b/src/detect.c
@@ -1711,16 +1711,25 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
         DetectTransaction *tx, Packet *p, const AppProto alproto, const uint8_t direction,
         const uint8_t start_hook, const uint8_t end_hook, const bool is_last)
 {
-    uint8_t actions = 0;
-    for (uint8_t hook = start_hook; hook <= end_hook; hook++) {
-        SCLogDebug("%" PRIu64 ": %s default policy for hook %u", p->pcap_cnt,
-                direction & STREAM_TOSERVER ? "toserver" : "toclient", hook);
+    DEBUG_VALIDATE_BUG_ON(start_hook > end_hook);
 
-        const bool apply_to_packet = is_last && hook == tx->tx_end_state;
+    const bool need_verdict =
+            is_last && (end_hook == tx->tx_end_state || end_hook == tx->tx_progress);
+    SCLogDebug("need_verdict:%s is_last:%s end_hook:%u tx->tx_end_state:%u tx->progress: %u",
+            BOOL2STR(need_verdict), BOOL2STR(is_last), end_hook, tx->tx_end_state, tx->tx_progress);
+
+    for (uint8_t hook = start_hook; hook <= end_hook; hook++) {
+        const bool apply_to_packet =
+                is_last && (hook == tx->tx_end_state || hook == tx->tx_progress);
+
+        SCLogDebug("%" PRIu64 ": %s default policy for hook %u, apply_to_packet %s", p->pcap_cnt,
+                direction & STREAM_TOSERVER ? "toserver" : "toclient", hook,
+                BOOL2STR(apply_to_packet));
+
         const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
                 det_ctx, det_ctx->de_ctx->fw_policies->app, p, alproto, direction, hook);
-        SCLogDebug("fw: hook:%u policy:%02x is_last:%s", hook, policy->action, BOOL2STR(is_last));
-        actions |= policy->action;
+        SCLogDebug("fw: hook:%u policy:%02x apply_to_packet:%s", hook, policy->action,
+                BOOL2STR(apply_to_packet));
         if (policy->action & ACTION_DROP) {
             SCLogDebug("fw: action %02x", policy->action);
             if (policy->action & ACTION_ALERT) {
@@ -1737,9 +1746,9 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
                 SCLogDebug("fw: accept flow");
                 if (policy->action & ACTION_ALERT) {
                     DetectRunAppendDefaultAppPolicyAlert(
-                            det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
+                            det_ctx, p, true, direction, tx->tx_id, alproto, hook);
                 } else {
-                    SCLogDebug("default accept");
+                    SCLogDebug("fw: ACTION_ACCEPT with ACTION_SCOPE_FLOW. Append default accept");
                     DetectRunAppendDefaultAccept(det_ctx, p);
                 }
                 return DETECT_TX_FW_FC_SKIP;
@@ -1757,6 +1766,7 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
                 return DETECT_TX_FW_FC_SKIP;
 
             } else if (policy->action_scope == ACTION_SCOPE_HOOK) {
+                SCLogDebug("ACTION_SCOPE_HOOK, applying to packet %s", BOOL2STR(apply_to_packet));
                 if (policy->action & ACTION_ALERT) {
                     DetectRunAppendDefaultAppPolicyAlert(
                             det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
@@ -1764,19 +1774,28 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
                     DetectRunAppendDefaultAccept(det_ctx, p);
                     SCLogDebug("DetectRunAppendDefaultAccept for last tx");
                 }
+                /* we're done */
+                if (apply_to_packet) {
+                    return DETECT_TX_FW_FC_SKIP;
+                }
+            } else {
+                DEBUG_VALIDATE_BUG_ON(1);
             }
         } else {
-            if (policy->action & ACTION_ALERT) {
-                DetectRunAppendDefaultAppPolicyAlert(
-                        det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
-            }
+            DEBUG_VALIDATE_BUG_ON(1);
         }
     }
 
-    if ((is_last && (actions & (ACTION_ACCEPT | ACTION_DROP)) == ACTION_ACCEPT)) {
-        SCLogDebug("default accept: last tx and at least one accept");
+    /* if the tx progress is at end_hook state, it means the rule that called us cannot
+     * match: it's app_progress_hook is not yet available. In this can we need to set
+     * a default accept. This happens if we got only `accept:hook` policies. */
+    if (need_verdict) {
+        SCLogDebug("default accept: last tx and progress at end_hook %u", end_hook);
         DetectRunAppendDefaultAccept(det_ctx, p);
+        /* break as we can't match the calling signature */
+        return DETECT_TX_FW_FC_BREAK;
     }
+
     return DETECT_TX_FW_FC_OK;
 }
 
@@ -1839,7 +1858,6 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         }
         /* if our first rule is beyond the starting state, we need to check if
          * there are rules missing for states in between. */
-        // TODO detect_progress_orig already is +1?
         if (s->app_progress_hook > tx->detect_progress_orig && can_idx == 0) {
             SCLogDebug("missing fw rules at list start: sid %u, progress %u (%u:%u)", s->id,
                     s->app_progress_hook, tx->detect_progress, tx->detect_progress_orig);
@@ -1848,7 +1866,9 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
             enum DetectTxFirewallFlowControl r = DetectFirewallApplyDefaultPolicies(det_ctx,
                     det_ctx->de_ctx->fw_policies->app, tx, p, s->alproto, direction,
                     tx->detect_progress_orig, s->app_progress_hook - 1, last_tx);
-            fw_state->tx_fw_verdict = true;
+            if (r != DETECT_TX_FW_FC_OK) {
+                fw_state->tx_fw_verdict = true;
+            }
             return r;
         }
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1541,6 +1541,22 @@ static inline void RuleMatchCandidateMergeStateRules(
 }
 
 /** \internal
+ *  \brief apply default policy
+ *  \param p packet to apply policy to
+ *  \param alproto app proto
+ *  \param progress hook / progress value to apply the policy to
+ *
+ *  \note alproto and progress are unused right now, will be used
+ *        to look up configurable default policies later
+ */
+static void DetectFirewallApplyDefaultPolicy(
+        Packet *p, const AppProto alproto, const uint8_t progress)
+{
+    PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_APP_POLICY);
+    p->flow->flags |= FLOW_ACTION_DROP;
+}
+
+/** \internal
  *  \brief run pre-rule inspection firewall policy checks
  *
  *  Check if:
@@ -1583,8 +1599,7 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
 
             /* if this rule was after the state we expected meaning that there are
              * no rules for that state. Invoke the default drop policy. */
-            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_APP_POLICY);
-            p->flow->flags |= FLOW_ACTION_DROP;
+            DetectFirewallApplyDefaultPolicy(p, s->alproto, tx->detect_progress_orig);
             *tx_fw_verdict = true;
             SCLogDebug("default app drop");
             return DETECT_TX_FW_FC_BREAK;
@@ -1740,8 +1755,7 @@ static bool ApplyAccept(Packet *p, const uint8_t flow_flags, const Signature *s,
         if (fw_next_progress_missing) {
             SCLogDebug("%" PRIu64 ": %s default drop for progress", p->pcap_cnt,
                     flow_flags & STREAM_TOSERVER ? "toserver" : "toclient");
-            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_APP_POLICY);
-            p->flow->flags |= FLOW_ACTION_DROP;
+            DetectFirewallApplyDefaultPolicy(p, s->alproto, s->app_progress_hook + 1);
             return true;
         }
         return false;
@@ -2045,8 +2059,7 @@ static void DetectRunTx(ThreadVars *tv,
                             flow_flags & STREAM_TOSERVER ? "toserver" : "toclient");
                     /* if this rule was the last for our progress state, and it didn't match,
                      * we have to invoke the default drop policy. */
-                    PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_APP_POLICY);
-                    p->flow->flags |= FLOW_ACTION_DROP;
+                    DetectFirewallApplyDefaultPolicy(p, s->alproto, s->app_progress_hook);
                     break_out_of_app_filter = true;
                     tx_fw_verdict = true;
                 }
@@ -2135,8 +2148,8 @@ static void DetectRunTx(ThreadVars *tv,
     if (tx_inspected && have_fw_rules && tx_inspected != fw_verdicted) {
         SCLogDebug("%" PRIu64 ": %s default drop", p->pcap_cnt,
                 flow_flags & STREAM_TOSERVER ? "toserver" : "toclient");
-        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_APP_POLICY);
-        p->flow->flags |= FLOW_ACTION_DROP;
+        DetectFirewallApplyDefaultPolicy(
+                p, ALPROTO_UNKNOWN, 0); // TODO can we assign this to a hook?
         return;
     }
     /* if all tables have been bypassed, we accept:packet */

--- a/src/detect.c
+++ b/src/detect.c
@@ -2014,9 +2014,13 @@ static inline bool ApplyAcceptToPacket(
 }
 
 /** \internal
- * \retval bool true: break_out_of_app_filter, false: don't break out */
-static bool ApplyAccept(DetectEngineThreadCtx *det_ctx, Packet *p, const uint8_t direction,
-        const Signature *s, DetectTransaction *tx, const int tx_end_state, const bool is_last,
+ * \brief apply an accept, but do check policies when needed
+ *
+ * Updates flow control where needed.
+ *
+ * */
+static void DetectRunTxFirewallApplyAccept(DetectEngineThreadCtx *det_ctx, Packet *p,
+        const uint8_t direction, const Signature *s, DetectTransaction *tx, const bool is_last,
         struct DetectFirewallAppTxState *fw_state)
 {
     const enum ActionScope as = s->action_scope;
@@ -2037,29 +2041,28 @@ static bool ApplyAccept(DetectEngineThreadCtx *det_ctx, Packet *p, const uint8_t
         if (fw_state->fw_next_progress_missing) {
             const uint8_t last_hook =
                     fw_state->last_fw_rule
-                            ? (uint8_t)tx_end_state
-                            : MIN((uint8_t)tx_end_state, s->app_progress_hook + (uint8_t)1);
+                            ? (uint8_t)tx->tx_end_state
+                            : MIN((uint8_t)tx->tx_end_state, s->app_progress_hook + (uint8_t)1);
             enum DetectTxFirewallFlowControl r = DetectFirewallApplyDefaultPolicies(det_ctx,
                     det_ctx->de_ctx->fw_policies->app, tx, p, s->alproto, direction,
                     s->app_progress_hook + 1, last_hook, is_last);
-            if (r == DETECT_TX_FW_FC_BREAK)
-                return true;
+            if (r == DETECT_TX_FW_FC_BREAK) {
+                fw_state->fw_skip_app_filter = true;
+                return;
+            }
         }
-        return false;
     } else if (as == ACTION_SCOPE_TX) {
         tx->tx_data_ptr->flags |= APP_LAYER_TX_ACCEPT;
         fw_state->skip_fw_hook = true;
-        fw_state->skip_before_progress = (uint8_t)tx_end_state + 1; // skip all hooks
+        fw_state->skip_before_progress = (uint8_t)tx->tx_end_state + 1; // skip all hooks
         SCLogDebug("accept:tx applied, skip_fw_hook, skip_before_progress %u",
                 fw_state->skip_before_progress);
-        return false;
     } else if (as == ACTION_SCOPE_PACKET) {
-        return true;
+        fw_state->fw_skip_app_filter = true;
     } else if (as == ACTION_SCOPE_FLOW) {
         SCLogDebug("sid %u: ACTION_ACCEPT with ACTION_SCOPE_FLOW", s->id);
-        return true;
+        fw_state->fw_skip_app_filter = true;
     }
-    return false;
 }
 
 /**
@@ -2149,8 +2152,7 @@ static void DetectRunTxFirewallRuleFullMatch(DetectEngineThreadCtx *det_ctx, con
          * policy matches that could add alerts. */
         AlertQueueAppend(det_ctx, s, p, tx->tx_id, alert_flags);
 
-        fw_state->fw_skip_app_filter =
-                ApplyAccept(det_ctx, p, flow_flags, s, tx, tx->tx_end_state, last_tx, fw_state);
+        DetectRunTxFirewallApplyAccept(det_ctx, p, flow_flags, s, tx, last_tx, fw_state);
     } else if (s->action & ACTION_DROP) {
         SCLogDebug("drop packet because of rule with drop action");
         PacketDrop(p, s->action, PKT_DROP_REASON_FW_RULES);
@@ -2245,8 +2247,7 @@ static void DetectRunTxFirewallRuleStatefulReApplyMatch(DetectEngineThreadCtx *d
     if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT) &&
             s->app_progress_hook == tx->tx_progress) {
         const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, tx, s);
-        fw_state->fw_skip_app_filter =
-                ApplyAccept(det_ctx, p, flow_flags, s, tx, tx->tx_end_state, last_tx, fw_state);
+        DetectRunTxFirewallApplyAccept(det_ctx, p, flow_flags, s, tx, last_tx, fw_state);
         if (fw_accept_to_packet) {
             SCLogDebug("packet %" PRIu64 ": apply accept to packet", p->pcap_cnt);
             DetectRunAppendDefaultAccept(det_ctx, p);

--- a/src/detect.c
+++ b/src/detect.c
@@ -1239,27 +1239,21 @@ void *DetectGetInnerTx(void *tx_ptr, AppProto alproto, AppProto engine_alproto, 
  *         If stored_flags is set it means we're continuing
  *         inspection from an earlier run.
  *
- *  \retval bool true sig matched, false didn't match
+ *  \retval  1 sig matched
+ *  \retval  0 partial incomplete match
+ *  \retval -1 failed to match
  */
-static bool DetectRunTxInspectRule(ThreadVars *tv,
-        DetectEngineCtx *de_ctx,
-        DetectEngineThreadCtx *det_ctx,
-        Packet *p,
-        Flow *f,
-        const uint8_t in_flow_flags,   // direction, EOF, etc
-        void *alstate,
-        DetectTransaction *tx,
-        const Signature *s,
-        uint32_t *stored_flags,
-        RuleMatchCandidateTx *can,
-        DetectRunScratchpad *scratch)
+static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, Packet *p, Flow *f,
+        const uint8_t in_flow_flags, // direction, EOF, etc
+        void *alstate, DetectTransaction *tx, const Signature *s, uint32_t *stored_flags,
+        RuleMatchCandidateTx *can, DetectRunScratchpad *scratch)
 {
     const uint8_t flow_flags = in_flow_flags;
     const int direction = (flow_flags & STREAM_TOSERVER) ? 0 : 1;
     uint32_t inspect_flags = stored_flags ? *stored_flags : 0;
     int total_matches = 0;
     uint16_t file_no_match = 0;
-    bool retval = false;
     bool mpm_before_progress = false;   // is mpm engine before progress?
     bool mpm_in_progress = false;       // is mpm engine in a buffer we will revisit?
 
@@ -1270,17 +1264,19 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         TRACE_SID_TXS(s->id, tx, "first inspect, run packet matches");
         if (!DetectRunInspectRuleHeader(p, f, s, s->flags, s->proto.flags)) {
             TRACE_SID_TXS(s->id, tx, "DetectRunInspectRuleHeader() no match");
-            return false;
+            return -1;
         }
         if (!DetectEnginePktInspectionRun(tv, det_ctx, s, f, p, NULL)) {
             TRACE_SID_TXS(s->id, tx, "DetectEnginePktInspectionRun no match");
-            return false;
+            return -1;
         }
         /* stream mpm and negated mpm sigs can end up here with wrong proto */
         if (!(AppProtoEquals(s->alproto, f->alproto) || s->alproto == ALPROTO_UNKNOWN)) {
             TRACE_SID_TXS(s->id, tx, "alproto mismatch");
-            return false;
+            return -1;
         }
+    } else {
+        TRACE_SID_TXS(s->id, tx, "continue, inspect_flags %x", inspect_flags);
     }
 
     const DetectEngineAppInspectionEngine *engine = s->app_inspect;
@@ -1346,8 +1342,9 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
 
                 /* we don't have to store a "hook" match, also don't want to keep any state to make
                  * sure the hook gets invoked again until tx progress progresses. */
-                if (tx->tx_progress <= engine->progress)
-                    return DETECT_ENGINE_INSPECT_SIG_MATCH;
+                if ((s->flags & SIG_FLAG_FW_HOOK_LTE) == 0 && tx->tx_progress <= engine->progress) {
+                    return 1; // DETECT_ENGINE_INSPECT_SIG_MATCH;
+                }
 
                 /* if progress > engine progress, track state to avoid additional matches */
                 match = DETECT_ENGINE_INSPECT_SIG_MATCH;
@@ -1407,10 +1404,11 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
     TRACE_SID_TXS(s->id, tx, "inspect_flags %x, total_matches %u, engine %p",
             inspect_flags, total_matches, engine);
 
+    bool full_match = false;
     if (engine == NULL && total_matches) {
         inspect_flags |= DE_STATE_FLAG_FULL_INSPECT;
         TRACE_SID_TXS(s->id, tx, "MATCH");
-        retval = true;
+        full_match = true;
     }
 
     if (stored_flags) {
@@ -1448,14 +1446,27 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         } else if ((inspect_flags & DE_STATE_FLAG_FULL_INSPECT) == 0 && mpm_in_progress) {
             TRACE_SID_TXS(s->id, tx, "no need to store no-match sig, "
                     "mpm will revisit it");
+            return -1; /* no match */
         } else if (inspect_flags != 0 || file_no_match != 0) {
             TRACE_SID_TXS(s->id, tx, "storing state: flags %08x", inspect_flags);
             DetectRunStoreStateTx(scratch->sgh, f, tx->tx_ptr, tx->tx_id, s,
                     inspect_flags, flow_flags, file_no_match);
+        } else {
+            if (inspect_flags == 0) {
+                TRACE_SID_TXS(s->id, tx, "no match: inspect_flags %08x", inspect_flags);
+                return -1;
+            }
         }
     }
-
-    return retval;
+    if (full_match) {
+        return 1;
+        /* can't be a partial match if we're at the end state */
+    } else if ((inspect_flags & DE_STATE_FLAG_SIG_CANT_MATCH) == 0 &&
+               tx->tx_progress < tx->tx_end_state) {
+        return 0;
+    } else {
+        return -1;
+    }
 }
 
 #define NO_TX                                                                                      \
@@ -1755,6 +1766,10 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         fw_state->fw_next_progress_missing = false;
         fw_state->fw_last_for_progress = false;
 
+        if (s->flags & SIG_FLAG_FW_HOOK_LTE) {
+            SCLogDebug("SIG_FLAG_FW_HOOK_LTE");
+            return DETECT_TX_FW_FC_OK; // TODO check for other cases
+        }
         /* if our first rule is beyond the starting state, we need to check if
          * there are rules missing for states in between. */
         // TODO detect_progress_orig already is +1?
@@ -2295,6 +2310,7 @@ static void DetectRunTx(ThreadVars *tv,
             RULE_PROFILING_START(p);
             const int r = DetectRunTxInspectRule(tv, de_ctx, det_ctx, p, f, flow_flags,
                     alstate, &tx, s, inspect_flags, can, scratch);
+            SCLogDebug("s %u r %d", s->id, r);
             if (r == 1) {
                 /* match */
                 DetectRunPostMatch(tv, det_ctx, p, s);
@@ -2327,7 +2343,21 @@ static void DetectRunTx(ThreadVars *tv,
                     }
                 }
                 AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
-
+            } else if (r == 0) {
+                SCLogDebug("sid %u partial match", s->id);
+                if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT)) {
+                    /* partial match always uses ACTION_SCOPE_HOOK. Final action only on the full
+                     * match */
+                    if (last_tx) {
+                        SCLogDebug("need to apply accept to packet");
+                        DetectRunAppendDefaultAccept(det_ctx, p);
+                    }
+                    if (s->action_scope == ACTION_SCOPE_FLOW) {
+                        SCLogDebug("only applying accept:flow on full match, downgrading to "
+                                   "accept:hook");
+                    }
+                    break;
+                }
             } else if (fw_state.fw_last_for_progress && (s->flags & SIG_FLAG_FIREWALL)) {
                 SCLogDebug("%" PRIu64 ": %s default policy for progress %u", p->pcap_cnt,
                         flow_flags & STREAM_TOSERVER ? "toserver" : "toclient",

--- a/src/detect.c
+++ b/src/detect.c
@@ -1990,9 +1990,7 @@ static void DetectRunTx(ThreadVars *tv,
                             tx.tx_ptr, tx.tx_id, s->id, s->iid, *inspect_flags);
                     continue;
                 }
-            }
 
-            if (inspect_flags) {
                 /* continue previous inspection */
                 SCLogDebug("%p/%" PRIu64 " Continuing sid %u", tx.tx_ptr, tx.tx_id, s->id);
             } else {

--- a/src/detect.c
+++ b/src/detect.c
@@ -1660,8 +1660,9 @@ static inline void DetectRunAppendDefaultAppPolicyAlert(DetectEngineThreadCtx *d
  *        to look up configurable default policies later
  */
 static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
-        DetectEngineThreadCtx *det_ctx, const struct DetectFirewallAppPolicy *policies, Packet *p,
-        const AppProto alproto, const uint8_t direction, const uint8_t progress)
+        DetectEngineThreadCtx *det_ctx, const struct DetectFirewallAppPolicy *policies,
+        const DetectTransaction *tx, Packet *p, const AppProto alproto, const uint8_t direction,
+        const uint8_t progress, const bool last_tx)
 {
     const struct DetectFirewallPolicy *policy;
     if (direction & STREAM_TOSERVER) {
@@ -1682,11 +1683,47 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
             p->flow->flags |= FLOW_ACTION_DROP;
             p->flow->aux_flags |= FLOW_AUX_ACTION_BY_FIREWALL;
         }
-    } else if (policy->action & ACTION_ACCEPT) {
-        if (policy->action_scope == ACTION_SCOPE_FLOW) {
-            p->flow->flags |= FLOW_ACTION_ACCEPT;
+        if (policy->action & ACTION_ALERT) {
+            DetectRunAppendDefaultAppPolicyAlert(
+                    det_ctx, p, true, direction, tx->tx_id, alproto, progress);
         }
-        SCLogDebug("packet %" PRIu64 " hook %u default policy ACCEPT", p->pcap_cnt, progress);
+    } else if (policy->action & ACTION_ACCEPT) {
+        /* should the accept be applied to the packet?
+         * ACTION_SCOPE_FLOW: yes
+         * ACTION_SCOPE_TX: only if last_tx
+         * ACTION_SCOPE_HOOK: only if last_tx and hook is highest available hook
+         */
+        const bool last_hook = progress == tx->tx_progress;
+        bool apply_to_packet = false;
+
+        switch (policy->action_scope) {
+            case ACTION_SCOPE_FLOW:
+                p->flow->flags |= FLOW_ACTION_ACCEPT;
+                apply_to_packet = true;
+                break;
+            case ACTION_SCOPE_TX:
+                tx->tx_data_ptr->flags |= APP_LAYER_TX_ACCEPT;
+                apply_to_packet = last_tx;
+                break;
+            case ACTION_SCOPE_HOOK:
+                apply_to_packet = last_tx && last_hook;
+                break;
+            default:
+                /* should be unreachable */
+                DEBUG_VALIDATE_BUG_ON(1);
+                break;
+        }
+        SCLogDebug("packet %" PRIu64 " hook %u default policy ACCEPT, apply_to_packet:%s",
+                p->pcap_cnt, progress, BOOL2STR(apply_to_packet));
+
+        if (policy->action & ACTION_ALERT) {
+            SCLogDebug("policy alert, do the append");
+            DetectRunAppendDefaultAppPolicyAlert(
+                    det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, progress);
+        } else if (apply_to_packet) {
+            SCLogDebug("default accept: last_tx");
+            DetectRunAppendDefaultAccept(det_ctx, p);
+        }
     } else {
         /* should be unreachable */
         DEBUG_VALIDATE_BUG_ON(1);
@@ -1726,16 +1763,12 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
                 direction & STREAM_TOSERVER ? "toserver" : "toclient", hook,
                 BOOL2STR(apply_to_packet));
 
-        const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
-                det_ctx, det_ctx->de_ctx->fw_policies->app, p, alproto, direction, hook);
+        const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(det_ctx,
+                det_ctx->de_ctx->fw_policies->app, tx, p, alproto, direction, hook, is_last);
         SCLogDebug("fw: hook:%u policy:%02x apply_to_packet:%s", hook, policy->action,
                 BOOL2STR(apply_to_packet));
         if (policy->action & ACTION_DROP) {
             SCLogDebug("fw: action %02x", policy->action);
-            if (policy->action & ACTION_ALERT) {
-                DetectRunAppendDefaultAppPolicyAlert(
-                        det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
-            }
             return DETECT_TX_FW_FC_BREAK;
 
         } else if (policy->action & ACTION_ACCEPT) {
@@ -1744,36 +1777,13 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
             /* accepting flow, so skip rest of the fw rules */
             if (policy->action_scope == ACTION_SCOPE_FLOW) {
                 SCLogDebug("fw: accept flow");
-                if (policy->action & ACTION_ALERT) {
-                    DetectRunAppendDefaultAppPolicyAlert(
-                            det_ctx, p, true, direction, tx->tx_id, alproto, hook);
-                } else {
-                    SCLogDebug("fw: ACTION_ACCEPT with ACTION_SCOPE_FLOW. Append default accept");
-                    DetectRunAppendDefaultAccept(det_ctx, p);
-                }
                 return DETECT_TX_FW_FC_SKIP;
 
+                /* accepting flow, so skip rest of the fw rules for this tx */
             } else if (policy->action_scope == ACTION_SCOPE_TX) {
-                tx->tx_data_ptr->flags |= APP_LAYER_TX_ACCEPT;
-                SCLogDebug("ACTION_SCOPE_TX, setting APP_LAYER_TX_ACCEPT");
-                if (policy->action & ACTION_ALERT) {
-                    DetectRunAppendDefaultAppPolicyAlert(
-                            det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
-                } else if (is_last) {
-                    DetectRunAppendDefaultAccept(det_ctx, p);
-                    SCLogDebug("DetectRunAppendDefaultAccept for last tx");
-                }
                 return DETECT_TX_FW_FC_SKIP;
 
             } else if (policy->action_scope == ACTION_SCOPE_HOOK) {
-                SCLogDebug("ACTION_SCOPE_HOOK, applying to packet %s", BOOL2STR(apply_to_packet));
-                if (policy->action & ACTION_ALERT) {
-                    DetectRunAppendDefaultAppPolicyAlert(
-                            det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
-                } else if (apply_to_packet) {
-                    DetectRunAppendDefaultAccept(det_ctx, p);
-                    SCLogDebug("DetectRunAppendDefaultAccept for last tx");
-                }
                 /* we're done */
                 if (apply_to_packet) {
                     return DETECT_TX_FW_FC_SKIP;
@@ -2468,16 +2478,12 @@ static void DetectRunTx(ThreadVars *tv,
                 /* if this rule was the last for our progress state, and it didn't match,
                  * we have to invoke the default policy. We only check the current rule hook. */
                 const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
-                        det_ctx, det_ctx->de_ctx->fw_policies->app, p, s->alproto, flow_flags,
-                        s->app_progress_hook);
+                        det_ctx, det_ctx->de_ctx->fw_policies->app, &tx, p, s->alproto, flow_flags,
+                        s->app_progress_hook, last_tx);
                 SCLogDebug("fw_last_for_progress policy %02x", policy->action);
                 if (policy->action & ACTION_DROP) {
                     fw_state.fw_skip_app_filter = true;
                     SCLogDebug("packet %02x", p->action);
-                    if (policy->action & ACTION_ALERT) {
-                        DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, true, flow_flags, tx.tx_id,
-                                alproto, s->app_progress_hook);
-                    }
                 } else if (policy->action & ACTION_ACCEPT) {
                     SCLogDebug("accept hook(s)? current hook %u (tx.detect_progress %u) max %u",
                             s->app_progress_hook, tx.detect_progress, tx.tx_progress);
@@ -2485,20 +2491,6 @@ static void DetectRunTx(ThreadVars *tv,
                     /* accepting flow, so skip rest of the fw rules */
                     if (policy->action_scope == ACTION_SCOPE_FLOW) {
                         fw_state.fw_skip_app_filter = true;
-                    }
-
-                    /* if this is also the last fw rule we'll inspect we have to issue a default
-                     * accept to the packet */
-                    if (s->app_progress_hook == tx.tx_progress ||
-                            policy->action_scope == ACTION_SCOPE_TX) {
-                        if (policy->action & ACTION_ALERT) {
-                            SCLogDebug("policy alert, do the append");
-                            DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, last_tx, flow_flags,
-                                    tx.tx_id, alproto, s->app_progress_hook);
-                        } else if (last_tx) {
-                            SCLogDebug("default accept: last_tx");
-                            DetectRunAppendDefaultAccept(det_ctx, p);
-                        }
                     }
                 }
                 fw_state.tx_fw_verdict = true;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1692,7 +1692,7 @@ static inline void DetectRunAppendDefaultAccept(DetectEngineThreadCtx *det_ctx, 
  * \brief see if the accept rule needs to apply to the packet
  */
 static inline bool ApplyAcceptToPacket(
-        const uint64_t total_txs, const DetectTransaction *tx, const Signature *s)
+        const bool last_tx, const DetectTransaction *tx, const Signature *s)
 {
     if ((s->flags & SIG_FLAG_FIREWALL) == 0) {
         return false;
@@ -1705,7 +1705,7 @@ static inline bool ApplyAcceptToPacket(
      * - packet will only be accepted if this is set on the last tx
      */
     if (s->action_scope == ACTION_SCOPE_TX) {
-        if (total_txs == tx->tx_id + 1) {
+        if (last_tx) {
             return true;
         }
     }
@@ -1713,8 +1713,7 @@ static inline bool ApplyAcceptToPacket(
      * - packet will only be accepted if this is set on the last tx
      * - the hook accepted should be the last progress available. */
     if (s->action_scope == ACTION_SCOPE_HOOK) {
-        if ((total_txs == tx->tx_id + 1) && /* last tx */
-                (s->app_progress_hook == tx->tx_progress)) {
+        if (last_tx && (s->app_progress_hook == tx->tx_progress)) {
             return true;
         }
     }
@@ -1803,6 +1802,7 @@ static void DetectRunTx(ThreadVars *tv,
         }
         tx_id_min = tx.tx_id + 1; // next look for cur + 1
         tx_inspected++;
+        const bool last_tx = (total_txs == tx.tx_id + 1);
 
         SCLogDebug("%p/%" PRIu64 " txd flags %02x", tx.tx_ptr, tx_id_min, tx.tx_data_ptr->flags);
 
@@ -1920,7 +1920,7 @@ static void DetectRunTx(ThreadVars *tv,
             fw_verdicted++;
 
             /* current tx is the last we have, append a blank accept:packet */
-            if (total_txs == tx.tx_id + 1) {
+            if (last_tx) {
                 DetectRunAppendDefaultAccept(det_ctx, p);
                 return;
             }
@@ -1941,7 +1941,7 @@ static void DetectRunTx(ThreadVars *tv,
 
             if (have_fw_rules) {
                 const enum DetectTxFirewallFlowControl fw_r = DetectRunTxPreCheckFirewallPolicy(
-                        det_ctx, p, &tx, s, i, &tx_fw_verdict, (total_txs == tx.tx_id + 1));
+                        det_ctx, p, &tx, s, i, &tx_fw_verdict, last_tx);
                 if (fw_r == DETECT_TX_FW_FC_SKIP)
                     continue;
                 else if (fw_r == DETECT_TX_FW_FC_BREAK)
@@ -1973,7 +1973,7 @@ static void DetectRunTx(ThreadVars *tv,
                      * match, we need to apply the same accept */
                     if (have_fw_rules && (s->flags & SIG_FLAG_FIREWALL) &&
                             (s->action & ACTION_ACCEPT) && s->app_progress_hook == tx.tx_progress) {
-                        const bool fw_accept_to_packet = ApplyAcceptToPacket(total_txs, &tx, s);
+                        const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
                         break_out_of_app_filter = ApplyAccept(p, flow_flags, s, &tx, tx_end_state,
                                 fw_next_progress_missing, &tx_fw_verdict, &skip_fw_hook,
                                 &skip_before_progress);
@@ -2020,7 +2020,7 @@ static void DetectRunTx(ThreadVars *tv,
                 /* see if we need to apply tx/hook accept to the packet. This can be needed when
                  * we've completed the inspection so far for an incomplete tx, and an accept:tx or
                  * accept:hook is the last match.*/
-                const bool fw_accept_to_packet = ApplyAcceptToPacket(total_txs, &tx, s);
+                const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
 
                 uint8_t alert_flags = (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_TX);
                 if (fw_accept_to_packet) {

--- a/src/detect.c
+++ b/src/detect.c
@@ -1640,6 +1640,7 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
         if (policy->action_scope == ACTION_SCOPE_FLOW) {
             SCLogDebug("dropping flow");
             p->flow->flags |= FLOW_ACTION_DROP;
+            p->flow->aux_flags |= FLOW_AUX_ACTION_BY_FIREWALL;
         }
     } else if (policy->action & ACTION_ACCEPT) {
         if (policy->action_scope == ACTION_SCOPE_FLOW) {
@@ -2321,6 +2322,7 @@ static void DetectRunTx(ThreadVars *tv,
                         if (s->action_scope == ACTION_SCOPE_FLOW) {
                             SCLogDebug("drop flow because of rule with drop action");
                             f->flags |= FLOW_ACTION_DROP;
+                            f->aux_flags |= FLOW_AUX_ACTION_BY_FIREWALL;
                         }
                     }
                 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -2121,6 +2121,139 @@ static int DetectTxFirewallNoRulesApplyPolicies(DetectEngineThreadCtx *det_ctx, 
     return 0;
 }
 
+/** \internal
+ *  \brief handle a full rule match for a firewall rule
+ *
+ *  For a drop/reject rule, excute action immediately.
+ *  For an accept rule, add an alert even to the queue. This will
+ *  allow TD rules to override the accept.
+ */
+static void DetectRunTxFirewallRuleFullMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
+        DetectTransaction *tx, struct DetectFirewallAppTxState *fw_state, Flow *f, Packet *p,
+        const uint8_t flow_flags, const bool last_tx)
+{
+    uint8_t alert_flags = (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_TX);
+    if (s->action & ACTION_ACCEPT) {
+        /* see if we need to apply tx/hook accept to the packet. This can be needed
+         * when we've completed the inspection so far for an incomplete tx, and an
+         * accept:tx or accept:hook is the last match.*/
+        const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, tx, s);
+        if (fw_accept_to_packet) {
+            SCLogDebug("packet %" PRIu64 ": apply accept to packet", p->pcap_cnt);
+            SCLogDebug("accept:(tx|hook): should be applied to the packet");
+            alert_flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET;
+        }
+        SCLogDebug("append alert");
+
+        /* add alert now, as ApplyAccept may also trigger
+         * policy matches that could add alerts. */
+        AlertQueueAppend(det_ctx, s, p, tx->tx_id, alert_flags);
+
+        fw_state->fw_skip_app_filter =
+                ApplyAccept(det_ctx, p, flow_flags, s, tx, tx->tx_end_state, last_tx, fw_state);
+    } else if (s->action & ACTION_DROP) {
+        SCLogDebug("drop packet because of rule with drop action");
+        PacketDrop(p, s->action, PKT_DROP_REASON_FW_RULES);
+        if (s->action_scope == ACTION_SCOPE_FLOW) {
+            SCLogDebug("drop flow because of rule with drop action");
+            f->flags |= FLOW_ACTION_DROP;
+            f->aux_flags |= FLOW_AUX_ACTION_BY_FIREWALL;
+        }
+        SCLogDebug("append alert");
+        AlertQueueAppend(det_ctx, s, p, tx->tx_id, alert_flags);
+    } else {
+        SCLogDebug("append alert");
+        AlertQueueAppend(det_ctx, s, p, tx->tx_id, alert_flags);
+    }
+}
+
+/** \internal
+ * \brief handle a partial match for firewall rules
+ *
+ * Currently only used for LTE mode. Regardless of the final action,
+ * the partial match acts as a `accept:hook`.
+ *
+ * A default accept is appended. TD has a chance to override this accept.
+ *
+ * \retval 1 accept partial, caller must break loop
+ * \retval 0 ok, caller must continue as normal
+ */
+static int DetectRunTxFirewallRulePartialMatch(
+        DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, const bool last_tx)
+{
+    if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT)) {
+        /* partial match always uses ACTION_SCOPE_HOOK. Final action only on the full
+         * match */
+        if (last_tx) {
+            SCLogDebug("need to apply accept to packet");
+            DetectRunAppendDefaultAccept(det_ctx, p);
+        }
+        if (s->action_scope == ACTION_SCOPE_FLOW) {
+            SCLogDebug("only applying accept:flow on full match, downgrading to "
+                       "accept:hook");
+        }
+        return 1;
+    }
+    return 0;
+}
+
+/** \internal
+ * \brief handle the no-match case for a firewall rule
+ *
+ * If the rule did not match we need to see if we need invoke the default
+ * policy for this hook. If that is the case, we handle a drop by telling the
+ * caller about it. Flow control for various accept options is handled by the
+ * next rule.
+ *
+ * \retval 1 dropped by policy, caller must return
+ * \retval 0 ok, caller must continue as normal
+ */
+static int DetectRunTxFirewallRuleNoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
+        DetectTransaction *tx, struct DetectFirewallAppTxState *fw_state, Packet *p,
+        const uint8_t flow_flags, const bool last_tx)
+{
+    if (fw_state->fw_last_for_progress && (s->flags & SIG_FLAG_FIREWALL)) {
+        SCLogDebug("%" PRIu64 ": %s default policy for progress %u", p->pcap_cnt,
+                flow_flags & STREAM_TOSERVER ? "toserver" : "toclient", s->app_progress_hook);
+        /* if this rule was the last for our progress state, and it didn't match,
+         * we have to invoke the default policy. We only check the current rule hook.
+         * DROP is immediate, flow control for various accept options is handled by
+         * the DetectRunTxPreCheckFirewallPolicy function for the next rule. */
+        const struct DetectFirewallPolicy *policy =
+                DetectFirewallApplyDefaultAppPolicy(det_ctx, det_ctx->de_ctx->fw_policies->app, tx,
+                        p, s->alproto, flow_flags, s->app_progress_hook, last_tx);
+        SCLogDebug("fw_last_for_progress policy %02x", policy->action);
+        if (policy->action & ACTION_DROP) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/** \internal
+ *  \brief handle full match on rule when state didn't progress yet
+ *
+ *  For a full rule match on a certain hook, we need to continue to enforce the
+ *  match as long as the tx progress doesn't move beyond that hook.
+ */
+static void DetectRunTxFirewallRuleStatefulReApplyMatch(DetectEngineThreadCtx *det_ctx,
+        const Signature *s, DetectTransaction *tx, struct DetectFirewallAppTxState *fw_state,
+        Packet *p, const uint8_t flow_flags, const bool last_tx)
+{
+    /* if we're still in the same progress state as an earlier full
+     * match, we need to apply the same accept */
+    if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT) &&
+            s->app_progress_hook == tx->tx_progress) {
+        const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, tx, s);
+        fw_state->fw_skip_app_filter =
+                ApplyAccept(det_ctx, p, flow_flags, s, tx, tx->tx_end_state, last_tx, fw_state);
+        if (fw_accept_to_packet) {
+            SCLogDebug("packet %" PRIu64 ": apply accept to packet", p->pcap_cnt);
+            DetectRunAppendDefaultAccept(det_ctx, p);
+        }
+    }
+}
+
 static void DetectRunTx(ThreadVars *tv,
                     DetectEngineCtx *de_ctx,
                     DetectEngineThreadCtx *det_ctx,
@@ -2356,15 +2489,9 @@ static void DetectRunTx(ThreadVars *tv,
 
                     /* if we're still in the same progress state as an earlier full
                      * match, we need to apply the same accept */
-                    if (have_fw_rules && (s->flags & SIG_FLAG_FIREWALL) &&
-                            (s->action & ACTION_ACCEPT) && s->app_progress_hook == tx.tx_progress) {
-                        const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
-                        fw_state.fw_skip_app_filter = ApplyAccept(
-                                det_ctx, p, flow_flags, s, &tx, tx_end_state, last_tx, &fw_state);
-                        if (fw_accept_to_packet) {
-                            SCLogDebug("packet %" PRIu64 ": apply accept to packet", p->pcap_cnt);
-                            DetectRunAppendDefaultAccept(det_ctx, p);
-                        }
+                    if (have_fw_rules) {
+                        DetectRunTxFirewallRuleStatefulReApplyMatch(
+                                det_ctx, s, &tx, &fw_state, p, flow_flags, last_tx);
                     }
                     continue;
                 }
@@ -2407,74 +2534,24 @@ static void DetectRunTx(ThreadVars *tv,
                 /* match */
                 DetectRunPostMatch(tv, det_ctx, p, s);
 
-                uint8_t alert_flags = (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_TX);
                 SCLogDebug(
                         "%p/%" PRIu64 " sig %u (%u) matched", tx.tx_ptr, tx.tx_id, s->id, s->iid);
 
                 if ((s->flags & SIG_FLAG_FIREWALL) == 0) {
-                    AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
+                    AlertQueueAppend(det_ctx, s, p, tx.tx_id,
+                            (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_TX));
                 } else {
-                    if (s->action & ACTION_ACCEPT) {
-                        /* see if we need to apply tx/hook accept to the packet. This can be needed
-                         * when we've completed the inspection so far for an incomplete tx, and an
-                         * accept:tx or accept:hook is the last match.*/
-                        const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
-                        if (fw_accept_to_packet) {
-                            SCLogDebug("packet %" PRIu64 ": apply accept to packet", p->pcap_cnt);
-                            SCLogDebug("accept:(tx|hook): should be applied to the packet");
-                            alert_flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET;
-                        }
-                        SCLogDebug("append alert");
-
-                        /* add alert now, as ApplyAccept may also trigger
-                         * policy matches that could add alerts. */
-                        AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
-
-                        fw_state.fw_skip_app_filter = ApplyAccept(
-                                det_ctx, p, flow_flags, s, &tx, tx_end_state, last_tx, &fw_state);
-                    } else if (s->action & ACTION_DROP) {
-                        SCLogDebug("drop packet because of rule with drop action");
-                        PacketDrop(p, s->action, PKT_DROP_REASON_FW_RULES);
-                        if (s->action_scope == ACTION_SCOPE_FLOW) {
-                            SCLogDebug("drop flow because of rule with drop action");
-                            f->flags |= FLOW_ACTION_DROP;
-                            f->aux_flags |= FLOW_AUX_ACTION_BY_FIREWALL;
-                        }
-                        SCLogDebug("append alert");
-                        AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
-                    } else {
-                        SCLogDebug("append alert");
-                        AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
-                    }
+                    DetectRunTxFirewallRuleFullMatch(
+                            det_ctx, s, &tx, &fw_state, f, p, flow_flags, last_tx);
                 }
             } else if (r == 0) {
                 SCLogDebug("sid %u partial match", s->id);
-                if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT)) {
-                    /* partial match always uses ACTION_SCOPE_HOOK. Final action only on the full
-                     * match */
-                    if (last_tx) {
-                        SCLogDebug("need to apply accept to packet");
-                        DetectRunAppendDefaultAccept(det_ctx, p);
-                    }
-                    if (s->action_scope == ACTION_SCOPE_FLOW) {
-                        SCLogDebug("only applying accept:flow on full match, downgrading to "
-                                   "accept:hook");
-                    }
+                if (DetectRunTxFirewallRulePartialMatch(det_ctx, s, p, last_tx) == 1) {
                     break;
                 }
-            } else if (fw_state.fw_last_for_progress && (s->flags & SIG_FLAG_FIREWALL)) {
-                SCLogDebug("%" PRIu64 ": %s default policy for progress %u", p->pcap_cnt,
-                        flow_flags & STREAM_TOSERVER ? "toserver" : "toclient",
-                        s->app_progress_hook);
-                /* if this rule was the last for our progress state, and it didn't match,
-                 * we have to invoke the default policy. We only check the current rule hook.
-                 * DROP is immediate, flow control for various accept options is handled by
-                 * the DetectRunTxPreCheckFirewallPolicy function for the next rule. */
-                const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
-                        det_ctx, det_ctx->de_ctx->fw_policies->app, &tx, p, s->alproto, flow_flags,
-                        s->app_progress_hook, last_tx);
-                SCLogDebug("fw_last_for_progress policy %02x", policy->action);
-                if (policy->action & ACTION_DROP) {
+            } else {
+                if (DetectRunTxFirewallRuleNoMatch(
+                            det_ctx, s, &tx, &fw_state, p, flow_flags, last_tx) == 1) {
                     return;
                 }
             }

--- a/src/detect.c
+++ b/src/detect.c
@@ -2389,11 +2389,10 @@ static void DetectRunTx(ThreadVars *tv,
                 SCLogDebug(
                         "%p/%" PRIu64 " sig %u (%u) matched", tx.tx_ptr, tx.tx_id, s->id, s->iid);
 
-                if (s->flags & SIG_FLAG_FIREWALL) {
+                if ((s->flags & SIG_FLAG_FIREWALL) == 0) {
+                    AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
+                } else {
                     if (s->action & ACTION_ACCEPT) {
-                        fw_state.fw_skip_app_filter = ApplyAccept(
-                                det_ctx, p, flow_flags, s, &tx, tx_end_state, last_tx, &fw_state);
-                        fw_state.fw_next_progress_missing = false; // reset
                         /* see if we need to apply tx/hook accept to the packet. This can be needed
                          * when we've completed the inspection so far for an incomplete tx, and an
                          * accept:tx or accept:hook is the last match.*/
@@ -2403,6 +2402,15 @@ static void DetectRunTx(ThreadVars *tv,
                             SCLogDebug("accept:(tx|hook): should be applied to the packet");
                             alert_flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET;
                         }
+                        SCLogDebug("append alert");
+
+                        /* add alert now, as ApplyAccept may also trigger
+                         * policy matches that could add alerts. */
+                        AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
+
+                        fw_state.fw_skip_app_filter = ApplyAccept(
+                                det_ctx, p, flow_flags, s, &tx, tx_end_state, last_tx, &fw_state);
+                        fw_state.fw_next_progress_missing = false; // reset
                     } else if (s->action & ACTION_DROP) {
                         SCLogDebug("drop packet because of rule with drop action");
                         PacketDrop(p, s->action, PKT_DROP_REASON_FW_RULES);
@@ -2411,9 +2419,13 @@ static void DetectRunTx(ThreadVars *tv,
                             f->flags |= FLOW_ACTION_DROP;
                             f->aux_flags |= FLOW_AUX_ACTION_BY_FIREWALL;
                         }
+                        SCLogDebug("append alert");
+                        AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
+                    } else {
+                        SCLogDebug("append alert");
+                        AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
                     }
                 }
-                AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
             } else if (r == 0) {
                 SCLogDebug("sid %u partial match", s->id);
                 if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT)) {

--- a/src/detect.c
+++ b/src/detect.c
@@ -2017,26 +2017,25 @@ static void DetectRunTx(ThreadVars *tv,
                 /* match */
                 DetectRunPostMatch(tv, det_ctx, p, s);
 
-                /* see if we need to apply tx/hook accept to the packet. This can be needed when
-                 * we've completed the inspection so far for an incomplete tx, and an accept:tx or
-                 * accept:hook is the last match.*/
-                const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
-
                 uint8_t alert_flags = (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_TX);
-                if (fw_accept_to_packet) {
-                    SCLogDebug("accept:(tx|hook): should be applied to the packet");
-                    alert_flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET;
-                }
-
                 SCLogDebug(
                         "%p/%" PRIu64 " sig %u (%u) matched", tx.tx_ptr, tx.tx_id, s->id, s->iid);
-                AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
 
                 if ((s->flags & SIG_FLAG_FIREWALL) && (s->action & ACTION_ACCEPT)) {
                     break_out_of_app_filter = ApplyAccept(p, flow_flags, s, &tx, tx_end_state,
                             fw_next_progress_missing, &tx_fw_verdict, &skip_fw_hook,
                             &skip_before_progress);
+                    /* see if we need to apply tx/hook accept to the packet. This can be needed when
+                     * we've completed the inspection so far for an incomplete tx, and an accept:tx
+                     * or accept:hook is the last match.*/
+                    const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
+                    if (fw_accept_to_packet) {
+                        SCLogDebug("accept:(tx|hook): should be applied to the packet");
+                        alert_flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET;
+                    }
                 }
+                AlertQueueAppend(det_ctx, s, p, tx.tx_id, alert_flags);
+
             } else if (last_for_progress) {
                 SCLogDebug("sid %u: not a match: %s rule, last_for_progress %s", s->id,
                         (s->flags & SIG_FLAG_FIREWALL) ? "firewall" : "regular",

--- a/src/detect.c
+++ b/src/detect.c
@@ -2030,11 +2030,14 @@ static void DetectRunTx(ThreadVars *tv,
     const bool have_fw_rules = EngineModeIsFirewall();
 
     SCLogDebug("packet %" PRIu64, p->pcap_cnt);
+    SCLogDebug("total_txs %" PRIu64, total_txs);
 
     while (1) {
         AppLayerGetTxIterTuple ires = IterFunc(ipproto, alproto, alstate, tx_id_min, total_txs, &state);
-        if (ires.tx_ptr == NULL)
+        if (ires.tx_ptr == NULL) {
+            SCLogDebug("%p/%" PRIu64 " no transaction to inspect", ires.tx_ptr, tx_id_min);
             break;
+        }
 
         DetectTransaction tx =
                 GetDetectTx(ipproto, alproto, ires.tx_id, ires.tx_ptr, tx_end_state, flow_flags);
@@ -2049,7 +2052,7 @@ static void DetectRunTx(ThreadVars *tv,
         tx_inspected++;
         const bool last_tx = (total_txs == tx.tx_id + 1);
 
-        SCLogDebug("%p/%" PRIu64 " txd flags %02x", tx.tx_ptr, tx_id_min, tx.tx_data_ptr->flags);
+        SCLogDebug("%p/%" PRIu64 " txd flags %02x", tx.tx_ptr, tx.tx_id, tx.tx_data_ptr->flags);
 
         det_ctx->tx_id = tx.tx_id;
         det_ctx->tx_id_set = true;

--- a/src/detect.c
+++ b/src/detect.c
@@ -159,7 +159,10 @@ static void DetectRun(ThreadVars *th_v,
         if (p->proto == IPPROTO_TCP) {
             if ((p->flags & PKT_STREAM_EST) == 0) {
                 SCLogDebug("packet %" PRIu64 ": skip tcp non-established", p->pcap_cnt);
-                DetectRunAppendDefaultAccept(det_ctx, p);
+                if (EngineModeIsFirewall()) {
+                    SCLogDebug("default accept: no PKT_STREAM_EST");
+                    DetectRunAppendDefaultAccept(det_ctx, p);
+                }
                 goto end;
             }
             const TcpSession *ssn = p->flow->protoctx;
@@ -179,7 +182,10 @@ static void DetectRun(ThreadVars *th_v,
                     ((PKT_IS_TOSERVER(p) && (p->flow->flags & FLOW_TS_APP_UPDATED) == 0) ||
                             (PKT_IS_TOCLIENT(p) && (p->flow->flags & FLOW_TC_APP_UPDATED) == 0))) {
                 SCLogDebug("packet %" PRIu64 ": no app-layer update", p->pcap_cnt);
-                DetectRunAppendDefaultAccept(det_ctx, p);
+                if (EngineModeIsFirewall()) {
+                    SCLogDebug("default accept: no app update");
+                    DetectRunAppendDefaultAccept(det_ctx, p);
+                }
                 goto end;
             }
         } else if (p->proto == IPPROTO_UDP) {
@@ -196,7 +202,10 @@ static void DetectRun(ThreadVars *th_v,
         PACKET_PROFILING_DETECT_END(p, PROF_DETECT_TX_UPDATE);
     } else {
         SCLogDebug("packet %" PRIu64 ": no flow / app-layer", p->pcap_cnt);
-        DetectRunAppendDefaultAccept(det_ctx, p);
+        if (EngineModeIsFirewall()) {
+            SCLogDebug("default accept: no flow/app");
+            DetectRunAppendDefaultAccept(det_ctx, p);
+        }
     }
 
 end:
@@ -1707,6 +1716,7 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
         SCLogDebug("%" PRIu64 ": %s default policy for hook %u", p->pcap_cnt,
                 direction & STREAM_TOSERVER ? "toserver" : "toclient", hook);
 
+        const bool apply_to_packet = is_last && hook == tx->tx_end_state;
         const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
                 det_ctx, det_ctx->de_ctx->fw_policies->app, p, alproto, direction, hook);
         SCLogDebug("fw: hook:%u policy:%02x is_last:%s", hook, policy->action, BOOL2STR(is_last));
@@ -1720,10 +1730,12 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
 
             /* accepting flow, so skip rest of the fw rules */
             if (policy->action_scope == ACTION_SCOPE_FLOW) {
+                SCLogDebug("fw: accept flow");
                 if (policy->action & ACTION_ALERT) {
                     DetectRunAppendDefaultAppPolicyAlert(
-                            det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
+                            det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
                 } else {
+                    SCLogDebug("default accept");
                     DetectRunAppendDefaultAccept(det_ctx, p);
                 }
                 return DETECT_TX_FW_FC_SKIP;
@@ -1743,8 +1755,8 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
             } else if (policy->action_scope == ACTION_SCOPE_HOOK) {
                 if (policy->action & ACTION_ALERT) {
                     DetectRunAppendDefaultAppPolicyAlert(
-                            det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
-                } else if (is_last) {
+                            det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
+                } else if (apply_to_packet) {
                     DetectRunAppendDefaultAccept(det_ctx, p);
                     SCLogDebug("DetectRunAppendDefaultAccept for last tx");
                 }
@@ -1752,12 +1764,13 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
         } else {
             if (policy->action & ACTION_ALERT) {
                 DetectRunAppendDefaultAppPolicyAlert(
-                        det_ctx, p, is_last, direction, tx->tx_id, alproto, hook);
+                        det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, hook);
             }
         }
     }
 
     if ((is_last && (actions & (ACTION_ACCEPT | ACTION_DROP)) == ACTION_ACCEPT)) {
+        SCLogDebug("default accept: last tx and at least one accept");
         DetectRunAppendDefaultAccept(det_ctx, p);
     }
     return DETECT_TX_FW_FC_OK;
@@ -1766,9 +1779,10 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
 /** \internal
  *  \brief run pre-rule inspection firewall policy checks
  *
- *  Check if:
+ *  Check for:
  *  - check if we're in accept:tx mode
  *  - check for missing accept hooks
+ *  -
  *
  * \retval DETECT_TX_FW_FC_OK no action needed
  * \retval DETECT_TX_FW_FC_BREAK rest of rules shouldn't be inspected
@@ -1785,6 +1799,7 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
     if (p->flow->flags & FLOW_ACTION_ACCEPT) {
         if (fw_state->tx_fw_verdict == false) {
             fw_state->tx_fw_verdict = true;
+            SCLogDebug("default accept due to flow accept");
             DetectRunAppendDefaultAccept(det_ctx, p);
         }
         if (s->flags & SIG_FLAG_FIREWALL) {
@@ -1798,7 +1813,7 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
         if (!fw_state->tx_fw_verdict) {
             const bool accept_tx_applies_to_packet = last_tx;
             if (accept_tx_applies_to_packet) {
-                SCLogDebug("accept:(tx|hook): should be applied to the packet");
+                SCLogDebug("accept:tx: should be applied to the packet");
                 DetectRunAppendDefaultAccept(det_ctx, p);
             }
             fw_state->tx_fw_verdict = true;
@@ -1843,10 +1858,10 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
  * \param skip_fw_hook bool to indicate firewall rules skips
  * For state `skip_before_progress` should be skipped.
  *
- * \param skip_before_progress progress value to skip rules before.
- * Only used if `skip_fw_hook` is set.
+ * \param skip_before_progress progress value to skip rules before.* Only used if `skip_fw_hook` is
+ * set.
  *
- * \param fw_last_for_progress[out] set to true if this is the last firewall rule for a progress
+ * \param fw_last_for_progress[out] set to true if this is  firewall rule for a progress
  * value
  *
  * \param fw_next_progress_missing[out] set to true if the next fw rule does not target the next
@@ -1921,17 +1936,19 @@ static enum DetectTxFirewallFlowControl DetectRunTxCheckFirewallPolicy(
 
 // TODO move into det_ctx?
 thread_local Signature default_accept;
-static inline void DetectRunAppendDefaultAccept(DetectEngineThreadCtx *det_ctx, Packet *p)
+static void DetectRunAppendDefaultAccept(DetectEngineThreadCtx *det_ctx, Packet *p)
 {
-    if (EngineModeIsFirewall()) {
-        memset(&default_accept, 0, sizeof(default_accept));
-        default_accept.action = ACTION_ACCEPT;
-        default_accept.action_scope = ACTION_SCOPE_PACKET;
-        default_accept.iid = UINT32_MAX;
-        default_accept.type = SIG_TYPE_PKT;
-        default_accept.flags = SIG_FLAG_FIREWALL;
-        AlertQueueAppend(det_ctx, &default_accept, p, 0, PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET);
-    }
+    DEBUG_VALIDATE_BUG_ON(!EngineModeIsFirewall());
+    SCLogDebug("packet %" PRIu64 ": appending default firewall accept", p->pcap_cnt);
+    memset(&default_accept, 0, sizeof(default_accept));
+    default_accept.action = ACTION_ACCEPT;
+    default_accept.action_scope = ACTION_SCOPE_PACKET;
+    default_accept.iid = UINT32_MAX;
+    default_accept.type = SIG_TYPE_PKT;
+    default_accept.flags = SIG_FLAG_FIREWALL;
+    default_accept.detect_table =
+            DETECT_TABLE_APP_FILTER; // TODO review, hope this makes it last in sorting
+    AlertQueueAppend(det_ctx, &default_accept, p, 0, PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET);
 }
 
 /** \internal
@@ -2012,7 +2029,7 @@ static bool ApplyAccept(DetectEngineThreadCtx *det_ctx, Packet *p, const uint8_t
     } else if (as == ACTION_SCOPE_PACKET) {
         return true;
     } else if (as == ACTION_SCOPE_FLOW) {
-        SCLogDebug("ACTION_ACCEPT with ACTION_SCOPE_FLOW");
+        SCLogDebug("sid %u: ACTION_ACCEPT with ACTION_SCOPE_FLOW", s->id);
         return true;
     }
     return false;
@@ -2037,12 +2054,14 @@ static int DetectTxFirewallNoRulesApplyPolicies(DetectEngineThreadCtx *det_ctx, 
         /* if there are no rules, make sure to handle accept:flow and accept:tx */
         if (rule_cnt == 0) {
             if (f->flags & FLOW_ACTION_ACCEPT) {
+                SCLogDebug("default accept:flow: no rules");
                 DetectRunAppendDefaultAccept(det_ctx, p);
                 return 1;
             }
             if (tx->tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
                 /* current tx is the last we have, append a blank accept:packet */
                 if (last_tx) {
+                    SCLogDebug("default accept:tx: no rules");
                     DetectRunAppendDefaultAccept(det_ctx, p);
                     return 1;
                 }
@@ -2316,8 +2335,10 @@ static void DetectRunTx(ThreadVars *tv,
                         const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
                         fw_state.fw_skip_app_filter = ApplyAccept(
                                 det_ctx, p, flow_flags, s, &tx, tx_end_state, last_tx, &fw_state);
-                        if (fw_accept_to_packet)
+                        if (fw_accept_to_packet) {
+                            SCLogDebug("packet %" PRIu64 ": apply accept to packet", p->pcap_cnt);
                             DetectRunAppendDefaultAccept(det_ctx, p);
+                        }
                     }
                     continue;
                 }
@@ -2374,6 +2395,7 @@ static void DetectRunTx(ThreadVars *tv,
                          * accept:tx or accept:hook is the last match.*/
                         const bool fw_accept_to_packet = ApplyAcceptToPacket(last_tx, &tx, s);
                         if (fw_accept_to_packet) {
+                            SCLogDebug("packet %" PRIu64 ": apply accept to packet", p->pcap_cnt);
                             SCLogDebug("accept:(tx|hook): should be applied to the packet");
                             alert_flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET;
                         }
@@ -2428,6 +2450,7 @@ static void DetectRunTx(ThreadVars *tv,
                     /* if this is also the last fw rule we'll inspect we have to issue a default
                      * accept to the packet */
                     if (last_tx && s->app_progress_hook == tx.tx_progress) {
+                        SCLogDebug("default accept: last_tx");
                         DetectRunAppendDefaultAccept(det_ctx, p);
                     }
                 }
@@ -2511,6 +2534,7 @@ static void DetectRunTx(ThreadVars *tv,
             fw_verdicted);
     /* if all tables have been bypassed, we accept:packet */
     if (tx_inspected == 0 && fw_verdicted == 0 && have_fw_rules) {
+        SCLogDebug("default accept: no app inspect performed");
         DetectRunAppendDefaultAccept(det_ctx, p);
     }
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -672,7 +672,8 @@ static inline bool SkipFwRules(const Packet *p)
  * packet:filter accept:hook to the packet as well.
  */
 static uint8_t DetectRunApplyPacketPolicy(const DetectEngineCtx *de_ctx,
-        const enum DetectFirewallPacketPolicies policy, Packet *p, const bool final)
+        DetectEngineThreadCtx *det_ctx, const enum DetectFirewallPacketPolicies policy, Packet *p,
+        const bool final)
 {
     DEBUG_VALIDATE_BUG_ON(de_ctx->fw_policies == NULL);
     const struct DetectFirewallPolicy *pol = &de_ctx->fw_policies->pkt[policy];
@@ -704,6 +705,10 @@ static uint8_t DetectRunApplyPacketPolicy(const DetectEngineCtx *de_ctx,
     } else {
         /* should be unreachable */
         DEBUG_VALIDATE_BUG_ON(1);
+    }
+    Signature *s = de_ctx->fw_policies->pkt_policy_signatures[policy];
+    if (s != NULL) {
+        AlertQueueAppend(det_ctx, s, p, 0, PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET);
     }
     return p->action;
 }
@@ -962,7 +967,7 @@ next:
         } else {
             DEBUG_VALIDATE_BUG_ON(action & ACTION_DROP);
             /* non-final call as we may have to consider app-layer still */
-            action |= DetectRunApplyPacketPolicy(de_ctx, scratch->fw_pkt_policy, p, false);
+            action |= DetectRunApplyPacketPolicy(de_ctx, det_ctx, scratch->fw_pkt_policy, p, false);
         }
     }
     return action;
@@ -1104,7 +1109,7 @@ static inline void DetectRunPostRules(ThreadVars *tv, const DetectEngineCtx *de_
             p->pkt_src == PKT_SRC_WIRE) {
         SCLogDebug("packet %" PRIu64 ": default action as no verdict set %02x (pkt %s)",
                 p->pcap_cnt, p->action, PktSrcToString(p->pkt_src));
-        (void)DetectRunApplyPacketPolicy(de_ctx, scratch->fw_pkt_policy, p, true);
+        (void)DetectRunApplyPacketPolicy(de_ctx, det_ctx, scratch->fw_pkt_policy, p, true);
         DEBUG_VALIDATE_BUG_ON((p->action & (ACTION_DROP | ACTION_ACCEPT)) == 0);
     }
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1496,8 +1496,12 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
 static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alproto,
         const uint64_t tx_id, void *tx_ptr, const int tx_end_state, const uint8_t flow_flags)
 {
+    DEBUG_VALIDATE_BUG_ON(tx_end_state >= 48);
+
     AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx_ptr);
     const int tx_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx_ptr, flow_flags);
+    DEBUG_VALIDATE_BUG_ON(tx_progress >= 48);
+
     bool updated = (flow_flags & STREAM_TOSERVER) ? txd->updated_ts : txd->updated_tc;
     if (!updated && tx_progress < tx_end_state && ((flow_flags & STREAM_EOF) == 0)) {
         DetectTransaction no_tx = NO_TX;
@@ -1534,8 +1538,8 @@ static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alpro
         .de_state = tx_dir_state,
         .detect_progress = detect_progress,
         .detect_progress_orig = detect_progress,
-        .tx_progress = tx_progress,
-        .tx_end_state = tx_end_state,
+        .tx_progress = (uint8_t)tx_progress,
+        .tx_end_state = (uint8_t)tx_end_state,
     };
     return tx;
 }
@@ -2039,10 +2043,9 @@ static void DetectRunTxFirewallApplyAccept(DetectEngineThreadCtx *det_ctx, Packe
         /* if there is no fw rule for the next progress value,
          * we invoke the defaul policies for the remaining available hooks. */
         if (fw_state->fw_next_progress_missing) {
-            const uint8_t last_hook =
-                    fw_state->last_fw_rule
-                            ? (uint8_t)tx->tx_end_state
-                            : MIN((uint8_t)tx->tx_end_state, s->app_progress_hook + (uint8_t)1);
+            const uint8_t last_hook = fw_state->last_fw_rule
+                                              ? tx->tx_end_state
+                                              : MIN(tx->tx_end_state, s->app_progress_hook + 1);
             enum DetectTxFirewallFlowControl r = DetectFirewallApplyDefaultPolicies(det_ctx,
                     det_ctx->de_ctx->fw_policies->app, tx, p, s->alproto, direction,
                     s->app_progress_hook + 1, last_hook, is_last);
@@ -2054,7 +2057,7 @@ static void DetectRunTxFirewallApplyAccept(DetectEngineThreadCtx *det_ctx, Packe
     } else if (as == ACTION_SCOPE_TX) {
         tx->tx_data_ptr->flags |= APP_LAYER_TX_ACCEPT;
         fw_state->skip_fw_hook = true;
-        fw_state->skip_before_progress = (uint8_t)tx->tx_end_state + 1; // skip all hooks
+        fw_state->skip_before_progress = tx->tx_end_state + 1; // skip all hooks
         SCLogDebug("accept:tx applied, skip_fw_hook, skip_before_progress %u",
                 fw_state->skip_before_progress);
     } else if (as == ACTION_SCOPE_PACKET) {
@@ -2110,7 +2113,7 @@ static int DetectTxFirewallNoRulesApplyPolicies(DetectEngineThreadCtx *det_ctx, 
             enum DetectTxFirewallFlowControl r =
                     DetectFirewallApplyDefaultPolicies(det_ctx, det_ctx->de_ctx->fw_policies->app,
                             tx, p, alproto, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT),
-                            tx->detect_progress_orig, (const uint8_t)tx->tx_progress, last_tx);
+                            tx->detect_progress_orig, tx->tx_progress, last_tx);
             SCLogDebug("r %u", r);
             if (r == DETECT_TX_FW_FC_BREAK)
                 return 1;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1540,6 +1540,59 @@ static inline void RuleMatchCandidateMergeStateRules(
     // and come before any other element later in the list
 }
 
+/** \internal
+ *  \brief run pre-rule inspection firewall policy checks
+ *
+ *  Check if:
+ *  - check if we're in accept:tx mode
+ *  - check for missing accept hooks
+ *
+ * \retval DETECT_TX_FW_FC_OK no action needed
+ * \retval DETECT_TX_FW_FC_BREAK rest of rules shouldn't be inspected
+ * \retval DETECT_TX_FW_FC_SKIP skip this rule
+ */
+static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
+        DetectEngineThreadCtx *det_ctx, Packet *p, DetectTransaction *tx, const Signature *s,
+        const uint32_t can_idx, bool *tx_fw_verdict, const bool last_tx)
+{
+    /* skip fw rules if we're in accept:tx mode */
+    if (tx->tx_data_ptr->flags & APP_LAYER_TX_ACCEPT) {
+        /* append a blank accept:packet action for the APP_LAYER_TX_ACCEPT,
+         * if this is the last tx */
+        if (!*tx_fw_verdict) {
+            const bool accept_tx_applies_to_packet = last_tx;
+            if (accept_tx_applies_to_packet) {
+                SCLogDebug("accept:(tx|hook): should be applied to the packet");
+                DetectRunAppendDefaultAccept(det_ctx, p);
+            }
+            *tx_fw_verdict = true;
+        }
+
+        if (s->flags & SIG_FLAG_FIREWALL) {
+            SCLogDebug("APP_LAYER_TX_ACCEPT, so skip rule");
+            return DETECT_TX_FW_FC_SKIP;
+        }
+
+        /* threat detect rules will be inspected */
+    } else if (s->flags & SIG_FLAG_FIREWALL) {
+        /* if our first rule is beyond the starting state, we need to check if
+         * there are rules missing for states in between. */
+        if (s->app_progress_hook > tx->detect_progress_orig && can_idx == 0) {
+            SCLogDebug("missing fw rules at list start: sid %u, progress %u (%u:%u)", s->id,
+                    s->app_progress_hook, tx->detect_progress, tx->detect_progress_orig);
+
+            /* if this rule was after the state we expected meaning that there are
+             * no rules for that state. Invoke the default drop policy. */
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_DEFAULT_APP_POLICY);
+            p->flow->flags |= FLOW_ACTION_DROP;
+            *tx_fw_verdict = true;
+            SCLogDebug("default app drop");
+            return DETECT_TX_FW_FC_BREAK;
+        }
+    }
+    return DETECT_TX_FW_FC_OK;
+}
+
 /**
  * \internal
  * \brief Check and update firewall rules state.
@@ -1886,6 +1939,15 @@ static void DetectRunTx(ThreadVars *tv,
                     flow_flags & STREAM_TOSERVER ? "toserver" : "toclient", tx.tx_progress,
                     tx.detect_progress, tx.detect_progress_orig, s->app_progress_hook);
 
+            if (have_fw_rules) {
+                const enum DetectTxFirewallFlowControl fw_r = DetectRunTxPreCheckFirewallPolicy(
+                        det_ctx, p, &tx, s, i, &tx_fw_verdict, (total_txs == tx.tx_id + 1));
+                if (fw_r == DETECT_TX_FW_FC_SKIP)
+                    continue;
+                else if (fw_r == DETECT_TX_FW_FC_BREAK)
+                    break;
+            }
+
             /* deduplicate: rules_array is sorted, but not deduplicated:
              * both mpm and stored state could give us the same sid.
              * As they are back to back in that case we can check for it
@@ -1896,27 +1958,6 @@ static void DetectRunTx(ThreadVars *tv,
                 SCLogDebug("%p/%" PRIu64 " inspecting SKIP NEXT: sid %u (%u), flags %08x",
                         tx.tx_ptr, tx.tx_id, s->id, s->iid, inspect_flags ? *inspect_flags : 0);
                 i++;
-            }
-
-            /* skip fw rules if we're in accept:tx mode */
-            if (have_fw_rules && (tx.tx_data_ptr->flags & APP_LAYER_TX_ACCEPT)) {
-                /* append a blank accept:packet action for the APP_LAYER_TX_ACCEPT,
-                 * if this is the last tx */
-                if (!tx_fw_verdict) {
-                    const bool accept_tx_applies_to_packet = total_txs == tx.tx_id + 1;
-                    if (accept_tx_applies_to_packet) {
-                        SCLogDebug("accept:(tx|hook): should be applied to the packet");
-                        DetectRunAppendDefaultAccept(det_ctx, p);
-                    }
-                }
-                tx_fw_verdict = true;
-
-                if (s->flags & SIG_FLAG_FIREWALL) {
-                    SCLogDebug("APP_LAYER_TX_ACCEPT, so skip rule");
-                    continue;
-                }
-
-                /* threat detect rules will be inspected */
             }
 
             SCLogDebug("%p/%" PRIu64 " inspecting: sid %u (%u), flags %08x", tx.tx_ptr, tx.tx_id,

--- a/src/detect.h
+++ b/src/detect.h
@@ -1327,6 +1327,8 @@ typedef struct DetectEngineThreadCtx_ {
     uint16_t counter_mpm_list;
     uint16_t counter_match_list;
 #endif
+    /** id for firewall discarded alerts counter */
+    uint16_t counter_firewall_discarded_alerts;
 
     struct {
         InspectionBuffer *buffers;

--- a/src/detect.h
+++ b/src/detect.h
@@ -929,6 +929,7 @@ struct DetectFirewallAppPolicy {
 struct DetectFirewallPolicies {
     /** policy for packet_filter, pre_flow, pre_stream hooks */
     struct DetectFirewallPolicy pkt[DETECT_FIREWALL_POLICY_SIZE];
+    Signature *pkt_policy_signatures[DETECT_FIREWALL_POLICY_SIZE];
 
     /* hash table with a Signature object per default policy that has `alert` enabled. */
     HashTable *policy_signatures;

--- a/src/detect.h
+++ b/src/detect.h
@@ -930,6 +930,9 @@ struct DetectFirewallPolicies {
     /** policy for packet_filter, pre_flow, pre_stream hooks */
     struct DetectFirewallPolicy pkt[DETECT_FIREWALL_POLICY_SIZE];
 
+    /* hash table with a Signature object per default policy that has `alert` enabled. */
+    HashTable *policy_signatures;
+
     /** app layer policies, one per alproto */
     struct DetectFirewallAppPolicy app[];
 };

--- a/src/detect.h
+++ b/src/detect.h
@@ -249,7 +249,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_APPLAYER               BIT_U32(6) /**< signature applies to app layer instead of packets */
 #define SIG_FLAG_TXBOTHDIR              BIT_U32(7) /**< signature needs tx with both directions to match */
 
-// vacancy
+#define SIG_FLAG_FW_HOOK_LTE BIT_U32(8) /**< Signature::app_progress_hook is to be used as LTE */
 
 #define SIG_FLAG_REQUIRE_PACKET         BIT_U32(9)  /**< signature is requiring packet match */
 #define SIG_FLAG_REQUIRE_STREAM         BIT_U32(10) /**< signature is requiring stream match */

--- a/src/detect.h
+++ b/src/detect.h
@@ -905,6 +905,35 @@ enum DetectEngineType
     DETECT_ENGINE_TYPE_TENANT = 3,
 };
 
+enum DetectFirewallPacketPolicies {
+    DETECT_FIREWALL_POLICY_PACKET_FILTER,
+    DETECT_FIREWALL_POLICY_PRE_FLOW,
+    DETECT_FIREWALL_POLICY_PRE_STREAM,
+#define DETECT_FIREWALL_POLICY_SIZE DETECT_FIREWALL_POLICY_PRE_STREAM + 1
+};
+
+/** Single Firewall Policy */
+struct DetectFirewallPolicy {
+    uint8_t action;       /**< same as Signature::action. Action flags to apply on policy match. */
+    uint8_t action_scope; /**< same as Signature::action_scope. Scope argument for the action. */
+};
+
+/** Application layer firewall policies per hook. */
+struct DetectFirewallAppPolicy {
+    /** policy per hook/progress value (max 48) for toserver direction. */
+    struct DetectFirewallPolicy ts[48];
+    /** policy per hook/progress value (max 48) for toclient direction. */
+    struct DetectFirewallPolicy tc[48];
+};
+
+struct DetectFirewallPolicies {
+    /** policy for packet_filter, pre_flow, pre_stream hooks */
+    struct DetectFirewallPolicy pkt[DETECT_FIREWALL_POLICY_SIZE];
+
+    /** app layer policies, one per alproto */
+    struct DetectFirewallAppPolicy app[];
+};
+
 /* Flow states:
  *  toserver
  *  toclient
@@ -1158,6 +1187,9 @@ typedef struct DetectEngineCtx_ {
     DetectPacketHookFunc PreFlowHook;
     /** pre_flow hook rule groups. Before flow we don't know a direction yet. */
     struct SigGroupHead_ *pre_flow_sgh;
+
+    /** firewall policy table entry point */
+    struct DetectFirewallPolicies *fw_policies;
 } DetectEngineCtx;
 
 /**

--- a/src/detect.h
+++ b/src/detect.h
@@ -549,6 +549,9 @@ enum SignatureHookType {
     SIGNATURE_HOOK_TYPE_APP,
 };
 
+/** detect table identifiers, ordered by how they logically
+ *  evaluated. Used in rule ordering to ensure the correct order
+ *  of rule actions. */
 enum DetectTable {
     DETECT_TABLE_NOT_SET = 0,
     DETECT_TABLE_PACKET_PRE_FLOW,

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -49,6 +49,7 @@
         (f)->parent_id = 0;                                                                        \
         (f)->probing_parser_toserver_alproto_masks = 0;                                            \
         (f)->probing_parser_toclient_alproto_masks = 0;                                            \
+        (f)->aux_flags = 0;                                                                        \
         (f)->flags = 0;                                                                            \
         (f)->file_flags = 0;                                                                       \
         (f)->protodetect_dp = 0;                                                                   \
@@ -93,6 +94,7 @@
         (f)->parent_id = 0;                                                                        \
         (f)->probing_parser_toserver_alproto_masks = 0;                                            \
         (f)->probing_parser_toclient_alproto_masks = 0;                                            \
+        (f)->aux_flags = 0;                                                                        \
         (f)->flags = 0;                                                                            \
         (f)->file_flags = 0;                                                                       \
         (f)->protodetect_dp = 0;                                                                   \

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -425,7 +425,11 @@ static inline void FlowWorkerStreamTCPUpdate(ThreadVars *tv, FlowWorkerThreadDat
     }
     if (FlowChangeProto(p->flow) && p->flow->flags & FLOW_ACTION_DROP) {
         // in case f->flags & FLOW_ACTION_DROP was set by one of the dequeued packets
-        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
+        if (p->flow->aux_flags & FLOW_AUX_ACTION_BY_FIREWALL) {
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FW_FLOW_DROP);
+        } else {
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
+        }
     }
 }
 

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -367,7 +367,7 @@ static inline void FlowWorkerStreamTCPUpdate(ThreadVars *tv, FlowWorkerThreadDat
     if (det_ctx != NULL && det_ctx->de_ctx->PreStreamHook != NULL) {
         const uint8_t action = det_ctx->de_ctx->PreStreamHook(tv, det_ctx, p);
         if (action & ACTION_DROP) {
-            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_STREAM_PRE_HOOK);
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FW_STREAM_PRE_HOOK);
             return;
         }
     }
@@ -566,7 +566,7 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
     if (det_ctx != NULL && det_ctx->de_ctx->PreFlowHook != NULL) {
         const uint8_t action = det_ctx->de_ctx->PreFlowHook(tv, det_ctx, p);
         if (action & ACTION_DROP) {
-            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_PRE_HOOK);
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FW_FLOW_PRE_HOOK);
             goto pre_flow_drop;
         }
     }

--- a/src/flow.c
+++ b/src/flow.c
@@ -519,7 +519,11 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
     }
 
     if (f->flags & FLOW_ACTION_DROP) {
-        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
+        if (f->aux_flags & FLOW_AUX_ACTION_BY_FIREWALL) {
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FW_FLOW_DROP);
+        } else {
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
+        }
     }
 
     if (f->flags & FLOW_NOPAYLOAD_INSPECTION) {

--- a/src/flow.c
+++ b/src/flow.c
@@ -521,6 +521,8 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
     if (f->flags & FLOW_ACTION_DROP) {
         if (f->aux_flags & FLOW_AUX_ACTION_BY_FIREWALL) {
             PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FW_FLOW_DROP);
+        } else if (f->aux_flags & FLOW_AUX_ACTION_BY_EXCEPTION_POLICY) {
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_EP_FLOW_DROP);
         } else {
             PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
         }

--- a/src/flow.h
+++ b/src/flow.h
@@ -122,6 +122,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 /** next packet in toserver direction will act on updated app-layer state */
 #define FLOW_TS_APP_UPDATE_NEXT BIT_U32(31)
 
+/* aux flags */
+
 /* File flags */
 
 #define FLOWFILE_INIT                   0
@@ -402,6 +404,10 @@ typedef struct Flow_
     SCTime_t lastts;
 
     FlowStateType flow_state;
+
+    /* additional flags: in >8 we updated the flags field to u64, but not breaking the ABI
+     * we add additional flags here. */
+    uint8_t aux_flags;
 
     /** flow tenant id, used to setup flow timeout and stream pseudo
      *  packets with the correct tenant id set */

--- a/src/flow.h
+++ b/src/flow.h
@@ -126,6 +126,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 
 /** Flow action issued by firewall */
 #define FLOW_AUX_ACTION_BY_FIREWALL BIT_U8(0)
+/** Flow action issued by exception policy */
+#define FLOW_AUX_ACTION_BY_EXCEPTION_POLICY BIT_U8(1)
 
 /* File flags */
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -124,6 +124,9 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 
 /* aux flags */
 
+/** Flow action issued by firewall */
+#define FLOW_AUX_ACTION_BY_FIREWALL BIT_U8(0)
+
 /* File flags */
 
 #define FLOWFILE_INIT                   0

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -39,6 +39,7 @@
 #include "util-misc.h"
 #include "util-time.h"
 
+#include "detect-parse.h"
 #include "detect-engine.h"
 #include "detect-metadata.h"
 #include "app-layer-parser.h"
@@ -647,6 +648,49 @@ static bool AlertJsonStreamData(const AlertJsonOutputCtx *json_output_ctx, JsonA
     return false;
 }
 
+static void AlertJsonAddFirewall(SCJsonBuilder *jb, const Signature *s)
+{
+    struct DetectFirewallPolicy pol = { .action = s->action, .action_scope = s->action_scope };
+
+    SCJbOpenObject(jb, "firewall");
+    const char *hook = NULL;
+    char hook_string[256];
+    switch (s->detect_table) {
+        case DETECT_TABLE_APP_FILTER:
+            if (s->flags & SIG_FLAG_TOSERVER) {
+                hook = AppLayerParserGetStateNameById(
+                        IPPROTO_TCP, s->alproto, s->app_progress_hook, STREAM_TOSERVER);
+            } else {
+                hook = AppLayerParserGetStateNameById(
+                        IPPROTO_TCP, s->alproto, s->app_progress_hook, STREAM_TOCLIENT);
+            }
+            if (hook) {
+                snprintf(hook_string, sizeof(hook_string), "%s:%s", AppProtoToString(s->alproto),
+                        hook);
+                hook = hook_string;
+            }
+            break;
+        case DETECT_TABLE_PACKET_FILTER:
+            hook = "packet:filter";
+            break;
+        case DETECT_TABLE_PACKET_PRE_FLOW:
+            hook = "packet:pre_flow";
+            break;
+        case DETECT_TABLE_PACKET_PRE_STREAM:
+            hook = "packet:pre_stream";
+            break;
+    }
+    if (hook) {
+        SCJbSetString(jb, "hook", hook);
+    }
+    char policy_string[64] = "";
+    DetectFirewallPolicyToString(&pol, policy_string, sizeof(policy_string));
+    if (strlen(policy_string) > 0) {
+        SCJbSetString(jb, "policy", policy_string);
+    }
+    SCJbClose(jb);
+}
+
 static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 {
     AlertJsonOutputCtx *json_output_ctx = aft->json_output_ctx;
@@ -708,6 +752,10 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
         if (PacketIsTunnel(p)) {
             AlertJsonTunnel(p, jb);
+        }
+
+        if (pa->s->flags & SIG_FLAG_FIREWALL) {
+            AlertJsonAddFirewall(jb, pa->s);
         }
 
         if (p->flow != NULL) {

--- a/src/packet.c
+++ b/src/packet.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -125,6 +125,7 @@ void PacketReinit(Packet *p)
 #define RESET_PKT_LEN(p) ((p)->pktlen = 0)
     RESET_PKT_LEN(p);
     p->alerts.discarded = 0;
+    p->alerts.firewall_discarded = 0;
     p->alerts.suppressed = 0;
     p->alerts.drop.action = 0;
     if (p->alerts.cnt > 0) {

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -163,6 +163,7 @@ void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDro
             SCLogDebug("EXCEPTION_POLICY_DROP_FLOW");
             if (p->flow) {
                 p->flow->flags |= FLOW_ACTION_DROP;
+                p->flow->aux_flags |= FLOW_AUX_ACTION_BY_EXCEPTION_POLICY;
                 FlowSetNoPayloadInspectionFlag(p->flow);
                 StreamTcpDisableAppLayer(p->flow);
             }

--- a/src/util-mpm-hs-cache.c
+++ b/src/util-mpm-hs-cache.c
@@ -303,7 +303,7 @@ int HSHashDb(const PatternDatabase *pd, char *hash, size_t hash_len)
     SCMutexLock(&g_hs_ref_info_mutex);
     const char *ref_info = HSGetReferenceDbInfo();
     if (ref_info != NULL) {
-        SCSha256Update(hasher, (const uint8_t *)ref_info, strlen(ref_info));
+        SCSha256Update(hasher, (const uint8_t *)ref_info, (uint32_t)strlen(ref_info));
     }
     SCMutexUnlock(&g_hs_ref_info_mutex);
 
@@ -312,7 +312,7 @@ int HSHashDb(const PatternDatabase *pd, char *hash, size_t hash_len)
         SCHSCachePatternHash(pd->parray[i], hasher);
     }
 
-    if (!SCSha256FinalizeToHex(hasher, hash, hash_len)) {
+    if (!SCSha256FinalizeToHex(hasher, hash, (uint32_t)hash_len)) {
         hasher = NULL;
         SCLogDebug("sha256 hashing failed");
         return -1;

--- a/src/util-profiling-rulegroups.c
+++ b/src/util-profiling-rulegroups.c
@@ -247,7 +247,8 @@ SCProfilingSghDump(DetectEngineCtx *de_ctx)
 void
 SCProfilingSghUpdateCounter(DetectEngineThreadCtx *det_ctx, const SigGroupHead *sgh)
 {
-    if (det_ctx != NULL && det_ctx->sgh_perf_data != NULL && sgh->id < det_ctx->de_ctx->sgh_array_cnt) {
+    if (det_ctx != NULL && sgh != NULL && det_ctx->sgh_perf_data != NULL &&
+            sgh->id < det_ctx->de_ctx->sgh_array_cnt) {
         SCProfileSghData *p = &det_ctx->sgh_perf_data[sgh->id];
         p->checks++;
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -2348,7 +2348,6 @@ firewall:
   #rule-files:
   #  - firewall.rules
 
-
 ##
 ## Include other configs
 ##


### PR DESCRIPTION
FW backports, replaces #15490. Tries harder to be somewhat ABI stable, through not everything is compatible:

```
1 variable with incompatible sub-type changes:

  [C] 'CaptureStats t_capture_stats' was changed at decode.c:1031:1:
    size of symbol changed from 50 to 62
    type of variable changed:
      underlying type 'struct CaptureStats_' at decode.c:1007:1 changed:
        type size changed from 400 to 496 (in bits)
        3 data member insertions:
          'uint16_t counter_fw_accepted', at offset 64 (in bits) at decode.c:1024:1
          'uint16_t counter_fw_blocked', at offset 80 (in bits) at decode.c:1025:1
          'uint16_t counter_fw_rejected', at offset 96 (in bits) at decode.c:1026:1
        there are data member changes:
          type 'uint16_t[21]' of 'CaptureStats_::counter_drop_reason' changed:
            type name changed from 'uint16_t[21]' to 'uint16_t[24]'
            array type size changed from 336 to 384
            array type subrange 1 changed length from 21 to 24
          and offset changed from 64 to 112 (in bits) (by +48 bits)

'enum PacketDropReason at decode.h:380:1' changed:
  type size hasn't changed
  3 enumerator insertions:
    'PacketDropReason::PKT_DROP_REASON_FW_STREAM_PRE_HOOK' value '21'
    'PacketDropReason::PKT_DROP_REASON_FW_FLOW_PRE_HOOK' value '22'
    'PacketDropReason::PKT_DROP_REASON_FW_FLOW_DROP' value '23'
  5 enumerator changes:
  from 'PacketDropReason::PKT_DROP_REASON_DEFAULT_PACKET_POLICY = 17' to 'PacketDropReason::PKT_DROP_REASON_EP_FLOW_DROP = 17' at decode.h:381:1
  from 'PacketDropReason::PKT_DROP_REASON_DEFAULT_APP_POLICY = 18' to 'PacketDropReason::PKT_DROP_REASON_FW_RULES = 18' at decode.h:381:1
  from 'PacketDropReason::PKT_DROP_REASON_STREAM_PRE_HOOK = 19' to 'PacketDropReason::PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY = 19' at decode.h:381:1
  from 'PacketDropReason::PKT_DROP_REASON_FLOW_PRE_HOOK = 20' to 'PacketDropReason::PKT_DROP_REASON_FW_DEFAULT_APP_POLICY = 20' at decode.h:381:1
    'PacketDropReason::PKT_DROP_REASON_MAX' from value '21' to '24' at decode.h:381:1
'struct CaptureStats_ at decode.c:1007:1' changed:
  details were reported earlier

'struct DetectEngineCtx_ at detect.h:932:1' changed:
  type size changed from 39552 to 39616 (in bits)
  1 data member insertion:
    'DetectFirewallPolicies* fw_policies', at offset 39552 (in bits) at detect.h:1199:1

'struct DetectEngineThreadCtx_ at detect.h:1244:1' changed:
  type size hasn't changed
  1 data member insertion:
    'uint16_t counter_firewall_discarded_alerts', at offset 944 (in bits) at detect.h:1338:1

'struct DetectTransaction_ at detect-engine-prefilter.h:31:1' changed:
  type size changed from 384 to 320 (in bits)
  1 data member insertion:
    'bool is_last', at offset 288 (in bits) at detect-engine-prefilter.h:45:1
  there are data member changes:
    type 'const int' of 'DetectTransaction_::tx_progress' changed:
      'const int' changed to 'const uint8_t'
      in unqualified underlying type 'int' at stdint-uintn.h:24:1:
        entity changed from 'int' to 'typedef uint8_t' at stdint-uintn.h:24:1
        type size changed from 32 to 8 (in bits)
    and offset changed from 288 to 272 (in bits) (by -16 bits)
    type 'const int' of 'DetectTransaction_::tx_end_state' changed:
      'const int' changed to 'const uint8_t'
      in unqualified underlying type 'int' at stdint-uintn.h:24:1:
        entity changed from 'int' to 'typedef uint8_t' at stdint-uintn.h:24:1
        type size changed from 32 to 8 (in bits)
    and offset changed from 320 to 280 (in bits) (by -40 bits)

'struct Flow_ at flow.h:347:1' changed:
  type size hasn't changed
  1 data member insertion:
    'uint8_t aux_flags', at offset 720 (in bits) at flow.h:415:1

'struct PacketAlerts_ at decode.h:286:1' changed:
  type size hasn't changed
  1 data member insertion:
    'uint16_t firewall_discarded', at offset 48 (in bits) at decode.h:290:1

'struct Packet_ at decode.h:500:1' changed:
  type size hasn't changed
  there are data member changes:
    type 'typedef PacketAlerts' of 'Packet_::alerts' changed:
      underlying type 'struct PacketAlerts_' changed at decode.h:286:1, as reported earlier

```
CaptureStats and DetectTransaction should be considered private. PacketAlerts and Flow should be OK. DetectEngineCtx should be ok as long as it is allocated using the correct functions. DetectEngineThreadCtx should be ok. The drop reason enum values have changed, so if someone used the MAX for sizing an array there will be issues.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3128