### PR TITLE
rust: exclude DETECT_BYTEMATH_ENDIAN_DEFAULT from bindings

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -119,6 +119,7 @@ exclude = [
     "SIGMATCH_NOOPT",
     "SIGMATCH_INFO_STICKY_BUFFER",
     "FtpCommand",
+    "DETECT_BYTEMATH_ENDIAN_DEFAULT",
 ]
 
 # Types of items that we'll generate. If empty, then all types of item are emitted.


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none, just make CI green again

Describe changes:
- unclean cherry-pick from 0345b91ddd3c7a33957f8fd58cedd3d464ffb43c
