### PR TITLE
ftp: fixups for firewall mode - v1

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -650,6 +650,10 @@ static AppLayerResult FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserS
         FTPTransaction *tx = FTPGetOldestTx(state, lasttx);
         if (tx == NULL) {
             tx = FTPTransactionCreate(state);
+            if (tx != NULL) {
+                /* This is a TC only transaction, skip TS inspection. */
+                tx->tx_data.flags |= APP_LAYER_TX_SKIP_INSPECT_TS;
+            }
         }
         if (unlikely(tx == NULL)) {
             SCReturnStruct(APP_LAYER_ERROR);

--- a/src/detect-ftpdata.c
+++ b/src/detect-ftpdata.c
@@ -105,17 +105,7 @@ static int DetectFtpdataMatch(DetectEngineThreadCtx *det_ctx,
     if (ftp_state == NULL)
         return 0;
 
-    if (ftpcommandd->command == ftp_state->command) {
-        /* Only match if the flow is in the good direction */
-        if ((flags & STREAM_TOSERVER) && (ftpcommandd->command == FTP_COMMAND_RETR)) {
-            return 0;
-        } else if ((flags & STREAM_TOCLIENT) && (ftpcommandd->command == FTP_COMMAND_STOR)) {
-            return 0;
-        }
-        return 1;
-    }
-
-    return 0;
+    return ftpcommandd->command == ftp_state->command;
 }
 
 /**


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8663
Ticket: https://redmine.openinfosecfoundation.org/issues/8662

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3167

First round of fixups for FTP in firewall mode.

First, allow the the first, to-client only transaction to pass so we can move
onto other transactions.

Second, remove the directionality of the ftpdata_command keyword. In firewall
mode, the request hooks never evaluation in passive mode, and the response
hooks never evaluate in active mode. And this data is information on the state
anyways, not really directional so I made the choice to just remove direction.
To be discussed here if not ideal.
