### PR TITLE
decode/sctp: prevent chunk_cnt wrap overrunning chunk_types

### DIFF
--- a/doc/userguide/rules/sctp-keywords.rst
+++ b/doc/userguide/rules/sctp-keywords.rst
@@ -130,7 +130,7 @@ sctp.chunk_cnt
 
 Match on the number of SCTP chunks in the packet.
 
-sctp.chunk_cnt uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+sctp.chunk_cnt uses an :ref:`unsigned 16-bit integer <rules-integer-keywords>`.
 
 Syntax::
 

--- a/src/decode-sctp.c
+++ b/src/decode-sctp.c
@@ -58,7 +58,11 @@ static int DecodeSCTPChunks(Packet *p, const uint8_t *pkt, uint16_t len)
     const SCTPHdr *sctph = PacketGetSCTP(p);
     const uint32_t vtag = SCTP_GET_RAW_VTAG(sctph);
     uint32_t offset = 0;
-    uint8_t chunk_cnt = 0;
+    /* A packet can carry one chunk per 4 bytes of data, so the running count
+     * has to hold up to len/4 chunks (len is u16, so this fits a u16). A uint8_t
+     * wraps past 255 and reopens the tracking gate below, letting
+     * tracked_chunk_cnt grow past chunk_types[]. */
+    uint16_t chunk_cnt = 0;
     uint8_t tracked_chunk_cnt = 0;
     bool has_init = false;
     bool has_init_ack = false;
@@ -677,6 +681,45 @@ static int SCTPDecodeSmallDataChunkTest12(void)
     PASS;
 }
 
+/** \test Many minimal chunks (> 255) must not push tracked_chunk_cnt past
+ *  the chunk_types[] array bound. */
+static int SCTPDecodeTooManyChunksTest13(void)
+{
+    const uint16_t n_chunks = 257;
+    uint8_t raw_sctp[SCTP_HEADER_LEN + 257 * SCTP_CHUNK_HDR_LEN];
+    memset(raw_sctp, 0, sizeof(raw_sctp));
+    /* common header: sport=1234, dport=80, vtag=1, checksum=0 */
+    raw_sctp[0] = 0x04;
+    raw_sctp[1] = 0xd2;
+    raw_sctp[3] = 0x50;
+    raw_sctp[7] = 0x01;
+    for (uint16_t i = 0; i < n_chunks; i++) {
+        uint8_t *c = raw_sctp + SCTP_HEADER_LEN + i * SCTP_CHUNK_HDR_LEN;
+        c[0] = SCTP_CHUNK_TYPE_SHUTDOWN_ACK; /* non-DATA, non-INIT */
+        c[3] = SCTP_CHUNK_HDR_LEN;           /* chunk length = 4 (header only) */
+    }
+
+    Packet *p = PacketGetFromAlloc();
+    FAIL_IF_NULL(p);
+    ThreadVars tv;
+    DecodeThreadVars dtv;
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&dtv, 0, sizeof(DecodeThreadVars));
+
+    FlowInitConfig(FLOW_QUIET);
+    DecodeSCTP(&tv, &dtv, p, raw_sctp, sizeof(raw_sctp));
+    FAIL_IF_NOT(PacketIsSCTP(p));
+
+    FAIL_IF(p->l4.vars.sctp.tracked_chunk_cnt > SCTP_MAX_TRACKED_CHUNKS);
+    FAIL_IF(p->l4.vars.sctp.chunk_cnt != n_chunks);
+    FAIL_IF_NOT(ENGINE_ISSET_EVENT(p, SCTP_TOO_MANY_CHUNKS));
+
+    PacketFree(p);
+    FlowShutdown();
+    PASS;
+}
+
 #endif /* UNITTESTS */
 
 void DecodeSCTPRegisterTests(void)
@@ -694,6 +737,7 @@ void DecodeSCTPRegisterTests(void)
     UtRegisterTest("SCTPDecodeDataOffsetTest10", SCTPDecodeDataOffsetTest10);
     UtRegisterTest("SCTPDecodeMultiDataTest11", SCTPDecodeMultiDataTest11);
     UtRegisterTest("SCTPDecodeSmallDataChunkTest12", SCTPDecodeSmallDataChunkTest12);
+    UtRegisterTest("SCTPDecodeTooManyChunksTest13", SCTPDecodeTooManyChunksTest13);
 #endif
 }
 /**

--- a/src/decode-sctp.h
+++ b/src/decode-sctp.h
@@ -77,7 +77,7 @@ typedef struct SCTPChunkHdr_ {
 
 typedef struct SCTPVars_ {
     uint16_t hlen;             /**< total header length (common header + chunks) */
-    uint8_t chunk_cnt;         /**< number of chunks parsed */
+    uint16_t chunk_cnt;        /**< number of chunks parsed */
     uint8_t tracked_chunk_cnt; /**< number of chunks tracked (capped at SCTP_MAX_TRACKED_CHUNKS) */
     uint8_t chunk_types[SCTP_MAX_TRACKED_CHUNKS]; /**< types of first N chunks */
     uint8_t data_chunk_cnt;                       /**< number of DATA chunk payloads tracked */

