### PR TITLE
detect/parse: assert HashListTableLookup results in duplicate sig check

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3390,7 +3390,9 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
             sw_tmp.s = de_ctx->sig_list;
             sw_old = HashListTableLookup(de_ctx->dup_sig_hash_table,
                                          (void *)&sw_tmp, 0);
-            /* sw_old == NULL case is impossible */
+            /* sw_old == NULL case is impossible: every sig in sig_list
+             * must have a corresponding dup_sig_hash_table entry */
+            DEBUG_VALIDATE_BUG_ON(sw_old == NULL);
             sw_old->s_prev = sig;
         }
 
@@ -3425,6 +3427,7 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
         if (sw_temp.s != NULL) {
             sw_next = HashListTableLookup(de_ctx->dup_sig_hash_table,
                                           (void *)&sw_temp, 0);
+            DEBUG_VALIDATE_BUG_ON(sw_next == NULL);
             sw_next->s_prev = sw_dup->s_prev;
         }
         SigFree(de_ctx, sw_dup->s);
@@ -3455,6 +3458,7 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
         if (sw_temp.s != NULL) {
             sw_next = HashListTableLookup(de_ctx->dup_sig_hash_table,
                                           (void *)&sw_temp, 0);
+            DEBUG_VALIDATE_BUG_ON(sw_next == NULL);
             sw_next->s_prev = sw_dup->s_prev;
         }
         SigFree(de_ctx, sw_dup->s);
@@ -3470,6 +3474,7 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
         sw_tmp.s = de_ctx->sig_list;
         SigDuplWrapper *sw_old = HashListTableLookup(de_ctx->dup_sig_hash_table,
                                                      (void *)&sw_tmp, 0);
+        DEBUG_VALIDATE_BUG_ON(sw_old == NULL);
         if (sw_old->s != sw_dup->s) {
             // Link on top of the list if there was another element
             sw_old->s_prev = sig;


### PR DESCRIPTION
Supersedes #15557. Only DEBUG_VALIDATE_BUG_ON additions as requested — no production NULL guards.