### PR TITLE
doc: clarify suricata.yaml location per install (v2)

### DIFF
--- a/doc/userguide/quickstart.rst
+++ b/doc/userguide/quickstart.rst
@@ -48,6 +48,15 @@ Use that information to configure Suricata::
 
     sudo vim /etc/suricata/suricata.yaml
 
+.. note::
+
+    The location of ``suricata.yaml`` depends on how Suricata was installed.
+    Distribution packages (such as the PPA used above) install it to
+    ``/etc/suricata/suricata.yaml``. A build from source installs it under the
+    prefix passed to ``configure``, which defaults to ``/usr/local``, so the
+    file is at ``/usr/local/etc/suricata/suricata.yaml`` instead. See
+    :ref:`installation` for details.
+
 There are many possible configuration options, we focus on the setup of
 the ``HOME_NET`` variable and the network interface configuration. The
 ``HOME_NET`` variable should include, in most scenarios, the IP address of


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in doc/userguide/) to reflect the changes made
- [ ] I have updated the JSON schema (in etc/schema.json) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8358

#### Describe changes:
- The Quickstart Basic Setup step pointed users at /etc/suricata/suricata.yaml, which is correct for the Ubuntu PPA install the guide uses but not for a build from source.
- Added a note next to the edit step explaining the config location depends on the install method, and linked to the installation chapter. Kept the package path as the default so the guide stays correct for PPA users.
- Verified the user guide builds cleanly with Sphinx and the cross reference to the installation chapter resolves.

Replaces #15587 (v1). v2 addresses review feedback from @jufajardini: the note now says a source build installs the config under the prefix passed to configure, which defaults to /usr/local, rather than implying /usr/local is fixed.

