### PR TITLE
output-json: avoid freeing caller-owned JSON builder

### DIFF
--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -148,8 +148,7 @@ static bool EveEmailLogJsonData(
             smtp_state = (SMTPState *)state;
             if (smtp_state == NULL) {
                 SCLogDebug("no smtp state, so no request logging");
-                SCJbFree(sjs);
-                SCReturnPtr(NULL, "SCJsonBuilder");
+                SCReturnBool(false);
             }
             SMTPTransaction *tx = vtx;
             mime_state = tx->mime_state;

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -53,6 +53,10 @@
 
 static void EveSmtpDataLogger(void *state, void *vtx, SCJsonBuilder *js)
 {
+    if (state == NULL || vtx == NULL) {
+        return;
+    }
+
     SMTPTransaction *tx = vtx;
     SMTPString *rcptto_str;
     if (((SMTPState *)state)->helo) {


### PR DESCRIPTION
Supersedes #15594.

Link to ticket:
https://redmine.openinfosecfoundation.org/issues/8647

Describe changes:

- Stop freeing the caller-owned SCJsonBuilder in EveEmailLogJsonData() when SMTP state is unavailable.
- Return failure and let the caller handle cleanup.
- Add defensive NULL checks in EveSmtpDataLogger() for state and vtx.

This is a small correctness/hardening fix to keep ownership handling consistent in the SMTP Eve logging path.