### PR TITLE
fix null pointer dereferences found by malloc-error-check cocci

### DIFF
--- a/qa/coccinelle/malloc-error-check.cocci
+++ b/qa/coccinelle/malloc-error-check.cocci
@@ -1,7 +1,7 @@
 @malloced@
 expression x;
 position p1;
-identifier func =~ "(SCMalloc|SCStrdup|SCCalloc|SCMallocAligned|SCRealloc)";
+identifier func =~ "SCMalloc\|SCStrdup\|SCCalloc\|SCMallocAligned\|SCRealloc";
 @@
 
 x@p1 = func(...)
@@ -10,7 +10,7 @@ x@p1 = func(...)
 expression x, E;
 statement S;
 position malloced.p1;
-identifier func =~ "(SCMalloc|SCStrdup|SCCalloc|SCMallocAligned|SCRealloc)";
+identifier func =~ "SCMalloc\|SCStrdup\|SCCalloc\|SCMallocAligned\|SCRealloc";
 @@
 
 (
@@ -22,7 +22,7 @@ if (E && (x@p1 = func(...)) == NULL) S
 @realloc exists@
 position malloced.p1;
 expression x, E1;
-identifier func =~ "(SCMalloc|SCCalloc|SCMallocAligned)";
+identifier func =~ "SCMalloc\|SCCalloc\|SCMallocAligned";
 @@
 
 x@p1 = func(...)
@@ -33,7 +33,7 @@ x = SCRealloc(x, E1)
 expression x, E1;
 position malloced.p1;
 statement S1, S2;
-identifier func =~ "(SCMalloc|SCStrdup|SCCalloc|SCMallocAligned|SCRealloc)";
+identifier func =~ "SCMalloc\|SCStrdup\|SCCalloc\|SCMallocAligned\|SCRealloc";
 @@
 
 x@p1 = func(...)

--- a/src/decode.c
+++ b/src/decode.c
@@ -143,10 +143,7 @@ ExceptionPolicyStatsSetts flow_memcap_eps_stats = {
  */
 PacketAlert *PacketAlertCreate(void)
 {
-    PacketAlert *pa_array = SCCalloc(packet_alert_max, sizeof(PacketAlert));
-    DEBUG_VALIDATE_BUG_ON(pa_array == NULL);
-
-    return pa_array;
+    return SCCalloc(packet_alert_max, sizeof(PacketAlert));
 }
 
 void PacketAlertRecycle(PacketAlert *pa_array, uint16_t cnt)
@@ -267,7 +264,10 @@ Packet *PacketGetFromAlloc(void)
     if (unlikely(p == NULL)) {
         return NULL;
     }
-    PacketInit(p);
+    if (!PacketInit(p)) {
+        SCFree(p);
+        return NULL;
+    }
     p->ReleasePacket = PacketFree;
 
     SCLogDebug("allocated a new packet only using alloc...");

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1158,7 +1158,10 @@ static Packet *BuildIpv4TestPacket(
     if (unlikely(p == NULL))
         return NULL;
 
-    PacketInit(p);
+    if (!PacketInit(p)) {
+        SCFree(p);
+        return NULL;
+    }
 
     struct timeval tval;
     gettimeofday(&tval, NULL);
@@ -1222,7 +1225,7 @@ static int BuildIpv4TestPacketWithContent(Packet **packet, uint8_t proto, uint16
     p = SCCalloc(1, sizeof(*p) + default_packet_size);
     FAIL_IF_NULL(p);
 
-    PacketInit(p);
+    FAIL_IF(!PacketInit(p));
 
     struct timeval tval;
     gettimeofday(&tval, NULL);
@@ -1277,7 +1280,10 @@ static Packet *BuildIpv6TestPacket(
     if (unlikely(p == NULL))
         return NULL;
 
-    PacketInit(p);
+    if (!PacketInit(p)) {
+        SCFree(p);
+        return NULL;
+    }
 
     struct timeval tval;
     gettimeofday(&tval, NULL);
@@ -1347,7 +1353,10 @@ static Packet *BuildIpv6TestPacketWithContent(
     if (unlikely(p == NULL))
         return NULL;
 
-    PacketInit(p);
+    if (!PacketInit(p)) {
+        SCFree(p);
+        return NULL;
+    }
 
     struct timeval tval;
     gettimeofday(&tval, NULL);

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -360,6 +360,9 @@ static inline int PacketAlertSetContext(
                     }
                 }
                 current_json->json_string = SCStrdup(det_ctx->json_content[i].json_content);
+                if (current_json->json_string == NULL) {
+                    return -1;
+                }
                 SCLogDebug("json content %u, value '%s' (%p)", (unsigned int)i,
                         current_json->json_string, s);
             }

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -793,11 +793,11 @@ int DetectFlowbitsAnalyze(DetectEngineCtx *de_ctx)
                     uint32_t new_fb_array_size = s->init_data->rule_state_flowbits_ids_size + 1;
                     void *tmp_fb_ptr = SCRealloc(s->init_data->rule_state_flowbits_ids_array,
                             new_fb_array_size * sizeof(uint32_t));
-                    s->init_data->rule_state_flowbits_ids_array = tmp_fb_ptr;
-                    if (s->init_data->rule_state_flowbits_ids_array == NULL) {
+                    if (tmp_fb_ptr == NULL) {
                         SCLogError("Failed to reallocate memory for rule_state_variable_idx");
                         goto error;
                     }
+                    s->init_data->rule_state_flowbits_ids_array = tmp_fb_ptr;
                     SCLogDebug(
                             "realloc'ed array for flowbits ids, new size is %u", new_fb_array_size);
                     s->init_data->rule_state_dependant_sids_size = new_array_size;

--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -153,6 +153,9 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
     if (strlen(scheme)) {
         SCLogConfig("scheme value %s overrides key %s", scheme, key);
         ref->key = SCStrdup(scheme);
+        if (ref->key == NULL) {
+            goto error;
+        }
         /* already bound checked to be REFERENCE_SYSTEM_NAME_MAX or less */
         ref->key_len = (uint16_t)strlen(scheme);
     } else {
@@ -160,6 +163,9 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
         SCRConfReference *lookup_ref_conf = SCRConfGetReference(key, de_ctx);
         if (lookup_ref_conf != NULL) {
             ref->key = SCStrdup(lookup_ref_conf->url);
+            if (ref->key == NULL) {
+                goto error;
+            }
             /* already bound checked to be REFERENCE_SYSTEM_NAME_MAX or less */
             ref->key_len = (uint16_t)strlen(ref->key);
         } else {

--- a/src/packet.c
+++ b/src/packet.c
@@ -70,12 +70,16 @@ uint8_t PacketGetAction(const Packet *p)
 /**
  *  \brief Initialize a packet structure for use.
  */
-void PacketInit(Packet *p)
+bool PacketInit(Packet *p)
 {
     SCSpinInit(&p->persistent.tunnel_lock, 0);
     p->alerts.alerts = PacketAlertCreate();
+    if (unlikely(p->alerts.alerts == NULL)) {
+        return false;
+    }
     p->livedev_id = 0;
     p->livedev_dst_id = 0;
+    return true;
 }
 
 void PacketReleaseRefs(Packet *p)

--- a/src/packet.h
+++ b/src/packet.h
@@ -32,7 +32,7 @@ static inline uint8_t PacketTestAction(const Packet *p, const uint8_t a)
 }
 #endif
 
-void PacketInit(Packet *p);
+bool PacketInit(Packet *p);
 void PacketReleaseRefs(Packet *p);
 void PacketReinit(Packet *p);
 void PacketRecycle(Packet *p);

--- a/src/tests/fuzz/fuzz_decodebase64.c
+++ b/src/tests/fuzz/fuzz_decodebase64.c
@@ -19,6 +19,8 @@ static void Base64FuzzTest(const uint8_t *src, size_t len)
 {
     uint32_t decoded_len = SCBase64DecodeBufferSize((uint32_t)len);
     uint8_t *decoded = SCCalloc(decoded_len, sizeof(uint8_t));
+    if (decoded == NULL)
+        return;
 
     for (uint8_t mode = SCBase64ModeRFC2045; mode <= SCBase64ModeStrict; mode++) {
         (void)SCBase64Decode(src, len, mode, decoded);

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -673,6 +673,9 @@ int SCConfLogOpenRedis(SCConfNode *redis_node, void *lf_ctx)
             format string, whose length is limited by the length of the
             maxlen integer formatted as a string */
             log_ctx->redis_setup.stream_format = SCCalloc(100, sizeof(char));
+            if (unlikely(log_ctx->redis_setup.stream_format == NULL)) {
+                FatalError("Unable to allocate redis stream format");
+            }
             snprintf(log_ctx->redis_setup.stream_format, 100, redis_stream_format_maxlen_tmpl, "%s",
                     "%s", exact ? '=' : '~', maxlen, "%s");
             log_ctx->redis_setup.format = log_ctx->redis_setup.stream_format;

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -641,7 +641,7 @@ static int CompileDataExtensionsInit(hs_expr_ext_t **ext, const SCHSPattern *p)
 {
     if (p->flags & (MPM_PATTERN_FLAG_OFFSET | MPM_PATTERN_FLAG_DEPTH)) {
         *ext = SCCalloc(1, sizeof(hs_expr_ext_t));
-        if ((*ext) == NULL) {
+        if (*ext == NULL) {
             return -1;
         }
         if (p->flags & MPM_PATTERN_FLAG_OFFSET) {
@@ -1178,8 +1178,7 @@ void SCHSPrintInfo(MpmCtx *mpm_ctx)
 
 static MpmConfig *SCHSConfigInit(void)
 {
-    MpmConfig *c = SCCalloc(1, sizeof(MpmConfig));
-    return c;
+    return SCCalloc(1, sizeof(MpmConfig));
 }
 
 static void SCHSConfigDeinit(MpmConfig **c)


### PR DESCRIPTION
Supersedes #15560. Changes from previous iteration:

- `qa/cocci`: added Ticket: 8641
- `decode`: commit message no longer references FatalError (not present in main)
- `decode`: defrag.c helpers — helpers returning `Packet *` use explicit NULL check; the one returning `int` keeps FAIL_IF style