--- a/src/detect-sctp-chunk-cnt.c
+++ b/src/detect-sctp-chunk-cnt.c
@@ -53,7 +53,7 @@ void DetectSCTPChunkCntRegister(void)
     sigmatch_table[DETECT_SCTP_CHUNK_CNT].Match = DetectSCTPChunkCntMatch;
     sigmatch_table[DETECT_SCTP_CHUNK_CNT].Setup = DetectSCTPChunkCntSetup;
     sigmatch_table[DETECT_SCTP_CHUNK_CNT].Free = DetectSCTPChunkCntFree;
-    sigmatch_table[DETECT_SCTP_CHUNK_CNT].flags = SIGMATCH_INFO_UINT8;
+    sigmatch_table[DETECT_SCTP_CHUNK_CNT].flags = SIGMATCH_INFO_UINT16;
     sigmatch_table[DETECT_SCTP_CHUNK_CNT].SupportsPrefilter = PrefilterSCTPChunkCntIsPrefilterable;
     sigmatch_table[DETECT_SCTP_CHUNK_CNT].SetupPrefilter = PrefilterSetupSCTPChunkCnt;
 }
@@ -67,14 +67,14 @@ static int DetectSCTPChunkCntMatch(
         return 0;
     }
 
-    uint8_t val = p->l4.vars.sctp.chunk_cnt;
-    const DetectU8Data *data = (const DetectU8Data *)ctx;
-    return DetectU8Match(val, data);
+    uint16_t val = p->l4.vars.sctp.chunk_cnt;
+    const DetectU16Data *data = (const DetectU16Data *)ctx;
+    return DetectU16Match(val, data);
 }
 
 static int DetectSCTPChunkCntSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    DetectU8Data *data = DetectU8Parse(str);
+    DetectU16Data *data = DetectU16Parse(str);
     if (data == NULL)
         return -1;
 
@@ -90,8 +90,8 @@ static int DetectSCTPChunkCntSetup(DetectEngineCtx *de_ctx, Signature *s, const 
 
 void DetectSCTPChunkCntFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    DetectU8Data *data = (DetectU8Data *)ptr;
-    SCDetectU8Free(data);
+    DetectU16Data *data = (DetectU16Data *)ptr;
+    SCDetectU16Free(data);
 }
 
 static void PrefilterPacketSCTPChunkCntMatch(
@@ -99,20 +99,28 @@ static void PrefilterPacketSCTPChunkCntMatch(
 {
     DEBUG_VALIDATE_BUG_ON(PKT_IS_PSEUDOPKT(p));
 
-    if (PacketIsSCTP(p)) {
-        uint8_t val = p->l4.vars.sctp.chunk_cnt;
-        const PrefilterPacketU8HashCtx *h = pectx;
-        const SigsArray *sa = h->array[val];
-        if (sa) {
-            PrefilterAddSids(&det_ctx->pmq, sa->sigs, sa->cnt);
-        }
+    if (!PacketIsSCTP(p))
+        return;
+
+    uint16_t val = p->l4.vars.sctp.chunk_cnt;
+
+    const PrefilterPacketHeaderCtx *ctx = pectx;
+    if (!PrefilterPacketHeaderExtraMatch(ctx, p))
+        return;
+
+    DetectU16Data du16;
+    du16.mode = ctx->v1.u8[0];
+    du16.arg1 = ctx->v1.u16[1];
+    du16.arg2 = ctx->v1.u16[2];
+    if (DetectU16Match(val, &du16)) {
+        PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }
 }
 
 static int PrefilterSetupSCTPChunkCnt(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
 {
-    return PrefilterSetupPacketHeaderU8Hash(de_ctx, sgh, DETECT_SCTP_CHUNK_CNT,
-            SIG_MASK_REQUIRE_REAL_PKT, PrefilterPacketU8Set, PrefilterPacketU8Compare,
+    return PrefilterSetupPacketHeader(de_ctx, sgh, DETECT_SCTP_CHUNK_CNT,
+            SIG_MASK_REQUIRE_REAL_PKT, PrefilterPacketU16Set, PrefilterPacketU16Compare,
             PrefilterPacketSCTPChunkCntMatch);
 }
 


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in doc/userguide/) to reflect the changes made
- [ ] I have updated the JSON schema (in etc/schema.json) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- DecodeSCTPChunks() counts chunks in a uint8_t. An SCTP packet can carry one chunk per four bytes, so a packet with more than 255 minimal 4-byte chunks wraps chunk_cnt back below SCTP_MAX_TRACKED_CHUNKS and reopens the `chunk_cnt < SCTP_MAX_TRACKED_CHUNKS` tracking gate. tracked_chunk_cnt then keeps incrementing past the 16-entry chunk_types[] array, and the consumers that walk chunk_types[] up to tracked_chunk_cnt (the SHUTDOWN scan in this file, the eve logger in output-json.c, and the sctp.chunk_type keyword) read off the end of the array.
- Before: a packet with 257 four-byte chunks leaves tracked_chunk_cnt at 17, and those readers go one byte past chunk_types[16] (ASan reports a heap-buffer-overflow on the array). After: the running counter is uint16_t, so the loop (already bounded by the L4 length, which is itself u16) can no longer wrap and tracked_chunk_cnt stays capped at 16. The count is then carried through to the rest of the engine as a u16 instead of being truncated: the stored chunk_cnt field is uint16_t, the sctp.chunk_cnt keyword now matches as a u16, and the eve logger already takes a u64 so it logs the real value.
- Added SCTPDecodeTooManyChunksTest13, which fails on the current tree and passes with this change.
