### PR TITLE
Smb raw inspection/v3

### DIFF
--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -18,6 +18,9 @@
 // written by Victor Julien
 
 use uuid;
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
+use crate::direction::Direction;
+use crate::flow::Flow;
 use crate::smb::smb::{cfg_max_stub_size, *};
 use crate::smb::smb2::*;
 use crate::smb::dcerpc_records::*;
@@ -182,6 +185,7 @@ impl SMBState {
 /// return bool indicating whether an tx has been created/updated.
 ///
 pub fn smb_write_dcerpc_record(state: &mut SMBState,
+        flow: *mut Flow,
         vercmd: SMBVerCmdStat,
         hdr: SMBCommonHdr,
         data: &[u8]) -> bool
@@ -219,6 +223,7 @@ pub fn smb_write_dcerpc_record(state: &mut SMBState,
                                 if dcer.last_frag {
                                     SCLogDebug!("last frag set, so request side of DCERPC closed");
                                     tx.request_done = true;
+                                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                                 } else {
                                     SCLogDebug!("NOT last frag, so request side of DCERPC remains open");
                                 }
@@ -260,6 +265,7 @@ pub fn smb_write_dcerpc_record(state: &mut SMBState,
                             }
                             if dcer.last_frag {
                                 tx.request_done = true;
+                                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                             } else {
                                 SCLogDebug!("NOT last frag, so request side of DCERPC remains open");
                             }
@@ -267,6 +273,7 @@ pub fn smb_write_dcerpc_record(state: &mut SMBState,
                         _ => {
                             tx.set_event(SMBEvent::MalformedData);
                             tx.request_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                         },
                     }
                 },
@@ -308,14 +315,17 @@ pub fn smb_write_dcerpc_record(state: &mut SMBState,
                         },
                     }
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 }
                 21..=255 => {
                     tx.set_event(SMBEvent::MalformedData);
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 },
                 _ => {
                     // valid type w/o special processing
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 },
             }
         },
@@ -338,6 +348,7 @@ pub fn smb_write_dcerpc_record(state: &mut SMBState,
 ///
 fn smb_dcerpc_response_bindack(
         state: &mut SMBState,
+        flow: *mut Flow,
         vercmd: SMBVerCmdStat,
         hdr: SMBCommonHdr,
         dcer: &DceRpcRecord,
@@ -354,6 +365,7 @@ fn smb_dcerpc_response_bindack(
                     }
                     tx.vercmd.set_ntstatus(ntstatus);
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                     true
                 },
                 None => false,
@@ -377,7 +389,7 @@ fn smb_dcerpc_response_bindack(
     }
 }
 
