### PR TITLE
conf-yaml: support glob patterns in include directive (v2)

### DIFF
--- a/doc/userguide/configuration/includes.rst
+++ b/doc/userguide/configuration/includes.rst
@@ -49,6 +49,24 @@ is the equivalent of::
       address-groups:
         HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
 
+Glob Patterns
+-------------
+
+Filenames in ``include`` may contain shell-style glob metacharacters
+(``*``, ``?``, ``[...]``). Patterns are expanded at startup via
+``glob(3)`` and each matching file is loaded in lexicographic order. A
+pattern that matches no files is logged as a warning and is not treated
+as an error, which allows drop-in ``conf.d/``-style directories to be
+empty.
+
+::
+
+    include:
+      - /etc/suricata/conf.d/*.yaml
+
+Relative patterns are resolved against the directory of the top-level
+configuration file, the same as literal includes.
+
 .. note:: Suricata versions less than 7 required multiple ``include``
     statements to be specified to include more than one file. While
     Suricata 7.0 still supports this it will issue a deprecation

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -27,6 +27,9 @@
 #include "conf.h"
 #include "conf-yaml-loader.h"
 #include <yaml.h>
+#ifdef HAVE_GLOB_H
+#include <glob.h>
+#endif
 #include "util-path.h"
 #include "util-debug.h"
 #include "util-unittest.h"
@@ -104,18 +107,17 @@ ConfYamlSetConfDirname(const char *filename)
 }
 
 /**
- * \brief Include a file in the configuration.
+ * \brief Include a single resolved file in the configuration.
  *
  * \param parent The configuration node the included configuration will be
  *          placed at.
- * \param filename The filename to include.
+ * \param filename The fully resolved filename to include.
  *
  * \retval 0 on success, -1 on failure.
  */
-int SCConfYamlHandleInclude(SCConfNode *parent, const char *filename)
+static int ConfYamlHandleIncludeOne(SCConfNode *parent, const char *filename)
 {
     yaml_parser_t parser;
-    char include_filename[PATH_MAX];
     FILE *file = NULL;
     int ret = -1;
 
@@ -124,18 +126,9 @@ int SCConfYamlHandleInclude(SCConfNode *parent, const char *filename)
         return -1;
     }
 
-    if (PathIsAbsolute(filename)) {
-        strlcpy(include_filename, filename, sizeof(include_filename));
-    }
-    else {
-        snprintf(include_filename, sizeof(include_filename), "%s/%s",
-            conf_dirname, filename);
-    }
-
-    file = fopen(include_filename, "r");
+    file = fopen(filename, "r");
     if (file == NULL) {
-        SCLogError("Failed to open configuration include file %s: %s", include_filename,
-                strerror(errno));
+        SCLogError("Failed to open configuration include file %s: %s", filename, strerror(errno));
         goto done;
     }
 
@@ -155,6 +148,62 @@ done:
     }
 
     return ret;
+}
+
+/**
+ * \brief Include a file or glob pattern in the configuration.
+ *
+ * Relative paths are resolved against the directory of the top-level config
+ * file. If the input contains glob metacharacters (\c *, \c ?, \c [) the
+ * pattern is expanded via glob(3) and each match is included in lexicographic
+ * order. A pattern that matches no files is logged as a warning and not
+ * treated as an error, to support drop-in `conf.d/` directories.
+ *
+ * \param parent The configuration node the included configuration will be
+ *          placed at.
+ * \param filename The filename or glob pattern to include.
+ *
+ * \retval 0 on success, -1 on failure.
+ */
+int SCConfYamlHandleInclude(SCConfNode *parent, const char *filename)
+{
+    char include_filename[PATH_MAX];
+
+    if (PathIsAbsolute(filename)) {
+        strlcpy(include_filename, filename, sizeof(include_filename));
+    } else {
+        snprintf(include_filename, sizeof(include_filename), "%s/%s", conf_dirname, filename);
+    }
+
+#ifdef HAVE_GLOB_H
+    if (strpbrk(filename, "*?[") != NULL) {
+        glob_t globbuf;
+        int gret = glob(include_filename, 0, NULL, &globbuf);
+
+        if (gret == GLOB_NOMATCH) {
+            SCLogWarning("No files match include pattern %s", include_filename);
+            return 0;
+        } else if (gret != 0) {
+            SCLogError(
+                    "Failed to expand include pattern %s: %s", include_filename, strerror(errno));
+            return -1;
+        }
+
+        int ret = 0;
+        for (size_t i = 0; i < (size_t)globbuf.gl_pathc; i++) {
+            const char *path = globbuf.gl_pathv[i];
+            SCLogInfo("Including configuration file %s (matched %s).", path, filename);
+            if (ConfYamlHandleIncludeOne(parent, path) != 0) {
+                ret = -1;
+                break;
+            }
+        }
+        globfree(&globbuf);
+        return ret;
+    }
+#endif
+
+    return ConfYamlHandleIncludeOne(parent, include_filename);
 }
 
 /**


### PR DESCRIPTION
Continuation of #15573 (v2). See "Changes since #15573" below.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8427

## Describe changes:

`SCConfYamlHandleInclude` now expands shell-style glob patterns (`*`, `?`, `[`) via `glob(3)` when the include path contains them. Each match is loaded in lexicographic (sorted) order; literal paths bypass `glob()` and take the existing per-file path. A pattern matching zero files is logged as a warning, not an error, so drop-in `conf.d/`-style directories may be empty. The precedent for the `glob(3)` shape and `HAVE_GLOB_H` gating is `rule-files:` in `src/detect-engine-loader.c`.

### Changes since #15573

- Moved the test coverage out of C unit tests and into suricata-verify, as requested in review (victorjulien, jasonish). The two `HAVE_GLOB_H` unit tests (`ConfYamlFileIncludeGlobTest`, `ConfYamlFileIncludeGlobNoMatchTest`) and their registration are removed.
- The new suricata-verify test (`config-includes-glob-order`) specifically asserts that glob matches are included in **deterministic lexicographic order** (the `01..99` drop-in convention jasonish asked about): three drop-ins set the same key and the highest-prefix file wins under `--dump-config`.
- Removing those C unit tests also resolves the two CodeQL "file created without restricting permissions (mode 0666)" High warnings, which were raised on the `fopen(..., "w")` calls inside the removed tests.


### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3151
