### PR TITLE
Yaml null 8651 v5

### DIFF
--- a/plugins/pfring/runmode-pfring.c
+++ b/plugins/pfring/runmode-pfring.c
@@ -134,7 +134,7 @@ static void *OldParsePfringConfig(const char *iface)
         SCLogInfo("%s: ZC interface detected, not setting cluster-id", pfconf->iface);
     } else if ((pfconf->threads == 1) && (strncmp(pfconf->iface, "dna", 3) == 0)) {
         SCLogInfo("DNA interface detected, not setting cluster-id");
-    } else if (SCConfGet("pfring.cluster-id", &tmpclusterid) != 1) {
+    } else if (SCConfGetNonNull("pfring.cluster-id", &tmpclusterid) != 1) {
         SCLogError("Could not get cluster-id from config");
     } else {
         if (StringParseInt32(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
@@ -152,7 +152,7 @@ static void *OldParsePfringConfig(const char *iface)
     } else if ((pfconf->threads == 1) && (strncmp(pfconf->iface, "dna", 3) == 0)) {
         SCLogInfo(
                 "%s: DNA interface detected, not setting cluster type for PF_RING", pfconf->iface);
-    } else if (SCConfGet("pfring.cluster-type", &tmpctype) != 1) {
+    } else if (SCConfGetNonNull("pfring.cluster-type", &tmpctype) != 1) {
         SCLogError("Could not get cluster-type from config");
     } else if (strcmp(tmpctype, "cluster_round_robin") == 0) {
         SCLogInfo("%s: Using round-robin cluster mode for PF_RING", pfconf->iface);
@@ -275,7 +275,7 @@ static void *ParsePfringConfig(const char *iface)
     (void)SC_ATOMIC_ADD(pfconf->ref, pfconf->threads);
 
     /* command line value has precedence */
-    if (SCConfGet("pfring.cluster-id", &tmpclusterid) == 1) {
+    if (SCConfGetNonNull("pfring.cluster-id", &tmpclusterid) == 1) {
         if (StringParseInt32(&pfconf->cluster_id, 10, 0, (const char *)tmpclusterid) < 0) {
             SCLogWarning("Invalid value for "
                          "pfring.cluster-id: '%s'. Resetting to 1.",
@@ -425,7 +425,7 @@ static int GetDevAndParser(const char **live_dev, ConfigIfaceParserFunc *parser)
         *parser = OldParsePfringConfig;
         /* In v1: try to get interface name from config */
         if (*live_dev == NULL) {
-            if (SCConfGet("pfring.interface", live_dev) == 1) {
+            if (SCConfGetNonNull("pfring.interface", live_dev) == 1) {
                 SCLogInfo("Using interface %s", *live_dev);
                 LiveRegisterDevice(*live_dev);
             } else {

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -263,6 +263,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn SCConfGetNonNull(
+        name: *const ::std::os::raw::c_char, vptr: *mut *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn SCConfGetInt(
         name: *const ::std::os::raw::c_char, val: *mut intmax_t,
     ) -> ::std::os::raw::c_int;

--- a/src/app-layer-htp-mem.c
+++ b/src/app-layer-htp-mem.c
@@ -48,7 +48,7 @@ void HTPParseMemcap(void)
 
     /** set config values for memcap, prealloc and hash_size */
     uint64_t memcap;
-    if ((SCConfGet("app-layer.protocols.http.memcap", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("app-layer.protocols.http.memcap", &conf_val)) == 1) {
         if (ParseSizeStringU64(conf_val, &memcap) < 0) {
             SCLogError("Error parsing http.memcap "
                        "from conf file - %s.  Killing engine",

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -172,7 +172,7 @@ void HttpRangeContainersInit(void)
     const char *str = NULL;
     uint64_t memcap = HTTP_RANGE_DEFAULT_MEMCAP;
     uint32_t timeout = HTTP_RANGE_DEFAULT_TIMEOUT;
-    if (SCConfGet("app-layer.protocols.http.byterange.memcap", &str) == 1) {
+    if (SCConfGetNonNull("app-layer.protocols.http.byterange.memcap", &str) == 1) {
         if (ParseSizeStringU64(str, &memcap) < 0) {
             SCLogWarning("memcap value cannot be deduced: %s,"
                          " resetting to default",
@@ -180,7 +180,7 @@ void HttpRangeContainersInit(void)
             memcap = 0;
         }
     }
-    if (SCConfGet("app-layer.protocols.http.byterange.timeout", &str) == 1) {
+    if (SCConfGetNonNull("app-layer.protocols.http.byterange.timeout", &str) == 1) {
         size_t slen = strlen(str);
         if (slen > UINT16_MAX || StringParseUint32(&timeout, 10, (uint16_t)slen, str) <= 0) {
             SCLogWarning("timeout value cannot be deduced: %s,"

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -452,7 +452,7 @@ static void SMTPConfigure(void) {
     uint64_t value = SMTP_DEFAULT_MAX_TX;
     smtp_config.max_tx = SMTP_DEFAULT_MAX_TX;
     const char *str = NULL;
-    if (SCConfGet("app-layer.protocols.smtp.max-tx", &str) == 1) {
+    if (SCConfGetNonNull("app-layer.protocols.smtp.max-tx", &str) == 1) {
         if (ParseSizeStringU64(str, &value) < 0) {
             SCLogWarning("max-tx value cannot be deduced: %s,"
                          " keeping default",

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -90,7 +90,7 @@ void RegisterSSHParsers(void)
         /* Check if we should generate Hassh fingerprints */
         int enable_hassh = SSH_CONFIG_DEFAULT_HASSH;
         const char *strval = NULL;
-        if (SCConfGet("app-layer.protocols.ssh.hassh", &strval) != 1) {
+        if (SCConfGetNonNull("app-layer.protocols.ssh.hassh", &strval) != 1) {
             enable_hassh = SSH_CONFIG_DEFAULT_HASSH;
         } else if (strcmp(strval, "auto") == 0) {
             enable_hassh = SSH_CONFIG_DEFAULT_HASSH;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -3137,7 +3137,7 @@ static void CheckJA3Enabled(void)
     const char *strval = NULL;
     /* Check if we should generate JA3 fingerprints */
     int enable_ja3 = SSL_CONFIG_DEFAULT_JA3;
-    if (SCConfGet("app-layer.protocols.tls.ja3-fingerprints", &strval) != 1) {
+    if (SCConfGetNonNull("app-layer.protocols.tls.ja3-fingerprints", &strval) != 1) {
         enable_ja3 = SSL_CONFIG_DEFAULT_JA3;
     } else if (strcmp(strval, "auto") == 0) {
         enable_ja3 = SSL_CONFIG_DEFAULT_JA3;
@@ -3162,7 +3162,7 @@ static void CheckJA4Enabled(void)
     const char *strval = NULL;
     /* Check if we should generate JA4 fingerprints */
     int enable_ja4 = SSL_CONFIG_DEFAULT_JA4;
-    if (SCConfGet("app-layer.protocols.tls.ja4-fingerprints", &strval) != 1) {
+    if (SCConfGetNonNull("app-layer.protocols.tls.ja4-fingerprints", &strval) != 1) {
         enable_ja4 = SSL_CONFIG_DEFAULT_JA4;
     } else if (strcmp(strval, "auto") == 0) {
         enable_ja4 = SSL_CONFIG_DEFAULT_JA4;

--- a/src/conf.c
+++ b/src/conf.c
@@ -361,6 +361,30 @@ int SCConfGet(const char *name, const char **vptr)
     }
 }
 
+/**
+ * \brief Retrieve the non-null value of a configuration node.
+ *
+ * This function will return the value for a configuration node based
+ * on the full name of the node. If the value were NULL, return 0
+ * (this could happen if the requested node does exist but is not a node
+ *  that contains a value, but contains children SCConfNodes instead.)
+ *
+ * \param name Name of configuration parameter to get.
+ * \param vptr Pointer that will be set to the configuration value parameter.
+ *   Note that this is just a reference to the actual value, not a copy.
+ *
+ * \retval 1 will be returned if the value is found, otherwise 0 will
+ *   be returned.
+ */
+int SCConfGetNonNull(const char *name, const char **vptr)
+{
+    int r = SCConfGet(name, vptr);
+    if (r == 1 && *vptr == NULL) {
+        return 0;
+    }
+    return r;
+}
+
 int SCConfGetChildValue(const SCConfNode *base, const char *name, const char **vptr)
 {
     SCConfNode *node = SCConfNodeLookupChild(base, name);
@@ -500,7 +524,7 @@ int SCConfGetBool(const char *name, int *val)
     const char *strval = NULL;
 
     *val = 0;
-    if (SCConfGet(name, &strval) != 1)
+    if (SCConfGetNonNull(name, &strval) != 1)
         return 0;
 
     *val = SCConfValIsTrue(strval);
@@ -604,7 +628,7 @@ int SCConfGetDouble(const char *name, double *val)
     double tmpdo;
     char *endptr;
 
-    if (SCConfGet(name, &strval) == 0)
+    if (SCConfGetNonNull(name, &strval) == 0)
         return 0;
 
     errno = 0;
@@ -634,7 +658,7 @@ int SCConfGetFloat(const char *name, float *val)
     double tmpfl;
     char *endptr;
 
-    if (SCConfGet(name, &strval) == 0)
+    if (SCConfGetNonNull(name, &strval) == 0)
         return 0;
 
     errno = 0;

--- a/src/conf.h
+++ b/src/conf.h
@@ -63,6 +63,7 @@ void SCConfInit(void);
 void SCConfDeInit(void);
 SCConfNode *SCConfGetRootNode(void);
 int SCConfGet(const char *name, const char **vptr);
+int SCConfGetNonNull(const char *name, const char **vptr);
 int SCConfGetInt(const char *name, intmax_t *val);
 int SCConfGetBool(const char *name, int *val);
 int SCConfGetDouble(const char *name, double *val);

--- a/src/counters.c
+++ b/src/counters.c
@@ -312,7 +312,7 @@ static void StatsInitCtxPreOutput(void)
         }
 
         const char *prefix = NULL;
-        if (SCConfGet("stats.decoder-events-prefix", &prefix) != 1) {
+        if (SCConfGetNonNull("stats.decoder-events-prefix", &prefix) != 1) {
             prefix = "decoder.event";
         }
         stats_decoder_events_prefix = prefix;

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -595,7 +595,7 @@ void DatasetPostReloadCleanup(void)
 void DatasetGetDefaultMemcap(uint64_t *memcap, uint32_t *hashsize)
 {
     const char *str = NULL;
-    if (SCConfGet("datasets.defaults.memcap", &str) == 1) {
+    if (SCConfGetNonNull("datasets.defaults.memcap", &str) == 1) {
         if (ParseSizeStringU64(str, memcap) < 0) {
             SCLogWarning("memcap value cannot be deduced: %s,"
                          " resetting to default",
@@ -605,7 +605,7 @@ void DatasetGetDefaultMemcap(uint64_t *memcap, uint32_t *hashsize)
     }
 
     *hashsize = (uint32_t)DATASETS_HASHSIZE_DEFAULT;
-    if (SCConfGet("datasets.defaults.hashsize", &str) == 1) {
+    if (SCConfGetNonNull("datasets.defaults.hashsize", &str) == 1) {
         if (ParseSizeStringU32(str, hashsize) < 0) {
             *hashsize = (uint32_t)DATASETS_HASHSIZE_DEFAULT;
             SCLogWarning("hashsize value cannot be deduced: %s,"
@@ -624,12 +624,12 @@ int DatasetsInit(void)
     DatasetGetDefaultMemcap(&default_memcap, &default_hashsize);
     if (datasets != NULL) {
         const char *str = NULL;
-        if (SCConfGet("datasets.limits.total-hashsizes", &str) == 1) {
+        if (SCConfGetNonNull("datasets.limits.total-hashsizes", &str) == 1) {
             if (ParseSizeStringU32(str, &dataset_max_total_hashsize) < 0) {
                 FatalError("failed to parse datasets.limits.total-hashsizes value: %s", str);
             }
         }
-        if (SCConfGet("datasets.limits.single-hashsize", &str) == 1) {
+        if (SCConfGetNonNull("datasets.limits.single-hashsize", &str) == 1) {
             if (ParseSizeStringU32(str, &dataset_max_one_hashsize) < 0) {
                 FatalError("failed to parse datasets.limits.single-hashsize value: %s", str);
             }

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -188,7 +188,7 @@ void DefragInitConfig(bool quiet)
 
     uint64_t defrag_memcap;
     /** set config values for memcap, prealloc and hash_size */
-    if ((SCConfGet("defrag.memcap", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("defrag.memcap", &conf_val)) == 1) {
         if (ParseSizeStringU64(conf_val, &defrag_memcap) < 0) {
             SCLogError("Error parsing defrag.memcap "
                        "from conf file - %s.  Killing engine",
@@ -198,7 +198,7 @@ void DefragInitConfig(bool quiet)
             SC_ATOMIC_SET(defrag_config.memcap, defrag_memcap);
         }
     }
-    if ((SCConfGet("defrag.hash-size", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("defrag.hash-size", &conf_val)) == 1) {
         if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             defrag_config.hash_size = configval;
@@ -207,7 +207,7 @@ void DefragInitConfig(bool quiet)
         }
     }
 
-    if ((SCConfGet("defrag.trackers", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("defrag.trackers", &conf_val)) == 1) {
         if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             defrag_config.prealloc = configval;
@@ -250,7 +250,7 @@ void DefragInitConfig(bool quiet)
                   (uintmax_t)sizeof(DefragTrackerHashRow));
     }
 
-    if ((SCConfGet("defrag.prealloc", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("defrag.prealloc", &conf_val)) == 1) {
         if (SCConfValIsTrue(conf_val)) {
             /* pre allocate defrag trackers */
             for (i = 0; i < defrag_config.prealloc; i++) {

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -342,7 +342,7 @@ static int ThresholdsInit(struct Thresholds *t)
     uint64_t memcap = 16 * 1024 * 1024;
 
     const char *str;
-    if (SCConfGet("detect.thresholds.memcap", &str) == 1) {
+    if (SCConfGetNonNull("detect.thresholds.memcap", &str) == 1) {
         if (ParseSizeStringU64(str, &memcap) < 0) {
             SCLogError("Error parsing detect.thresholds.memcap from conf file - %s", str);
             return -1;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -4464,7 +4464,7 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
         master->multi_tenant_enabled = 1;
 
         const char *handler = NULL;
-        if (SCConfGet("multi-detect.selector", &handler) == 1) {
+        if (SCConfGetNonNull("multi-detect.selector", &handler) == 1) {
             SCLogConfig("multi-tenant selector type %s", handler);
 
             if (strcmp(handler, "vlan") == 0) {

--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -113,7 +113,7 @@ int DetectUricontentSetup(DetectEngineCtx *de_ctx, Signature *s, const char *con
     SCEnter();
 
     const char *legacy = NULL;
-    if (SCConfGet("legacy.uricontent", &legacy) == 1) {
+    if (SCConfGetNonNull("legacy.uricontent", &legacy) == 1) {
         if (strcasecmp("disabled", legacy) == 0) {
             SCLogError("uricontent deprecated.  To "
                        "use a rule with \"uricontent\", either set the "

--- a/src/host.c
+++ b/src/host.c
@@ -192,7 +192,7 @@ void HostInitConfig(bool quiet)
     uint32_t configval = 0;
 
     /** set config values for memcap, prealloc and hash_size */
-    if ((SCConfGet("host.memcap", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("host.memcap", &conf_val)) == 1) {
         uint64_t host_memcap = 0;
         if (ParseSizeStringU64(conf_val, &host_memcap) < 0) {
             SCLogError("Error parsing host.memcap "
@@ -203,14 +203,14 @@ void HostInitConfig(bool quiet)
             SC_ATOMIC_SET(host_config.memcap, host_memcap);
         }
     }
-    if ((SCConfGet("host.hash-size", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("host.hash-size", &conf_val)) == 1) {
         if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             host_config.hash_size = configval;
         }
     }
 
-    if ((SCConfGet("host.prealloc", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("host.prealloc", &conf_val)) == 1) {
         if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             host_config.prealloc = configval;

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -187,7 +187,7 @@ void IPPairInitConfig(bool quiet)
 
     /** set config values for memcap, prealloc and hash_size */
     uint64_t ippair_memcap;
-    if ((SCConfGet("ippair.memcap", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("ippair.memcap", &conf_val)) == 1) {
         if (ParseSizeStringU64(conf_val, &ippair_memcap) < 0) {
             SCLogError("Error parsing ippair.memcap "
                        "from conf file - %s.  Killing engine",
@@ -197,14 +197,14 @@ void IPPairInitConfig(bool quiet)
             SC_ATOMIC_SET(ippair_config.memcap, ippair_memcap);
         }
     }
-    if ((SCConfGet("ippair.hash-size", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("ippair.hash-size", &conf_val)) == 1) {
         if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             ippair_config.hash_size = configval;
         }
     }
 
-    if ((SCConfGet("ippair.prealloc", &conf_val)) == 1) {
+    if ((SCConfGetNonNull("ippair.prealloc", &conf_val)) == 1) {
         if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             ippair_config.prealloc = configval;

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -515,7 +515,7 @@ static char *SRepCompleteFilePath(char *file)
 
     /* Path not specified */
     if (PathIsRelative(file)) {
-        if (SCConfGet("default-reputation-path", &defaultpath) == 1) {
+        if (SCConfGetNonNull("default-reputation-path", &defaultpath) == 1) {
             SCLogDebug("Default path: %s", defaultpath);
             size_t path_len = sizeof(char) * (strlen(defaultpath) +
                           strlen(file) + 2);

--- a/src/runmode-erf-file.c
+++ b/src/runmode-erf-file.c
@@ -53,7 +53,7 @@ int RunModeErfFileSingle(void)
 
     SCEnter();
 
-    if (SCConfGet("erf-file.file", &file) == 0) {
+    if (SCConfGetNonNull("erf-file.file", &file) == 0) {
         FatalError("Failed to get erf-file.file from config.");
     }
 
@@ -110,7 +110,7 @@ int RunModeErfFileAutoFp(void)
     uint16_t thread;
 
     const char *file = NULL;
-    if (SCConfGet("erf-file.file", &file) == 0) {
+    if (SCConfGetNonNull("erf-file.file", &file) == 0) {
         FatalError("Failed retrieving erf-file.file from config");
     }
 

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -55,7 +55,7 @@ int RunModeFilePcapSingle(void)
     const char *file = NULL;
     char tname[TM_THREAD_NAME_MAX];
 
-    if (SCConfGet("pcap-file.file", &file) == 0) {
+    if (SCConfGetNonNull("pcap-file.file", &file) == 0) {
         FatalError("Failed retrieving pcap-file from Conf");
     }
 
@@ -125,7 +125,7 @@ int RunModeFilePcapAutoFp(void)
     uint16_t thread;
 
     const char *file = NULL;
-    if (SCConfGet("pcap-file.file", &file) == 0) {
+    if (SCConfGetNonNull("pcap-file.file", &file) == 0) {
         FatalError("Failed retrieving pcap-file from Conf");
     }
     SCLogDebug("file %s", file);

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -100,7 +100,7 @@ static void *ParsePcapConfig(const char *iface)
 
     aconf->checksum_mode = CHECKSUM_VALIDATION_AUTO;
     aconf->bpf_filter = NULL;
-    if ((SCConfGet("bpf-filter", &tmpbpf)) == 1) {
+    if ((SCConfGetNonNull("bpf-filter", &tmpbpf)) == 1) {
         aconf->bpf_filter = tmpbpf;
     }
 

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -215,7 +215,7 @@ void NFQInitConfig(bool quiet)
 
     memset(&nfq_config,  0, sizeof(nfq_config));
 
-    if ((SCConfGet("nfq.mode", &nfq_mode)) == 0) {
+    if ((SCConfGetNonNull("nfq.mode", &nfq_mode)) == 0) {
         nfq_config.mode = NFQ_ACCEPT_MODE;
     } else {
         if (!strcmp("accept", nfq_mode)) {

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -441,7 +441,7 @@ PcapFileDeleteMode PcapFileParseDeleteMode(void)
     PcapFileDeleteMode delete_mode = PCAP_FILE_DELETE_NONE;
     const char *delete_when_done_str = NULL;
 
-    if (SCConfGet("pcap-file.delete-when-done", &delete_when_done_str) == 1) {
+    if (SCConfGetNonNull("pcap-file.delete-when-done", &delete_when_done_str) == 1) {
         if (strcmp(delete_when_done_str, "non-alerts") == 0) {
             delete_mode = PCAP_FILE_DELETE_NON_ALERTS;
         } else {

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -155,7 +155,7 @@ void PcapFileGlobalInit(void)
     pcap_g.read_buffer_size = PCAP_FILE_BUFFER_SIZE_DEFAULT;
 
     const char *str = NULL;
-    if (SCConfGet("pcap-file.buffer-size", &str) == 1) {
+    if (SCConfGetNonNull("pcap-file.buffer-size", &str) == 1) {
         uint32_t value = 0;
         if (ParseSizeStringU32(str, &value) < 0) {
             SCLogWarning("failed to parse pcap-file.buffer-size %s", str);
@@ -267,7 +267,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         }
     }
 
-    if (SCConfGet("bpf-filter", &(tmp_bpf_string)) != 1) {
+    if (SCConfGetNonNull("bpf-filter", &(tmp_bpf_string)) != 1) {
         SCLogDebug("could not get bpf or none specified");
     } else {
         ptv->shared.bpf_string = SCStrdup(tmp_bpf_string);
@@ -388,7 +388,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         ptv->behavior.directory = pv;
     }
 
-    if (SCConfGet("pcap-file.checksum-checks", &tmpstring) != 1) {
+    if (SCConfGetNonNull("pcap-file.checksum-checks", &tmpstring) != 1) {
         pcap_g.conf_checksum_mode = CHECKSUM_VALIDATION_AUTO;
     } else {
         if (strcmp(tmpstring, "auto") == 0) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -533,7 +533,7 @@ void StreamTcpInitConfig(bool quiet)
     }
 
     const char *temp_stream_memcap_str;
-    if (SCConfGet("stream.memcap", &temp_stream_memcap_str) == 1) {
+    if (SCConfGetNonNull("stream.memcap", &temp_stream_memcap_str) == 1) {
         uint64_t stream_memcap_copy;
         if (ParseSizeStringU64(temp_stream_memcap_str, &stream_memcap_copy) < 0) {
             SCLogError("Error parsing stream.memcap "
@@ -585,7 +585,7 @@ void StreamTcpInitConfig(bool quiet)
     }
 
     const char *temp_stream_inline_str;
-    if (SCConfGet("stream.inline", &temp_stream_inline_str) == 1) {
+    if (SCConfGetNonNull("stream.inline", &temp_stream_inline_str) == 1) {
         int inl = 0;
 
         /* checking for "auto" and falling back to boolean to provide
@@ -705,7 +705,7 @@ void StreamTcpInitConfig(bool quiet)
     }
 
     const char *temp_stream_reassembly_memcap_str;
-    if (SCConfGet("stream.reassembly.memcap", &temp_stream_reassembly_memcap_str) == 1) {
+    if (SCConfGetNonNull("stream.reassembly.memcap", &temp_stream_reassembly_memcap_str) == 1) {
         uint64_t stream_reassembly_memcap_copy;
         if (ParseSizeStringU64(temp_stream_reassembly_memcap_str,
                                &stream_reassembly_memcap_copy) < 0) {
@@ -727,7 +727,7 @@ void StreamTcpInitConfig(bool quiet)
     }
 
     const char *temp_stream_reassembly_depth_str;
-    if (SCConfGet("stream.reassembly.depth", &temp_stream_reassembly_depth_str) == 1) {
+    if (SCConfGetNonNull("stream.reassembly.depth", &temp_stream_reassembly_depth_str) == 1) {
         if (ParseSizeStringU32(temp_stream_reassembly_depth_str,
                                &stream_config.reassembly_depth) < 0) {
             SCLogError("Error parsing "
@@ -754,7 +754,7 @@ void StreamTcpInitConfig(bool quiet)
 
     if (randomize) {
         const char *temp_rdrange;
-        if (SCConfGet("stream.reassembly.randomize-chunk-range", &temp_rdrange) == 1) {
+        if (SCConfGetNonNull("stream.reassembly.randomize-chunk-range", &temp_rdrange) == 1) {
             if (ParseSizeStringU16(temp_rdrange, &rdrange) < 0) {
                 SCLogError("Error parsing "
                            "stream.reassembly.randomize-chunk-range "
@@ -769,7 +769,7 @@ void StreamTcpInitConfig(bool quiet)
     }
 
     const char *temp_stream_reassembly_toserver_chunk_size_str;
-    if (SCConfGet("stream.reassembly.toserver-chunk-size",
+    if (SCConfGetNonNull("stream.reassembly.toserver-chunk-size",
                 &temp_stream_reassembly_toserver_chunk_size_str) == 1) {
         if (ParseSizeStringU16(temp_stream_reassembly_toserver_chunk_size_str,
                                &stream_config.reassembly_toserver_chunk_size) < 0) {
@@ -791,7 +791,7 @@ void StreamTcpInitConfig(bool quiet)
                         rdrange / 100);
     }
     const char *temp_stream_reassembly_toclient_chunk_size_str;
-    if (SCConfGet("stream.reassembly.toclient-chunk-size",
+    if (SCConfGetNonNull("stream.reassembly.toclient-chunk-size",
                 &temp_stream_reassembly_toclient_chunk_size_str) == 1) {
         if (ParseSizeStringU16(temp_stream_reassembly_toclient_chunk_size_str,
                                &stream_config.reassembly_toclient_chunk_size) < 0) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2237,7 +2237,7 @@ static int MayDaemonize(SCInstance *suri)
     if (suri->daemon == 1 && suri->pid_filename == NULL) {
         const char *pid_filename;
 
-        if (SCConfGet("pid-file", &pid_filename) == 1) {
+        if (SCConfGetNonNull("pid-file", &pid_filename) == 1) {
             SCLogInfo("Use pid file %s from config file.", pid_filename);
         } else {
             pid_filename = DEFAULT_PID_FILENAME;
@@ -2602,7 +2602,7 @@ static int ConfigGetCaptureValue(SCInstance *suri)
     /* Pull the default packet size from the config, if not found fall
      * back on a sane default. */
     const char *temp_default_packet_size;
-    if ((SCConfGet("default-packet-size", &temp_default_packet_size)) != 1) {
+    if ((SCConfGetNonNull("default-packet-size", &temp_default_packet_size)) != 1) {
         int lthread;
         int nlive;
         int strip_trailing_plus = 0;
@@ -2739,7 +2739,7 @@ static void PostConfLoadedSetupHostMode(void)
 {
     const char *hostmode = NULL;
 
-    if (SCConfGet("host-mode", &hostmode) == 1) {
+    if (SCConfGetNonNull("host-mode", &hostmode) == 1) {
         if (!strcmp(hostmode, "router")) {
             g_engine_host_mode = ENGINE_HOST_IS_ROUTER;
         } else if (!strcmp(hostmode, "bridge")) {
@@ -2834,7 +2834,7 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     if (suri->checksum_validation == -1) {
         const char *cv = NULL;
-        if (SCConfGet("capture.checksum-validation", &cv) == 1) {
+        if (SCConfGetNonNull("capture.checksum-validation", &cv) == 1) {
             if (strcmp(cv, "none") == 0) {
                 suri->checksum_validation = 0;
             } else if (strcmp(cv, "all") == 0) {
@@ -2903,7 +2903,7 @@ int PostConfLoadedSetup(SCInstance *suri)
     /* Suricata will use this umask if provided. By default it will use the
        umask passed on from the shell. */
     const char *custom_umask;
-    if (SCConfGet("umask", &custom_umask) == 1) {
+    if (SCConfGetNonNull("umask", &custom_umask) == 1) {
         uint16_t mask;
         if (StringParseUint16(&mask, 8, (uint16_t)strlen(custom_umask), custom_umask) > 0) {
             umask((mode_t)mask);

--- a/src/tests/stream-tcp.c
+++ b/src/tests/stream-tcp.c
@@ -1074,7 +1074,7 @@ static const char *StreamTcpParseOSPolicy(char *conf_var_name)
         goto end;
     }
 
-    if (SCConfGet(conf_var_full_name, &conf_var_value) != 1) {
+    if (SCConfGetNonNull(conf_var_full_name, &conf_var_value) != 1) {
         SCLogError("Error in getting conf value for conf name %s", conf_var_full_name);
         goto end;
     }

--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -57,7 +57,7 @@ void TmqhFlowRegister(void)
     tmqh_table[TMQH_FLOW].RegisterTests = TmqhFlowRegisterTests;
 
     const char *scheduler = NULL;
-    if (SCConfGet("autofp-scheduler", &scheduler) == 1) {
+    if (SCConfGetNonNull("autofp-scheduler", &scheduler) == 1) {
         if (strcasecmp(scheduler, "round-robin") == 0) {
             SCLogNotice("using flow hash instead of round robin");
             tmqh_table[TMQH_FLOW].OutHandler = TmqhOutputFlowHash;

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -121,7 +121,7 @@ static int UnixNew(UnixCommand * this)
     TAILQ_INIT(&this->clients);
 
     int check_dir = 0;
-    if (SCConfGet("unix-command.filename", &socketname) == 1) {
+    if (SCConfGetNonNull("unix-command.filename", &socketname) == 1) {
         if (PathIsAbsolute(socketname)) {
             strlcpy(sockettarget, socketname, sizeof(sockettarget));
         } else {
@@ -888,7 +888,7 @@ static TmEcode UnixManagerConfGetCommand(json_t *cmd,
     }
 
     variable = (char *)json_string_value(jarg);
-    if (SCConfGet(variable, &confval) != 1) {
+    if (SCConfGetNonNull(variable, &confval) != 1) {
         json_object_set_new(server_msg, "message", json_string("Unable to get value"));
         SCReturnInt(TM_ECODE_FAILED);
     }

--- a/src/util-bpf.c
+++ b/src/util-bpf.c
@@ -36,7 +36,7 @@ void ConfSetBPFFilter(
     }
 
     /* command line value has precedence */
-    if (SCConfGet("bpf-filter", bpf_filter) == 1) {
+    if (SCConfGetNonNull("bpf-filter", bpf_filter) == 1) {
         if (strlen(*bpf_filter) > 0) {
             SCLogConfig("%s: using command-line provided bpf filter '%s'", iface, *bpf_filter);
         }

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -161,13 +161,13 @@ static const char *SCClassConfGetConfFilename(const DetectEngineCtx *de_ctx)
 
         /* try loading prefix setting, fall back to global if that
          * fails. */
-        if (SCConfGet(config_value, &log_filename) != 1) {
-            if (SCConfGet("classification-file", &log_filename) != 1) {
+        if (SCConfGetNonNull(config_value, &log_filename) != 1) {
+            if (SCConfGetNonNull("classification-file", &log_filename) != 1) {
                 log_filename = (char *)SC_CLASS_CONF_DEF_CONF_FILEPATH;
             }
         }
     } else {
-        if (SCConfGet("classification-file", &log_filename) != 1) {
+        if (SCConfGetNonNull("classification-file", &log_filename) != 1) {
             log_filename = (char *)SC_CLASS_CONF_DEF_CONF_FILEPATH;
         }
     }

--- a/src/util-conf.c
+++ b/src/util-conf.c
@@ -39,7 +39,7 @@ const char *SCConfigGetLogDirectory(void)
 {
     const char *log_dir = NULL;
 
-    if (SCConfGet("default-log-dir", &log_dir) != 1) {
+    if (SCConfGetNonNull("default-log-dir", &log_dir) != 1) {
 #ifdef OS_WIN32
         log_dir = _getcwd(NULL, 0);
         if (log_dir == NULL) {
@@ -86,7 +86,7 @@ const char *ConfigGetDataDirectory(void)
 {
     const char *data_dir = NULL;
 
-    if (SCConfGet("default-data-dir", &data_dir) != 1) {
+    if (SCConfGetNonNull("default-data-dir", &data_dir) != 1) {
 #ifdef OS_WIN32
         data_dir = _getcwd(NULL, 0);
         if (data_dir == NULL) {

--- a/src/util-daemon.c
+++ b/src/util-daemon.c
@@ -131,7 +131,7 @@ void Daemonize (void)
             FatalError("Error creating new session");
         }
 
-        if (SCConfGet("daemon-directory", &daemondir) == 1) {
+        if (SCConfGetNonNull("daemon-directory", &daemondir) == 1) {
             if ((chdir(daemondir)) < 0) {
                 FatalError("Error changing to working directory");
             }

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -1451,7 +1451,7 @@ void SCLogLoadConfig(int daemon, int verbose, uint32_t userid, uint32_t groupid)
 
     /* Get default log level and format. */
     const char *default_log_level_s = NULL;
-    if (SCConfGet("logging.default-log-level", &default_log_level_s) == 1) {
+    if (SCConfGetNonNull("logging.default-log-level", &default_log_level_s) == 1) {
         SCLogLevel default_log_level =
             SCMapEnumNameToValue(default_log_level_s, sc_log_level_map);
         if (default_log_level == -1) {
@@ -1463,7 +1463,7 @@ void SCLogLoadConfig(int daemon, int verbose, uint32_t userid, uint32_t groupid)
         sc_lid->global_log_level = MAX(min_level, SC_LOG_NOTICE);
     }
 
-    if (SCConfGet("logging.default-log-format", &sc_lid->global_log_format) != 1)
+    if (SCConfGetNonNull("logging.default-log-format", &sc_lid->global_log_format) != 1)
         sc_lid->global_log_format = SCLogGetDefaultLogFormat(sc_lid->global_log_level);
 
     (void)SCConfGet("logging.default-output-filter", &sc_lid->op_filter);

--- a/src/util-landlock.c
+++ b/src/util-landlock.c
@@ -208,7 +208,7 @@ void LandlockSandboxing(SCInstance *suri)
     }
     if (suri->run_mode == RUNMODE_PCAP_FILE) {
         const char *pcap_file;
-        if (SCConfGet("pcap-file.file", &pcap_file) == 1) {
+        if (SCConfGetNonNull("pcap-file.file", &pcap_file) == 1) {
             char *file_name = SCStrdup(pcap_file);
             if (file_name != NULL) {
                 struct stat statbuf;
@@ -241,7 +241,7 @@ void LandlockSandboxing(SCInstance *suri)
     }
     if (ConfUnixSocketIsEnable()) {
         const char *socketname;
-        if (SCConfGet("unix-command.filename", &socketname) == 1) {
+        if (SCConfGetNonNull("unix-command.filename", &socketname) == 1) {
             if (PathIsAbsolute(socketname)) {
                 char *file_name = SCStrdup(socketname);
                 if (file_name != NULL) {
@@ -257,7 +257,7 @@ void LandlockSandboxing(SCInstance *suri)
     }
     if (!suri->sig_file_exclusive) {
         const char *rule_path;
-        if (SCConfGet("default-rule-path", &rule_path) == 1 && rule_path) {
+        if (SCConfGetNonNull("default-rule-path", &rule_path) == 1 && rule_path) {
             LandlockSandboxingReadPath(ruleset, rule_path);
         }
     }

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -151,13 +151,13 @@ static const char *SCRConfGetConfFilename(const DetectEngineCtx *de_ctx)
 
         /* try loading prefix setting, fall back to global if that
          * fails. */
-        if (SCConfGet(config_value, &path) != 1) {
-            if (SCConfGet("reference-config-file", &path) != 1) {
+        if (SCConfGetNonNull(config_value, &path) != 1) {
+            if (SCConfGetNonNull("reference-config-file", &path) != 1) {
                 return (char *)SC_RCONF_DEFAULT_FILE_PATH;
             }
         }
     } else {
-        if (SCConfGet("reference-config-file", &path) != 1) {
+        if (SCConfGetNonNull("reference-config-file", &path) != 1) {
             return (char *)SC_RCONF_DEFAULT_FILE_PATH;
         }
     }

--- a/src/util-rule-vars.c
+++ b/src/util-rule-vars.c
@@ -97,7 +97,7 @@ const char *SCRuleVarsGetConfVar(const DetectEngineCtx *de_ctx,
         }
     }
 
-    if (SCConfGet(conf_var_full_name, &conf_var_full_name_value) != 1) {
+    if (SCConfGetNonNull(conf_var_full_name, &conf_var_full_name_value) != 1) {
         SCLogError("Variable \"%s\" is not defined in "
                    "configuration file",
                 conf_var_name);

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -226,7 +226,7 @@ static int THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
 
     /** set config values for memcap, prealloc and hash_size */
     GET_VAR(cnf_prefix, "memcap");
-    if ((SCConfGet(varname, &conf_val)) == 1) {
+    if ((SCConfGetNonNull(varname, &conf_val)) == 1) {
         uint64_t memcap;
         if (ParseSizeStringU64(conf_val, &memcap) < 0) {
             SCLogError("Error parsing %s "
@@ -238,14 +238,14 @@ static int THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
         SC_ATOMIC_SET(ctx->config.memcap, memcap);
     }
     GET_VAR(cnf_prefix, "hash-size");
-    if ((SCConfGet(varname, &conf_val)) == 1) {
+    if ((SCConfGetNonNull(varname, &conf_val)) == 1) {
         if (StringParseUint32(&configval, 10, (uint16_t)strlen(conf_val), conf_val) > 0) {
             ctx->config.hash_size = configval;
         }
     }
 
     GET_VAR(cnf_prefix, "prealloc");
-    if ((SCConfGet(varname, &conf_val)) == 1) {
+    if ((SCConfGetNonNull(varname, &conf_val)) == 1) {
         if (StringParseUint32(&configval, 10, (uint16_t)strlen(conf_val), conf_val) > 0) {
             ctx->config.prealloc = configval;
         } else {

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -139,13 +139,13 @@ static const char *SCThresholdConfGetConfFilename(const DetectEngineCtx *de_ctx)
 
         /* try loading prefix setting, fall back to global if that
          * fails. */
-        if (SCConfGet(config_value, &log_filename) != 1) {
-            if (SCConfGet("threshold-file", &log_filename) != 1) {
+        if (SCConfGetNonNull(config_value, &log_filename) != 1) {
+            if (SCConfGetNonNull("threshold-file", &log_filename) != 1) {
                 log_filename = (char *)THRESHOLD_CONF_DEF_CONF_FILEPATH;
             }
         }
     } else {
-        if (SCConfGet("threshold-file", &log_filename) != 1) {
+        if (SCConfGetNonNull("threshold-file", &log_filename) != 1) {
             log_filename = (char *)THRESHOLD_CONF_DEF_CONF_FILEPATH;
         }
     }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8651

Describe changes:
- conf: introduce SCConfGetNonNull to not null deref on yaml null values or such

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3162

https://github.com/OISF/suricata/pull/15622 with better `SCConfGetNonNull` 