-fn smb_read_dcerpc_record_error(state: &mut SMBState,
+fn smb_read_dcerpc_record_error(state: &mut SMBState, flow: *mut Flow,
         hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, ntstatus: u32)
     -> bool
 {
@@ -395,6 +407,7 @@ fn smb_read_dcerpc_record_error(state: &mut SMBState,
             SCLogDebug!("found");
             tx.set_status(ntstatus, false);
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
             true
         },
         None => {
@@ -405,7 +418,7 @@ fn smb_read_dcerpc_record_error(state: &mut SMBState,
     return found;
 }
 
-fn dcerpc_response_handle(tx: &mut SMBTransaction,
+fn dcerpc_response_handle(flow: *mut Flow, tx: &mut SMBTransaction,
         vercmd: SMBVerCmdStat,
         dcer: &DceRpcRecord)
 {
@@ -428,6 +441,9 @@ fn dcerpc_response_handle(tx: &mut SMBTransaction,
                     }
                     tx.vercmd.set_ntstatus(ntstatus);
                     tx.response_done = dcer.last_frag;
+                    if dcer.last_frag {
+                        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
+                    }
                 },
                 _ => {
                     tx.set_event(SMBEvent::MalformedData);
@@ -443,6 +459,7 @@ fn dcerpc_response_handle(tx: &mut SMBTransaction,
             }
             tx.vercmd.set_ntstatus(ntstatus);
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
             tx.set_event(SMBEvent::MalformedData);
         }
         _ => { // valid type w/o special processing
@@ -451,6 +468,7 @@ fn dcerpc_response_handle(tx: &mut SMBTransaction,
             }
             tx.vercmd.set_ntstatus(ntstatus);
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
         },
     }
 }
@@ -458,6 +476,7 @@ fn dcerpc_response_handle(tx: &mut SMBTransaction,
 /// Handle DCERPC reply record. Called for READ, TRANS, IOCTL
 ///
 pub fn smb_read_dcerpc_record(state: &mut SMBState,
+        flow: *mut Flow,
         vercmd: SMBVerCmdStat,
         hdr: SMBCommonHdr,
         guid: &[u8],
@@ -466,7 +485,7 @@ pub fn smb_read_dcerpc_record(state: &mut SMBState,
     let (_, ntstatus) = vercmd.get_ntstatus();
 
     if ntstatus != SMB_NTSTATUS_SUCCESS && ntstatus != SMB_NTSTATUS_BUFFER_OVERFLOW {
-        return smb_read_dcerpc_record_error(state, hdr, vercmd, ntstatus);
+        return smb_read_dcerpc_record_error(state, flow, hdr, vercmd, ntstatus);
     }
 
     SCLogDebug!("lets first see if we have prior data");
@@ -499,13 +518,13 @@ pub fn smb_read_dcerpc_record(state: &mut SMBState,
                 }
 
                 if dcer.packet_type == DCERPC_TYPE_BINDACK {
-                    smb_dcerpc_response_bindack(state, vercmd, hdr, &dcer, ntstatus);
+                    smb_dcerpc_response_bindack(state, flow, vercmd, hdr, &dcer, ntstatus);
                     return true;
                 }
 
                 let found = match state.get_dcerpc_tx(&hdr, &vercmd, dcer.call_id) {
                     Some(tx) => {
-                        dcerpc_response_handle(tx, vercmd.clone(), &dcer);
+                        dcerpc_response_handle(flow, tx, vercmd.clone(), &dcer);
                         true
                     },
                     None => {
@@ -516,7 +535,7 @@ pub fn smb_read_dcerpc_record(state: &mut SMBState,
                 if !found {
                     // pick up DCERPC tx even if we missed the request
                     let tx = state.new_dcerpc_tx_for_response(hdr, vercmd.clone(), dcer.call_id);
-                    dcerpc_response_handle(tx, vercmd, &dcer);
+                    dcerpc_response_handle(flow, tx, vercmd, &dcer);
                 }
             },
             _ => {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2022 Open Information Security Foundation
+/* Copyright (C) 2017-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -359,7 +359,6 @@ impl SMBState {
                         filename, fid, subcmd, loi, delete_on_close)));
         tx.request_done = true;
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
-
         SCLogDebug!("SMB: TX SETFILEPATHINFO created: ID {}", tx.id);
         self.transactions.push_back(tx);
         let tx_ref = self.transactions.back_mut();
@@ -845,7 +844,6 @@ impl SMBState {
                 }
             }
             self.tx_index_completed = index;
-
         }
         return tx;
     }
@@ -1116,7 +1114,7 @@ impl SMBState {
         (name, is_dcerpc)
     }
 
-    fn post_gap_housekeeping_for_files(&mut self)
+    fn post_gap_housekeeping_for_files(&mut self, flow: *mut Flow)
     {
         let mut post_gap_txs = false;
         for tx in &mut self.transactions {
@@ -1124,7 +1122,9 @@ impl SMBState {
                 if f.post_gap_ts > 0 {
                     if self.ts > f.post_gap_ts {
                         tx.request_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                         filetracker_trunc(&mut f.file_tracker);
                     } else {
                         post_gap_txs = true;
@@ -1140,7 +1140,7 @@ impl SMBState {
      * can handle gaps. For the file transactions we set the current
      * (flow) time and prune them in 60 seconds if no update for them
      * was received. */
-    fn post_gap_housekeeping(&mut self, dir: Direction)
+    fn post_gap_housekeeping(&mut self, flow: *mut Flow, dir: Direction)
     {
         if self.ts_ssn_gap && dir == Direction::ToServer {
             for tx in &mut self.transactions {
@@ -1158,6 +1158,7 @@ impl SMBState {
                 } else {
                     SCLogDebug!("post_gap_housekeeping: tx {} marked as done TS", tx.id);
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 }
             }
         } else if self.tc_ssn_gap && dir == Direction::ToClient {
@@ -1176,7 +1177,9 @@ impl SMBState {
                 } else {
                     SCLogDebug!("post_gap_housekeeping: tx {} marked as done TC", tx.id);
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                 }
             }
 
@@ -1300,7 +1303,7 @@ impl SMBState {
                 if let Ok((_, ref hdr)) = parse_nbss_record_partial(input) {
                     if !hdr.is_smb() {
                         SCLogDebug!("partial NBSS, not SMB and no known msg type {}", hdr.message_type);
-                        self.trunc_ts();
+                        self.trunc_ts(flow);
                         return 0;
                     }
                 }
@@ -1332,7 +1335,7 @@ impl SMBState {
                                 // So that we can check that further parsed offsets and lengths
                                 // stay within the NBSS record.
                                 let nbss_remaining = nbss_part_hdr.length - nbss_part_hdr.data.len() as u32;
-                                smb1_write_request_record(self, r, SMB1_HEADER_SIZE, SMB1_COMMAND_WRITE_ANDX, nbss_remaining);
+                                smb1_write_request_record(self, flow, r, SMB1_HEADER_SIZE, SMB1_COMMAND_WRITE_ANDX, nbss_remaining);
 
                                 self.add_nbss_ts_frames(flow, stream_slice, input, nbss_part_hdr.length as i64);
                                 self.add_smb1_ts_pdu_frame(flow, stream_slice, nbss_part_hdr.data, nbss_part_hdr.length as i64);
@@ -1352,7 +1355,7 @@ impl SMBState {
                                 // So that we can check that further parsed offsets and lengths
                                 // stay within the NBSS record.
                                 let nbss_remaining = nbss_part_hdr.length - nbss_part_hdr.data.len() as u32;
-                                smb2_write_request_record(self, smb_record, nbss_remaining);
+                                smb2_write_request_record(self, flow, smb_record, nbss_remaining);
 
                                 self.add_nbss_ts_frames(flow, stream_slice, input, nbss_part_hdr.length as i64);
                                 self.add_smb2_ts_pdu_frame(flow, stream_slice, nbss_part_hdr.data, nbss_part_hdr.length as i64);
@@ -1449,7 +1452,7 @@ impl SMBState {
                                             let pdu_frame = self.add_smb1_ts_pdu_frame(flow, stream_slice, nbss_hdr.data, nbss_hdr.length as i64);
                                             self.add_smb1_ts_hdr_data_frames(flow, stream_slice, nbss_hdr.data, nbss_hdr.length as i64);
                                             if smb_record.is_request() {
-                                                smb1_request_record(self, smb_record);
+                                                smb1_request_record(self, flow, smb_record);
                                             } else {
                                                 // If we received a response when expecting a request, set an event
                                                 // on the PDU frame instead of handling the response.
@@ -1478,7 +1481,7 @@ impl SMBState {
                                                 self.add_smb2_ts_hdr_data_frames(flow, stream_slice, nbss_data, record_len, smb_record.header_len as i64);
                                                 SCLogDebug!("nbss_data_rem {}", nbss_data_rem.len());
                                                 if smb_record.is_request() {
-                                                    smb2_request_record(self, smb_record);
+                                                    smb2_request_record(self, flow, smb_record);
                                                 } else {
                                                     // If we received a response when expecting a request, set an event
                                                     // on the PDU frame instead of handling the response.
@@ -1564,9 +1567,9 @@ impl SMBState {
             }
         };
 
-        self.post_gap_housekeeping(Direction::ToServer);
+        self.post_gap_housekeeping(flow, Direction::ToServer);
         if self.check_post_gap_file_txs && !self.post_gap_files_checked {
-            self.post_gap_housekeeping_for_files();
+            self.post_gap_housekeeping_for_files(flow);
             self.post_gap_files_checked = true;
         }
         AppLayerResult::ok()
@@ -1636,7 +1639,7 @@ impl SMBState {
                 if let Ok((_, ref hdr)) = parse_nbss_record_partial(input) {
                     if !hdr.is_smb() {
                         SCLogDebug!("partial NBSS, not SMB and no known msg type {}", hdr.message_type);
-                        self.trunc_tc();
+                        self.trunc_tc(flow);
                         return 0;
                     }
                 }
@@ -1675,7 +1678,7 @@ impl SMBState {
                                 // So that we can check that further parsed offsets and lengths
                                 // stay within the NBSS record.
                                 let nbss_remaining = nbss_part_hdr.length - nbss_part_hdr.data.len() as u32;
-                                smb1_read_response_record(self, r, SMB1_HEADER_SIZE, nbss_remaining);
+                                smb1_read_response_record(self, flow, r, SMB1_HEADER_SIZE, nbss_remaining);
                                 let consumed = input.len() - output.len();
                                 return consumed;
                             }
@@ -1696,7 +1699,7 @@ impl SMBState {
                                 // So that we can check that further parsed offsets and lengths
                                 // stay within the NBSS record.
                                 let nbss_remaining = nbss_part_hdr.length - nbss_part_hdr.data.len() as u32;
-                                smb2_read_response_record(self, smb_record, nbss_remaining);
+                                smb2_read_response_record(self, flow, smb_record, nbss_remaining);
                                 let consumed = input.len() - output.len();
                                 return consumed;
                             }
@@ -1787,7 +1790,7 @@ impl SMBState {
                                             // see https://github.com/rust-lang/rust-clippy/issues/15158
                                             #[allow(clippy::collapsible_else_if)]
                                             if smb_record.is_response() {
-                                                smb1_response_record(self, smb_record);
+                                                smb1_response_record(self, flow, smb_record);
                                             } else {
                                                 SCLogDebug!("SMB1 request seen from server to client");
                                                 if let Some(frame) = pdu_frame {
@@ -1812,7 +1815,7 @@ impl SMBState {
                                                 // see https://github.com/rust-lang/rust-clippy/issues/15158
                                                 #[allow(clippy::collapsible_else_if)]
                                                 if smb_record.is_response() {
-                                                    smb2_response_record(self, smb_record);
+                                                    smb2_response_record(self, flow, smb_record);
                                                 } else {
                                                     SCLogDebug!("SMB2 request seen from server to client");
                                                     if let Some(frame) = pdu_frame {
@@ -1893,9 +1896,9 @@ impl SMBState {
                 },
             }
         };
-        self.post_gap_housekeeping(Direction::ToClient);
+        self.post_gap_housekeeping(flow, Direction::ToClient);
         if self.check_post_gap_file_txs && !self.post_gap_files_checked {
-            self.post_gap_housekeeping_for_files();
+            self.post_gap_housekeeping_for_files(flow);
             self.post_gap_files_checked = true;
         }
         self._debug_tx_stats();
@@ -1966,7 +1969,7 @@ impl SMBState {
         return AppLayerResult::ok();
     }
 
-    pub fn trunc_ts(&mut self) {
+    pub fn trunc_ts(&mut self, flow: *mut Flow) {
         SCLogDebug!("TRUNC TS");
         self.ts_trunc = true;
 
@@ -1974,10 +1977,11 @@ impl SMBState {
             if !tx.request_done {
                 SCLogDebug!("TRUNCATING TX {} in TOSERVER direction", tx.id);
                 tx.request_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
             }
        }
     }
-    pub fn trunc_tc(&mut self) {
+    pub fn trunc_tc(&mut self, flow: *mut Flow) {
         SCLogDebug!("TRUNC TC");
         self.tc_trunc = true;
 
@@ -1985,6 +1989,7 @@ impl SMBState {
             if !tx.response_done {
                 SCLogDebug!("TRUNCATING TX {} in TOCLIENT direction", tx.id);
                 tx.response_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
             }
         }
     }

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -20,10 +20,12 @@
  */
 
 use crate::direction::Direction;
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
 use crate::smb::smb::*;
 use crate::smb::dcerpc::*;
 use crate::smb::events::*;
 use crate::smb::files::*;
+use crate::flow::Flow;
 
 use crate::smb::smb1_records::*;
 use crate::smb::smb1_session::*;
@@ -147,7 +149,7 @@ pub fn smb1_check_tx(cmd: u8) -> bool {
     }
 }
 
-fn smb1_close_file(state: &mut SMBState, fid: &[u8], direction: Direction)
+fn smb1_close_file(state: &mut SMBState, flow: *mut Flow, fid: &[u8], direction: Direction)
 {
     if let Some(tx) = state.get_file_tx_by_fuid(fid, direction) {
         SCLogDebug!("found tx {}", tx.id);
@@ -156,7 +158,9 @@ fn smb1_close_file(state: &mut SMBState, fid: &[u8], direction: Direction)
                 SCLogDebug!("closing file tx {} FID {:?}", tx.id, fid);
                 filetracker_close(&mut tdf.file_tracker);
                 tx.request_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 tx.response_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                 SCLogDebug!("tx {} is done", tx.id);
             }
         }
@@ -181,7 +185,7 @@ fn smb1_command_is_andx(c: u8) -> bool {
     }
 }
 
-fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, andx_offset: &mut usize) {
+fn smb1_request_record_one(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, command: u8, andx_offset: &mut usize) {
     let mut events : Vec<SMBEvent> = Vec::new();
     let mut no_response_expected = false;
 
@@ -200,6 +204,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
                     let tx = state.new_rename_tx(Vec::new(), oldname, newname);
                     tx.hdr = tx_hdr;
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                     tx.vercmd.set_smb1_cmd(SMB1_COMMAND_RENAME);
                     true
                 },
@@ -230,6 +235,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
                                                     rd.subcmd, pd.loi, disp.delete);
                                             tx.hdr = tx_hdr;
                                             tx.request_done = true;
+                                            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                                             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TRANS2);
                                             true
 
@@ -259,6 +265,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
                                             let tx = state.new_rename_tx(fid, pd.oldname, newname);
                                             tx.hdr = tx_hdr;
                                             tx.request_done = true;
+                                            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                                             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TRANS2);
                                             true
                                         },
@@ -313,6 +320,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
                                                     rd.subcmd, pd.loi, disp.delete);
                                             tx.hdr = tx_hdr;
                                             tx.request_done = true;
+                                            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                                             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TRANS2);
                                             true
 
@@ -347,6 +355,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
                                             let tx = state.new_rename_tx(pd.fid.to_vec(), oldname, newname);
                                             tx.hdr = tx_hdr;
                                             tx.request_done = true;
+                                            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                                             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TRANS2);
                                             true
                                         },
@@ -416,11 +425,11 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
         SMB1_COMMAND_WRITE_ANDX |
         SMB1_COMMAND_WRITE |
         SMB1_COMMAND_WRITE_AND_CLOSE => {
-            smb1_write_request_record(state, r, *andx_offset, command, 0);
+            smb1_write_request_record(state, flow, r, *andx_offset, command, 0);
             true // tx handling in func
         },
         SMB1_COMMAND_TRANS => {
-            smb1_trans_request_record(state, r);
+            smb1_trans_request_record(state, flow, r);
             true
         },
         SMB1_COMMAND_NEGOTIATE_PROTOCOL => {
@@ -456,6 +465,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
                             tdn.dialects = dialects;
                         }
                         tx.request_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                         if bad_dialects {
                             tx.set_event(SMBEvent::NegotiateMalformedDialects);
                         }
@@ -484,6 +494,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
                     let tx = state.new_create_tx(&cr.file_name,
                             cr.disposition, del, dir, tx_hdr);
                     tx.vercmd.set_smb1_cmd(command);
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                     SCLogDebug!("TS CREATE TX {} created", tx.id);
                     true
                 },
@@ -495,7 +506,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
         },
         SMB1_COMMAND_SESSION_SETUP_ANDX => {
             SCLogDebug!("SMB1_COMMAND_SESSION_SETUP_ANDX user_id {}", r.user_id);
-            smb1_session_setup_request(state, r, *andx_offset);
+            smb1_session_setup_request(state, flow, r, *andx_offset);
             true
         },
         SMB1_COMMAND_TREE_CONNECT_ANDX => {
@@ -515,6 +526,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
                         tdn.req_service = Some(tr.service.to_vec());
                     }
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                     tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TREE_CONNECT_ANDX);
                     true
                 },
@@ -539,7 +551,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
                     state.ssn2vec_cache.put(SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID), fid.to_vec());
 
                     SCLogDebug!("closing FID {:?}/{:?}", cd.fid, fid);
-                    smb1_close_file(state, &fid, Direction::ToServer);
+                    smb1_close_file(state, flow, &fid, Direction::ToServer);
                 },
                 _ => {
                     events.push(SMBEvent::MalformedData);
@@ -573,21 +585,23 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
     if !have_tx && smb1_create_new_tx(command) {
         let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
         let tx = state.new_generic_tx(1, command as u16, tx_key);
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
         SCLogDebug!("tx {} created for {}/{}", tx.id, command, &smb1_command_string(command));
         tx.set_events(events);
         if no_response_expected {
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
         }
     }
 }
 
-pub fn smb1_request_record(state: &mut SMBState, r: &SmbRecord) -> u32 {
+pub fn smb1_request_record(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord) -> u32 {
     SCLogDebug!("record: command {}: record {:?}", r.command, r);
 
     let mut andx_offset = SMB1_HEADER_SIZE;
     let mut command = r.command;
     loop {
-        smb1_request_record_one(state, r, command, &mut andx_offset);
+        smb1_request_record_one(state, flow, r, command, &mut andx_offset);
 
         // continue for next andx command if any
         if smb1_command_is_andx(command) {
@@ -607,7 +621,7 @@ pub fn smb1_request_record(state: &mut SMBState, r: &SmbRecord) -> u32 {
     0
 }
 
-fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, andx_offset: &mut usize) {
+fn smb1_response_record_one(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, command: u8, andx_offset: &mut usize) {
     SCLogDebug!("record: command {} status {} -> {:?}", r.command, r.nt_status, r);
 
     let key_ssn_id = r.ssn_id;
@@ -618,7 +632,7 @@ fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, an
 
     let have_tx = match command {
         SMB1_COMMAND_READ_ANDX => {
-            smb1_read_response_record(state, r, *andx_offset, 0);
+            smb1_read_response_record(state, flow, r, *andx_offset, 0);
             true // tx handling in func
         },
         SMB1_COMMAND_NEGOTIATE_PROTOCOL => {
@@ -629,6 +643,7 @@ fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, an
                         Some(tx) => {
                             tx.set_status(r.nt_status, r.is_dos_error);
                             tx.response_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                             SCLogDebug!("tx {} is done", tx.id);
                             let d = match tx.type_data {
                                 Some(SMBTransactionTypeData::NEGOTIATE(ref mut x)) => {
@@ -672,6 +687,7 @@ fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, an
                     }
                     tx.set_status(r.nt_status, r.is_dos_error);
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                     SCLogDebug!("tx {} is done", tx.id);
                 }
                 return;
@@ -693,6 +709,7 @@ fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, an
                             tx.hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
                             tx.set_status(r.nt_status, r.is_dos_error);
                             tx.response_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                             SCLogDebug!("tx {} is done", tx.id);
                             true
                         },
@@ -742,6 +759,7 @@ fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, an
                                 tx.id, command, &smb1_command_string(command));
                         tx.set_status(r.nt_status, false);
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
 
                         if let Some(SMBTransactionTypeData::CREATE(ref mut tdn)) = tx.type_data {
                             tdn.create_ts = cr.create_ts.as_unix();
@@ -764,16 +782,16 @@ fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, an
             let fid = state.ssn2vec_cache.pop(&SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID));
             if let Some(fid) = fid {
                 SCLogDebug!("closing FID {:?}", fid);
-                smb1_close_file(state, &fid, Direction::ToClient);
+                smb1_close_file(state, flow, &fid, Direction::ToClient);
             }
             false
         },
         SMB1_COMMAND_TRANS => {
-            smb1_trans_response_record(state, r);
+            smb1_trans_response_record(state, flow, r);
             true
         },
         SMB1_COMMAND_SESSION_SETUP_ANDX => {
-            smb1_session_setup_response(state, r, *andx_offset);
+            smb1_session_setup_response(state, flow, r, *andx_offset);
             true
         },
         SMB1_COMMAND_LOGOFF_ANDX => {
@@ -789,6 +807,7 @@ fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, an
         if let Some(tx) = state.get_last_tx(1, command as u16) {
             SCLogDebug!("last TX {} is CMD {}", tx.id, &smb1_command_string(command));
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
             SCLogDebug!("tx {} cmd {} is done", tx.id, command);
             tx.set_status(r.nt_status, r.is_dos_error);
             tx.set_events(events);
@@ -799,7 +818,9 @@ fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, an
         let _have_tx2 = match state.get_generic_tx(1, command as u16, &tx_key) {
             Some(tx) => {
                 tx.request_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 tx.response_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                 SCLogDebug!("tx {} cmd {} is done", tx.id, command);
                 tx.set_status(r.nt_status, r.is_dos_error);
                 tx.set_events(events);
@@ -815,11 +836,11 @@ fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, an
     }
 }
 
-pub fn smb1_response_record(state: &mut SMBState, r: &SmbRecord) -> u32 {
+pub fn smb1_response_record(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord) -> u32 {
     let mut andx_offset = SMB1_HEADER_SIZE;
     let mut command = r.command;
     loop {
-        smb1_response_record_one(state, r, command, &mut andx_offset);
+        smb1_response_record_one(state, flow, r, command, &mut andx_offset);
 
         // continue for next andx command if any
         if smb1_command_is_andx(command) {
@@ -839,7 +860,7 @@ pub fn smb1_response_record(state: &mut SMBState, r: &SmbRecord) -> u32 {
     0
 }
 
-pub fn smb1_trans_request_record(state: &mut SMBState, r: &SmbRecord)
+pub fn smb1_trans_request_record(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord)
 {
     let mut events : Vec<SMBEvent> = Vec::new();
 
@@ -867,17 +888,17 @@ pub fn smb1_trans_request_record(state: &mut SMBState, r: &SmbRecord)
                 SCLogDebug!("SMBv1 TRANS TO PIPE");
                 let hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
                 let vercmd = SMBVerCmdStat::new1(r.command);
-                smb_write_dcerpc_record(state, vercmd, hdr, rd.data.data);
+                smb_write_dcerpc_record(state, flow, vercmd, hdr, rd.data.data);
             }
         },
         _ => {
             events.push(SMBEvent::MalformedData);
         },
     }
-    smb1_request_record_generic(state, r, events);
+    smb1_request_record_generic(state, flow, r, events);
 }
 
-pub fn smb1_trans_response_record(state: &mut SMBState, r: &SmbRecord)
+pub fn smb1_trans_response_record(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord)
 {
     let mut events : Vec<SMBEvent> = Vec::new();
 
@@ -908,7 +929,7 @@ pub fn smb1_trans_response_record(state: &mut SMBState, r: &SmbRecord)
                 SCLogDebug!("SMBv1 TRANS TO PIPE");
                 let hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
                 let vercmd = SMBVerCmdStat::new1_with_ntstatus(r.command, r.nt_status);
-                smb_read_dcerpc_record(state, vercmd, hdr, &fid, rd.data);
+                smb_read_dcerpc_record(state, flow, vercmd, hdr, &fid, rd.data);
             }
         },
         _ => {
@@ -917,11 +938,11 @@ pub fn smb1_trans_response_record(state: &mut SMBState, r: &SmbRecord)
     }
 
     // generic tx as well. Set events if needed.
-    smb1_response_record_generic(state, r, events);
+    smb1_response_record_generic(state, flow, r, events);
 }
 
 /// Handle WRITE, WRITE_ANDX, WRITE_AND_CLOSE request records
-pub fn smb1_write_request_record(state: &mut SMBState, r: &SmbRecord, andx_offset: usize, command: u8, nbss_remaining: u32)
+pub fn smb1_write_request_record(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, andx_offset: usize, command: u8, nbss_remaining: u32)
 {
     let mut events : Vec<SMBEvent> = Vec::new();
 
@@ -978,7 +999,7 @@ pub fn smb1_write_request_record(state: &mut SMBState, r: &SmbRecord, andx_offse
                     SCLogDebug!("SMBv1 WRITE TO PIPE");
                     let hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
                     let vercmd = SMBVerCmdStat::new1_with_ntstatus(command, r.nt_status);
-                    smb_write_dcerpc_record(state, vercmd, hdr, rd.data);
+                    smb_write_dcerpc_record(state, flow, vercmd, hdr, rd.data);
                 } else {
                     let tx = state.new_file_tx(&file_fid, &file_name, Direction::ToServer);
                     if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
@@ -1005,17 +1026,17 @@ pub fn smb1_write_request_record(state: &mut SMBState, r: &SmbRecord, andx_offse
             if command == SMB1_COMMAND_WRITE_AND_CLOSE {
                 let _name = state.guid2name_cache.pop(&file_fid);
                 SCLogDebug!("closing FID {:?}", file_fid);
-                smb1_close_file(state, &file_fid, Direction::ToServer);
+                smb1_close_file(state, flow, &file_fid, Direction::ToServer);
             }
         },
         _ => {
             events.push(SMBEvent::MalformedData);
         },
     }
-    smb1_request_record_generic(state, r, events);
+    smb1_request_record_generic(state, flow, r, events);
 }
 
-pub fn smb1_read_response_record(state: &mut SMBState, r: &SmbRecord, andx_offset: usize, nbss_remaining: u32)
+pub fn smb1_read_response_record(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, andx_offset: usize, nbss_remaining: u32)
 {
     let mut events : Vec<SMBEvent> = Vec::new();
 
@@ -1095,7 +1116,7 @@ pub fn smb1_read_response_record(state: &mut SMBState, r: &SmbRecord, andx_offse
                     // hack: we store fid with ssn id mixed in, but here we want the
                     // real thing instead.
                     let pure_fid = if file_fid.len() > 2 { &file_fid[0..2] } else { &[] };
-                    smb_read_dcerpc_record(state, vercmd, hdr, pure_fid, rd.data);
+                    smb_read_dcerpc_record(state, flow, vercmd, hdr, pure_fid, rd.data);
                 }
 
                 state.set_file_left(Direction::ToClient, rd.len, rd.data.len() as u32, file_fid.to_vec());
@@ -1107,16 +1128,18 @@ pub fn smb1_read_response_record(state: &mut SMBState, r: &SmbRecord, andx_offse
     }
 
     // generic tx as well. Set events if needed.
-    smb1_response_record_generic(state, r, events);
+    smb1_response_record_generic(state, flow, r, events);
 }
 
 /// create a tx for a command / response pair if we're
 /// configured to do so, or if this is a tx especially
 /// for setting an event.
-fn smb1_request_record_generic(state: &mut SMBState, r: &SmbRecord, events: Vec<SMBEvent>) {
+fn smb1_request_record_generic(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, events: Vec<SMBEvent>) {
+    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
     if smb1_create_new_tx(r.command) || !events.is_empty() {
         let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
         let tx = state.new_generic_tx(1, r.command as u16, tx_key);
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
         tx.set_events(events);
     }
 }
@@ -1124,11 +1147,13 @@ fn smb1_request_record_generic(state: &mut SMBState, r: &SmbRecord, events: Vec<
 /// update or create a tx for a command / response pair based
 /// on the response. We only create a tx for the response side
 /// if we didn't already update a tx, and we have to set events
-fn smb1_response_record_generic(state: &mut SMBState, r: &SmbRecord, events: Vec<SMBEvent>) {
+fn smb1_response_record_generic(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, events: Vec<SMBEvent>) {
     let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
     if let Some(tx) = state.get_generic_tx(1, r.command as u16, &tx_key) {
         tx.request_done = true;
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
         tx.response_done = true;
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
         SCLogDebug!("tx {} cmd {} is done", tx.id, r.command);
         tx.set_status(r.nt_status, r.is_dos_error);
         tx.set_events(events);
@@ -1137,8 +1162,10 @@ fn smb1_response_record_generic(state: &mut SMBState, r: &SmbRecord, events: Vec
     if !events.is_empty() {
         let tx = state.new_generic_tx(1, r.command as u16, tx_key);
         tx.request_done = true;
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
         tx.response_done = true;
         SCLogDebug!("tx {} cmd {} is done", tx.id, r.command);
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
         tx.set_status(r.nt_status, r.is_dos_error);
         tx.set_events(events);
     }

--- a/rust/src/smb/smb1_session.rs
+++ b/rust/src/smb/smb1_session.rs
@@ -20,6 +20,9 @@ use crate::smb::smb1_records::*;
 use crate::smb::smb::*;
 use crate::smb::events::*;
 use crate::smb::auth::*;
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
+use crate::flow::Flow;
+use crate::direction::Direction;
 
 #[derive(Debug)]
 pub struct SessionSetupResponse {
@@ -65,7 +68,7 @@ pub fn smb1_session_setup_response_host_info(r: &SmbRecord, blob: &[u8]) -> Sess
     }
 }
 
-pub fn smb1_session_setup_request(state: &mut SMBState, r: &SmbRecord, andx_offset: usize)
+pub fn smb1_session_setup_request(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, andx_offset: usize)
 {
     SCLogDebug!("SMB1_COMMAND_SESSION_SETUP_ANDX user_id {}", r.user_id);
     #[allow(clippy::single_match)]
@@ -75,6 +78,7 @@ pub fn smb1_session_setup_request(state: &mut SMBState, r: &SmbRecord, andx_offs
                     r.ssn_id as u64, 0, r.multiplex_id as u64);
             let tx = state.new_sessionsetup_tx(hdr);
             tx.vercmd.set_smb1_cmd(r.command);
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
 
             if let Some(SMBTransactionTypeData::SESSIONSETUP(ref mut td)) = tx.type_data {
                 td.request_host = Some(setup.request_host);
@@ -95,7 +99,7 @@ pub fn smb1_session_setup_request(state: &mut SMBState, r: &SmbRecord, andx_offs
     }
 }
 
-fn smb1_session_setup_update_tx(tx: &mut SMBTransaction, r: &SmbRecord, andx_offset: usize)
+fn smb1_session_setup_update_tx(flow: *mut Flow, tx: &mut SMBTransaction, r: &SmbRecord, andx_offset: usize)
 {
     match parse_smb_response_setup_andx_record(&r.data[andx_offset-SMB1_HEADER_SIZE..]) {
         Ok((rem, _setup)) => {
@@ -111,9 +115,10 @@ fn smb1_session_setup_update_tx(tx: &mut SMBTransaction, r: &SmbRecord, andx_off
     tx.hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER); // to overwrite ssn_id 0
     tx.set_status(r.nt_status, r.is_dos_error);
     tx.response_done = true;
+    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
 }
 
-pub fn smb1_session_setup_response(state: &mut SMBState, r: &SmbRecord, andx_offset: usize)
+pub fn smb1_session_setup_response(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, andx_offset: usize)
 {
     // try exact match with session id already set (e.g. NTLMSSP AUTH phase)
     let found = r.ssn_id != 0 && match state.get_sessionsetup_tx(
@@ -121,7 +126,7 @@ pub fn smb1_session_setup_response(state: &mut SMBState, r: &SmbRecord, andx_off
                     r.ssn_id as u64, 0, r.multiplex_id as u64))
     {
         Some(tx) => {
-            smb1_session_setup_update_tx(tx, r, andx_offset);
+            smb1_session_setup_update_tx(flow, tx, r, andx_offset);
             SCLogDebug!("smb1_session_setup_response: tx {:?}", tx);
             true
         },
@@ -132,7 +137,7 @@ pub fn smb1_session_setup_response(state: &mut SMBState, r: &SmbRecord, andx_off
         if let Some(tx) = state.get_sessionsetup_tx(
                 SMBCommonHdr::new(SMBHDR_TYPE_HEADER, 0, 0, r.multiplex_id as u64))
         {
-            smb1_session_setup_update_tx(tx, r, andx_offset);
+            smb1_session_setup_update_tx(flow, tx, r, andx_offset);
             SCLogDebug!("smb1_session_setup_response: tx {:?}", tx);
         } else {
             SCLogDebug!("smb1_session_setup_response: tx not found for {:?}", r);

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -18,6 +18,8 @@
 use nom8::Err;
 
 use crate::direction::Direction;
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
+use crate::flow::Flow;
 use crate::smb::smb::*;
 use crate::smb::smb2_records::*;
 use crate::smb::smb2_session::*;
@@ -100,7 +102,7 @@ fn smb2_create_new_tx(cmd: u16) -> bool {
     }
 }
 
-fn smb2_read_response_record_generic(state: &mut SMBState, r: &Smb2Record)
+fn smb2_read_response_record_generic(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record)
 {
     if smb2_create_new_tx(r.command) {
         let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
@@ -108,16 +110,17 @@ fn smb2_read_response_record_generic(state: &mut SMBState, r: &Smb2Record)
         if let Some(tx) = tx {
             tx.set_status(r.nt_status, false);
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
         }
     }
 }
 
-pub fn smb2_read_response_record(state: &mut SMBState, r: &Smb2Record, nbss_remaining: u32)
+pub fn smb2_read_response_record(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record, nbss_remaining: u32)
 {
     let max_queue_size = unsafe { SMB_CFG_MAX_READ_QUEUE_SIZE };
     let max_queue_cnt = unsafe { SMB_CFG_MAX_READ_QUEUE_CNT };
 
-    smb2_read_response_record_generic(state, r);
+    smb2_read_response_record_generic(state, flow, r);
 
     match parse_smb2_response_read(r.data) {
         Ok((_, rd)) => {
@@ -222,7 +225,7 @@ pub fn smb2_read_response_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
                     SCLogDebug!("SMBv2 DCERPC read");
                     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
                     let vercmd = SMBVerCmdStat::new2_with_ntstatus(SMB2_COMMAND_READ, r.nt_status);
-                    smb_read_dcerpc_record(state, vercmd, hdr, &file_guid, rd.data);
+                    smb_read_dcerpc_record(state, flow, vercmd, hdr, &file_guid, rd.data);
                 } else if is_pipe {
                     SCLogDebug!("non-DCERPC pipe");
                     state.set_skip(Direction::ToClient, nbss_remaining);
@@ -269,7 +272,7 @@ pub fn smb2_read_response_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
     }
 }
 
-pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record, nbss_remaining: u32)
+pub fn smb2_write_request_record(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record, nbss_remaining: u32)
 {
     let max_queue_size = unsafe { SMB_CFG_MAX_WRITE_QUEUE_SIZE };
     let max_queue_cnt = unsafe { SMB_CFG_MAX_WRITE_QUEUE_CNT };
@@ -279,6 +282,7 @@ pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
         let tx_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
         let tx = state.new_generic_tx(2, r.command, tx_key);
         tx.request_done = true;
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
     }
     match parse_smb2_request_write(r.data) {
         Ok((_, wr)) => {
@@ -366,7 +370,7 @@ pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
                     SCLogDebug!("SMBv2 DCERPC write");
                     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
                     let vercmd = SMBVerCmdStat::new2(SMB2_COMMAND_WRITE);
-                    smb_write_dcerpc_record(state, vercmd, hdr, wr.data);
+                    smb_write_dcerpc_record(state, flow, vercmd, hdr, wr.data);
                 } else if is_pipe {
                     SCLogDebug!("non-DCERPC pipe: skip rest of the record");
                     state.set_skip(Direction::ToServer, nbss_remaining);
@@ -407,7 +411,7 @@ pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
     }
 }
 
-pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
+pub fn smb2_request_record(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record)
 {
     SCLogDebug!("SMBv2 request record, command {} tree {} session {}",
             &smb2_command_string(r.command), r.tree_id, r.session_id);
@@ -433,6 +437,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
                             let tx = state.new_rename_tx(rd.guid.to_vec(), oldname, newname);
                             tx.hdr = tx_hdr;
                             tx.request_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                             tx.vercmd.set_smb2_cmd(SMB2_COMMAND_SET_INFO);
                             true
                         }
@@ -457,6 +462,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
                             let tx = state.new_setfileinfo_tx(fname, rd.guid.to_vec(), rd.class as u16, rd.infolvl as u16, dis.delete);
                             tx.hdr = tx_hdr;
                             tx.request_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                             tx.vercmd.set_smb2_cmd(SMB2_COMMAND_SET_INFO);
                             true
                         }
@@ -478,7 +484,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
             have_si_tx
         },
         SMB2_COMMAND_IOCTL => {
-            smb2_ioctl_request_record(state, r);
+            smb2_ioctl_request_record(state, flow, r);
             true
         },
         SMB2_COMMAND_TREE_DISCONNECT => {
@@ -502,6 +508,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
                         tdn.client_guid = Some(rd.client_guid.to_vec());
                     }
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 }
                 true
             } else {
@@ -510,7 +517,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
             }
         },
         SMB2_COMMAND_SESSION_SETUP => {
-            smb2_session_setup_request(state, r);
+            smb2_session_setup_request(state, flow, r);
             true
         },
         SMB2_COMMAND_TREE_CONNECT => {
@@ -524,6 +531,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
 
                 let tx = state.new_treeconnect_tx(name_key, name_val);
                 tx.request_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 tx.vercmd.set_smb2_cmd(SMB2_COMMAND_TREE_CONNECT);
                 true
             } else {
@@ -562,6 +570,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
                 let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
                 let tx = state.new_create_tx(cr.data, cr.disposition, del, dir, tx_hdr);
                 tx.vercmd.set_smb2_cmd(r.command);
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 SCLogDebug!("TS CREATE TX {} created", tx.id);
                 true
             } else {
@@ -570,7 +579,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
             }
         },
         SMB2_COMMAND_WRITE => {
-            smb2_write_request_record(state, r, 0);
+            smb2_write_request_record(state, flow, r, 0);
             true // write handling creates both file tx and generic tx
         },
         SMB2_COMMAND_CLOSE => {
@@ -584,7 +593,9 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
                         }
                     }
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                     tx.set_status(SMB_NTSTATUS_SUCCESS, false);
                     true
                 } else {
@@ -597,7 +608,9 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
                         }
                     }
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                     tx.set_status(SMB_NTSTATUS_SUCCESS, false);
                     true
                 } else {
@@ -621,11 +634,12 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
         let tx = state.new_generic_tx(2, r.command, tx_key);
         SCLogDebug!("TS TX {} command {} created with session_id {} tree_id {} message_id {}",
                 tx.id, r.command, r.session_id, r.tree_id, r.message_id);
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
         tx.set_events(events);
     }
 }
 
-pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
+pub fn smb2_response_record(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record)
 {
     SCLogDebug!("SMBv2 response record, command {} status {} tree {} session {} message {}",
             &smb2_command_string(r.command), r.nt_status,
@@ -635,11 +649,11 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
 
     let have_tx = match r.command {
         SMB2_COMMAND_IOCTL => {
-            smb2_ioctl_response_record(state, r);
+            smb2_ioctl_response_record(state, flow, r);
             true
         },
         SMB2_COMMAND_SESSION_SETUP => {
-            smb2_session_setup_response(state, r);
+            smb2_session_setup_response(state, flow, r);
             true
         },
         SMB2_COMMAND_WRITE => {
@@ -661,7 +675,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
         SMB2_COMMAND_READ => {
             if r.nt_status == SMB_NTSTATUS_SUCCESS ||
                r.nt_status == SMB_NTSTATUS_BUFFER_OVERFLOW {
-                smb2_read_response_record(state, r, 0);
+                smb2_read_response_record(state, flow, r, 0);
             } else if r.nt_status == SMB_NTSTATUS_END_OF_FILE {
                 SCLogDebug!("SMBv2: read response => EOF");
 
@@ -680,6 +694,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
                     }
                     tx.set_status(r.nt_status, false);
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 }
             } else {
                 SCLogDebug!("SMBv2 READ: status {}", r.nt_status);
@@ -705,6 +720,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
                             tx.id, r.command, &smb2_command_string(r.command));
                         tx.set_status(r.nt_status, false);
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
 
                         if let Some(SMBTransactionTypeData::CREATE(ref mut tdn)) = tx.type_data {
                             tdn.create_ts = cr.create_ts.as_unix();
@@ -747,6 +763,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
                             // update hdr now that we have a tree_id
                             tx.hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
                             tx.response_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                             tx.set_status(r.nt_status, false);
                             true
                         },
@@ -766,6 +783,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
                 let name_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_TREE);
                 if let Some(tx) = state.get_treeconnect_tx(name_key) {
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                     tx.set_status(r.nt_status, false);
                     true
                 } else {
@@ -802,6 +820,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
                         }
                         tx.set_status(r.nt_status, false);
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                         true
                     },
                     None => { false },
@@ -814,6 +833,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
                         }
                         tx.set_status(r.nt_status, false);
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                         true
                     },
                     None => { false },
@@ -840,6 +860,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
                         tx.id, r.command, &smb2_command_string(r.command));
                 if r.nt_status != SMB_NTSTATUS_PENDING {
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                 }
                 tx.set_status(r.nt_status, false);
                 tx.set_events(events);

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -20,9 +20,12 @@ use crate::smb::smb2::*;
 use crate::smb::smb2_records::*;
 use crate::smb::dcerpc::*;
 use crate::smb::events::*;
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
+use crate::direction::Direction;
 #[cfg(feature = "debug")]
 use crate::smb::funcs::*;
 use crate::smb::smb_status::*;
+use crate::flow::Flow;
 
 #[derive(Debug)]
 pub struct SMBTransactionIoctl {
@@ -57,7 +60,7 @@ impl SMBState {
 }
 
 // IOCTL responses ASYNC don't set the tree id
-pub fn smb2_ioctl_request_record(state: &mut SMBState, r: &Smb2Record)
+pub fn smb2_ioctl_request_record(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record)
 {
     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
     match parse_smb2_request_ioctl(r.data) {
@@ -71,22 +74,24 @@ pub fn smb2_ioctl_request_record(state: &mut SMBState, r: &Smb2Record)
             if is_dcerpc {
                 SCLogDebug!("IOCTL request data is_pipe. Calling smb_write_dcerpc_record");
                 let vercmd = SMBVerCmdStat::new2(SMB2_COMMAND_IOCTL);
-                smb_write_dcerpc_record(state, vercmd, hdr, rd.data);
+                smb_write_dcerpc_record(state, flow, vercmd, hdr, rd.data);
             } else {
                 SCLogDebug!("IOCTL {:08x} {}", rd.function, &fsctl_func_to_string(rd.function));
                 let tx = state.new_ioctl_tx(hdr, rd.function);
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 tx.vercmd.set_smb2_cmd(SMB2_COMMAND_IOCTL);
             }
         },
         _ => {
             let tx = state.new_generic_tx(2, r.command, hdr);
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
             tx.set_event(SMBEvent::MalformedData);
         },
     };
 }
 
 // IOCTL responses ASYNC don't set the tree id
-pub fn smb2_ioctl_response_record(state: &mut SMBState, r: &Smb2Record)
+pub fn smb2_ioctl_response_record(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record)
 {
     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
     match parse_smb2_response_ioctl(r.data) {
@@ -104,13 +109,14 @@ pub fn smb2_ioctl_response_record(state: &mut SMBState, r: &Smb2Record)
                 SCLogDebug!("IOCTL response data is_pipe. Calling smb_read_dcerpc_record");
                 let vercmd = SMBVerCmdStat::new2_with_ntstatus(SMB2_COMMAND_IOCTL, r.nt_status);
                 SCLogDebug!("TODO passing empty GUID");
-                smb_read_dcerpc_record(state, vercmd, hdr, &[],rd.data);
+                smb_read_dcerpc_record(state, flow, vercmd, hdr, &[],rd.data);
             } else {
                 SCLogDebug!("SMB2_COMMAND_IOCTL/SMB_NTSTATUS_PENDING looking for {:?}", hdr);
                 if let Some(tx) = state.get_generic_tx(2, SMB2_COMMAND_IOCTL, &hdr) {
                     tx.set_status(r.nt_status, false);
                     if r.nt_status != SMB_NTSTATUS_PENDING {
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                     }
                 }
             }
@@ -122,6 +128,7 @@ pub fn smb2_ioctl_response_record(state: &mut SMBState, r: &Smb2Record)
                 tx.set_status(r.nt_status, false);
                 if r.nt_status != SMB_NTSTATUS_PENDING {
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                 }
                 
                 // parsing failed for 'SUCCESS' record, set event

--- a/rust/src/smb/smb2_session.rs
+++ b/rust/src/smb/smb2_session.rs
@@ -19,8 +19,11 @@ use crate::smb::smb2_records::*;
 use crate::smb::smb::*;
 use crate::smb::events::*;
 use crate::smb::auth::*;
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
+use crate::direction::Direction;
+use crate::flow::Flow;
 
-pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record)
+pub fn smb2_session_setup_request(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record)
 {
     SCLogDebug!("SMB2_COMMAND_SESSION_SETUP: r.data.len() {}", r.data.len());
     #[allow(clippy::single_match)]
@@ -29,6 +32,7 @@ pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record)
             let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
             let tx = state.new_sessionsetup_tx(hdr);
             tx.vercmd.set_smb2_cmd(r.command);
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
 
             if let Some(SMBTransactionTypeData::SESSIONSETUP(ref mut td)) = tx.type_data {
                 if let Some(s) = parse_secblob(setup.data) {
@@ -48,21 +52,22 @@ pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record)
     }
 }
 
-fn smb2_session_setup_update_tx(tx: &mut SMBTransaction, r: &Smb2Record)
+fn smb2_session_setup_update_tx(flow: *mut Flow, tx: &mut SMBTransaction, r: &Smb2Record)
 {
     tx.hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER); // to overwrite ssn_id 0
     tx.set_status(r.nt_status, false);
     tx.response_done = true;
+    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
 }
 
-pub fn smb2_session_setup_response(state: &mut SMBState, r: &Smb2Record)
+pub fn smb2_session_setup_response(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record)
 {
     // try exact match with session id already set (e.g. NTLMSSP AUTH phase)
     let found = r.session_id != 0 && match state.get_sessionsetup_tx(
                 SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER))
     {
         Some(tx) => {
-            smb2_session_setup_update_tx(tx, r);
+            smb2_session_setup_update_tx(flow, tx, r);
             SCLogDebug!("smb2_session_setup_response: tx {:?}", tx);
             true
         },
@@ -73,7 +78,7 @@ pub fn smb2_session_setup_response(state: &mut SMBState, r: &Smb2Record)
         if let Some(tx) = state.get_sessionsetup_tx(
                 SMBCommonHdr::new(SMBHDR_TYPE_HEADER, 0, 0, r.message_id))
         {
-            smb2_session_setup_update_tx(tx, r);
+            smb2_session_setup_update_tx(flow, tx, r);
             SCLogDebug!("smb2_session_setup_response: tx {:?}", tx);
         } else {
             SCLogDebug!("smb2_session_setup_response: tx not found for {:?}", r);

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1302,7 +1302,8 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     if (s->flags & SIG_FLAG_APPLAYER) {
         SCJbAppendString(ctx.js, "applayer");
     }
-    if (s->flags & SIG_FLAG_REQUIRE_PACKET) {
+    if ((s->flags & SIG_FLAG_REQUIRE_PACKET) ||
+            (s->flags & SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD)) { // STODO add new output if accepted
         SCJbAppendString(ctx.js, "need_packet");
     }
     if (s->flags & SIG_FLAG_REQUIRE_STREAM) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1886,6 +1886,11 @@ static int DetectEngineInspectRulePayloadMatches(
         if (pmatch == 0) {
             SCLogDebug("no match in stream, fall back to packet payload");
 
+            if ((s->flags & SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD) &&
+                    !(s->flags & SIG_FLAG_REQUIRE_PACKET)) {
+                SCLogDebug("no packet payload match required");
+                return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
+            }
             /* skip if we don't have to inspect the packet and segment was
              * added to stream */
             if (!(s->flags & SIG_FLAG_REQUIRE_PACKET) && (p->flags & PKT_STREAM_ADD)) {

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2856,7 +2856,7 @@ static void SigConsolidateTcpBuffer(Signature *s)
                 for (const SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_MATCH]; sm != NULL;
                         sm = sm->next) {
                     if (sm->type == DETECT_STREAM_SIZE) {
-                        s->flags |= SIG_FLAG_REQUIRE_PACKET;
+                        s->flags |= SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD;
                         break;
                     }
                 }

--- a/src/detect.h
+++ b/src/detect.h
@@ -261,6 +261,7 @@ typedef struct DetectPort_ {
     BIT_U32(13) /**< signature is requiring stream match. Stream match is not optional, so no      \
                    fallback to packet payload. */
 
+#define SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD BIT_U32(14)
 // vacancies
 
 #define SIG_FLAG_REQUIRE_FLOWVAR        BIT_U32(17) /**< signature can only match if a flowbit, flowvar or flowint is available. */


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/14649

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7863

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3164

Changes since v1:
- removed redundant calls
- additional fix in the detection engine to avoid the extra alerts seen

Note: An internal test failure is blocked and to be evaluated.

If this is acceptable, I'll clear the TODOs and submit a clean PR.