### PR TITLE
decode/sctp: chunk_cnt can be a u16

### DIFF
--- a/doc/userguide/rules/sctp-keywords.rst
+++ b/doc/userguide/rules/sctp-keywords.rst
@@ -130,7 +130,7 @@ sctp.chunk_cnt
 
 Match on the number of SCTP chunks in the packet.
 
-sctp.chunk_cnt uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+sctp.chunk_cnt uses an :ref:`unsigned 16-bit integer <rules-integer-keywords>`.
 
 Syntax::
 

--- a/src/decode-sctp.c
+++ b/src/decode-sctp.c
@@ -58,7 +58,7 @@ static int DecodeSCTPChunks(Packet *p, const uint8_t *pkt, uint16_t len)
     const SCTPHdr *sctph = PacketGetSCTP(p);
     const uint32_t vtag = SCTP_GET_RAW_VTAG(sctph);
     uint32_t offset = 0;
-    uint8_t chunk_cnt = 0;
+    uint16_t chunk_cnt = 0;
     uint8_t tracked_chunk_cnt = 0;
     bool has_init = false;
     bool has_init_ack = false;

--- a/src/decode-sctp.h
+++ b/src/decode-sctp.h
@@ -77,7 +77,7 @@ typedef struct SCTPChunkHdr_ {
 
 typedef struct SCTPVars_ {
     uint16_t hlen;             /**< total header length (common header + chunks) */
-    uint8_t chunk_cnt;         /**< number of chunks parsed */
+    uint16_t chunk_cnt;        /**< number of chunks parsed */
     uint8_t tracked_chunk_cnt; /**< number of chunks tracked (capped at SCTP_MAX_TRACKED_CHUNKS) */
     uint8_t chunk_types[SCTP_MAX_TRACKED_CHUNKS]; /**< types of first N chunks */
     uint8_t data_chunk_cnt;                       /**< number of DATA chunk payloads tracked */

--- a/src/detect-sctp-chunk-cnt.c
+++ b/src/detect-sctp-chunk-cnt.c
@@ -53,7 +53,7 @@ void DetectSCTPChunkCntRegister(void)
     sigmatch_table[DETECT_SCTP_CHUNK_CNT].Match = DetectSCTPChunkCntMatch;
     sigmatch_table[DETECT_SCTP_CHUNK_CNT].Setup = DetectSCTPChunkCntSetup;
     sigmatch_table[DETECT_SCTP_CHUNK_CNT].Free = DetectSCTPChunkCntFree;
-    sigmatch_table[DETECT_SCTP_CHUNK_CNT].flags = SIGMATCH_INFO_UINT8;
+    sigmatch_table[DETECT_SCTP_CHUNK_CNT].flags = SIGMATCH_INFO_UINT16;
     sigmatch_table[DETECT_SCTP_CHUNK_CNT].SupportsPrefilter = PrefilterSCTPChunkCntIsPrefilterable;
     sigmatch_table[DETECT_SCTP_CHUNK_CNT].SetupPrefilter = PrefilterSetupSCTPChunkCnt;
 }
@@ -67,14 +67,14 @@ static int DetectSCTPChunkCntMatch(
         return 0;
     }
 
-    uint8_t val = p->l4.vars.sctp.chunk_cnt;
-    const DetectU8Data *data = (const DetectU8Data *)ctx;
-    return DetectU8Match(val, data);
+    uint16_t val = p->l4.vars.sctp.chunk_cnt;
+    const DetectU16Data *data = (const DetectU16Data *)ctx;
+    return DetectU16Match(val, data);
 }
 
 static int DetectSCTPChunkCntSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    DetectU8Data *data = DetectU8Parse(str);
+    DetectU16Data *data = DetectU16Parse(str);
     if (data == NULL)
         return -1;
 
@@ -90,8 +90,8 @@ static int DetectSCTPChunkCntSetup(DetectEngineCtx *de_ctx, Signature *s, const 
 
 void DetectSCTPChunkCntFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    DetectU8Data *data = (DetectU8Data *)ptr;
-    SCDetectU8Free(data);
+    DetectU16Data *data = (DetectU16Data *)ptr;
+    SCDetectU16Free(data);
 }
 
 static void PrefilterPacketSCTPChunkCntMatch(
@@ -100,20 +100,22 @@ static void PrefilterPacketSCTPChunkCntMatch(
     DEBUG_VALIDATE_BUG_ON(PKT_IS_PSEUDOPKT(p));
 
     if (PacketIsSCTP(p)) {
-        uint8_t val = p->l4.vars.sctp.chunk_cnt;
-        const PrefilterPacketU8HashCtx *h = pectx;
-        const SigsArray *sa = h->array[val];
-        if (sa) {
-            PrefilterAddSids(&det_ctx->pmq, sa->sigs, sa->cnt);
+        uint16_t val = p->l4.vars.sctp.chunk_cnt;
+        const PrefilterPacketHeaderCtx *ctx = pectx;
+        DetectU16Data du16;
+        du16.mode = ctx->v1.u8[0];
+        du16.arg1 = ctx->v1.u16[1];
+        du16.arg2 = ctx->v1.u16[2];
+        if (DetectU16Match(val, &du16)) {
+            PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
         }
     }
 }
 
 static int PrefilterSetupSCTPChunkCnt(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
 {
-    return PrefilterSetupPacketHeaderU8Hash(de_ctx, sgh, DETECT_SCTP_CHUNK_CNT,
-            SIG_MASK_REQUIRE_REAL_PKT, PrefilterPacketU8Set, PrefilterPacketU8Compare,
-            PrefilterPacketSCTPChunkCntMatch);
+    return PrefilterSetupPacketHeader(de_ctx, sgh, DETECT_SCTP_CHUNK_CNT, SIG_MASK_REQUIRE_REAL_PKT,
+            PrefilterPacketU16Set, PrefilterPacketU16Compare, PrefilterPacketSCTPChunkCntMatch);
 }
 
 static bool PrefilterSCTPChunkCntIsPrefilterable(const Signature *s)


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8661

Describe changes:
- decode/sctp: chunk_cnt can be a u16

@glongo told me there was already https://github.com/OISF/suricata/pull/15642 opened but I see there are requested changes there, so putting my work here