### PR TITLE
pcap-file: skip setvbuf on non-seekable streams (v4)

### DIFF
--- a/doc/userguide/capture-hardware/pcap-file.rst
+++ b/doc/userguide/capture-hardware/pcap-file.rst
@@ -33,6 +33,10 @@ This can improve performance, especially for large files.
 The size can be specified through the command line option, see
 :ref:`--pcap-file-buffer-size <cmdline-option-pcap-file-buffer-size>`
 
+Setting ``buffer-size`` to ``0`` disables ``setvbuf`` buffering. This is the
+explicit opt-out for non-seekable sources such as ``/dev/stdin`` or named
+pipes, where buffering the underlying file descriptor is not supported.
+
 Directory-related options
 -------------------------
 

--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -103,7 +103,8 @@
 .. option:: --pcap-file-buffer-size <value>
 
    Set read buffer size using ``setvbuf`` to speed up pcap reading. Valid values
-   are 4 KiB to 64 MiB. Default value is 128 KiB. Supported on Linux only.
+   are 0, which disables ``setvbuf`` buffering, or 4 KiB to 64 MiB. Default
+   value is 128 KiB. Supported on Linux only.
 
 .. option::  -i <interface>
 

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -271,10 +271,16 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
 
 #if defined(HAVE_SETVBUF) && defined(OS_LINUX)
     if (pcap_g.read_buffer_size > 0) {
-        errno = 0;
-        if (setvbuf(pcap_file(pfv->pcap_handle), pfv->buffer, _IOFBF, pcap_g.read_buffer_size) <
-                0) {
-            SCLogWarning("Failed to setvbuf on PCAP file handle: %s", strerror(errno));
+        struct stat sb;
+        int fd = fileno(pcap_file(pfv->pcap_handle));
+        if (fd >= 0 && fstat(fd, &sb) == 0 && !S_ISREG(sb.st_mode)) {
+            SCLogInfo("%s: skipping setvbuf, underlying fd is not a regular file", pfv->filename);
+        } else {
+            errno = 0;
+            if (setvbuf(pcap_file(pfv->pcap_handle), pfv->buffer, _IOFBF,
+                        pcap_g.read_buffer_size) != 0) {
+                SCLogWarning("Failed to setvbuf on PCAP file handle: %s", strerror(errno));
+            }
         }
     }
 #endif

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2016 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -158,13 +158,19 @@ void PcapFileGlobalInit(void)
     if (SCConfGet("pcap-file.buffer-size", &str) == 1) {
         uint32_t value = 0;
         if (ParseSizeStringU32(str, &value) < 0) {
-            SCLogWarning("failed to parse pcap-file.buffer-size %s", str);
-        }
-        if (value >= PCAP_FILE_BUFFER_SIZE_MIN && value <= PCAP_FILE_BUFFER_SIZE_MAX) {
-            SCLogInfo("Pcap-file will use %u buffer size", value);
+            SCLogWarning("failed to parse pcap-file.buffer-size %s; keeping default %u", str,
+                    PCAP_FILE_BUFFER_SIZE_DEFAULT);
+        } else if (value == 0 ||
+                   (value >= PCAP_FILE_BUFFER_SIZE_MIN && value <= PCAP_FILE_BUFFER_SIZE_MAX)) {
+            if (value == 0) {
+                SCLogInfo("Pcap-file buffering disabled");
+            } else {
+                SCLogInfo("Pcap-file will use %u buffer size", value);
+            }
             pcap_g.read_buffer_size = value;
         } else {
-            SCLogWarning("pcap-file.buffer-size value of %u is invalid. Valid range is %u-%u",
+            SCLogWarning("pcap-file.buffer-size value of %u is invalid. Valid values are 0 to "
+                         "disable buffering, or %u-%u",
                     value, PCAP_FILE_BUFFER_SIZE_MIN, PCAP_FILE_BUFFER_SIZE_MAX);
         }
     }


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8464

Replaces #15629.

### Changes since #15629
- Copyright dates in the touched source modules now include 2026 (`source-pcap-file.c` was still 2007-2016; `source-pcap-file-helper.c` already included 2026). (Addresses @jlucovsky's review.)

### Description
Reading a pcap from /dev/stdin or a named pipe regressed in 8.0.0 with the setvbuf change in 7b730c2e6 and currently fails with `failed to get first packet timestamp. pcap_next_ex(): -1`. The reason is that InitPcapFile calls setvbuf on the FILE* underlying the pcap handle after libpcap has already consumed the pcap header, and on a non seekable fd glibc cannot recover from that and the very next read returns -1. This change detects non regular files via fstat on the underlying fd and skips setvbuf for that handle, so reading from stdin, named pipes, and other non seekable sources keeps working. `pcap-file.buffer-size = 0` remains available as an explicit opt out, matching the workaround proposed on the ticket.

Describe changes:
- In InitPcapFile, fstat the fd behind pcap_file(handle) and skip setvbuf when the file is not a regular file. An info log explains the skip.
- Accept buffer-size 0 as an explicit setvbuf opt-out while keeping the 4 KiB minimum for actual buffering lengths.
- On a buffer-size parse error, retain the default instead of setting it to 0.
- Treat any non-zero setvbuf return value as an error.
- Verified locally that tcpdump piping a pcap into /dev/stdin and reading from a named pipe both now complete with 2 packets read and 0 errors. Regular file reads are unchanged.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3108
