### PR TITLE
detect: fail thread init on keyword ctx error (and fix cbindgen build break)

### DIFF
--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -58,7 +58,13 @@
 
 static int DetectByteMathSetup(DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
+/* Newer cbindgen (>= 0.29.3) exports the Rust DETECT_BYTEMATH_ENDIAN_DEFAULT
+ * constant into rust-bindings.h as a macro. Only define it here when that
+ * binding did not, to avoid a -Werror macro redefinition while still building
+ * with older cbindgen versions that do not emit it. */
+#ifndef DETECT_BYTEMATH_ENDIAN_DEFAULT
 #define DETECT_BYTEMATH_ENDIAN_DEFAULT (uint8_t) BigEndian
+#endif
 #define DETECT_BYTEMATH_BASE_DEFAULT   (uint8_t) BaseDec
 
 static void DetectByteMathRegisterTests(void);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3423,8 +3423,8 @@ static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *
     }
     det_ctx->multi_inspect.to_clear_idx = 0;
 
-
-    DetectEngineThreadCtxInitKeywords(de_ctx, det_ctx);
+    if (DetectEngineThreadCtxInitKeywords(de_ctx, det_ctx) != TM_ECODE_OK)
+        return TM_ECODE_FAILED;
     DetectEngineThreadCtxInitGlobalKeywords(det_ctx);
 #ifdef PROFILE_RULES
     SCProfilingRuleThreadSetup(de_ctx->profile_ctx, det_ctx);
@@ -5435,6 +5435,52 @@ static int DetectEngineTest09(void)
     PASS;
 }
 
+/** \brief keyword thread-context init stub that always fails, used to mimic a
+ *  failing per-thread keyword init such as DetectFilemagicThreadInit. */
+static void *DetectEngineFailingThreadKeywordInit(void *data)
+{
+    (void)data;
+    return NULL;
+}
+
+static void DetectEngineNoopThreadKeywordFree(void *ctx)
+{
+    (void)ctx;
+}
+
+/** \test Ticket #8237: a failing per-thread keyword init must make the detect
+ *  thread context init fail rather than silently continuing with a partially
+ *  initialized keyword context array. */
+static int DetectEngineThreadCtxInitKeywordFailTest(void)
+{
+    ThreadVars th_v;
+    memset(&th_v, 0, sizeof(th_v));
+    DetectEngineThreadCtx *det_ctx = NULL;
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (sid:1;)");
+    FAIL_IF_NULL(s);
+
+    SigGroupBuild(de_ctx);
+
+    /* Register a keyword whose per-thread init fails (returns NULL). */
+    int id = DetectRegisterThreadCtxFuncs(de_ctx, "test_failing_keyword",
+            DetectEngineFailingThreadKeywordInit, NULL, DetectEngineNoopThreadKeywordFree, 0);
+    FAIL_IF(id < 0);
+
+    /* Thread context init must report failure and not hand back a context. */
+    TmEcode r = DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+    FAIL_IF(r != TM_ECODE_FAILED);
+    FAIL_IF_NOT_NULL(det_ctx);
+
+    DetectEngineCtxFree(de_ctx);
+
+    PASS;
+}
+
 #endif
 
 void DetectEngineRegisterTests(void)
@@ -5446,5 +5492,7 @@ void DetectEngineRegisterTests(void)
     UtRegisterTest("DetectEngineTest04", DetectEngineTest04);
     UtRegisterTest("DetectEngineTest08", DetectEngineTest08);
     UtRegisterTest("DetectEngineTest09", DetectEngineTest09);
+    UtRegisterTest(
+            "DetectEngineThreadCtxInitKeywordFailTest", DetectEngineThreadCtxInitKeywordFailTest);
 #endif
 }


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in doc/userguide/) to reflect the changes made
- [ ] I have updated the JSON schema (in etc/schema.json) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8237

Describe changes:
- Supersedes #15588. This version also fixes the unrelated build break that was failing CI there.
- **Commit 1 (build fix): `detect: guard duplicate bytemath endian macro`.** Newer cbindgen (>= 0.29.3, e.g. 0.29.4) now exports the long-standing Rust `pub const DETECT_BYTEMATH_ENDIAN_DEFAULT` into `rust-bindings.h` as a macro. That collides under `-Werror` with the macro defined under `UNITTESTS` in `detect-bytemath.c`, which is why every build job on `main` started failing. The C macro is now guarded with `#ifndef`, so it is only defined when the binding did not, keeping the build working with both newer and older cbindgen (the `min` supported is 0.20.0; the `commit-check` job uses 0.24.3, which does not emit the macro). Validated by building `detect-bytemath.o` both with the macro present (newer cbindgen) and absent (older cbindgen) and running the bytemath unit tests (19 passed).
- **Commit 2 (the actual fix, Ticket #8237): `detect: fail thread init on keyword ctx error`.** `ThreadCtxDoInit` ignored the return of `DetectEngineThreadCtxInitKeywords`, so a failing per-thread keyword init (for example `DetectFilemagicThreadInit`) left a partially initialized keyword context array and the detect thread ran with indeterminate results. The failure is now propagated so the callers abort thread init and clean up, with a unit test that fails without the fix and passes with it.
