### PR TITLE
output-json: avoid freeing caller-owned JSON builder

### DIFF
--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -148,8 +148,7 @@ static bool EveEmailLogJsonData(
             smtp_state = (SMTPState *)state;
             if (smtp_state == NULL) {
                 SCLogDebug("no smtp state, so no request logging");
-                SCJbFree(sjs);
-                SCReturnPtr(NULL, "SCJsonBuilder");
+                SCReturnBool(false);
             }
             SMTPTransaction *tx = vtx;
             mime_state = tx->mime_state;

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -53,6 +53,10 @@
 
 static void EveSmtpDataLogger(void *state, void *vtx, SCJsonBuilder *js)
 {
+    if (state == NULL || vtx == NULL) {
+        return;
+    }
+
     SMTPTransaction *tx = vtx;
     SMTPString *rcptto_str;
     if (((SMTPState *)state)->helo) {


### PR DESCRIPTION
Link to ticket:
https://redmine.openinfosecfoundation.org/issues/8647

Describe changes:

* Stop freeing the caller-owned `SCJsonBuilder` in `EveEmailLogJsonData()` when SMTP state is unavailable.
* Return failure and let the caller handle cleanup.
* Add defensive NULL checks in `EveSmtpDataLogger()` for `state` and `vtx`.

The builder is owned by the caller and may still be used during cleanup after `EveEmailLogJsonData()` returns. This change keeps ownership handling consistent and makes the SMTP Eve logging path more robust.

This is a small correctness/hardening fix. I have not verified whether the NULL-state path is reachable during normal runtime.
