### PR TITLE
Tx sub states/v1.11

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -8982,6 +8982,10 @@
             "type": "object",
             "additionalProperties": true
         },
+        "sub_state": {
+            "type": "string",
+            "description": "Transaction type or sub state."
+        },
         "suricata_version": {
             "type": "string"
         },

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -79,6 +79,8 @@ include = [
     "FtpStateValues",
     "FtpDataStateValues",
     "HTTP2TxProgress",
+    "HTTP2TxGlobalProgress",
+    "HTTP2TxType",
     "DataRepType",
 ]
 

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -29,14 +29,17 @@ use crate::detect::{
     SIGMATCH_INFO_MULTI_UINT, SIGMATCH_INFO_UINT16, SIGMATCH_INFO_UINT8,
 };
 use crate::direction::Direction;
+use crate::http2::http2::{HTTP2TxProgress, HTTP2TxType};
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
-    DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
-    SCDetectHelperBufferProgressRegister, SCDetectHelperKeywordAliasRegister,
-    SCDetectHelperKeywordRegister, SCDetectHelperMultiBufferProgressMpmRegister,
-    SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx,
-    Signature, SIGMATCH_SUPPORT_FIREWALL,
+    AppProtoEnum, DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
+    SCDetectHelperBufferProgressRegister, SCDetectHelperBufferProgressRegisterSubState,
+    SCDetectHelperKeywordAliasRegister, SCDetectHelperKeywordRegister,
+    SCDetectHelperMultiBufferProgressMpmRegister,
+    SCDetectHelperMultiBufferProgressMpmRegisterSubState, SCDetectSignatureSetAppProto,
+    SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+    SIGMATCH_SUPPORT_FIREWALL,
 };
 
 /// Perform the DNS opcode match.
@@ -374,6 +377,18 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         Some(dns_tx_get_answer_name),
         1, // response complete
     );
+    _ = SCDetectHelperMultiBufferProgressMpmRegisterSubState(
+        b"dns.answer.name\0".as_ptr() as *const libc::c_char,
+        b"dns answer name\0".as_ptr() as *const libc::c_char,
+        AppProtoEnum::ALPROTO_DOH2 as u16,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        /* Register also in the TO_SERVER direction, even though this is not
+        normal, it could be provided as part of a request. */
+        Some(dns_tx_get_answer_name),
+        HTTP2TxType::HTTP2TxTypeStream as u8,
+        HTTP2TxProgress::HTTP2ProgClosed as u8,
+    );
+
     let kw = SCSigTableAppLiteElmt {
         name: b"dns.opcode\0".as_ptr() as *const libc::c_char,
         desc: b"Match the DNS header opcode flag.\0".as_ptr() as *const libc::c_char,
@@ -390,6 +405,14 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         STREAM_TOSERVER | STREAM_TOCLIENT,
         1,
     );
+    _ = SCDetectHelperBufferProgressRegisterSubState(
+        b"dns.opcode\0".as_ptr() as *const libc::c_char,
+        AppProtoEnum::ALPROTO_DOH2 as u16,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        HTTP2TxType::HTTP2TxTypeStream as u8,
+        HTTP2TxProgress::HTTP2ProgClosed as u8,
+    );
+
     let kw = SigTableElmtStickyBuffer {
         name: String::from("dns.query.name"),
         desc: String::from("DNS query name sticky buffer"),
@@ -407,6 +430,18 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         Some(dns_tx_get_query_name),
         1, // request or response complete
     );
+    _ = SCDetectHelperMultiBufferProgressMpmRegisterSubState(
+        b"dns.query.name\0".as_ptr() as *const libc::c_char,
+        b"dns query name\0".as_ptr() as *const libc::c_char,
+        AppProtoEnum::ALPROTO_DOH2 as u16,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        /* Register in both directions as the query is usually echoed back
+        in the response. */
+        Some(dns_tx_get_query_name),
+        HTTP2TxType::HTTP2TxTypeStream as u8,
+        HTTP2TxProgress::HTTP2ProgClosed as u8,
+    );
+
     let kw = SCSigTableAppLiteElmt {
         name: b"dns.rcode\0".as_ptr() as *const libc::c_char,
         desc: b"Match the DNS header rcode flag.\0".as_ptr() as *const libc::c_char,
@@ -423,6 +458,14 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         STREAM_TOSERVER | STREAM_TOCLIENT,
         1,
     );
+    _ = SCDetectHelperBufferProgressRegisterSubState(
+        b"dns.rcode\0".as_ptr() as *const libc::c_char,
+        AppProtoEnum::ALPROTO_DOH2 as u16,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        HTTP2TxType::HTTP2TxTypeStream as u8,
+        HTTP2TxProgress::HTTP2ProgClosed as u8,
+    );
+
     let kw = SCSigTableAppLiteElmt {
         name: b"dns.rrtype\0".as_ptr() as *const libc::c_char,
         desc: b"Match the DNS rrtype in message body.\0".as_ptr() as *const libc::c_char,
@@ -439,6 +482,14 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         STREAM_TOSERVER | STREAM_TOCLIENT,
         1,
     );
+    _ = SCDetectHelperBufferProgressRegisterSubState(
+        b"dns.rrtype\0".as_ptr() as *const libc::c_char,
+        AppProtoEnum::ALPROTO_DOH2 as u16,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        HTTP2TxType::HTTP2TxTypeStream as u8,
+        HTTP2TxProgress::HTTP2ProgClosed as u8,
+    );
+
     let kw = SigTableElmtStickyBuffer {
         name: String::from("dns.query"),
         desc: String::from("sticky buffer to match DNS query-buffer"),
@@ -457,6 +508,15 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         STREAM_TOSERVER,
         Some(dns_tx_get_query), // reuse, will be called only toserver
         1,                      // request complete
+    );
+    _ = SCDetectHelperMultiBufferProgressMpmRegisterSubState(
+        b"dns_query\0".as_ptr() as *const libc::c_char,
+        b"dns request query\0".as_ptr() as *const libc::c_char,
+        AppProtoEnum::ALPROTO_DOH2 as u16,
+        STREAM_TOSERVER,
+        Some(dns_tx_get_query),
+        HTTP2TxType::HTTP2TxTypeStream as u8,
+        HTTP2TxProgress::HTTP2ProgClosed as u8,
     );
 }
 

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -16,7 +16,8 @@
  */
 
 use super::http2::{
-    HTTP2Event, HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TxProgress,
+    HTTP2Event, HTTP2Frame, HTTP2FrameTypeData, HTTP2Progress, HTTP2State, HTTP2Transaction,
+    HTTP2TxProgress,
 };
 use super::parser;
 use crate::detect::uint::{
@@ -42,11 +43,7 @@ pub unsafe extern "C" fn SCHttp2TxHasFrametype(
     } else {
         &tx.frames_tc
     };
-    let eof = if direction & Direction::ToServer as u8 != 0 {
-        tx.progress_ts >= HTTP2TxProgress::HTTP2ProgComplete
-    } else {
-        tx.progress_tc >= HTTP2TxProgress::HTTP2ProgComplete
-    };
+    let eof = tx.progress.is_complete_for_direction(direction);
     return detect_uint_match_at_index::<HTTP2Frame, u8>(
         frames,
         ctx,
@@ -89,11 +86,7 @@ pub unsafe extern "C" fn SCHttp2TxHasErrorCode(
     } else {
         &tx.frames_tc
     };
-    let eof = if direction & Direction::ToServer as u8 != 0 {
-        tx.progress_ts >= HTTP2TxProgress::HTTP2ProgComplete
-    } else {
-        tx.progress_tc >= HTTP2TxProgress::HTTP2ProgComplete
-    };
+    let eof = tx.progress.is_complete_for_direction(direction);
     return detect_uint_match_at_index::<HTTP2Frame, u32>(frames, ctx, http2_tx_get_errorcode, eof);
 }
 
@@ -147,11 +140,7 @@ fn http2_match_priority(
     } else {
         &tx.frames_tc
     };
-    let eof = if direction == Direction::ToServer {
-        tx.progress_ts >= HTTP2TxProgress::HTTP2ProgComplete
-    } else {
-        tx.progress_tc >= HTTP2TxProgress::HTTP2ProgComplete
-    };
+    let eof = tx.progress.is_complete_for_direction(direction.into());
     return detect_uint_match_at_index::<HTTP2Frame, u8>(frames, ctx, get_http2_priority, eof);
 }
 
@@ -180,11 +169,7 @@ fn http2_match_window(
         &tx.frames_tc
     };
     // WINDOW_UPDATE frames may be sent in half-closed state
-    let eof = if direction == Direction::ToServer {
-        tx.progress_ts >= HTTP2TxProgress::HTTP2ProgComplete
-    } else {
-        tx.progress_tc >= HTTP2TxProgress::HTTP2ProgComplete
-    };
+    let eof = tx.progress.is_complete_for_direction(direction.into());
     return detect_uint_match_at_index::<HTTP2Frame, u32>(frames, ctx, get_http2_window, eof);
 }
 
@@ -1013,7 +998,9 @@ fn http2_tx_set_header(state: &mut HTTP2State, name: &[u8], input: &[u8]) {
         data: txdata,
     });
     //we do not expect more data from client
-    tx.progress_ts = HTTP2TxProgress::HTTP2ProgClosed;
+    if let HTTP2Progress::STREAM(ref mut stream_tx) = tx.progress {
+        stream_tx.progress_ts = HTTP2TxProgress::HTTP2ProgClosed;
+    }
 }
 
 #[no_mangle]

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -535,8 +535,6 @@ impl HTTP2Transaction {
                         if stream_tx.progress_tc < HTTP2TxProgress::HTTP2ProgHeaders {
                             stream_tx.progress_tc = HTTP2TxProgress::HTTP2ProgHeaders;
                         }
-                    } else {
-                        panic!("global");
                     }
                 }
                 r = self.handle_headers(&hs.blocks, dir);

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -1396,6 +1396,22 @@ impl HTTP2State {
                     if let Some(frame) = frame_pdu {
                         frame.set_tx(flow, tx.tx_id);
                     }
+                    // Validate: per RFC 9113 only SETTINGS, WINDOW_UPDATE, PING, and GOAWAY are allowed on stream 0
+                    if head.stream_id == 0
+                        && head.ftype != parser::HTTP2FrameType::Settings as u8
+                        && head.ftype != parser::HTTP2FrameType::WindowUpdate as u8
+                        && head.ftype != parser::HTTP2FrameType::Ping as u8
+                        && head.ftype != parser::HTTP2FrameType::GoAway as u8
+                    {
+                        if head.ftype == parser::HTTP2FrameType::Data as u8 && head.stream_id == 0 {
+                            tx.tx_data.set_event(HTTP2Event::DataStreamZero as u8);
+                        } else {
+                            tx.tx_data.set_event(HTTP2Event::InvalidFrameHeader as u8);
+                        }
+                        input = &rem[hlsafe..];
+                        continue; // skip this frame, continue parsing the next
+                    }
+
                     if let Some(doh_req_buf) = tx.handle_frame(&head, &txdata, dir) {
                         if let Ok(mut dtx) = dns_parse_request(&doh_req_buf, &DnsVariant::Dns) {
                             dtx.id = 1;
@@ -1434,9 +1450,7 @@ impl HTTP2State {
                     } else {
                         tx.tx_data.set_event(HTTP2Event::TooManyFrames as u8);
                     }
-                    if ftype == parser::HTTP2FrameType::Data as u8 && sid == 0 {
-                        tx.tx_data.set_event(HTTP2Event::DataStreamZero as u8);
-                    } else if ftype == parser::HTTP2FrameType::Data as u8 && sid > 0 {
+                    if ftype == parser::HTTP2FrameType::Data as u8 && sid > 0 {
                         tx.handle_data_frame(rem, hlsafe, dir, flow, padded, over);
                         let (il, ol) = if dir == Direction::ToClient {
                             (

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -137,7 +137,7 @@ pub enum HTTP2FrameTypeData {
 #[derive(AppLayerState, Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
 #[suricata(alstate_strip_prefix = "HTTP2Prog")]
 pub enum HTTP2TxProgress {
-    HTTP2ProgStart = 0,
+    HTTP2ProgStarted = 0,
     HTTP2ProgHeaders = 1,
     HTTP2ProgData = 2,
     HTTP2ProgClosed = 3,
@@ -148,7 +148,7 @@ pub enum HTTP2TxProgress {
 #[derive(AppLayerState, Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
 #[suricata(alstate_strip_prefix = "HTTP2ProgGlobal")]
 pub enum HTTP2TxGlobalProgress {
-    HTTP2ProgGlobalStart = 0,
+    HTTP2ProgGlobalStarted = 0,
     HTTP2ProgGlobalComplete = 1,
 }
 
@@ -180,8 +180,8 @@ pub struct HTTP2StreamProgress {
 impl HTTP2StreamProgress {
     fn init() -> Self {
         Self {
-            progress_ts: HTTP2TxProgress::HTTP2ProgStart,
-            progress_tc: HTTP2TxProgress::HTTP2ProgStart,
+            progress_ts: HTTP2TxProgress::HTTP2ProgStarted,
+            progress_tc: HTTP2TxProgress::HTTP2ProgStarted,
         }
     }
     fn complete() -> Self {
@@ -212,8 +212,8 @@ pub struct HTTP2GlobalProgress {
 impl HTTP2GlobalProgress {
     fn _init() -> Self {
         Self {
-            progress_ts: HTTP2TxGlobalProgress::HTTP2ProgGlobalStart,
-            progress_tc: HTTP2TxGlobalProgress::HTTP2ProgGlobalStart,
+            progress_ts: HTTP2TxGlobalProgress::HTTP2ProgGlobalStarted,
+            progress_tc: HTTP2TxGlobalProgress::HTTP2ProgGlobalStarted,
         }
     }
     fn complete() -> Self {

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -1707,6 +1707,7 @@ const PARSER_NAME: &[u8] = b"http2\0";
 
 #[no_mangle]
 pub unsafe extern "C" fn SCRegisterHttp2Parser() {
+    let mut http2_enabled = false;
     let default_port = CString::new("[80]").unwrap();
     let mut parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
@@ -1749,6 +1750,7 @@ pub unsafe extern "C" fn SCRegisterHttp2Parser() {
         ALPROTO_HTTP2 = alproto;
         if SCAppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
             let _ = AppLayerRegisterParser(&parser, alproto);
+            http2_enabled = true;
         }
         if let Some(val) = conf_get("app-layer.protocols.http2.max-streams") {
             if let Ok(v) = val.parse::<usize>() {
@@ -1813,7 +1815,11 @@ pub unsafe extern "C" fn SCRegisterHttp2Parser() {
         let alproto = applayer_register_protocol_detection(&parser, 1);
         ALPROTO_DOH2 = alproto;
         if SCAppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
-            let _ = AppLayerRegisterParser(&parser, alproto);
+            if http2_enabled {
+                let _ = AppLayerRegisterParser(&parser, alproto);
+            } else {
+                SCLogWarning!("DOH2 cannot be enabled if http2 is disabled");
+            }
         } else {
             SCLogWarning!("DOH2 is not meant to be detection-only.");
         }

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -134,7 +134,8 @@ pub enum HTTP2FrameTypeData {
 }
 
 #[repr(u8)]
-#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
+#[derive(AppLayerState, Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
+#[suricata(alstate_strip_prefix = "HTTP2Prog")]
 pub enum HTTP2TxProgress {
     HTTP2ProgStart = 0,
     HTTP2ProgHeaders = 1,
@@ -144,7 +145,8 @@ pub enum HTTP2TxProgress {
 }
 
 #[repr(u8)]
-#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
+#[derive(AppLayerState, Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
+#[suricata(alstate_strip_prefix = "HTTP2ProgGlobal")]
 pub enum HTTP2TxGlobalProgress {
     HTTP2ProgGlobalStart = 0,
     HTTP2ProgGlobalComplete = 1,

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -42,9 +42,9 @@ use std::io;
 use suricata_sys::sys::AppProtoEnum::ALPROTO_HTTP1;
 use suricata_sys::sys::{
     AppLayerParserState, AppProto, HttpRangeContainerBlock, SCAppLayerForceProtocolChange,
-    SCAppLayerParserConfParserEnabled, SCAppLayerParserRegisterLogger,
-    SCAppLayerProtoDetectConfProtoDetectionEnabled, SCFileFlowFlagsToFlags,
-    SCHTTP2MimicHttp1Request,
+    SCAppLayerParserConfParserEnabled, SCAppLayerParserRegisterGetTxSubStateFuncs,
+    SCAppLayerParserRegisterLogger, SCAppLayerProtoDetectConfProtoDetectionEnabled,
+    SCFileFlowFlagsToFlags, SCHTTP2MimicHttp1Request,
 };
 
 static mut ALPROTO_HTTP2: AppProto = ALPROTO_UNKNOWN;
@@ -1774,6 +1774,20 @@ pub unsafe extern "C" fn SCRegisterHttp2Parser() {
             }
         }
         SCAppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_HTTP2);
+
+        SCAppLayerParserRegisterGetTxSubStateFuncs(
+            ALPROTO_HTTP2,
+            HTTP2TxType::HTTP2TxTypeStream as u8,
+            Some(HTTP2TxProgress::ffi_id_from_name),
+            Some(HTTP2TxProgress::ffi_name_from_id),
+        );
+        SCAppLayerParserRegisterGetTxSubStateFuncs(
+            ALPROTO_HTTP2,
+            HTTP2TxType::HTTP2TxTypeGlobal as u8,
+            Some(HTTP2TxGlobalProgress::ffi_id_from_name),
+            Some(HTTP2TxGlobalProgress::ffi_name_from_id),
+        );
+
         SCLogDebug!("Rust http2 parser registered.");
     } else {
         SCLogNotice!("Protocol detector and parser disabled for HTTP2.");

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -83,6 +83,13 @@ static mut HTTP2_MAX_STREAMS: usize = 4096; // 0x1000
 static mut HTTP2_MAX_FRAMES: usize = 65536;
 pub(super) static mut HTTP2_COMPRESSION_BOMB_LIMIT: u64 = 1_048_576;
 
+#[repr(u8)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
+pub enum HTTP2TxType {
+    HTTP2TxTypeStream = 1,
+    HTTP2TxTypeGlobal = 2,
+}
+
 #[derive(AppLayerFrameType)]
 pub enum Http2FrameType {
     Hdr,
@@ -133,9 +140,14 @@ pub enum HTTP2TxProgress {
     HTTP2ProgHeaders = 1,
     HTTP2ProgData = 2,
     HTTP2ProgClosed = 3,
-    HTTP2ProgComplete = 4,
-    //not a RFC-defined state, used for stream 0 frames applying to the global connection
-    HTTP2ProgGlobal = 5,
+    HTTP2ProgComplete = 4, // complete is a pseudo state set only when both sides are closed
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
+pub enum HTTP2TxGlobalProgress {
+    HTTP2ProgGlobalStart = 0,
+    HTTP2ProgGlobalComplete = 1,
 }
 
 #[derive(Debug)]
@@ -158,11 +170,121 @@ pub struct DohHttp2Tx {
 }
 
 #[derive(Debug)]
+pub struct HTTP2StreamProgress {
+    pub progress_ts: HTTP2TxProgress,
+    pub progress_tc: HTTP2TxProgress,
+}
+
+impl HTTP2StreamProgress {
+    fn init() -> Self {
+        Self {
+            progress_ts: HTTP2TxProgress::HTTP2ProgStart,
+            progress_tc: HTTP2TxProgress::HTTP2ProgStart,
+        }
+    }
+    fn complete() -> Self {
+        Self {
+            progress_ts: HTTP2TxProgress::HTTP2ProgComplete,
+            progress_tc: HTTP2TxProgress::HTTP2ProgComplete,
+        }
+    }
+    fn is_complete(&self) -> bool {
+        self.progress_ts >= HTTP2TxProgress::HTTP2ProgComplete
+            && self.progress_tc >= HTTP2TxProgress::HTTP2ProgComplete
+    }
+    fn is_complete_for_direction(&self, direction: u8) -> bool {
+        if direction & Direction::ToServer as u8 != 0 {
+            self.progress_ts >= HTTP2TxProgress::HTTP2ProgComplete
+        } else {
+            self.progress_tc >= HTTP2TxProgress::HTTP2ProgComplete
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct HTTP2GlobalProgress {
+    pub progress_ts: HTTP2TxGlobalProgress,
+    pub progress_tc: HTTP2TxGlobalProgress,
+}
+
+impl HTTP2GlobalProgress {
+    fn _init() -> Self {
+        Self {
+            progress_ts: HTTP2TxGlobalProgress::HTTP2ProgGlobalStart,
+            progress_tc: HTTP2TxGlobalProgress::HTTP2ProgGlobalStart,
+        }
+    }
+    fn complete() -> Self {
+        Self {
+            progress_ts: HTTP2TxGlobalProgress::HTTP2ProgGlobalComplete,
+            progress_tc: HTTP2TxGlobalProgress::HTTP2ProgGlobalComplete,
+        }
+    }
+    fn is_complete(&self) -> bool {
+        self.progress_ts >= HTTP2TxGlobalProgress::HTTP2ProgGlobalComplete
+            && self.progress_tc >= HTTP2TxGlobalProgress::HTTP2ProgGlobalComplete
+    }
+    fn is_complete_for_direction(&self, direction: u8) -> bool {
+        if direction & Direction::ToServer as u8 != 0 {
+            self.progress_ts >= HTTP2TxGlobalProgress::HTTP2ProgGlobalComplete
+        } else {
+            self.progress_tc >= HTTP2TxGlobalProgress::HTTP2ProgGlobalComplete
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum HTTP2Progress {
+    STREAM(HTTP2StreamProgress),
+    GLOBAL(HTTP2GlobalProgress),
+}
+
+impl HTTP2Progress {
+    fn get(&self, direction: u8) -> i32 {
+        if let HTTP2Progress::STREAM(ref s) = self {
+            if direction == STREAM_TOSERVER {
+                return s.progress_ts as i32;
+            } else {
+                return s.progress_tc as i32;
+            }
+        } else if let HTTP2Progress::GLOBAL(ref g) = self {
+            if direction == STREAM_TOSERVER {
+                return g.progress_ts as i32;
+            } else {
+                return g.progress_tc as i32;
+            }
+        }
+        0
+    }
+
+    fn is_complete(&self) -> bool {
+        let complete = if let HTTP2Progress::STREAM(ref s) = self {
+            s.is_complete()
+        } else if let HTTP2Progress::GLOBAL(ref g) = self {
+            g.is_complete()
+        } else {
+            false
+        };
+        complete
+    }
+
+    pub fn is_complete_for_direction(&self, direction: u8) -> bool {
+        let complete = if let HTTP2Progress::STREAM(ref s) = self {
+            s.is_complete_for_direction(direction)
+        } else if let HTTP2Progress::GLOBAL(ref g) = self {
+            g.is_complete_for_direction(direction)
+        } else {
+            false
+        };
+        complete
+    }
+}
+
+#[derive(Debug)]
 pub struct HTTP2Transaction {
     tx_id: u64,
     pub stream_id: u32,
-    pub progress_tc: HTTP2TxProgress,
-    pub progress_ts: HTTP2TxProgress,
+    pub progress: HTTP2Progress,
     to_drop: bool,
     child_stream_id: u32,
 
@@ -200,8 +322,7 @@ impl HTTP2Transaction {
             tx_id: 0,
             stream_id: 0,
             child_stream_id: 0,
-            progress_tc: HTTP2TxProgress::HTTP2ProgStart,
-            progress_ts: HTTP2TxProgress::HTTP2ProgStart,
+            progress: HTTP2Progress::STREAM(HTTP2StreamProgress::init()),
             to_drop: false,
             frames_tc: Vec::new(),
             frames_ts: Vec::new(),
@@ -217,6 +338,7 @@ impl HTTP2Transaction {
     }
 
     pub fn free(&mut self) {
+        SCLogDebug!("free: tx_id {} stream_id {}", self.tx_id, self.stream_id);
         if !self.file_range.is_null() {
             if let Some(sfcm) = unsafe { SURICATA_HTTP2_FILE_CONFIG } {
                 //TODO get a file container instead of NULL
@@ -407,8 +529,12 @@ impl HTTP2Transaction {
                     if header.flags & parser::HTTP2_FLAG_HEADER_END_HEADERS == 0 {
                         self.child_stream_id = hs.stream_id;
                     }
-                    if self.progress_tc < HTTP2TxProgress::HTTP2ProgHeaders {
-                        self.progress_tc = HTTP2TxProgress::HTTP2ProgHeaders;
+                    if let HTTP2Progress::STREAM(ref mut stream_tx) = self.progress {
+                        if stream_tx.progress_tc < HTTP2TxProgress::HTTP2ProgHeaders {
+                            stream_tx.progress_tc = HTTP2TxProgress::HTTP2ProgHeaders;
+                        }
+                    } else {
+                        panic!("global");
                     }
                 }
                 r = self.handle_headers(&hs.blocks, dir);
@@ -432,34 +558,36 @@ impl HTTP2Transaction {
             }
             _ => {}
         }
-        //handle closing state changes
-        let state = if dir == Direction::ToServer {
-            &mut self.progress_ts
-        } else {
-            &mut self.progress_tc
-        };
-        match data {
-            HTTP2FrameTypeData::HEADERS(_) | HTTP2FrameTypeData::DATA => {
-                if header.flags & parser::HTTP2_FLAG_HEADER_EOS != 0 {
-                    if *state < HTTP2TxProgress::HTTP2ProgClosed {
-                        *state = HTTP2TxProgress::HTTP2ProgClosed;
-                        if self.progress_ts == HTTP2TxProgress::HTTP2ProgClosed
-                            && self.progress_tc == HTTP2TxProgress::HTTP2ProgClosed
-                        {
-                            self.progress_ts = HTTP2TxProgress::HTTP2ProgComplete;
-                            self.progress_tc = HTTP2TxProgress::HTTP2ProgComplete;
+        if let HTTP2Progress::STREAM(ref mut stream_tx) = self.progress {
+            //handle closing state changes
+            let state = if dir == Direction::ToServer {
+                &mut stream_tx.progress_ts
+            } else {
+                &mut stream_tx.progress_tc
+            };
+            match data {
+                HTTP2FrameTypeData::HEADERS(_) | HTTP2FrameTypeData::DATA => {
+                    if header.flags & parser::HTTP2_FLAG_HEADER_EOS != 0 {
+                        if *state < HTTP2TxProgress::HTTP2ProgClosed {
+                            *state = HTTP2TxProgress::HTTP2ProgClosed;
+                            if stream_tx.progress_ts == HTTP2TxProgress::HTTP2ProgClosed
+                                && stream_tx.progress_tc == HTTP2TxProgress::HTTP2ProgClosed
+                            {
+                                stream_tx.progress_ts = HTTP2TxProgress::HTTP2ProgComplete;
+                                stream_tx.progress_tc = HTTP2TxProgress::HTTP2ProgComplete;
+                            }
                         }
+                    } else if header.ftype == parser::HTTP2FrameType::Data as u8 {
+                        //not end of stream
+                        if *state < HTTP2TxProgress::HTTP2ProgData {
+                            *state = HTTP2TxProgress::HTTP2ProgData;
+                        }
+                    } else if *state < HTTP2TxProgress::HTTP2ProgHeaders {
+                        *state = HTTP2TxProgress::HTTP2ProgHeaders;
                     }
-                } else if header.ftype == parser::HTTP2FrameType::Data as u8 {
-                    //not end of stream
-                    if *state < HTTP2TxProgress::HTTP2ProgData {
-                        *state = HTTP2TxProgress::HTTP2ProgData;
-                    }
-                } else if *state < HTTP2TxProgress::HTTP2ProgHeaders {
-                    *state = HTTP2TxProgress::HTTP2ProgHeaders;
                 }
+                _ => {}
             }
-            _ => {}
         }
         return r;
     }
@@ -753,10 +881,13 @@ impl HTTP2State {
         //as it affects the global connection, there is no end to it
         let mut tx = HTTP2Transaction::new();
         tx.tx_data = AppLayerTxData::for_direction(dir);
+        tx.tx_data.0.tx_type = HTTP2TxType::HTTP2TxTypeGlobal as u8;
+        tx.tx_data.0.tx_type_eop_ts = HTTP2TxGlobalProgress::HTTP2ProgGlobalComplete as u8;
+        tx.tx_data.0.tx_type_eop_tc = HTTP2TxGlobalProgress::HTTP2ProgGlobalComplete as u8;
         self.tx_id += 1;
         tx.tx_id = self.tx_id;
-        tx.progress_tc = HTTP2TxProgress::HTTP2ProgGlobal;
-        tx.progress_ts = HTTP2TxProgress::HTTP2ProgGlobal;
+        tx.progress = HTTP2Progress::GLOBAL(HTTP2GlobalProgress::complete());
+        SCLogDebug!("global tx created {:?}", tx);
         // a global tx (stream id 0) does not hold files cf RFC 9113 section 5.1.1
         self.transactions.push_back(tx);
         return self.transactions.back_mut().unwrap();
@@ -774,8 +905,7 @@ impl HTTP2State {
                     }
                     tx_old.set_event(HTTP2Event::TooManyStreams);
                     // use a distinct state, even if we do not log it
-                    tx_old.progress_ts = HTTP2TxProgress::HTTP2ProgComplete;
-                    tx_old.progress_tc = HTTP2TxProgress::HTTP2ProgComplete;
+                    tx_old.progress = HTTP2Progress::STREAM(HTTP2StreamProgress::complete());
                     tx_old.to_drop = true;
                     tx_old.tx_data.0.updated_tc = true;
                     tx_old.tx_data.0.updated_ts = true;
@@ -799,9 +929,7 @@ impl HTTP2State {
         };
         let index = self.find_tx_index(sid);
         if index > 0 {
-            if self.transactions[index - 1].progress_tc >= HTTP2TxProgress::HTTP2ProgClosed
-                && self.transactions[index - 1].progress_ts >= HTTP2TxProgress::HTTP2ProgClosed
-            {
+            if self.transactions[index - 1].progress.is_complete() {
                 //these frames can be received in this state for a short period
                 if header.ftype != parser::HTTP2FrameType::RstStream as u8
                     && header.ftype != parser::HTTP2FrameType::WindowUpdate as u8
@@ -827,8 +955,7 @@ impl HTTP2State {
                     }
                     tx_old.set_event(HTTP2Event::TooManyStreams);
                     // use a distinct state, even if we do not log it
-                    tx_old.progress_ts = HTTP2TxProgress::HTTP2ProgComplete;
-                    tx_old.progress_tc = HTTP2TxProgress::HTTP2ProgComplete;
+                    tx_old.progress = HTTP2Progress::STREAM(HTTP2StreamProgress::complete());
                     tx_old.to_drop = true;
                     tx_old.tx_data.0.updated_tc = true;
                     tx_old.tx_data.0.updated_ts = true;
@@ -842,6 +969,9 @@ impl HTTP2State {
             tx.tx_data.update_file_flags(self.state_data.file_flags);
             tx.update_file_flags(tx.tx_data.0.file_flags);
             tx.tx_data.0.file_tx = STREAM_TOSERVER | STREAM_TOCLIENT; // might hold files in both directions
+            tx.tx_data.0.tx_type = HTTP2TxType::HTTP2TxTypeStream as u8;
+            tx.tx_data.0.tx_type_eop_ts = HTTP2TxProgress::HTTP2ProgComplete as u8;
+            tx.tx_data.0.tx_type_eop_tc = HTTP2TxProgress::HTTP2ProgComplete as u8;
             self.transactions.push_back(tx);
             return Some(self.transactions.back_mut().unwrap());
         }
@@ -1249,6 +1379,12 @@ impl HTTP2State {
                         return AppLayerResult::err();
                     }
                     let tx = tx.unwrap();
+                    SCLogDebug!(
+                        "tx stream_id {} tx id {} progress {:?}",
+                        tx.stream_id,
+                        tx.tx_id,
+                        tx.progress
+                    );
                     if let Some(frame) = frame_hdr {
                         frame.set_tx(flow, tx.tx_id);
                     }
@@ -1529,11 +1665,7 @@ unsafe extern "C" fn http2_tx_get_alstate_progress(
     tx: *mut std::os::raw::c_void, direction: u8,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
-    if direction == STREAM_TOSERVER {
-        return tx.progress_ts as i32;
-    } else {
-        return tx.progress_tc as i32;
-    }
+    return tx.progress.get(direction);
 }
 
 unsafe extern "C" fn http2_getfiles(

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -880,6 +880,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn SCDetectHelperBufferProgressRegisterSubState(
+        name: *const ::std::os::raw::c_char, alproto: AppProto, direction: u8, sub_state: u8,
+        progress: u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn SCDetectRegisterMpmGeneric(
         name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
         alproto: AppProto, direction: u8, GetData: InspectionBufferGetDataPtr,
@@ -901,6 +907,13 @@ extern "C" {
     pub fn SCDetectHelperMultiBufferProgressMpmRegister(
         name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
         alproto: AppProto, direction: u8, GetData: InspectionMultiBufferGetDataPtr, progress: u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SCDetectHelperMultiBufferProgressMpmRegisterSubState(
+        name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
+        alproto: AppProto, direction: u8, GetData: InspectionMultiBufferGetDataPtr, sub_state: u8,
+        progress: u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -1478,6 +1478,12 @@ pub struct AppLayerTxData {
     #[doc = " detection engine progress tracking for use by detection engine\n Reflects the \"progress\" of prefilter engines into this TX, where\n the value is offset by 1. So if for progress state 0 the engines\n are done, the value here will be 1. So a value of 0 means, no\n progress tracked yet.\n"]
     pub detect_progress_ts: u8,
     pub detect_progress_tc: u8,
+    #[doc = " Type of transaction. Meaning is defined by the parser. Used to\n select a state machine. 0 means it is not used."]
+    pub tx_type: u8,
+    #[doc = " End of TX progress values\n\n toserver end of tx progress value"]
+    pub tx_type_eop_ts: u8,
+    #[doc = " toclient end of tx progress value"]
+    pub tx_type_eop_tc: u8,
     pub de_state: *mut DetectEngineState,
     pub events: *mut AppLayerDecoderEvents,
     pub txbits: *mut GenericVar,
@@ -1520,6 +1526,13 @@ extern "C" {
 }
 extern "C" {
     pub fn SCAppLayerParserRegisterLogger(ipproto: u8, alproto: AppProto);
+}
+extern "C" {
+    #[doc = " \\brief register state<>name funcs for a substate"]
+    pub fn SCAppLayerParserRegisterGetTxSubStateFuncs(
+        alproto: AppProto, sub_state: u8, GetIdByNameFunc: AppLayerParserGetStateIdByNameFn,
+        GetNameByIdFunc: AppLayerParserGetStateNameByIdFn,
+    );
 }
 extern "C" {
     pub fn SCAppLayerParserTriggerRawStreamInspection(

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1288,7 +1288,7 @@ int8_t AppLayerParserGetSubStateProgressId(
                 return -1;
             }
             SCLogDebug("state:%s v:%u", state, v);
-            BUG_ON(v > 48);
+            BUG_ON(v >= APP_LAYER_MAX_PROGRESS);
             return (int8_t)v;
         }
     }

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -61,6 +61,12 @@ struct AppLayerParserThreadCtx_ {
     void *(*alproto_local_storage)[FLOW_PROTO_MAX];
 };
 
+struct AppLayerParserSubStateMapping {
+    uint8_t sub_state;
+    AppLayerParserGetStateIdByNameFn GetStateIdByName;
+    AppLayerParserGetStateNameByIdFn GetStateNameById;
+    struct AppLayerParserSubStateMapping *next;
+};
 
 /**
  * \brief App layer protocol parser context.
@@ -125,6 +131,13 @@ typedef struct AppLayerParserProtoCtx_
 #ifdef UNITTESTS
     void (*RegisterUnittests)(void);
 #endif
+
+    /* list of mappings per sub state
+     * only set for FLOW_PROTO_DEFAULT */
+    struct AppLayerParserSubStateMapping *sub_state_mappings;
+    /* max value of a sub state
+     * only set for FLOW_PROTO_DEFAULT */
+    uint8_t max_sub_state;
 } AppLayerParserProtoCtx;
 
 typedef struct AppLayerParserCtx_ {
@@ -151,6 +164,10 @@ struct AppLayerParserState_ {
 
     FramesContainer *frames;
 };
+
+static inline uint8_t GetTxEndProgress(uint8_t ipproto, AppProto alproto, void *tx, uint8_t flags);
+static inline uint8_t GetTxdEndProgress(uint8_t ipproto, AppProto alproto,
+        const AppLayerTxData *txd, uint8_t flags, uint8_t complete);
 
 enum ExceptionPolicy g_applayerparser_error_policy = EXCEPTION_POLICY_NOT_SET;
 
@@ -285,6 +302,21 @@ void AppLayerParserPostStreamSetup(void)
 int AppLayerParserDeSetup(void)
 {
     SCEnter();
+
+    /* inclusive loop as some parsers use FLOW_PROTO_DEFAULT */
+    for (int flow_proto = 0; flow_proto <= FLOW_PROTO_DEFAULT; flow_proto++) {
+        for (AppProto a = 0; a < g_alproto_max; a++) {
+            if (alp_ctx.ctxs[a][flow_proto].sub_state_mappings == NULL)
+                continue;
+
+            while (alp_ctx.ctxs[a][flow_proto].sub_state_mappings) {
+                struct AppLayerParserSubStateMapping *next =
+                        alp_ctx.ctxs[a][flow_proto].sub_state_mappings->next;
+                SCFree(alp_ctx.ctxs[a][flow_proto].sub_state_mappings);
+                alp_ctx.ctxs[a][flow_proto].sub_state_mappings = next;
+            }
+        }
+    }
 
     SCFree(alp_ctx.ctxs);
 
@@ -576,6 +608,38 @@ void AppLayerParserRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto,
     SCReturn;
 }
 
+void SCAppLayerParserRegisterGetTxSubStateFuncs(AppProto alproto, const uint8_t sub_state,
+        AppLayerParserGetStateIdByNameFn GetIdByNameFunc,
+        AppLayerParserGetStateNameByIdFn GetNameByIdFunc)
+{
+    SCEnter();
+    /* validate input */
+    BUG_ON(sub_state == 0);
+    BUG_ON(GetIdByNameFunc == NULL);
+    BUG_ON(GetNameByIdFunc == NULL);
+
+    AppLayerParserProtoCtx *p = &alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT];
+    /* double registration not allowed */
+    for (struct AppLayerParserSubStateMapping *m = p->sub_state_mappings; m != NULL; m = m->next) {
+        BUG_ON(sub_state == m->sub_state);
+    }
+    struct AppLayerParserSubStateMapping *m = SCCalloc(1, sizeof(*m));
+    if (m == NULL)
+        FatalError("failed to register substate");
+
+    m->sub_state = sub_state;
+    m->GetStateIdByName = GetIdByNameFunc;
+    m->GetStateNameById = GetNameByIdFunc;
+    m->next = p->sub_state_mappings;
+    p->sub_state_mappings = m;
+
+    p->max_sub_state = MAX(p->max_sub_state, sub_state);
+    SCLogDebug("alproto %u:%s, sub_state:%u max:%u %p:%p", alproto, AppProtoToString(alproto),
+            sub_state, p->max_sub_state, m->GetStateIdByName, m->GetStateNameById);
+
+    SCReturn;
+}
+
 void AppLayerParserRegisterGetStateFuncs(uint8_t ipproto, AppProto alproto,
         AppLayerParserGetStateIdByNameFn GetIdByNameFunc,
         AppLayerParserGetStateNameByIdFn GetNameByIdFunc)
@@ -798,11 +862,13 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
         void *tx = ires.tx_ptr;
         idx = ires.tx_id;
 
+        AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx);
+        const int tx_end_state =
+                GetTxdEndProgress(ipproto, alproto, txd, flags, (uint8_t)state_done_progress);
         int state_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx, flags);
-        if (state_progress < state_done_progress)
+        if (state_progress < tx_end_state)
             break;
 
-        AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx);
         if (tag_txs_as_inspected) {
             const uint8_t inspected_flag = (flags & STREAM_TOSERVER) ? APP_LAYER_TX_INSPECTED_TS
                                                                      : APP_LAYER_TX_INSPECTED_TC;
@@ -837,11 +903,13 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
             }
             idx = ires.tx_id;
 
+            AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx);
+            const int tx_end_state =
+                    GetTxdEndProgress(ipproto, alproto, txd, flags, (uint8_t)state_done_progress);
             const int state_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx, flags);
-            if (state_progress < state_done_progress)
+            if (state_progress < tx_end_state)
                 break;
 
-            AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx);
             const uint8_t inspected_flag = (flags & STREAM_TOSERVER) ? APP_LAYER_TX_INSPECTED_TS
                                                                      : APP_LAYER_TX_INSPECTED_TC;
             if (!(txd->flags & inspected_flag)) {
@@ -979,14 +1047,18 @@ void AppLayerParserTransactionsCleanup(Flow *f, const uint8_t pkt_dir)
         }
         const int tx_progress_tc =
                 AppLayerParserGetStateProgress(ipproto, alproto, tx, tc_disrupt_flags);
-        if (tx_progress_tc < tx_end_state_tc) {
+        const int end_state_tc =
+                GetTxdEndProgress(ipproto, alproto, txd, STREAM_TOCLIENT, (uint8_t)tx_end_state_tc);
+        if (tx_progress_tc < end_state_tc) {
             SCLogDebug("%p/%"PRIu64" skipping: tc parser not done", tx, i);
             skipped = true;
             goto next;
         }
+        const int end_state_ts =
+                GetTxdEndProgress(ipproto, alproto, txd, STREAM_TOSERVER, (uint8_t)tx_end_state_ts);
         const int tx_progress_ts =
                 AppLayerParserGetStateProgress(ipproto, alproto, tx, ts_disrupt_flags);
-        if (tx_progress_ts < tx_end_state_ts) {
+        if (tx_progress_ts < end_state_ts) {
             SCLogDebug("%p/%"PRIu64" skipping: ts parser not done", tx, i);
             skipped = true;
             goto next;
@@ -1096,6 +1168,55 @@ static inline int StateGetProgressCompletionStatus(const AppProto alproto, const
     }
 }
 
+/** \internal
+ *  \brief get the end state (progress) for a TX
+ *  If the TX is supporting sub-states, return the value from the txd.
+ *  \param tx pointer to the transaction
+ */
+static inline uint8_t GetTxEndProgress(uint8_t ipproto, AppProto alproto, void *tx, uint8_t flags)
+{
+    const AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx);
+    DEBUG_VALIDATE_BUG_ON(txd == NULL);
+    uint8_t tx_end_state;
+    if (txd->tx_type == 0) {
+        tx_end_state = (uint8_t)AppLayerParserGetStateProgressCompletionStatus(alproto, flags);
+    } else {
+        if (flags & STREAM_TOSERVER)
+            tx_end_state = txd->tx_type_eop_ts;
+        else
+            tx_end_state = txd->tx_type_eop_tc;
+    }
+    return tx_end_state;
+}
+
+/** \internal
+ *  \brief get the end state (progress) for a TX(D)
+ *  If the TX is supporting sub-states, return the value from the txd.
+ *  \param txd pointer to the transactions txd
+ *  \param complete optional final progress for the protocol
+ *
+ *  `complete` can be passed in as it is often already looked up
+ *  outside of the tx loop.
+ */
+static inline uint8_t GetTxdEndProgress(uint8_t ipproto, AppProto alproto,
+        const AppLayerTxData *txd, uint8_t flags, uint8_t complete)
+{
+    DEBUG_VALIDATE_BUG_ON(txd == NULL);
+    uint8_t tx_end_state;
+    if (txd->tx_type == 0) {
+        if (complete)
+            tx_end_state = complete;
+        else
+            tx_end_state = (uint8_t)AppLayerParserGetStateProgressCompletionStatus(alproto, flags);
+    } else {
+        if (flags & STREAM_TOSERVER)
+            tx_end_state = txd->tx_type_eop_ts;
+        else
+            tx_end_state = txd->tx_type_eop_tc;
+    }
+    return tx_end_state;
+}
+
 /**
  *  \brief get the progress value for a tx/protocol
  *
@@ -1106,7 +1227,7 @@ int AppLayerParserGetStateProgress(uint8_t ipproto, AppProto alproto, void *tx, 
     SCEnter();
     int r;
     if (unlikely(IS_DISRUPTED(flags))) {
-        r = StateGetProgressCompletionStatus(alproto, flags);
+        r = (int)GetTxEndProgress(ipproto, alproto, tx, flags);
     } else {
         const uint8_t direction = flags & (STREAM_TOCLIENT | STREAM_TOSERVER);
         r = alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].StateGetProgress(tx, direction);
@@ -1134,6 +1255,106 @@ uint8_t AppLayerParserGetStateProgressCompletionStatus(AppProto alproto, uint8_t
     int r = StateGetProgressCompletionStatus(alproto, direction);
     // TODO convert StateGetProgressCompletionStatus and more to uint8_t
     return (uint8_t)r;
+}
+
+/**
+ *  \brief
+ *
+ *  Translate name to progress value for a substate `sub_state`. Calls the
+ *  registered callbacks.
+ *
+ *  \retval -1 not found
+ *  \retval id value belonging to the state name
+ */
+int8_t AppLayerParserGetSubStateProgressId(
+        const AppProto alproto, const uint8_t sub_state, const char *state, const uint8_t dir_flag)
+{
+    BUG_ON(alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].max_sub_state == 0);
+    BUG_ON(dir_flag != STREAM_TOSERVER && dir_flag != STREAM_TOCLIENT);
+
+    for (struct AppLayerParserSubStateMapping *m =
+                    alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].sub_state_mappings;
+            m != NULL; m = m->next) {
+        if (m->sub_state == sub_state) {
+            BUG_ON(m->GetStateNameById == NULL);
+            BUG_ON(m->GetStateIdByName == NULL);
+
+            int v = m->GetStateIdByName(state, dir_flag);
+            if (v < 0) {
+                /* name not found */
+                return -1;
+            }
+            SCLogDebug("state:%s v:%u", state, v);
+            BUG_ON(v > 48);
+            return (int8_t)v;
+        }
+    }
+
+    return -1;
+}
+
+const char *AppLayerParserGetSubStateProgressName(const AppProto alproto, const uint8_t sub_state,
+        const uint8_t state, const uint8_t dir_flag)
+{
+    BUG_ON(alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].max_sub_state == 0);
+    BUG_ON(dir_flag != STREAM_TOSERVER && dir_flag != STREAM_TOCLIENT);
+
+    for (struct AppLayerParserSubStateMapping *m =
+                    alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].sub_state_mappings;
+            m != NULL; m = m->next) {
+        if (m->sub_state == sub_state) {
+            BUG_ON(m->GetStateNameById == NULL);
+            BUG_ON(m->GetStateIdByName == NULL);
+
+            return m->GetStateNameById(state, dir_flag);
+        }
+    }
+
+    return NULL;
+}
+
+uint8_t AppLayerParserGetSubStateCompletion(const AppProto alproto, const uint8_t sub_state)
+{
+    BUG_ON(alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].max_sub_state == 0);
+
+    /* TODO hard coded for now */
+    BUG_ON(alproto != ALPROTO_HTTP2);
+
+    if (sub_state == 1) {
+        return 4;
+    } else if (sub_state == 2) {
+        return 1;
+    } else {
+        BUG_ON(1);
+    }
+    return 0;
+}
+
+const char *AppLayerParserGetSubStateName(const AppProto alproto, const uint8_t sub_state)
+{
+    BUG_ON(alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].max_sub_state == 0);
+
+    /* TODO hard coded for now */
+    BUG_ON(alproto != ALPROTO_HTTP2);
+
+    if (sub_state == 1) {
+        return "stream";
+    } else if (sub_state == 2) {
+        return "global";
+    } else {
+        BUG_ON(1);
+    }
+    return NULL;
+}
+
+uint8_t AppLayerParserGetMaxSubState(const AppProto alproto)
+{
+    return alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].max_sub_state;
+}
+
+bool AppLayerParserSupportsSubStates(const AppProto alproto)
+{
+    return AppLayerParserGetMaxSubState(alproto) != 0;
 }
 
 int AppLayerParserGetEventInfo(uint8_t ipproto, AppProto alproto, const char *event_name,

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1269,6 +1269,9 @@ uint8_t AppLayerParserGetStateProgressCompletionStatus(AppProto alproto, uint8_t
 int8_t AppLayerParserGetSubStateProgressId(
         const AppProto alproto, const uint8_t sub_state, const char *state, const uint8_t dir_flag)
 {
+    if (alproto == ALPROTO_DOH2)
+        return AppLayerParserGetSubStateProgressId(ALPROTO_HTTP2, sub_state, state, dir_flag);
+
     BUG_ON(alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].max_sub_state == 0);
     BUG_ON(dir_flag != STREAM_TOSERVER && dir_flag != STREAM_TOCLIENT);
 
@@ -1296,6 +1299,9 @@ int8_t AppLayerParserGetSubStateProgressId(
 const char *AppLayerParserGetSubStateProgressName(const AppProto alproto, const uint8_t sub_state,
         const uint8_t state, const uint8_t dir_flag)
 {
+    if (alproto == ALPROTO_DOH2)
+        return AppLayerParserGetSubStateProgressName(ALPROTO_HTTP2, sub_state, state, dir_flag);
+
     BUG_ON(alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].max_sub_state == 0);
     BUG_ON(dir_flag != STREAM_TOSERVER && dir_flag != STREAM_TOCLIENT);
 
@@ -1315,6 +1321,9 @@ const char *AppLayerParserGetSubStateProgressName(const AppProto alproto, const 
 
 uint8_t AppLayerParserGetSubStateCompletion(const AppProto alproto, const uint8_t sub_state)
 {
+    if (alproto == ALPROTO_DOH2)
+        return AppLayerParserGetSubStateCompletion(ALPROTO_HTTP2, sub_state);
+
     BUG_ON(alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].max_sub_state == 0);
 
     /* TODO hard coded for now */
@@ -1332,6 +1341,9 @@ uint8_t AppLayerParserGetSubStateCompletion(const AppProto alproto, const uint8_
 
 const char *AppLayerParserGetSubStateName(const AppProto alproto, const uint8_t sub_state)
 {
+    if (alproto == ALPROTO_DOH2)
+        return AppLayerParserGetSubStateName(ALPROTO_HTTP2, sub_state);
+
     BUG_ON(alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].max_sub_state == 0);
 
     /* TODO hard coded for now */
@@ -1349,6 +1361,8 @@ const char *AppLayerParserGetSubStateName(const AppProto alproto, const uint8_t 
 
 uint8_t AppLayerParserGetMaxSubState(const AppProto alproto)
 {
+    if (alproto == ALPROTO_DOH2)
+        return AppLayerParserGetMaxSubState(ALPROTO_HTTP2);
     return alp_ctx.ctxs[alproto][FLOW_PROTO_DEFAULT].max_sub_state;
 }
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1264,11 +1264,15 @@ uint8_t AppLayerParserGetStateProgressCompletionStatus(AppProto alproto, uint8_t
  *  registered callbacks.
  *
  *  \retval -1 not found
+ *  \retval -2 parser is not enabled
  *  \retval id value belonging to the state name
  */
 int8_t AppLayerParserGetSubStateProgressId(
         const AppProto alproto, const uint8_t sub_state, const char *state, const uint8_t dir_flag)
 {
+    if (!AppLayerParserIsEnabled(alproto))
+        return -2;
+
     if (alproto == ALPROTO_DOH2)
         return AppLayerParserGetSubStateProgressId(ALPROTO_HTTP2, sub_state, state, dir_flag);
 
@@ -1299,6 +1303,9 @@ int8_t AppLayerParserGetSubStateProgressId(
 const char *AppLayerParserGetSubStateProgressName(const AppProto alproto, const uint8_t sub_state,
         const uint8_t state, const uint8_t dir_flag)
 {
+    if (!AppLayerParserIsEnabled(alproto))
+        return NULL;
+
     if (alproto == ALPROTO_DOH2)
         return AppLayerParserGetSubStateProgressName(ALPROTO_HTTP2, sub_state, state, dir_flag);
 
@@ -1321,6 +1328,9 @@ const char *AppLayerParserGetSubStateProgressName(const AppProto alproto, const 
 
 uint8_t AppLayerParserGetSubStateCompletion(const AppProto alproto, const uint8_t sub_state)
 {
+    if (!AppLayerParserIsEnabled(alproto))
+        return 0;
+
     if (alproto == ALPROTO_DOH2)
         return AppLayerParserGetSubStateCompletion(ALPROTO_HTTP2, sub_state);
 
@@ -1341,6 +1351,9 @@ uint8_t AppLayerParserGetSubStateCompletion(const AppProto alproto, const uint8_
 
 const char *AppLayerParserGetSubStateName(const AppProto alproto, const uint8_t sub_state)
 {
+    if (!AppLayerParserIsEnabled(alproto))
+        return NULL;
+
     if (alproto == ALPROTO_DOH2)
         return AppLayerParserGetSubStateName(ALPROTO_HTTP2, sub_state);
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -71,6 +71,9 @@ typedef struct AppLayerGetFileState AppLayerGetFileState;
 
 int AppLayerParserProtoIsRegistered(uint8_t ipproto, AppProto alproto);
 
+/** progress values need to stay under this. */
+#define APP_LAYER_MAX_PROGRESS 48
+
 /***** transaction handling *****/
 
 int AppLayerParserSetup(void);

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -201,6 +201,16 @@ typedef struct AppLayerTxData {
     uint8_t detect_progress_ts;
     uint8_t detect_progress_tc;
 
+    /// Type of transaction. Meaning is defined by the parser. Used to
+    /// select a state machine. 0 means it is not used.
+    uint8_t tx_type;
+    /// End of TX progress values
+    ///
+    /// toserver end of tx progress value
+    uint8_t tx_type_eop_ts;
+    /// toclient end of tx progress value
+    uint8_t tx_type_eop_tc;
+
     DetectEngineState *de_state;
     AppLayerDecoderEvents *events;
     GenericVar *txbits;
@@ -282,6 +292,11 @@ void AppLayerParserRegisterGetStateFuncs(uint8_t ipproto, AppProto alproto,
         AppLayerParserGetStateIdByNameFn GetStateIdByName,
         AppLayerParserGetStateNameByIdFn GetStateNameById);
 
+/** \brief register state<>name funcs for a substate */
+void SCAppLayerParserRegisterGetTxSubStateFuncs(AppProto alproto, const uint8_t sub_state,
+        AppLayerParserGetStateIdByNameFn GetIdByNameFunc,
+        AppLayerParserGetStateNameByIdFn GetNameByIdFunc);
+
 void AppLayerParserRegisterTxDataFunc(uint8_t ipproto, AppProto alproto,
         AppLayerTxData *(*GetTxData)(void *tx));
 void AppLayerParserRegisterApplyTxConfigFunc(uint8_t ipproto, AppProto alproto,
@@ -314,7 +329,15 @@ int AppLayerParserGetStateProgress(uint8_t ipproto, AppProto alproto,
                         void *alstate, uint8_t direction);
 uint64_t AppLayerParserGetTxCnt(const Flow *, void *alstate);
 void *AppLayerParserGetTx(uint8_t ipproto, AppProto alproto, void *alstate, uint64_t tx_id);
+int8_t AppLayerParserGetSubStateProgressId(
+        const AppProto alproto, const uint8_t sub_state, const char *state, const uint8_t dir_flag);
+const char *AppLayerParserGetSubStateProgressName(const AppProto alproto, const uint8_t sub_state,
+        const uint8_t state, const uint8_t dir_flag);
+uint8_t AppLayerParserGetSubStateCompletion(const AppProto alproto, const uint8_t sub_state);
 uint8_t AppLayerParserGetStateProgressCompletionStatus(AppProto alproto, uint8_t direction);
+const char *AppLayerParserGetSubStateName(const AppProto alproto, const uint8_t sub_state);
+uint8_t AppLayerParserGetMaxSubState(const AppProto alproto);
+bool AppLayerParserSupportsSubStates(const AppProto alproto);
 int AppLayerParserGetEventInfo(uint8_t ipproto, AppProto alproto, const char *event_name,
         uint8_t *event_id, AppLayerEventType *event_type);
 int AppLayerParserGetEventInfoById(uint8_t ipproto, AppProto alproto, uint8_t event_id,

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -118,6 +118,24 @@ static inline bool AppProtoEquals(AppProto sigproto, AppProto alproto)
 }
 
 // whether a signature AppProto matches a flow (or signature) AppProto
+// only see DOH2/HTTP2 as the same
+static inline bool AppProtoEqualsStrict(AppProto sigproto, AppProto alproto)
+{
+    if (sigproto == alproto) {
+        return true;
+    }
+    switch (sigproto) {
+        case ALPROTO_HTTP2:
+            // a HTTP2 signature matches on either HTTP2 or DOH2 flows
+            return (alproto == ALPROTO_DOH2);
+        case ALPROTO_DOH2:
+            // a DOH2 signature accepts dns, http2 or http generic keywords
+            return (alproto == ALPROTO_HTTP2);
+    }
+    return false;
+}
+
+// whether a signature AppProto matches a flow (or signature) AppProto
 static inline AppProto AppProtoCommon(AppProto sigproto, AppProto alproto)
 {
     switch (sigproto) {

--- a/src/decode.h
+++ b/src/decode.h
@@ -250,6 +250,7 @@ typedef struct PacketAlert_ {
     SigIntId iid;   /* Internal ID, used for sorting */
     uint8_t action; /* Rule or threshold action to be applied to packet */
     uint8_t flags;
+    uint8_t sub_state; /**< tx sub state. 0 if not used. */
     const struct Signature_ *s;
     uint64_t tx_id; /* Used for sorting */
     int64_t frame_id;

--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -122,9 +122,17 @@ static uint8_t DetectEngineAptEventInspect(DetectEngineCtx *de_ctx, DetectEngine
     if (r == 1) {
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
     } else {
-        if (AppLayerParserGetStateProgress(f->proto, alproto, tx, flags) ==
-            AppLayerParserGetStateProgressCompletionStatus(alproto, flags))
-        {
+        AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, alproto, tx);
+        uint8_t tx_end_state;
+        if (txd->tx_type == 0) {
+            tx_end_state = (uint8_t)AppLayerParserGetStateProgressCompletionStatus(alproto, flags);
+        } else {
+            if (flags & STREAM_TOSERVER)
+                tx_end_state = txd->tx_type_eop_ts;
+            else
+                tx_end_state = txd->tx_type_eop_tc;
+        }
+        if (AppLayerParserGetStateProgress(f->proto, alproto, tx, flags) == tx_end_state) {
             return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
         } else {
             return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;

--- a/src/detect-app-layer-state.c
+++ b/src/detect-app-layer-state.c
@@ -128,8 +128,17 @@ end:
         SCLogDebug("DETECT_ENGINE_INSPECT_SIG_MATCH");
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
     } else {
-        if (AppLayerParserGetStateProgress(f->proto, alproto, tx, flags) ==
-                AppLayerParserGetStateProgressCompletionStatus(alproto, flags)) {
+        AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, alproto, tx);
+        uint8_t tx_end_state;
+        if (txd->tx_type == 0) {
+            tx_end_state = (uint8_t)AppLayerParserGetStateProgressCompletionStatus(alproto, flags);
+        } else {
+            if (flags & STREAM_TOSERVER)
+                tx_end_state = txd->tx_type_eop_ts;
+            else
+                tx_end_state = txd->tx_type_eop_tc;
+        }
+        if (AppLayerParserGetStateProgress(f->proto, alproto, tx, flags) == tx_end_state) {
             SCLogDebug("DETECT_ENGINE_INSPECT_SIG_CANT_MATCH");
             return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
         } else {

--- a/src/detect-dns-name.c
+++ b/src/detect-dns-name.c
@@ -173,21 +173,39 @@ static int Register(const char *keyword, const char *desc, const char *doc,
     return DetectBufferTypeGetByName(keyword);
 }
 
+/* helper to register the same buffer for DOH2 as we had for DNS, with their
+ * own alproto, substate and progress. But don't reregister the keyword itself. */
+static void RegisterDoh2(const char *keyword, InspectionMultiBufferGetDataPtr GetBufferFn)
+{
+    const AppProto alproto = ALPROTO_DOH2;
+    DetectAppLayerMultiRegisterSubState(keyword, alproto, SIG_FLAG_TOSERVER, HTTP2TxTypeStream,
+            HTTP2ProgClosed, GetBufferFn, 2);
+    DetectAppLayerMultiRegisterSubState(keyword, alproto, SIG_FLAG_TOCLIENT, HTTP2TxTypeStream,
+            HTTP2ProgClosed, GetBufferFn, 2);
+}
+
 void DetectDnsNameRegister(void)
 {
     query_buffer_id = Register("dns.queries.rrname", "DNS query rrname sticky buffer",
             "/rules/dns-keywords.html#dns-queries-rrname", SetupQueryBuffer, SCDnsTxGetQueryName,
             ALPROTO_DNS);
+    RegisterDoh2("dns.queries.rrname", SCDnsTxGetQueryName);
+
     answer_buffer_id = Register("dns.answers.rrname", "DNS answer rrname sticky buffer",
             "/rules/dns-keywords.html#dns-answers-rrname", SetupAnswerBuffer, SCDnsTxGetAnswerName,
             ALPROTO_DNS);
+    RegisterDoh2("dns.answers.rrname", SCDnsTxGetAnswerName);
+
     additional_buffer_id =
             Register("dns.additionals.rrname", "DNS additionals rrname sticky buffer",
                     "/rules/dns-keywords.html#dns-additionals-rrname", SetupAdditionalsBuffer,
                     SCDnsTxGetAdditionalName, ALPROTO_DNS);
+    RegisterDoh2("dns.additionals.rrname", SCDnsTxGetAdditionalName);
+
     authority_buffer_id = Register("dns.authorities.rrname", "DNS authorities rrname sticky buffer",
             "/rules/dns-keywords.html#dns-authorities-rrname", SetupAuthoritiesBuffer,
             SCDnsTxGetAuthorityName, ALPROTO_DNS);
+    RegisterDoh2("dns.authorities.rrname", SCDnsTxGetAuthorityName);
 
     mdns_query_buffer_id = Register("mdns.queries.rrname", "mDNS query rrname sticky buffer",
             "/rules/mdns-keywords.html#mdns-queries-rrname", SetupQueryBufferMdns,

--- a/src/detect-dns-response.c
+++ b/src/detect-dns-response.c
@@ -334,9 +334,9 @@ static int DetectDnsResponsePrefilterMpmRegister(DetectEngineCtx *de_ctx, SigGro
     pectx->mpm_ctx = mpm_ctx;
     pectx->transforms = &mpm_reg->transforms;
 
-    return PrefilterAppendTxEngine(de_ctx, sgh, DetectDnsResponsePrefilterTx,
-            mpm_reg->app_v2.alproto, mpm_reg->app_v2.tx_min_progress, pectx,
-            DetectDnsResponsePrefilterMpmFree, mpm_reg->pname);
+    return PrefilterAppendTxEngineSubState(de_ctx, sgh, DetectDnsResponsePrefilterTx,
+            mpm_reg->app_v2.alproto, mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
+            pectx, DetectDnsResponsePrefilterMpmFree, mpm_reg->pname);
 }
 
 static void SCDetectMdnsResponseRrnameRegister(void)
@@ -399,6 +399,13 @@ void DetectDnsResponseRegister(void)
             keyword, ALPROTO_DNS, SIG_FLAG_TOCLIENT, 1, DetectEngineInspectCb, NULL);
     DetectAppLayerMpmRegister(keyword, SIG_FLAG_TOCLIENT, 2, DetectDnsResponsePrefilterMpmRegister,
             NULL, ALPROTO_DNS, 1);
+
+    /* DOH2: Register in the TO_CLIENT direction. */
+    DetectAppLayerInspectEngineRegisterSubState(keyword, ALPROTO_DOH2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgClosed, DetectEngineInspectCb, NULL);
+    DetectAppLayerMpmRegisterSubState(keyword, SIG_FLAG_TOCLIENT, 2,
+            DetectDnsResponsePrefilterMpmRegister, NULL, ALPROTO_DOH2, HTTP2TxTypeStream,
+            HTTP2ProgClosed);
 
     DetectBufferTypeSetDescriptionByName(keyword, "dns response rrname");
     DetectBufferTypeSupportsMultiInstance(keyword);

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -374,8 +374,8 @@ static inline int PacketAlertSetContext(
 
 /** \internal
  */
-static inline PacketAlert PacketAlertSet(
-        DetectEngineThreadCtx *det_ctx, const Signature *s, uint64_t tx_id, uint8_t alert_flags)
+static inline PacketAlert PacketAlertSet(DetectEngineThreadCtx *det_ctx, const Signature *s,
+        uint64_t tx_id, const uint8_t sub_state, uint8_t alert_flags)
 {
     PacketAlert pa;
     pa.iid = s->iid;
@@ -384,6 +384,7 @@ static inline PacketAlert PacketAlertSet(
     pa.flags = alert_flags;
     /* Set tx_id if the frame has it */
     pa.tx_id = tx_id;
+    pa.sub_state = sub_state;
     pa.frame_id = (alert_flags & PACKET_ALERT_FLAG_FRAME) ? det_ctx->frame_id : 0;
     PacketAlertSetContext(det_ctx, &pa, s);
     return pa;
@@ -393,12 +394,12 @@ static inline PacketAlert PacketAlertSet(
  * \brief Append signature to local packet alert queue for later preprocessing
  */
 static void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p,
-        uint64_t tx_id, uint8_t alert_flags)
+        const uint64_t tx_id, const uint8_t sub_state, uint8_t alert_flags)
 {
     /* first time we see a drop action signature, set that in the packet */
     /* we do that even before inserting into the queue, so we save it even if appending fails */
     if (p->alerts.drop.action == 0 && s->action & ACTION_DROP) {
-        p->alerts.drop = PacketAlertSet(det_ctx, s, tx_id, alert_flags);
+        p->alerts.drop = PacketAlertSet(det_ctx, s, tx_id, sub_state, alert_flags);
         SCLogDebug("sid %u: set PacketAlert drop action. s->iid %" PRIu32 "", s->id, s->iid);
     }
 
@@ -411,7 +412,7 @@ static void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s,
             return;
         }
     }
-    det_ctx->alert_queue[pos] = PacketAlertSet(det_ctx, s, tx_id, alert_flags);
+    det_ctx->alert_queue[pos] = PacketAlertSet(det_ctx, s, tx_id, sub_state, alert_flags);
 
     SCLogDebug("packet %" PRIu64 ": appending sid %" PRIu32 ", s->iid %" PRIu32 " to alert queue",
             PcapPacketCntGet(p), s->id, s->iid);
@@ -422,10 +423,10 @@ static void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s,
  * \brief Append signature to local packet alert queue for later preprocessing
  */
 void AlertQueueAppendAppTx(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p,
-        uint64_t tx_id, uint8_t alert_flags)
+        uint64_t tx_id, uint8_t sub_state, uint8_t alert_flags)
 {
     alert_flags |= (PACKET_ALERT_FLAG_TX | PACKET_ALERT_FLAG_STATE_MATCH);
-    return AlertQueueAppend(det_ctx, s, p, tx_id, alert_flags);
+    return AlertQueueAppend(det_ctx, s, p, tx_id, sub_state, alert_flags);
 }
 
 /**
@@ -434,10 +435,10 @@ void AlertQueueAppendAppTx(DetectEngineThreadCtx *det_ctx, const Signature *s, P
  * comes from the packet alert path.
  */
 void AlertQueueAppendAppTxFromPacket(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p,
-        uint64_t tx_id, uint8_t alert_flags)
+        uint64_t tx_id, const uint8_t sub_state, uint8_t alert_flags)
 {
     alert_flags |= PACKET_ALERT_FLAG_TX;
-    return AlertQueueAppend(det_ctx, s, p, tx_id, alert_flags);
+    return AlertQueueAppend(det_ctx, s, p, tx_id, sub_state, alert_flags);
 }
 
 /**
@@ -446,7 +447,7 @@ void AlertQueueAppendAppTxFromPacket(DetectEngineThreadCtx *det_ctx, const Signa
 void AlertQueueAppendPacket(
         DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint8_t alert_flags)
 {
-    return AlertQueueAppend(det_ctx, s, p, PACKET_ALERT_NOTX, alert_flags);
+    return AlertQueueAppend(det_ctx, s, p, PACKET_ALERT_NOTX, 0, alert_flags);
 }
 
 /** \internal

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -33,9 +33,9 @@ void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
 void AlertQueueAppendPacket(
         DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint8_t alert_flags);
 void AlertQueueAppendAppTxFromPacket(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p,
-        uint64_t tx_id, uint8_t alert_flags);
+        uint64_t tx_id, const uint8_t sub_state, uint8_t alert_flags);
 void AlertQueueAppendAppTx(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p,
-        uint64_t tx_id, uint8_t alert_flags);
+        uint64_t tx_id, const uint8_t sub_state, uint8_t alert_flags);
 void PacketAlertFinalize(const DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
 #ifdef UNITTESTS
 int PacketAlertCheck(Packet *, uint32_t);

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -57,6 +57,7 @@
 #include "util-var-name.h"
 #include "detect-icmp-id.h"
 #include "detect-tcp-window.h"
+#include "app-layer-parser.h"
 
 static int rule_warnings_only = 0;
 
@@ -1444,6 +1445,9 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
             SCJbSetBool(ctx.js, "is_mpm", app->mpm);
             SCJbSetString(ctx.js, "app_proto", AppProtoToString(app->alproto));
             SCJbSetUint(ctx.js, "progress", app->progress);
+            if (app->sub_state)
+                SCJbSetString(ctx.js, "sub_state",
+                        AppLayerParserGetSubStateName(app->alproto, app->sub_state));
 
             if (app->v2.transforms != NULL) {
                 SCJbOpenArray(ctx.js, "transforms");

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -2116,12 +2116,12 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
 #include "app-layer-parser.h"
 
 static void AddPolicy(const DetectEngineCtx *de_ctx, RuleAnalyzer *ctx, const AppProto a,
-        const uint8_t state, const uint8_t direction)
+        const uint8_t sub_state, const uint8_t state, const uint8_t direction)
 {
     char policy_string[64] = "";
     const struct DetectFirewallPolicies *fw_policies = de_ctx->fw_policies;
     const struct DetectFirewallAppPolicy lookup = {
-        .alproto = a, .sub_state = 0, .progress = state, .direction = direction
+        .alproto = a, .sub_state = sub_state, .progress = state, .direction = direction
     };
     const struct DetectFirewallAppPolicy *ap =
             HashTableLookup(fw_policies->app_policies, (void *)&lookup, 0);
@@ -2159,12 +2159,12 @@ static void AddPolicy(const DetectEngineCtx *de_ctx, RuleAnalyzer *ctx, const Ap
 }
 
 static void FirewallAddRulesForState(const DetectEngineCtx *de_ctx, const AppProto a,
-        const uint8_t state, const uint8_t direction, RuleAnalyzer *ctx)
+        const uint8_t sub_state, const uint8_t state, const uint8_t direction, RuleAnalyzer *ctx)
 {
     uint32_t accept_rules = 0;
-    AddPolicy(de_ctx, ctx, a, state, direction);
+    AddPolicy(de_ctx, ctx, a, sub_state, state, direction);
     SCJbOpenArray(ctx->js, "rules");
-    for (Signature *s = de_ctx->sig_list; s != NULL; s = s->next) {
+    for (const Signature *s = de_ctx->sig_list; s != NULL; s = s->next) {
         if ((s->flags & SIG_FLAG_FIREWALL) == 0)
             break;
         if (s->type != SIG_TYPE_APP_TX)
@@ -2182,6 +2182,25 @@ static void FirewallAddRulesForState(const DetectEngineCtx *de_ctx, const AppPro
             }
         }
 
+        /* sig has no sub_state field, so check the app inspect engines (if any).
+         * We assume that the only engines we have either:
+         * - are unknown/substate 0
+         * - matching the rule's substate */
+        if (s->app_inspect != NULL) {
+            bool skip_rule = false;
+            for (const DetectEngineAppInspectionEngine *engine = s->app_inspect; engine != NULL;
+                    engine = engine->next) {
+                if (engine->alproto == ALPROTO_UNKNOWN) {
+                    // skip engines targeting unknown, like stream or app-layer-event
+                } else if (engine->sub_state != sub_state) {
+                    skip_rule = true;
+                    break;
+                }
+            }
+            if (skip_rule) {
+                continue;
+            }
+        }
         if ((s->flags & SIG_FLAG_FW_HOOK_LTE) && state < s->app_progress_hook) {
             SCJbAppendString(ctx->js, s->sig_str);
             accept_rules += ((s->action & ACTION_ACCEPT) != 0);
@@ -2241,6 +2260,57 @@ int FirewallAnalyzer(const DetectEngineCtx *de_ctx)
         if (!AppProtoIsValid(a))
             continue;
 
+        if (AppLayerParserSupportsSubStates(a)) {
+            SCJbOpenObject(ctx.js, AppProtoToString(a));
+            const uint8_t max_sub_state = AppLayerParserGetMaxSubState(a);
+            for (uint8_t sub_state = 1; sub_state <= max_sub_state; sub_state++) {
+                const char *sub_state_name = AppLayerParserGetSubStateName(a, sub_state);
+                const uint8_t max_progress = AppLayerParserGetSubStateCompletion(a, sub_state);
+                for (uint8_t state = 0; state <= max_progress; state++) {
+                    const char *name = AppLayerParserGetSubStateProgressName(
+                            a, sub_state, state, STREAM_TOSERVER);
+                    if (name == NULL)
+                        continue;
+
+                    char table_name[256];
+                    snprintf(table_name, sizeof(table_name), "app:%s:%s:%s", AppProtoToString(a),
+                            sub_state_name, name);
+                    SCJbOpenObject(ctx.js, table_name);
+                    FirewallAddRulesForState(de_ctx, a, sub_state, state, STREAM_TOSERVER, &ctx);
+                    if (ctx.js_warnings) {
+                        SCJbClose(ctx.js_warnings);
+                        SCJbSetObject(ctx.js, "warnings", ctx.js_warnings);
+                        SCJbFree(ctx.js_warnings);
+                        ctx.js_warnings = NULL;
+                    }
+                    SCJbClose(ctx.js);
+                }
+                for (uint8_t state = 0; state <= max_progress; state++) {
+                    const char *name = AppLayerParserGetSubStateProgressName(
+                            a, sub_state, state, STREAM_TOCLIENT);
+                    if (name == NULL)
+                        continue;
+
+                    char table_name[256];
+                    snprintf(table_name, sizeof(table_name), "app:%s:%s:%s", AppProtoToString(a),
+                            sub_state_name, name);
+                    SCJbOpenObject(ctx.js, table_name);
+                    FirewallAddRulesForState(de_ctx, a, sub_state, state, STREAM_TOCLIENT, &ctx);
+                    if (ctx.js_warnings) {
+                        SCJbClose(ctx.js_warnings);
+                        SCJbSetObject(ctx.js, "warnings", ctx.js_warnings);
+                        SCJbFree(ctx.js_warnings);
+                        ctx.js_warnings = NULL;
+                    }
+                    SCJbClose(ctx.js);
+                }
+            }
+            SCJbClose(ctx.js); // app layer
+            continue;
+        }
+
+        /* no sub state follows */
+
         const uint8_t complete_state_ts =
                 (const uint8_t)AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOSERVER);
         SCJbOpenObject(ctx.js, AppProtoToString(a));
@@ -2259,7 +2329,7 @@ int FirewallAnalyzer(const DetectEngineCtx *de_ctx)
             char table_name[128];
             snprintf(table_name, sizeof(table_name), "app:%s:%s", AppProtoToString(a), name);
             SCJbOpenObject(ctx.js, table_name);
-            FirewallAddRulesForState(de_ctx, a, state, STREAM_TOSERVER, &ctx);
+            FirewallAddRulesForState(de_ctx, a, 0, state, STREAM_TOSERVER, &ctx);
             if (ctx.js_warnings) {
                 SCJbClose(ctx.js_warnings);
                 SCJbSetObject(ctx.js, "warnings", ctx.js_warnings);
@@ -2284,7 +2354,7 @@ int FirewallAnalyzer(const DetectEngineCtx *de_ctx)
             char table_name[128];
             snprintf(table_name, sizeof(table_name), "app:%s:%s", AppProtoToString(a), name);
             SCJbOpenObject(ctx.js, table_name);
-            FirewallAddRulesForState(de_ctx, a, state, STREAM_TOCLIENT, &ctx);
+            FirewallAddRulesForState(de_ctx, a, 0, state, STREAM_TOCLIENT, &ctx);
             if (ctx.js_warnings) {
                 SCJbClose(ctx.js_warnings);
                 SCJbSetObject(ctx.js, "warnings", ctx.js_warnings);

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1134,6 +1134,13 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
 
     const char *alproto = AppProtoToString(s->alproto);
     SCJbSetString(ctx.js, "app_proto", alproto);
+    if (s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP && s->init_data->hook.t.app.sub_state) {
+        SCJbSetString(ctx.js, "sub_state",
+                AppLayerParserGetSubStateName(s->alproto, s->init_data->hook.t.app.sub_state));
+    } else if (s->app_sub_state) {
+        SCJbSetString(
+                ctx.js, "sub_state", AppLayerParserGetSubStateName(s->alproto, s->app_sub_state));
+    }
 
     SCJbOpenArray(ctx.js, "requirements");
     if (s->mask & SIG_MASK_REQUIRE_PAYLOAD) {

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -2119,13 +2119,16 @@ static void AddPolicy(const DetectEngineCtx *de_ctx, RuleAnalyzer *ctx, const Ap
         const uint8_t state, const uint8_t direction)
 {
     char policy_string[64] = "";
-    const struct DetectFirewallPolicy *p = NULL;
     const struct DetectFirewallPolicies *fw_policies = de_ctx->fw_policies;
-    if (direction == STREAM_TOSERVER) {
-        p = &fw_policies->app[a].ts[state];
-    } else {
-        p = &fw_policies->app[a].tc[state];
-    }
+    const struct DetectFirewallAppPolicy lookup = {
+        .alproto = a, .sub_state = 0, .progress = state, .direction = direction
+    };
+    const struct DetectFirewallAppPolicy *ap =
+            HashTableLookup(fw_policies->app_policies, (void *)&lookup, 0);
+    if (ap == NULL)
+        return;
+    const struct DetectFirewallPolicy *p = &ap->policy;
+
     const char *as = ActionScopeToString(p->action_scope);
     DEBUG_VALIDATE_BUG_ON(as == NULL);
     if (as == NULL)

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -30,10 +30,13 @@
 #include "detect-parse.h"
 #include "detect-engine-content-inspection.h"
 #include "rust.h"
+#include "app-layer-parser.h"
+#include "util-validate.h"
 
 int SCDetectHelperBufferProgressRegister(
         const char *name, AppProto alproto, uint8_t direction, uint8_t progress)
 {
+    DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto));
     if (direction & STREAM_TOSERVER) {
         DetectAppLayerInspectEngineRegister(
                 name, alproto, SIG_FLAG_TOSERVER, progress, DetectEngineInspectGenericList, NULL);
@@ -48,6 +51,7 @@ int SCDetectHelperBufferProgressRegister(
 int SCDetectHelperBufferProgressRegisterSubState(
         const char *name, AppProto alproto, uint8_t direction, uint8_t sub_state, uint8_t progress)
 {
+    DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
     if (direction & STREAM_TOSERVER) {
         DetectAppLayerInspectEngineRegisterSubState(name, alproto, SIG_FLAG_TOSERVER, sub_state,
                 (uint8_t)progress, DetectEngineInspectGenericList, NULL);
@@ -62,6 +66,7 @@ int SCDetectHelperBufferProgressRegisterSubState(
 int SCDetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionSingleBufferGetDataPtr GetData)
 {
+    DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto));
     if (direction & STREAM_TOSERVER) {
         DetectAppLayerInspectEngineRegisterSingle(
                 name, alproto, SIG_FLAG_TOSERVER, 0, DetectEngineInspectBufferSingle, GetData);
@@ -81,6 +86,7 @@ int SCDetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto
 int SCDetectRegisterMpmGeneric(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionBufferGetDataPtr GetData)
 {
+    DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto));
     if (direction & STREAM_TOSERVER) {
         DetectAppLayerInspectEngineRegister(
                 name, alproto, SIG_FLAG_TOSERVER, 0, DetectEngineInspectBufferGeneric, GetData);
@@ -100,6 +106,7 @@ int SCDetectRegisterMpmGeneric(const char *name, const char *desc, AppProto alpr
 int SCDetectHelperBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionSingleBufferGetDataPtr GetData, uint8_t progress)
 {
+    DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto));
     if (direction & STREAM_TOSERVER) {
         DetectAppLayerInspectEngineRegisterSingle(name, alproto, SIG_FLAG_TOSERVER, progress,
                 DetectEngineInspectBufferSingle, GetData);
@@ -120,6 +127,7 @@ int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *d
         AppProto alproto, uint8_t direction, InspectionMultiBufferGetDataPtr GetData,
         uint8_t progress)
 {
+    DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto));
     if (direction & STREAM_TOSERVER) {
         DetectAppLayerMultiRegister(name, alproto, SIG_FLAG_TOSERVER, progress, GetData, 2);
     }
@@ -135,6 +143,7 @@ int SCDetectHelperMultiBufferProgressMpmRegisterSubState(const char *name, const
         AppProto alproto, uint8_t direction, InspectionMultiBufferGetDataPtr GetData,
         uint8_t sub_state, uint8_t progress)
 {
+    DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
     if (direction & STREAM_TOSERVER) {
         DetectAppLayerMultiRegisterSubState(
                 name, alproto, SIG_FLAG_TOSERVER, sub_state, progress, GetData, 2);
@@ -151,6 +160,7 @@ int SCDetectHelperMultiBufferProgressMpmRegisterSubState(const char *name, const
 int SCDetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData)
 {
+    DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto));
     return SCDetectHelperMultiBufferProgressMpmRegister(name, desc, alproto, direction, GetData, 0);
 }
 

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -45,6 +45,20 @@ int SCDetectHelperBufferProgressRegister(
     return DetectBufferTypeRegister(name);
 }
 
+int SCDetectHelperBufferProgressRegisterSubState(
+        const char *name, AppProto alproto, uint8_t direction, uint8_t sub_state, uint8_t progress)
+{
+    if (direction & STREAM_TOSERVER) {
+        DetectAppLayerInspectEngineRegisterSubState(name, alproto, SIG_FLAG_TOSERVER, sub_state,
+                (uint8_t)progress, DetectEngineInspectGenericList, NULL);
+    }
+    if (direction & STREAM_TOCLIENT) {
+        DetectAppLayerInspectEngineRegisterSubState(name, alproto, SIG_FLAG_TOCLIENT, sub_state,
+                (uint8_t)progress, DetectEngineInspectGenericList, NULL);
+    }
+    return DetectBufferTypeRegister(name);
+}
+
 int SCDetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionSingleBufferGetDataPtr GetData)
 {
@@ -111,6 +125,23 @@ int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *d
     }
     if (direction & STREAM_TOCLIENT) {
         DetectAppLayerMultiRegister(name, alproto, SIG_FLAG_TOCLIENT, progress, GetData, 2);
+    }
+    DetectBufferTypeSupportsMultiInstance(name);
+    DetectBufferTypeSetDescriptionByName(name, desc);
+    return DetectBufferTypeGetByName(name);
+}
+
+int SCDetectHelperMultiBufferProgressMpmRegisterSubState(const char *name, const char *desc,
+        AppProto alproto, uint8_t direction, InspectionMultiBufferGetDataPtr GetData,
+        uint8_t sub_state, uint8_t progress)
+{
+    if (direction & STREAM_TOSERVER) {
+        DetectAppLayerMultiRegisterSubState(
+                name, alproto, SIG_FLAG_TOSERVER, sub_state, progress, GetData, 2);
+    }
+    if (direction & STREAM_TOCLIENT) {
+        DetectAppLayerMultiRegisterSubState(
+                name, alproto, SIG_FLAG_TOCLIENT, sub_state, progress, GetData, 2);
     }
     DetectBufferTypeSupportsMultiInstance(name);
     DetectBufferTypeSetDescriptionByName(name, desc);

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -85,6 +85,8 @@ int SCDetectHelperBufferProgressRegister(
 
 int SCDetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionSingleBufferGetDataPtr GetData);
+int SCDetectHelperBufferProgressRegisterSubState(
+        const char *name, AppProto alproto, uint8_t direction, uint8_t sub_state, uint8_t progress);
 int SCDetectRegisterMpmGeneric(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionBufferGetDataPtr GetData);
 int SCDetectHelperBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
@@ -94,6 +96,9 @@ int SCDetectHelperMultiBufferMpmRegister(const char *name, const char *desc, App
 int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc,
         AppProto alproto, uint8_t direction, InspectionMultiBufferGetDataPtr GetData,
         uint8_t progress);
+int SCDetectHelperMultiBufferProgressMpmRegisterSubState(const char *name, const char *desc,
+        AppProto alproto, uint8_t direction, InspectionMultiBufferGetDataPtr GetData,
+        uint8_t sub_state, uint8_t progress);
 
 int SCDetectHelperTransformRegister(const SCTransformTableElmt *kw);
 

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -107,11 +107,6 @@ static void RegisterInternal(const char *name, int direction, int priority,
         FatalError("MPM engine registration for %s failed", name);
     }
 
-    // every HTTP2 can be accessed from DOH2
-    if (alproto == ALPROTO_HTTP2 || alproto == ALPROTO_DNS) {
-        RegisterInternal(name, direction, priority, PrefilterRegister, GetData, GetDataSingle,
-                GetMultiData, ALPROTO_DOH2, sub_state, tx_min_progress);
-    }
     DetectBufferMpmRegistry *am = SCCalloc(1, sizeof(*am));
     BUG_ON(am == NULL);
     am->name = name;

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -104,7 +104,7 @@ static void RegisterInternal(const char *name, int direction, int priority,
     DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
     DEBUG_VALIDATE_BUG_ON(!AppLayerParserSupportsSubStates(alproto) && sub_state != 0);
 
-    BUG_ON(tx_min_progress >= 48);
+    BUG_ON(tx_min_progress >= APP_LAYER_MAX_PROGRESS);
 
     // must register GetData with PrefilterGenericMpmRegister
     BUG_ON(PrefilterRegister == PrefilterGenericMpmRegister && GetData == NULL);

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -28,6 +28,7 @@
 #include "suricata-common.h"
 
 #include "app-layer-protos.h"
+#include "app-layer-parser.h"
 
 #include "decode.h"
 #include "detect.h"
@@ -94,6 +95,12 @@ static void RegisterInternal(const char *name, int direction, int priority,
 {
     SCLogDebug("registering %s/%d/%d/%p/%p/%u/%d", name, direction, priority,
             PrefilterRegister, GetData, alproto, tx_min_progress);
+
+    if (!AppLayerParserIsEnabled(alproto)) {
+        SCLogDebug("%s is disabled", AppProtoToString(alproto));
+        return;
+    }
+    SCLogDebug("%s is enabled", AppProtoToString(alproto));
 
     BUG_ON(tx_min_progress >= 48);
 

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -101,6 +101,8 @@ static void RegisterInternal(const char *name, int direction, int priority,
         return;
     }
     SCLogDebug("%s is enabled", AppProtoToString(alproto));
+    DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
+    DEBUG_VALIDATE_BUG_ON(!AppLayerParserSupportsSubStates(alproto) && sub_state != 0);
 
     BUG_ON(tx_min_progress >= 48);
 

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -2216,8 +2216,16 @@ static void PrepareMpms(DetectEngineCtx *de_ctx, SigGroupHead *sh)
             case DETECT_BUFFER_MPM_TYPE_APP: {
                 for (size_t e = 0; e < engines[list].idx; e++) {
                     const AppProto alproto = engines[list].array[e];
-                    if (!(AppProtoEquals(s->alproto, alproto) || s->alproto == 0))
-                        continue;
+                    if (s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {
+                        /* SIGNATURE_HOOK_TYPE_APP rules are exact about their protocol */
+                        if (!(AppProtoEqualsStrict(s->alproto, alproto))) {
+                            continue;
+                        }
+                    } else {
+                        /* other rules use the more relax AppProtoEquals logic */
+                        if (!(AppProtoEquals(s->alproto, alproto) || s->alproto == 0))
+                            continue;
+                    }
 
                     DetectBufferInstance lookup = { .list = list, .alproto = alproto };
                     DetectBufferInstance *instance = HashListTableLookup(bufs, &lookup, 0);

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -89,7 +89,8 @@ static int g_mpm_list_cnt[DETECT_BUFFER_MPM_TYPE_SIZE] = { 0, 0, 0 };
 static void RegisterInternal(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionBufferGetDataPtr GetData,
         InspectionSingleBufferGetDataPtr GetDataSingle,
-        InspectionMultiBufferGetDataPtr GetMultiData, AppProto alproto, uint8_t tx_min_progress)
+        InspectionMultiBufferGetDataPtr GetMultiData, AppProto alproto, uint8_t sub_state,
+        uint8_t tx_min_progress)
 {
     SCLogDebug("registering %s/%d/%d/%p/%p/%u/%d", name, direction, priority,
             PrefilterRegister, GetData, alproto, tx_min_progress);
@@ -109,7 +110,7 @@ static void RegisterInternal(const char *name, int direction, int priority,
     // every HTTP2 can be accessed from DOH2
     if (alproto == ALPROTO_HTTP2 || alproto == ALPROTO_DNS) {
         RegisterInternal(name, direction, priority, PrefilterRegister, GetData, GetDataSingle,
-                GetMultiData, ALPROTO_DOH2, tx_min_progress);
+                GetMultiData, ALPROTO_DOH2, sub_state, tx_min_progress);
     }
     DetectBufferMpmRegistry *am = SCCalloc(1, sizeof(*am));
     BUG_ON(am == NULL);
@@ -132,6 +133,7 @@ static void RegisterInternal(const char *name, int direction, int priority,
     }
     am->app_v2.alproto = alproto;
     am->app_v2.tx_min_progress = tx_min_progress;
+    am->app_v2.sub_state = sub_state;
 
     if (g_mpm_list[DETECT_BUFFER_MPM_TYPE_APP] == NULL) {
         g_mpm_list[DETECT_BUFFER_MPM_TYPE_APP] = am;
@@ -147,21 +149,31 @@ static void RegisterInternal(const char *name, int direction, int priority,
     g_mpm_list_cnt[DETECT_BUFFER_MPM_TYPE_APP]++;
 
     SupportFastPatternForSigMatchList(sm_list, priority);
+    SCLogDebug("%s: sub_state %u", name, am->app_v2.sub_state);
 }
 
 void DetectAppLayerMpmRegister(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionBufferGetDataPtr GetData,
         AppProto alproto, uint8_t tx_min_progress)
 {
-    RegisterInternal(name, direction, priority, PrefilterRegister, GetData, NULL, NULL, alproto,
+    RegisterInternal(name, direction, priority, PrefilterRegister, GetData, NULL, NULL, alproto, 0,
             tx_min_progress);
+}
+
+void DetectAppLayerMpmRegisterSubState(const char *name, int direction, int priority,
+        PrefilterRegisterFunc PrefilterRegister, InspectionBufferGetDataPtr GetData,
+        AppProto alproto, uint8_t sub_state, uint8_t tx_min_progress)
+{
+    SCLogDebug("%s: sub_state %u", name, sub_state);
+    RegisterInternal(name, direction, priority, PrefilterRegister, GetData, NULL, NULL, alproto,
+            sub_state, tx_min_progress);
 }
 
 void DetectAppLayerMpmRegisterSingle(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionSingleBufferGetDataPtr GetData,
         AppProto alproto, uint8_t tx_min_progress)
 {
-    RegisterInternal(name, direction, priority, PrefilterRegister, NULL, GetData, NULL, alproto,
+    RegisterInternal(name, direction, priority, PrefilterRegister, NULL, GetData, NULL, alproto, 0,
             tx_min_progress);
 }
 
@@ -169,8 +181,16 @@ void DetectAppLayerMpmMultiRegister(const char *name, int direction, int priorit
         PrefilterRegisterFunc PrefilterRegister, InspectionMultiBufferGetDataPtr GetData,
         AppProto alproto, uint8_t tx_min_progress)
 {
-    RegisterInternal(name, direction, priority, PrefilterRegister, NULL, NULL, GetData, alproto,
+    RegisterInternal(name, direction, priority, PrefilterRegister, NULL, NULL, GetData, alproto, 0,
             tx_min_progress);
+}
+
+void DetectAppLayerMpmMultiRegisterSubState(const char *name, int direction, int priority,
+        PrefilterRegisterFunc PrefilterRegister, InspectionMultiBufferGetDataPtr GetData,
+        AppProto alproto, uint8_t sub_state, uint8_t tx_min_progress)
+{
+    RegisterInternal(name, direction, priority, PrefilterRegister, NULL, NULL, GetData, alproto,
+            sub_state, tx_min_progress);
 }
 
 /** \internal
@@ -263,6 +283,7 @@ void DetectAppLayerMpmRegisterByParentId(DetectEngineCtx *de_ctx,
             am->app_v2.GetData = t->app_v2.GetData;
             am->app_v2.alproto = t->app_v2.alproto;
             am->app_v2.tx_min_progress = t->app_v2.tx_min_progress;
+            am->app_v2.sub_state = t->app_v2.sub_state;
             am->priority = t->priority;
             am->sgh_mpm_context = t->sgh_mpm_context;
             am->sgh_mpm_context = MpmFactoryRegisterMpmCtxProfile(

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -87,12 +87,19 @@ typedef int (*PrefilterRegisterFunc)(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
 void DetectAppLayerMpmRegister(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionBufferGetDataPtr GetData,
         AppProto alproto, uint8_t tx_min_progress);
+void DetectAppLayerMpmRegisterSubState(const char *name, int direction, int priority,
+        PrefilterRegisterFunc PrefilterRegister, InspectionBufferGetDataPtr GetData,
+        AppProto alproto, uint8_t sub_state, uint8_t tx_min_progress);
 void DetectAppLayerMpmRegisterSingle(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionSingleBufferGetDataPtr GetData,
         AppProto alproto, uint8_t tx_min_progress);
 void DetectAppLayerMpmMultiRegister(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionMultiBufferGetDataPtr GetData,
         AppProto alproto, uint8_t tx_min_progress);
+/** As DetectAppLayerMpmMultiRegister, but with a sub state argument */
+void DetectAppLayerMpmMultiRegisterSubState(const char *name, int direction, int priority,
+        PrefilterRegisterFunc PrefilterRegister, InspectionMultiBufferGetDataPtr GetData,
+        AppProto alproto, uint8_t sub_state, uint8_t tx_min_progress);
 void DetectAppLayerMpmRegisterByParentId(
         DetectEngineCtx *de_ctx,
         const int id, const int parent_id,

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -973,14 +973,15 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
             for (uint8_t state = 0; state < s->app_progress_hook; state++) {
                 SCLogDebug("handle HOOK %u LTE", state);
                 const int dir = (s->flags & SIG_FLAG_TOSERVER) ? 0 : 1;
+                const uint8_t sub_state = s->init_data->hook.t.app.sub_state;
                 const char *pname = DetectEngineAppHookToName(
-                        s->alproto, state, dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT);
+                        s->alproto, sub_state, state, dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT);
                 if (pname == NULL) {
                     goto error;
                 }
-                const int sm_list = DetectEngineAppHookToSmlist(
-                        s->alproto, state, dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT);
-                uint8_t sub_state = s->init_data->hook.t.app.sub_state;
+                const uint8_t direction = dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT;
+                const int sm_list =
+                        DetectEngineAppHookToSmlist(s->alproto, sub_state, state, direction);
                 if (TxNonPFAddSig(de_ctx, tx_engines_hash, s->alproto, sub_state, dir, state,
                             sm_list, pname, s) != 0) {
                     goto error;

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -104,11 +104,20 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
     /* reset rule store */
     det_ctx->pmq.rule_id_array_cnt = 0;
 
-    SCLogDebug("packet %" PRIu64 " tx %p progress %d tx->detect_progress %02x", PcapPacketCntGet(p),
-            tx->tx_ptr, tx->tx_progress, tx->detect_progress);
+    SCLogDebug("packet %" PRIu64 " tx %p id %" PRIu64 " progress %d tx->detect_progress %02x",
+            PcapPacketCntGet(p), tx->tx_ptr, tx->tx_id, tx->tx_progress, tx->detect_progress);
 
     PrefilterEngine *engine = sgh->tx_engines;
     do {
+        SCLogDebug("%" PRIu64 ": engine %p for %s progress %u  sub_state %u tx %u",
+                PcapPacketCntGet(p), engine, AppProtoToString(engine->alproto),
+                engine->ctx.app.tx_min_progress, engine->ctx.app.sub_state, tx->tx_type);
+        if (engine->alproto != ALPROTO_UNKNOWN && engine->ctx.app.sub_state != tx->tx_type) {
+            SCLogDebug("%" PRIu64 ": engine %p sub_state %u mismatch with tx %u",
+                    PcapPacketCntGet(p), engine, engine->ctx.app.sub_state, tx->tx_type);
+            // not for the tx sub state
+            goto next;
+        }
         // based on flow alproto, and engine, we get right tx_ptr
         void *tx_ptr = DetectGetInnerTx(tx->tx_ptr, alproto, engine->alproto, flow_flags);
         if (tx_ptr == NULL) {
@@ -116,30 +125,31 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
             goto next;
         }
 
-        if (engine->ctx.tx_min_progress != -1) {
+        if (engine->ctx.app.tx_min_progress != -1) {
 #ifdef DEBUG
             const char *pname = AppLayerParserGetStateNameById(ipproto, engine->alproto,
-                    engine->ctx.tx_min_progress, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT));
-            SCLogDebug("engine %p min_progress %d %s:%s", engine, engine->ctx.tx_min_progress,
+                    engine->ctx.app.tx_min_progress,
+                    flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT));
+            SCLogDebug("engine %p min_progress %d %s:%s", engine, engine->ctx.app.tx_min_progress,
                     AppProtoToString(engine->alproto), pname);
 #endif
             /* if engine needs tx state to be higher, break out. */
-            if (engine->ctx.tx_min_progress > tx->tx_progress)
+            if (engine->ctx.app.tx_min_progress > tx->tx_progress)
                 break;
-            if (tx->tx_progress > engine->ctx.tx_min_progress) {
-                SCLogDebug("tx->tx_progress %u > engine->ctx.tx_min_progress %d", tx->tx_progress,
-                        engine->ctx.tx_min_progress);
+            if (tx->tx_progress > engine->ctx.app.tx_min_progress) {
+                SCLogDebug("tx->tx_progress %u > engine->ctx.app.tx_min_progress %d",
+                        tx->tx_progress, engine->ctx.app.tx_min_progress);
 
                 /* if state value is at or beyond engine state, we can skip it. It means we ran at
                  * least once already. */
-                if (tx->detect_progress > engine->ctx.tx_min_progress) {
+                if (tx->detect_progress > engine->ctx.app.tx_min_progress) {
                     SCLogDebug("tx already marked progress as beyond engine: %u > %u",
-                            tx->detect_progress, engine->ctx.tx_min_progress);
+                            tx->detect_progress, engine->ctx.app.tx_min_progress);
                     goto next;
                 } else {
-                    SCLogDebug("tx->tx_progress %u > engine->ctx.tx_min_progress %d: "
+                    SCLogDebug("tx->tx_progress %u > engine->ctx.app.tx_min_progress %d: "
                                "tx->detect_progress %u",
-                            tx->tx_progress, engine->ctx.tx_min_progress, tx->detect_progress);
+                            tx->tx_progress, engine->ctx.app.tx_min_progress, tx->detect_progress);
                 }
             }
 #ifdef DEBUG
@@ -150,21 +160,21 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
                     tx->tx_data_ptr, flow_flags);
             PREFILTER_PROFILING_END(det_ctx, engine->gid);
             SCLogDebug("engine %p min_progress %d %s:%s: results %u", engine,
-                    engine->ctx.tx_min_progress, AppProtoToString(engine->alproto), pname,
+                    engine->ctx.app.tx_min_progress, AppProtoToString(engine->alproto), pname,
                     det_ctx->pmq.rule_id_array_cnt - old);
 
-            if (tx->tx_progress > engine->ctx.tx_min_progress && engine->is_last_for_progress &&
+            if (tx->tx_progress > engine->ctx.app.tx_min_progress && engine->is_last_for_progress &&
                     tx->tx_ptr == tx_ptr) {
                 /* track with an offset of one, so that tx->progress 0 complete is tracked
                  * as 1, progress 1 as 2, etc. This is to allow 0 to mean: nothing tracked, even
                  * though a parser may use 0 as a valid value. */
                 // tx->tx_ptr == tx_ptr ensures we do not use a dns engine progress
                 // to update a HTTP2 tx detect_progress in case of DOH2
-                tx->detect_progress = engine->ctx.tx_min_progress + 1;
-                SCLogDebug("tx->tx_progress %d engine->ctx.tx_min_progress %d "
+                tx->detect_progress = engine->ctx.app.tx_min_progress + 1;
+                SCLogDebug("tx->tx_progress %d engine->ctx.app.tx_min_progress %d "
                            "engine->is_last_for_progress %d => tx->detect_progress updated to %02x",
-                        tx->tx_progress, engine->ctx.tx_min_progress, engine->is_last_for_progress,
-                        tx->detect_progress);
+                        tx->tx_progress, engine->ctx.app.tx_min_progress,
+                        engine->is_last_for_progress, tx->detect_progress);
             }
         } else {
             PREFILTER_PROFILING_START(det_ctx);
@@ -353,9 +363,9 @@ int PrefilterAppendPayloadEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
     return 0;
 }
 
-int PrefilterAppendTxEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
-        PrefilterTxFn PrefilterTxFunc, AppProto alproto, int8_t tx_min_progress, void *pectx,
-        void (*FreeFunc)(void *pectx), const char *name)
+int PrefilterAppendTxEngineSubState(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
+        PrefilterTxFn PrefilterTxFunc, AppProto alproto, uint8_t sub_state,
+        const int8_t tx_min_progress, void *pectx, void (*FreeFunc)(void *pectx), const char *name)
 {
     if (sgh == NULL || PrefilterTxFunc == NULL || pectx == NULL)
         return -1;
@@ -369,6 +379,7 @@ int PrefilterAppendTxEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
     e->pectx = pectx;
     e->alproto = alproto;
     e->tx_min_progress = tx_min_progress;
+    e->sub_state = sub_state;
     e->Free = FreeFunc;
 
     if (sgh->init->tx_engines == NULL) {
@@ -385,7 +396,16 @@ int PrefilterAppendTxEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
 
     e->name = name;
     e->gid = PrefilterStoreGetId(de_ctx, e->name, e->Free);
+    SCLogDebug("%s: sub_state %u", name, e->sub_state);
     return 0;
+}
+
+int PrefilterAppendTxEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
+        PrefilterTxFn PrefilterTxFunc, AppProto alproto, const int8_t tx_min_progress, void *pectx,
+        void (*FreeFunc)(void *pectx), const char *name)
+{
+    return PrefilterAppendTxEngineSubState(
+            de_ctx, sgh, PrefilterTxFunc, alproto, 0, tx_min_progress, pectx, FreeFunc, name);
 }
 
 int PrefilterAppendFrameEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
@@ -520,14 +540,18 @@ static int PrefilterSetupRuleGroupSortHelper(const void *a, const void *b)
 {
     const PrefilterEngine *s0 = a;
     const PrefilterEngine *s1 = b;
-    if (s1->ctx.tx_min_progress == s0->ctx.tx_min_progress) {
-        if (s1->alproto == s0->alproto) {
-            return s0->local_id > s1->local_id ? 1 : -1;
+    if (s1->ctx.app.sub_state == s0->ctx.app.sub_state) {
+        if (s1->ctx.app.tx_min_progress == s0->ctx.app.tx_min_progress) {
+            if (s1->alproto == s0->alproto) {
+                return s0->local_id > s1->local_id ? 1 : -1;
+            } else {
+                return s0->alproto > s1->alproto ? 1 : -1;
+            }
         } else {
-            return s0->alproto > s1->alproto ? 1 : -1;
+            return s0->ctx.app.tx_min_progress > s1->ctx.app.tx_min_progress ? 1 : -1;
         }
     } else {
-        return s0->ctx.tx_min_progress > s1->ctx.tx_min_progress ? 1 : -1;
+        return s0->ctx.app.sub_state > s1->ctx.app.sub_state ? 1 : -1;
     }
 }
 
@@ -701,6 +725,7 @@ static void NonPFNamesFree(void *data)
 
 struct TxNonPFData {
     AppProto alproto;
+    uint8_t sub_state;
     int dir;      /**< 0: toserver, 1: toclient */
     uint8_t progress; /**< progress state value to register at */
     int sig_list; /**< special handling: normally 0, but for special cases (app-layer-state,
@@ -713,15 +738,15 @@ struct TxNonPFData {
 static uint32_t TxNonPFHash(HashListTable *h, void *data, uint16_t _len)
 {
     struct TxNonPFData *d = data;
-    return (d->alproto + d->progress + d->dir + d->sig_list) % h->array_size;
+    return (d->alproto + d->sub_state + d->progress + d->dir + d->sig_list) % h->array_size;
 }
 
 static char TxNonPFCompare(void *data1, uint16_t _len1, void *data2, uint16_t len2)
 {
     struct TxNonPFData *d1 = data1;
     struct TxNonPFData *d2 = data2;
-    return d1->alproto == d2->alproto && d1->progress == d2->progress && d1->dir == d2->dir &&
-           d1->sig_list == d2->sig_list;
+    return d1->alproto == d2->alproto && d1->sub_state == d2->sub_state &&
+           d1->progress == d2->progress && d1->dir == d2->dir && d1->sig_list == d2->sig_list;
 }
 
 static void TxNonPFFree(void *data)
@@ -732,13 +757,14 @@ static void TxNonPFFree(void *data)
 }
 
 static int TxNonPFAddSig(DetectEngineCtx *de_ctx, HashListTable *tx_engines_hash,
-        const AppProto alproto, const int dir, const uint8_t progress, const int sig_list,
-        const char *name, const Signature *s)
+        const AppProto alproto, const uint8_t sub_state, const int dir, const uint8_t progress,
+        const int sig_list, const char *name, const Signature *s)
 {
     const uint32_t max_sids = DetectEngineGetMaxSigId(de_ctx);
 
     struct TxNonPFData lookup = {
         .alproto = alproto,
+        .sub_state = sub_state,
         .dir = dir,
         .progress = progress,
         .sig_list = sig_list,
@@ -770,6 +796,7 @@ static int TxNonPFAddSig(DetectEngineCtx *de_ctx, HashListTable *tx_engines_hash
         return -1;
     }
     add->dir = dir;
+    add->sub_state = sub_state;
     add->alproto = alproto;
     add->progress = progress;
     add->sig_list = sig_list;
@@ -950,8 +977,9 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
                 }
                 const int sm_list = DetectEngineAppHookToSmlist(
                         s->alproto, state, dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT);
-                if (TxNonPFAddSig(de_ctx, tx_engines_hash, s->alproto, dir, state, sm_list, pname,
-                            s) != 0) {
+                uint8_t sub_state = s->init_data->hook.t.app.sub_state;
+                if (TxNonPFAddSig(de_ctx, tx_engines_hash, s->alproto, sub_state, dir, state,
+                            sm_list, pname, s) != 0) {
                     goto error;
                 }
                 tx_non_pf = true;
@@ -1014,7 +1042,8 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
                     int sig_list = 0;
                     if (list_id == app_state_list_id)
                         sig_list = app_state_list_id;
-                    if (TxNonPFAddSig(de_ctx, tx_engines_hash, app->alproto, app->dir,
+                    const uint8_t sub_state = app->sub_state;
+                    if (TxNonPFAddSig(de_ctx, tx_engines_hash, app->alproto, sub_state, app->dir,
                                 app->progress, sig_list, buf->name, s) != 0) {
                         goto error;
                     }
@@ -1035,7 +1064,8 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
                     s->alproto, s->init_data->hook.t.app.app_progress,
                     dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT);
 
-            if (TxNonPFAddSig(de_ctx, tx_engines_hash, s->alproto, dir,
+            uint8_t sub_state = s->init_data->hook.t.app.sub_state;
+            if (TxNonPFAddSig(de_ctx, tx_engines_hash, s->alproto, sub_state, dir,
                         s->init_data->hook.t.app.app_progress, s->init_data->hook.sm_list, pname,
                         s) != 0) {
                 goto error;
@@ -1129,8 +1159,8 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
         for (uint32_t i = 0; i < t->sigs_cnt; i++) {
             data->array[i] = t->sigs[i].sid;
         }
-        if (PrefilterAppendTxEngine(de_ctx, sgh, PrefilterTxNonPF, t->alproto, engine_progress,
-                    (void *)data, PrefilterNonPFDataFree, t->engine_name) < 0) {
+        if (PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterTxNonPF, t->alproto, t->sub_state,
+                    engine_progress, (void *)data, PrefilterNonPFDataFree, t->engine_name) < 0) {
             SCFree(data);
             goto error;
         }
@@ -1308,7 +1338,8 @@ int PrefilterSetupRuleGroup(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
         for (el = sgh->init->tx_engines ; el != NULL; el = el->next) {
             e->local_id = local_id++;
             e->alproto = el->alproto;
-            e->ctx.tx_min_progress = el->tx_min_progress;
+            e->ctx.app.tx_min_progress = el->tx_min_progress;
+            e->ctx.app.sub_state = el->sub_state;
             e->cb.PrefilterTx = el->PrefilterTx;
             e->pectx = el->pectx;
             el->pectx = NULL; // e now owns the ctx
@@ -1323,45 +1354,58 @@ int PrefilterSetupRuleGroup(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
         sgh->tx_engines[local_id - 1].is_last_for_progress = true;
 
         PrefilterEngine *engine;
-
         /* per alproto to set is_last_for_progress per alproto because the inspect
          * loop skips over engines that are not the correct alproto */
         for (AppProto a = ALPROTO_FAILED + 1; a < g_alproto_max; a++) {
-            int last_tx_progress = 0;
-            bool last_tx_progress_set = false;
-            PrefilterEngine *prev_engine = NULL;
-            engine = sgh->tx_engines;
-            do {
-                if (engine->ctx.tx_min_progress != -1)
-                    BUG_ON(engine->ctx.tx_min_progress < last_tx_progress);
-                if (engine->alproto == a) {
-                    if (last_tx_progress_set && engine->ctx.tx_min_progress > last_tx_progress) {
-                        if (prev_engine) {
-                            prev_engine->is_last_for_progress = true;
-                        }
-                    }
+            /* loop over sub-states. Protocols not supporting sub-states
+             * will just use 0. */
+            const uint8_t max_sub_state = AppLayerParserGetMaxSubState(a);
+            for (uint8_t sub = 0; sub <= max_sub_state; sub++) {
+                int last_tx_progress = 0;
+                bool last_tx_progress_set = false;
+                PrefilterEngine *prev_engine = NULL;
+                engine = sgh->tx_engines;
+                do {
+                    if (engine->ctx.app.sub_state == sub) {
+                        if (engine->ctx.app.tx_min_progress != -1)
+                            BUG_ON(engine->ctx.app.tx_min_progress < last_tx_progress);
+                        if (engine->alproto == a) {
+                            if (last_tx_progress_set &&
+                                    engine->ctx.app.tx_min_progress > last_tx_progress) {
+                                if (prev_engine) {
+                                    prev_engine->is_last_for_progress = true;
+                                }
+                            }
 
-                    last_tx_progress_set = true;
-                    prev_engine = engine;
-                } else {
-                    if (prev_engine) {
-                        prev_engine->is_last_for_progress = true;
+                            last_tx_progress_set = true;
+                            prev_engine = engine;
+                            if (!engine->is_last) {
+                                PrefilterEngine *next_engine = engine + 1;
+                                engine->is_last_for_progress =
+                                        (next_engine->ctx.app.sub_state != sub);
+                            }
+
+                        } else {
+                            if (prev_engine) {
+                                prev_engine->is_last_for_progress = true;
+                            }
+                        }
+                        last_tx_progress = engine->ctx.app.tx_min_progress;
                     }
-                }
-                last_tx_progress = engine->ctx.tx_min_progress;
-                if (engine->is_last)
-                    break;
-                engine++;
-            } while (1);
+                    if (engine->is_last)
+                        break;
+                    engine++;
+                } while (1);
+            }
         }
 #ifdef DEBUG
         SCLogDebug("sgh %p", sgh);
         engine = sgh->tx_engines;
         do {
-            SCLogDebug("engine: gid %u alproto %s tx_min_progress %d is_last %s "
+            SCLogDebug("engine: gid %u alproto %s sub_state %u tx_min_progress %d is_last %s "
                        "is_last_for_progress %s",
-                    engine->gid, AppProtoToString(engine->alproto), engine->ctx.tx_min_progress,
-                    engine->is_last ? "true" : "false",
+                    engine->gid, AppProtoToString(engine->alproto), engine->ctx.app.sub_state,
+                    engine->ctx.app.tx_min_progress, engine->is_last ? "true" : "false",
                     engine->is_last_for_progress ? "true" : "false");
             if (engine->is_last)
                 break;
@@ -1622,9 +1666,10 @@ int PrefilterGenericMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmC
     pectx->mpm_ctx = mpm_ctx;
     pectx->transforms = &mpm_reg->transforms;
 
-    int r = PrefilterAppendTxEngine(de_ctx, sgh, PrefilterMpm,
-        mpm_reg->app_v2.alproto, mpm_reg->app_v2.tx_min_progress,
-        pectx, PrefilterGenericMpmFree, mpm_reg->pname);
+    SCLogDebug("mpm_reg %s sub_state %u", mpm_reg->name, mpm_reg->app_v2.sub_state);
+    int r = PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterMpm, mpm_reg->app_v2.alproto,
+            mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress, pectx,
+            PrefilterGenericMpmFree, mpm_reg->pname);
     if (r != 0) {
         SCFree(pectx);
     }
@@ -1643,8 +1688,10 @@ int PrefilterSingleMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCt
     pectx->mpm_ctx = mpm_ctx;
     pectx->transforms = &mpm_reg->transforms;
 
-    int r = PrefilterAppendTxEngine(de_ctx, sgh, PrefilterMpmTxSingle, mpm_reg->app_v2.alproto,
-            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterGenericMpmFree, mpm_reg->pname);
+    SCLogDebug("mpm_reg %s sub_state %u", mpm_reg->name, mpm_reg->app_v2.sub_state);
+    int r = PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterMpmTxSingle,
+            mpm_reg->app_v2.alproto, mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
+            pectx, PrefilterGenericMpmFree, mpm_reg->pname);
     if (r != 0) {
         SCFree(pectx);
     }
@@ -1696,8 +1743,10 @@ int PrefilterMultiGenericMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
     pectx->mpm_ctx = mpm_ctx;
     pectx->transforms = &mpm_reg->transforms;
 
-    int r = PrefilterAppendTxEngine(de_ctx, sgh, PrefilterMultiMpm, mpm_reg->app_v2.alproto,
-            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterMultiGenericMpmFree, mpm_reg->pname);
+    SCLogDebug("mpm_reg %s sub_state %u", mpm_reg->name, mpm_reg->app_v2.sub_state);
+    int r = PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterMultiMpm, mpm_reg->app_v2.alproto,
+            mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress, pectx,
+            PrefilterMultiGenericMpmFree, mpm_reg->pname);
     if (r != 0) {
         SCFree(pectx);
     }

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -1038,6 +1038,13 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
                             AppProtoToString(app->alproto), app->sm_list,
                             s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT));
 
+                    /* extra strict alproto check for SIGNATURE_HOOK_TYPE_APP,
+                     * just like with mpm and per rule app engine. */
+                    if (s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {
+                        if (!AppProtoEqualsStrict(s->alproto, app->alproto))
+                            continue;
+                    }
+
                     /* skip if:
                      * - not in our dir
                      * - not our list

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -112,6 +112,12 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
         SCLogDebug("%" PRIu64 ": engine %p for %s progress %u  sub_state %u tx %u",
                 PcapPacketCntGet(p), engine, AppProtoToString(engine->alproto),
                 engine->ctx.app.tx_min_progress, engine->ctx.app.sub_state, tx->tx_type);
+
+        DEBUG_VALIDATE_BUG_ON(
+                AppLayerParserSupportsSubStates(engine->alproto) && engine->ctx.app.sub_state == 0);
+        DEBUG_VALIDATE_BUG_ON(!AppLayerParserSupportsSubStates(engine->alproto) &&
+                              engine->ctx.app.sub_state != 0);
+
         if (engine->alproto != ALPROTO_UNKNOWN && engine->ctx.app.sub_state != tx->tx_type) {
             SCLogDebug("%" PRIu64 ": engine %p sub_state %u mismatch with tx %u",
                     PcapPacketCntGet(p), engine, engine->ctx.app.sub_state, tx->tx_type);

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -126,6 +126,7 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
         }
 
         if (engine->ctx.app.tx_min_progress != -1) {
+            DEBUG_VALIDATE_BUG_ON(engine->alproto == ALPROTO_UNKNOWN);
 #ifdef DEBUG
             const char *pname = AppLayerParserGetStateNameById(ipproto, engine->alproto,
                     engine->ctx.app.tx_min_progress,
@@ -177,6 +178,7 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
                         engine->is_last_for_progress, tx->detect_progress);
             }
         } else {
+            DEBUG_VALIDATE_BUG_ON(engine->alproto != ALPROTO_UNKNOWN);
             PREFILTER_PROFILING_START(det_ctx);
             engine->cb.PrefilterTx(det_ctx, engine->pectx, p, p->flow, tx_ptr, tx->tx_id,
                     tx->tx_data_ptr, flow_flags);
@@ -367,6 +369,7 @@ int PrefilterAppendTxEngineSubState(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
         PrefilterTxFn PrefilterTxFunc, AppProto alproto, uint8_t sub_state,
         const int8_t tx_min_progress, void *pectx, void (*FreeFunc)(void *pectx), const char *name)
 {
+    BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
     if (sgh == NULL || PrefilterTxFunc == NULL || pectx == NULL)
         return -1;
 

--- a/src/detect-engine-prefilter.h
+++ b/src/detect-engine-prefilter.h
@@ -43,6 +43,9 @@ typedef struct DetectTransaction_ {
     const uint8_t tx_progress;
     const uint8_t tx_end_state;
     bool is_last; /* is this the last tx? */
+
+    /** app-layer specific transaction type (for sub-state support). 0 if not used. */
+    const uint8_t tx_type;
 } DetectTransaction;
 
 typedef struct PrefilterStore_ {
@@ -63,6 +66,9 @@ void PrefilterPostRuleMatch(
 
 int PrefilterAppendPayloadEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
         PrefilterPktFn PrefilterFunc, void *pectx, void (*FreeFunc)(void *pectx), const char *name);
+int PrefilterAppendTxEngineSubState(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
+        PrefilterTxFn PrefilterTxFunc, AppProto alproto, uint8_t sub_state,
+        const int8_t tx_min_progress, void *pectx, void (*FreeFunc)(void *pectx), const char *name);
 int PrefilterAppendTxEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
         PrefilterTxFn PrefilterTxFunc, const AppProto alproto, const int8_t tx_min_progress,
         void *pectx, void (*FreeFunc)(void *pectx), const char *name);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -836,37 +836,46 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
  * \param direction STREAM_TOSERVER or STREAM_TOCLIENT
  */
 const char *DetectEngineAppHookToName(
-        const AppProto p, const uint8_t state, const uint8_t direction)
+        const AppProto p, const uint8_t sub_state, const uint8_t state, const uint8_t direction)
 {
     if (!((direction & (STREAM_TOSERVER | STREAM_TOCLIENT)) == STREAM_TOSERVER) &&
             !((direction & (STREAM_TOSERVER | STREAM_TOCLIENT)) == STREAM_TOCLIENT))
         return NULL;
 
-    const char *pname = AppLayerParserGetStateNameById(IPPROTO_TCP, // TODO
-            p, state, direction);
-    if (pname == NULL) {
-        if (state == 0) {
-            if (direction == STREAM_TOSERVER) {
-                pname = "request_started";
-            } else {
-                pname = "response_started";
-            }
-        } else {
-            const int complete = AppLayerParserGetStateProgressCompletionStatus(p, direction);
-            if (state == complete) {
+    if (sub_state == 0) {
+        const char *pname = AppLayerParserGetStateNameById(IPPROTO_TCP, // TODO
+                p, state, direction);
+        if (pname == NULL) {
+            if (state == 0) {
                 if (direction == STREAM_TOSERVER) {
-                    pname = "request_complete";
+                    pname = "request_started";
                 } else {
-                    pname = "response_complete";
+                    pname = "response_started";
+                }
+            } else {
+                const int complete = AppLayerParserGetStateProgressCompletionStatus(p, direction);
+                if (state == complete) {
+                    if (direction == STREAM_TOSERVER) {
+                        pname = "request_complete";
+                    } else {
+                        pname = "response_complete";
+                    }
                 }
             }
         }
+        return pname;
+    } else {
+        BUG_ON(!AppLayerParserSupportsSubStates(p));
+        const char *name = AppLayerParserGetSubStateProgressName(p, sub_state, state, direction);
+        return name;
     }
-    return pname;
 }
 
-/** \brief get the sm_list for a app hook */
-int DetectEngineAppHookToSmlist(const AppProto p, const uint8_t state, const int direction)
+/** \brief get the sm_list for a app hook
+ *  \param sub_state sub_state to use or 0 if not in use
+ * */
+int DetectEngineAppHookToSmlist(
+        const AppProto p, const uint8_t sub_state, const uint8_t state, const uint8_t direction)
 {
     const char *app_proto = AppProtoToString(p);
     if (app_proto == NULL) {
@@ -876,20 +885,45 @@ int DetectEngineAppHookToSmlist(const AppProto p, const uint8_t state, const int
     if (strcmp(app_proto, "http") == 0)
         app_proto = "http1";
 
-    const char *name =
-            DetectEngineAppHookToName(p, state, direction & (STREAM_TOSERVER | STREAM_TOCLIENT));
-    if (name == NULL) {
-        return -1;
-    }
-
     char generic_hook_name[256];
-    snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", app_proto, name);
-    int list = DetectBufferTypeGetByName(generic_hook_name);
-    if (list < 0) {
-        SCLogError("no list registered as %s for %s hook %s", generic_hook_name, app_proto, name);
-        return -1;
+    if (sub_state == 0) {
+        const char *name = DetectEngineAppHookToName(
+                p, 0, state, direction & (STREAM_TOSERVER | STREAM_TOCLIENT));
+        if (name == NULL) {
+            return -1;
+        }
+
+        snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", app_proto, name);
+
+        int list = DetectBufferTypeGetByName(generic_hook_name);
+        if (list < 0) {
+            SCLogError(
+                    "no list registered as %s for %s hook %s", generic_hook_name, app_proto, name);
+            return -1;
+        }
+        return list;
+    } else {
+        BUG_ON(!AppLayerParserSupportsSubStates(p));
+
+        const char *sname = AppLayerParserGetSubStateName(p, sub_state);
+        if (sname == NULL)
+            return -1;
+
+        const char *name = AppLayerParserGetSubStateProgressName(p, sub_state, state, direction);
+        if (name == NULL)
+            return -1;
+
+        snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:%s:generic", app_proto, sname,
+                name);
+
+        int list = DetectBufferTypeGetByName(generic_hook_name);
+        if (list < 0) {
+            SCLogError("no list registered as %s for %s sub_state %s hook %s", generic_hook_name,
+                    app_proto, sname, name);
+            return -1;
+        }
+        return list;
     }
-    return list;
 }
 
 /**
@@ -908,7 +942,7 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
         SCLogDebug("need an inspect engine per state, range 0-%u", s->app_progress_hook);
         for (uint8_t state = 0; state < s->app_progress_hook; state++) {
             uint8_t dir = 0;
-            int direction = 0;
+            uint8_t direction = 0;
             BUG_ON((s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)) ==
                     (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT));
             BUG_ON((s->flags & (SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)) == 0);
@@ -920,8 +954,8 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
                 dir = 1;
             }
 
-            int sm_list =
-                    DetectEngineAppHookToSmlist(s->init_data->hook.t.app.alproto, 0, direction);
+            int sm_list = DetectEngineAppHookToSmlist(s->init_data->hook.t.app.alproto,
+                    s->init_data->hook.t.app.sub_state, 0, direction);
             if (sm_list < 0)
                 return -1;
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -736,7 +736,7 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
     } else if (s->alproto != ALPROTO_UNKNOWN) {
         if (s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {
             /* SIGNATURE_HOOK_TYPE_APP rules are exact about their protocol */
-            if (t->alproto != s->alproto) {
+            if (!(AppProtoEqualsStrict(s->alproto, t->alproto))) {
                 return;
             }
         } else {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2889,6 +2889,7 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
             }
         }
         HashTableFree(de_ctx->fw_policies->policy_signatures);
+        HashTableFree(de_ctx->fw_policies->app_policies);
     }
     SCFree(de_ctx->fw_policies);
     SCFree(de_ctx);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2888,7 +2888,6 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
                 SCFree(de_ctx->fw_policies->pkt_policy_signatures[i]);
             }
         }
-        HashTableFree(de_ctx->fw_policies->policy_signatures);
         HashTableFree(de_ctx->fw_policies->app_policies);
     }
     SCFree(de_ctx->fw_policies);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -204,7 +204,7 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
         DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
         DEBUG_VALIDATE_BUG_ON(!AppLayerParserSupportsSubStates(alproto) && sub_state != 0);
     }
-    BUG_ON(progress >= 48);
+    BUG_ON(progress >= APP_LAYER_MAX_PROGRESS);
 
     DetectBufferTypeRegister(name);
     const int sm_list = DetectBufferTypeGetByName(name);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -233,12 +233,6 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
     } else {
         direction = 1;
     }
-    // every DNS or HTTP2 can be accessed from DOH2
-    if (alproto == ALPROTO_HTTP2 || alproto == ALPROTO_DNS) {
-        AppLayerInspectEngineRegisterInternal(name, ALPROTO_DOH2, dir, sub_state, progress,
-                Callback, GetData, GetDataSingle, GetMultiData);
-    }
-
     DetectEngineAppInspectionEngine *new_engine =
             SCCalloc(1, sizeof(DetectEngineAppInspectionEngine));
     if (unlikely(new_engine == NULL)) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -749,6 +749,12 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
             if (!AppProtoEquals(s->alproto, t->alproto)) {
                 return;
             }
+            /* Signature::sub_state check: 0 here means we don't check. E.g.
+             * `alert http2 ... http2.frametype...` would apply to both stream
+             * and global sub states. */
+            if (s->app_sub_state != 0 && s->app_sub_state != t->sub_state) {
+                return;
+            }
         }
     }
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -739,6 +739,11 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
             if (!(AppProtoEqualsStrict(s->alproto, t->alproto))) {
                 return;
             }
+
+            /* skip engines not for us */
+            if (s->init_data->hook.t.app.sub_state != t->sub_state) {
+                return;
+            }
         } else {
             /* other rules use the more relax AppProtoEquals logic */
             if (!AppProtoEquals(s->alproto, t->alproto)) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -199,6 +199,11 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
         InspectionBufferGetDataPtr GetData, InspectionSingleBufferGetDataPtr GetDataSingle,
         InspectionMultiBufferGetDataPtr GetMultiData)
 {
+    /* ignore special case unknown */
+    if (alproto != ALPROTO_UNKNOWN && AppLayerParserIsEnabled(alproto)) {
+        DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
+        DEBUG_VALIDATE_BUG_ON(!AppLayerParserSupportsSubStates(alproto) && sub_state != 0);
+    }
     BUG_ON(progress >= 48);
 
     DetectBufferTypeRegister(name);
@@ -2229,6 +2234,7 @@ uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineTh
 void DetectAppLayerMultiRegisterSubState(const char *name, AppProto alproto, uint32_t dir,
         uint8_t sub_state, uint8_t progress, InspectionMultiBufferGetDataPtr GetData, int priority)
 {
+    BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
     AppLayerInspectEngineRegisterInternal(name, alproto, dir, sub_state, progress,
             DetectEngineInspectMultiBufferGeneric, NULL, NULL, GetData);
     DetectAppLayerMpmMultiRegisterSubState(name, dir, priority, PrefilterMultiGenericMpmRegister,
@@ -2240,6 +2246,7 @@ void DetectAppLayerMultiRegisterSubState(const char *name, AppProto alproto, uin
 void DetectAppLayerMultiRegister(const char *name, AppProto alproto, uint32_t dir, uint8_t progress,
         InspectionMultiBufferGetDataPtr GetData, int priority)
 {
+    BUG_ON(AppLayerParserSupportsSubStates(alproto));
     AppLayerInspectEngineRegisterInternal(name, alproto, dir, 0, (uint8_t)progress,
             DetectEngineInspectMultiBufferGeneric, NULL, NULL, GetData);
     DetectAppLayerMpmMultiRegister(

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -195,8 +195,8 @@ void DetectPktInspectEngineRegister(const char *name,
  *
  *  \note errors are fatal */
 static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alproto, uint32_t dir,
-        uint8_t progress, InspectEngineFuncPtr Callback, InspectionBufferGetDataPtr GetData,
-        InspectionSingleBufferGetDataPtr GetDataSingle,
+        uint8_t sub_state, uint8_t progress, InspectEngineFuncPtr Callback,
+        InspectionBufferGetDataPtr GetData, InspectionSingleBufferGetDataPtr GetDataSingle,
         InspectionMultiBufferGetDataPtr GetMultiData)
 {
     BUG_ON(progress >= 48);
@@ -209,7 +209,8 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
     SCLogDebug("name %s id %d", name, sm_list);
 
     if ((alproto == ALPROTO_FAILED) || (!(dir == SIG_FLAG_TOSERVER || dir == SIG_FLAG_TOCLIENT)) ||
-            (sm_list < DETECT_SM_LIST_MATCH) || (sm_list >= SHRT_MAX) || (Callback == NULL)) {
+            (sm_list < DETECT_SM_LIST_MATCH) || (sm_list >= SHRT_MAX) || (progress >= 48) ||
+            (Callback == NULL)) {
         SCLogError("Invalid arguments");
         BUG_ON(1);
     } else if (Callback == DetectEngineInspectBufferGeneric && GetData == NULL) {
@@ -234,8 +235,8 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
     }
     // every DNS or HTTP2 can be accessed from DOH2
     if (alproto == ALPROTO_HTTP2 || alproto == ALPROTO_DNS) {
-        AppLayerInspectEngineRegisterInternal(
-                name, ALPROTO_DOH2, dir, progress, Callback, GetData, GetDataSingle, GetMultiData);
+        AppLayerInspectEngineRegisterInternal(name, ALPROTO_DOH2, dir, sub_state, progress,
+                Callback, GetData, GetDataSingle, GetMultiData);
     }
 
     DetectEngineAppInspectionEngine *new_engine =
@@ -248,6 +249,7 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
     new_engine->sm_list = (uint16_t)sm_list;
     new_engine->sm_list_base = (uint16_t)sm_list;
     new_engine->progress = progress;
+    new_engine->sub_state = sub_state;
     new_engine->v2.Callback = Callback;
     if (Callback == DetectEngineInspectBufferGeneric) {
         new_engine->v2.GetData = GetData;
@@ -280,7 +282,8 @@ void DetectAppLayerInspectEngineRegister(const char *name, AppProto alproto, uin
         const int sm_list = DetectBufferTypeGetByName(name);
 
         if (t->sm_list == sm_list && t->alproto == alproto && t_direction == dir &&
-                t->progress == progress && t->v2.Callback == Callback && t->v2.GetData == GetData) {
+                t->sub_state == 0 && t->progress == progress && t->v2.Callback == Callback &&
+                t->v2.GetData == GetData) {
             DEBUG_VALIDATE_BUG_ON(1);
             return;
         }
@@ -288,9 +291,32 @@ void DetectAppLayerInspectEngineRegister(const char *name, AppProto alproto, uin
     }
 
     AppLayerInspectEngineRegisterInternal(
-            name, alproto, dir, progress, Callback, GetData, NULL, NULL);
+            name, alproto, dir, 0, (uint8_t)progress, Callback, GetData, NULL, NULL);
 }
 
+void DetectAppLayerInspectEngineRegisterSubState(const char *name, AppProto alproto, uint32_t dir,
+        uint8_t sub_state, uint8_t progress, InspectEngineFuncPtr Callback,
+        InspectionBufferGetDataPtr GetData)
+{
+    /* before adding, check that we don't add a duplicate entry, which will
+     * propagate all the way into the packet runtime if allowed. */
+    DetectEngineAppInspectionEngine *t = g_app_inspect_engines;
+    while (t != NULL) {
+        const uint32_t t_direction = t->dir == 0 ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;
+        const int sm_list = DetectBufferTypeGetByName(name);
+
+        if (t->sm_list == sm_list && t->alproto == alproto && t_direction == dir &&
+                t->sub_state == sub_state && t->progress == progress &&
+                t->v2.Callback == Callback && t->v2.GetData == GetData) {
+            DEBUG_VALIDATE_BUG_ON(1);
+            return;
+        }
+        t = t->next;
+    }
+
+    AppLayerInspectEngineRegisterInternal(
+            name, alproto, dir, sub_state, progress, Callback, GetData, NULL, NULL);
+}
 void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alproto, uint32_t dir,
         uint8_t progress, InspectEngineFuncPtr Callback, InspectionSingleBufferGetDataPtr GetData)
 {
@@ -311,7 +337,7 @@ void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alprot
     }
 
     AppLayerInspectEngineRegisterInternal(
-            name, alproto, dir, progress, Callback, NULL, GetData, NULL);
+            name, alproto, dir, 0, (uint8_t)progress, Callback, NULL, GetData, NULL);
 }
 
 /* copy an inspect engine with transforms to a new list id. */
@@ -334,6 +360,7 @@ static void DetectAppLayerInspectEngineCopy(
             DEBUG_VALIDATE_BUG_ON(sm_list < 0 || sm_list > UINT16_MAX);
             new_engine->sm_list_base = (uint16_t)sm_list;
             new_engine->progress = t->progress;
+            new_engine->sub_state = t->sub_state;
             new_engine->v2 = t->v2;
             new_engine->v2.transforms = transforms; /* assign transforms */
 
@@ -367,6 +394,7 @@ static void DetectAppLayerInspectEngineCopyListToDetectCtx(DetectEngineCtx *de_c
         new_engine->sm_list = t->sm_list;
         new_engine->sm_list_base = t->sm_list;
         new_engine->progress = t->progress;
+        new_engine->sub_state = t->sub_state;
         new_engine->v2 = t->v2;
 
         if (list == NULL) {
@@ -750,6 +778,7 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
     new_engine->smd = smd;
     new_engine->match_on_null = smd ? DetectContentInspectionMatchOnAbsentBuffer(smd) : false;
     new_engine->progress = t->progress;
+    new_engine->sub_state = t->sub_state;
     new_engine->v2 = t->v2;
     SCLogDebug("sm_list %d new_engine->v2 %p/%p/%p", new_engine->sm_list, new_engine->v2.Callback,
             new_engine->v2.GetData, new_engine->v2.transforms);
@@ -900,6 +929,7 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
             DetectEngineAppInspectionEngine t = {
                 .alproto = s->init_data->hook.t.app.alproto,
                 .progress = state,
+                .sub_state = s->init_data->hook.t.app.sub_state,
                 .sm_list = (uint16_t)sm_list,
                 .sm_list_base = (uint16_t)sm_list,
                 .dir = dir,
@@ -982,6 +1012,7 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
         DetectEngineAppInspectionEngine t = {
             .alproto = s->init_data->hook.t.app.alproto,
             .progress = s->init_data->hook.t.app.app_progress,
+            .sub_state = s->init_data->hook.t.app.sub_state,
             .sm_list = (uint16_t)s->init_data->hook.sm_list,
             .sm_list_base = (uint16_t)s->init_data->hook.sm_list,
             .dir = dir,
@@ -2201,10 +2232,21 @@ uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineTh
 
 // wrapper for both DetectAppLayerInspectEngineRegister and DetectAppLayerMpmRegister
 // with cast of callback function
+void DetectAppLayerMultiRegisterSubState(const char *name, AppProto alproto, uint32_t dir,
+        uint8_t sub_state, uint8_t progress, InspectionMultiBufferGetDataPtr GetData, int priority)
+{
+    AppLayerInspectEngineRegisterInternal(name, alproto, dir, sub_state, progress,
+            DetectEngineInspectMultiBufferGeneric, NULL, NULL, GetData);
+    DetectAppLayerMpmMultiRegisterSubState(name, dir, priority, PrefilterMultiGenericMpmRegister,
+            GetData, alproto, sub_state, progress);
+}
+
+// wrapper for both DetectAppLayerInspectEngineRegister and DetectAppLayerMpmRegister
+// with cast of callback function
 void DetectAppLayerMultiRegister(const char *name, AppProto alproto, uint32_t dir, uint8_t progress,
         InspectionMultiBufferGetDataPtr GetData, int priority)
 {
-    AppLayerInspectEngineRegisterInternal(name, alproto, dir, progress,
+    AppLayerInspectEngineRegisterInternal(name, alproto, dir, 0, (uint8_t)progress,
             DetectEngineInspectMultiBufferGeneric, NULL, NULL, GetData);
     DetectAppLayerMpmMultiRegister(
             name, dir, priority, PrefilterMultiGenericMpmRegister, GetData, alproto, progress);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -222,7 +222,8 @@ void DetectLowerSetupCallback(
 void DeStateRegisterTests(void);
 
 const char *DetectEngineAppHookToName(
-        const AppProto p, const uint8_t state, const uint8_t direction);
-int DetectEngineAppHookToSmlist(const AppProto p, const uint8_t state, const int direction);
+        const AppProto p, const uint8_t sub_state, const uint8_t state, const uint8_t direction);
+int DetectEngineAppHookToSmlist(
+        const AppProto p, const uint8_t sub_state, const uint8_t state, const uint8_t direction);
 
 #endif /* SURICATA_DETECT_ENGINE_H */

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -166,8 +166,19 @@ int DetectEngineInspectPktBufferGeneric(
 void DetectAppLayerInspectEngineRegister(const char *name, AppProto alproto, uint32_t dir,
         uint8_t progress, InspectEngineFuncPtr Callback2, InspectionBufferGetDataPtr GetData);
 
+/**
+ * \brief register an app inspection engine for a tx type
+ * \param type the tx type
+ */
+void DetectAppLayerInspectEngineRegisterSubState(const char *name, AppProto alproto, uint32_t dir,
+        uint8_t type, uint8_t progress, InspectEngineFuncPtr Callback2,
+        InspectionBufferGetDataPtr GetData);
+
 void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alproto, uint32_t dir,
         uint8_t progress, InspectEngineFuncPtr Callback2, InspectionSingleBufferGetDataPtr GetData);
+
+void DetectAppLayerMultiRegisterSubState(const char *name, AppProto alproto, uint32_t dir,
+        uint8_t sub_state, uint8_t progress, InspectionMultiBufferGetDataPtr GetData, int priority);
 
 void DetectAppLayerMultiRegister(const char *name, AppProto alproto, uint32_t dir, uint8_t progress,
         InspectionMultiBufferGetDataPtr GetData, int priority);

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -71,7 +71,9 @@ typedef struct {
     int direction;
     AppProto alproto;
     uint8_t progress_ts;
+    uint8_t sub_state_ts;
     uint8_t progress_tc;
+    uint8_t sub_state_tc;
 } DetectFileHandlerProtocol;
 
 /* Table with all filehandler registrations */
@@ -89,10 +91,14 @@ DetectFileHandlerProtocol al_protocols[ALPROTO_WITHFILES_MAX] = {
             .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT,
             .progress_tc = HTP_RESPONSE_PROGRESS_BODY,
             .progress_ts = HTP_REQUEST_PROGRESS_BODY },
-    { .alproto = ALPROTO_HTTP2,
+    {
+            .alproto = ALPROTO_HTTP2,
             .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT,
             .progress_tc = HTTP2ProgData,
-            .progress_ts = HTTP2ProgData },
+            .sub_state_tc = HTTP2TxTypeStream,
+            .progress_ts = HTTP2ProgData,
+            .sub_state_ts = HTTP2TxTypeStream,
+    },
     { .alproto = ALPROTO_SMTP, .direction = SIG_FLAG_TOSERVER }, { .alproto = ALPROTO_UNKNOWN }
 };
 
@@ -118,24 +124,24 @@ void DetectFileRegisterProto(
 void DetectFileRegisterFileProtocols(DetectFileHandlerTableElmt *reg)
 {
     for (size_t i = 0; i < g_alproto_max; i++) {
-        if (al_protocols[i].alproto == ALPROTO_UNKNOWN) {
+        DetectFileHandlerProtocol *p = &al_protocols[i];
+        if (p->alproto == ALPROTO_UNKNOWN) {
             break;
         }
-        int direction = al_protocols[i].direction == 0
-                                ? (int)(SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)
-                                : al_protocols[i].direction;
+        int direction =
+                p->direction == 0 ? (int)(SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT) : p->direction;
 
         if (direction & SIG_FLAG_TOCLIENT) {
-            DetectAppLayerMpmRegister(reg->name, SIG_FLAG_TOCLIENT, reg->priority, reg->PrefilterFn,
-                    NULL, al_protocols[i].alproto, al_protocols[i].progress_tc);
-            DetectAppLayerInspectEngineRegister(reg->name, al_protocols[i].alproto,
-                    SIG_FLAG_TOCLIENT, al_protocols[i].progress_tc, reg->Callback, NULL);
+            DetectAppLayerMpmRegisterSubState(reg->name, SIG_FLAG_TOCLIENT, reg->priority,
+                    reg->PrefilterFn, NULL, p->alproto, p->sub_state_tc, p->progress_tc);
+            DetectAppLayerInspectEngineRegisterSubState(reg->name, p->alproto, SIG_FLAG_TOCLIENT,
+                    p->sub_state_tc, p->progress_tc, reg->Callback, NULL);
         }
         if (direction & SIG_FLAG_TOSERVER) {
-            DetectAppLayerMpmRegister(reg->name, SIG_FLAG_TOSERVER, reg->priority, reg->PrefilterFn,
-                    NULL, al_protocols[i].alproto, al_protocols[i].progress_ts);
-            DetectAppLayerInspectEngineRegister(reg->name, al_protocols[i].alproto,
-                    SIG_FLAG_TOSERVER, al_protocols[i].progress_ts, reg->Callback, NULL);
+            DetectAppLayerMpmRegisterSubState(reg->name, SIG_FLAG_TOSERVER, reg->priority,
+                    reg->PrefilterFn, NULL, p->alproto, p->sub_state_ts, p->progress_ts);
+            DetectAppLayerInspectEngineRegisterSubState(reg->name, p->alproto, SIG_FLAG_TOSERVER,
+                    p->sub_state_ts, p->progress_ts, reg->Callback, NULL);
         }
     }
 }
@@ -595,8 +601,8 @@ int PrefilterMpmFiledataRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, Mpm
     pectx->mpm_ctx = mpm_ctx;
     pectx->transforms = &mpm_reg->transforms;
 
-    return PrefilterAppendTxEngine(de_ctx, sgh, PrefilterTxFiledata,
-            mpm_reg->app_v2.alproto, mpm_reg->app_v2.tx_min_progress,
+    return PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterTxFiledata,
+            mpm_reg->app_v2.alproto, mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
             pectx, PrefilterMpmFiledataFree, mpm_reg->pname);
 }
 

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -405,8 +405,8 @@ static int PrefilterMpmFilemagicRegister(DetectEngineCtx *de_ctx, SigGroupHead *
     pectx->mpm_ctx = mpm_ctx;
     pectx->transforms = &mpm_reg->transforms;
 
-    return PrefilterAppendTxEngine(de_ctx, sgh, PrefilterTxFilemagic,
-            mpm_reg->app_v2.alproto, mpm_reg->app_v2.tx_min_progress,
+    return PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterTxFilemagic,
+            mpm_reg->app_v2.alproto, mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
             pectx, PrefilterMpmFilemagicFree, mpm_reg->pname);
 }
 

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -342,8 +342,8 @@ static int PrefilterMpmFilenameRegister(DetectEngineCtx *de_ctx, SigGroupHead *s
     pectx->mpm_ctx = mpm_ctx;
     pectx->transforms = &mpm_reg->transforms;
 
-    return PrefilterAppendTxEngine(de_ctx, sgh, PrefilterTxFilename,
-            mpm_reg->app_v2.alproto, mpm_reg->app_v2.tx_min_progress,
+    return PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterTxFilename,
+            mpm_reg->app_v2.alproto, mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
             pectx, PrefilterMpmFilenameFree, mpm_reg->pname);
 }
 

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -111,10 +111,10 @@ void DetectHttpClientBodyRegister(void)
     DetectAppLayerMpmRegister("http_client_body", SIG_FLAG_TOSERVER, 2,
             PrefilterMpmHttpRequestBodyRegister, NULL, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_BODY);
 
-    DetectAppLayerInspectEngineRegister("http_client_body", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgData, DetectEngineInspectFiledata, NULL);
-    DetectAppLayerMpmRegister("http_client_body", SIG_FLAG_TOSERVER, 2,
-            PrefilterMpmFiledataRegister, NULL, ALPROTO_HTTP2, HTTP2ProgData);
+    DetectAppLayerInspectEngineRegisterSubState("http_client_body", ALPROTO_HTTP2,
+            SIG_FLAG_TOSERVER, HTTP2TxTypeStream, HTTP2ProgData, DetectEngineInspectFiledata, NULL);
+    DetectAppLayerMpmRegisterSubState("http_client_body", SIG_FLAG_TOSERVER, 2,
+            PrefilterMpmFiledataRegister, NULL, ALPROTO_HTTP2, HTTP2TxTypeStream, HTTP2ProgData);
 
     DetectBufferTypeSetDescriptionByName("http_client_body",
             "http request body");

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -119,15 +119,18 @@ void DetectHttpCookieRegister(void)
     DetectAppLayerMpmRegister("http_cookie", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
             GetResponseData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_HEADERS);
 
-    DetectAppLayerInspectEngineRegister("http_cookie", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetRequestData2);
-    DetectAppLayerInspectEngineRegister("http_cookie", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetResponseData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_cookie", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetRequestData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_cookie", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric,
+            GetResponseData2);
 
-    DetectAppLayerMpmRegister("http_cookie", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetRequestData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
-    DetectAppLayerMpmRegister("http_cookie", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetResponseData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_cookie", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetRequestData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_cookie", SIG_FLAG_TOCLIENT, 2,
+            PrefilterGenericMpmRegister, GetResponseData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_cookie",
             "http cookie header");

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -234,15 +234,17 @@ void DetectHttpHeaderNamesRegister(void)
             HTP_RESPONSE_PROGRESS_HEADERS, DetectEngineInspectBufferGeneric, GetBuffer1ForTX);
 
     /* http2 */
-    DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2ProgHeaders);
-    DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,
+            PrefilterGenericMpmRegister, GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 
-    DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
-    DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+    DetectAppLayerInspectEngineRegisterSubState(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+    DetectAppLayerInspectEngineRegisterSubState(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME,
             BUFFER_DESC);

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -399,6 +399,12 @@ void DetectHttpHeaderRegister(void)
             0); /* not used, registered twice: HEADERS/TRAILER */
 
     /* header is for stream TX type */
+    DetectAppLayerInspectEngineRegisterSubState("http_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+    DetectAppLayerMpmRegisterSubState("http_header", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
+
     DetectAppLayerInspectEngineRegisterSubState("http_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
             HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
     DetectAppLayerMpmRegisterSubState("http_header", SIG_FLAG_TOCLIENT, 2,
@@ -608,8 +614,8 @@ void DetectHttpResponseHeaderRegister(void)
     sigmatch_table[DETECT_HTTP_RESPONSE_HEADER].flags |=
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER;
 
-    DetectAppLayerMultiRegister("http_response_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgHeaders, GetHttp2HeaderData, 2);
+    DetectAppLayerMultiRegisterSubState("http_response_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, GetHttp2HeaderData, 2);
     DetectAppLayerMultiRegister("http_response_header", ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
             HTP_RESPONSE_PROGRESS_HEADERS, GetHttp1HeaderData, 2);
 

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -398,15 +398,12 @@ void DetectHttpHeaderRegister(void)
             PrefilterMpmHttpHeaderResponseRegister, NULL, ALPROTO_HTTP1,
             0); /* not used, registered twice: HEADERS/TRAILER */
 
-    DetectAppLayerInspectEngineRegister("http_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
-    DetectAppLayerMpmRegister("http_header", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2ProgHeaders);
-
-    DetectAppLayerInspectEngineRegister("http_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
-    DetectAppLayerMpmRegister("http_header", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    /* header is for stream TX type */
+    DetectAppLayerInspectEngineRegisterSubState("http_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+    DetectAppLayerMpmRegisterSubState("http_header", SIG_FLAG_TOCLIENT, 2,
+            PrefilterGenericMpmRegister, GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_header",
             "http headers");
@@ -574,8 +571,9 @@ void DetectHttpRequestHeaderRegister(void)
     sigmatch_table[DETECT_HTTP_REQUEST_HEADER].flags |=
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER;
 
-    DetectAppLayerMultiRegister("http_request_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, GetHttp2HeaderData, 2);
+    DetectAppLayerMultiRegisterSubState("http_request_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, GetHttp2HeaderData, 2);
+
     DetectAppLayerMultiRegister("http_request_header", ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
             HTP_REQUEST_PROGRESS_HEADERS, GetHttp1HeaderData, 2);
 

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -197,26 +197,29 @@ static void DetectHttpHeadersRegisterStub(void)
 #ifdef KEYWORD_TOSERVER
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetRequestData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_HEADERS);
-    DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetRequestData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetRequestData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 #endif
 #ifdef KEYWORD_TOCLIENT
     DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
             GetResponseData, ALPROTO_HTTP1, HTP_RESPONSE_PROGRESS_HEADERS);
-    DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetResponseData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,
+            PrefilterGenericMpmRegister, GetResponseData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 #endif
 #ifdef KEYWORD_TOSERVER
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
             HTP_REQUEST_PROGRESS_HEADERS, DetectEngineInspectBufferGeneric, GetRequestData);
-    DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetRequestData2);
+    DetectAppLayerInspectEngineRegisterSubState(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetRequestData2);
 #endif
 #ifdef KEYWORD_TOCLIENT
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
             HTP_RESPONSE_PROGRESS_HEADERS, DetectEngineInspectBufferGeneric, GetResponseData);
-    DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetResponseData2);
+    DetectAppLayerInspectEngineRegisterSubState(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric,
+            GetResponseData2);
 #endif
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -115,11 +115,12 @@ void DetectHttpHHRegister(void)
     DetectAppLayerMpmRegister("http_host", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_HEADERS);
 
-    DetectAppLayerInspectEngineRegister("http_host", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_host", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
-    DetectAppLayerMpmRegister("http_host", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_host", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 
     DetectBufferTypeRegisterValidateCallback("http_host",
             DetectHttpHostValidateCallback);
@@ -154,11 +155,12 @@ void DetectHttpHHRegister(void)
     DetectAppLayerMpmRegister("http_raw_host", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetRawData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_HEADERS);
 
-    DetectAppLayerInspectEngineRegister("http_raw_host", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetRawData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_raw_host", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetRawData2);
 
-    DetectAppLayerMpmRegister("http_raw_host", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetRawData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_raw_host", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetRawData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_raw_host",
             "http raw host header");

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -106,11 +106,12 @@ void DetectHttpMethodRegister(void)
     DetectAppLayerMpmRegister("http_method", SIG_FLAG_TOSERVER, 4, PrefilterGenericMpmRegister,
             GetData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_LINE);
 
-    DetectAppLayerInspectEngineRegister("http_method", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_method", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
-    DetectAppLayerMpmRegister("http_method", SIG_FLAG_TOSERVER, 4, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_method", SIG_FLAG_TOSERVER, 4,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_method",
             "http request method");

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -173,15 +173,15 @@ void DetectHttpProtocolRegister(void)
             HTP_RESPONSE_PROGRESS_LINE, DetectEngineInspectBufferGeneric, GetData);
 
     DetectAppLayerInspectEngineRegisterSubState(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2TxTypeStream, HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2TxTypeStream, HTTP2ProgStarted, DetectEngineInspectBufferGeneric, GetData2);
     DetectAppLayerMpmRegisterSubState(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
             PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
-            HTTP2ProgStart);
+            HTTP2ProgStarted);
     DetectAppLayerInspectEngineRegisterSubState(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2TxTypeStream, HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2TxTypeStream, HTTP2ProgStarted, DetectEngineInspectBufferGeneric, GetData2);
     DetectAppLayerMpmRegisterSubState(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,
             PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
-            HTTP2ProgStart);
+            HTTP2ProgStarted);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME,
             BUFFER_DESC);

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -172,14 +172,16 @@ void DetectHttpProtocolRegister(void)
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
             HTP_RESPONSE_PROGRESS_LINE, DetectEngineInspectBufferGeneric, GetData);
 
-    DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
-    DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgStart);
-    DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
-    DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgStart);
+    DetectAppLayerInspectEngineRegisterSubState(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerMpmRegisterSubState(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgStart);
+    DetectAppLayerInspectEngineRegisterSubState(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerMpmRegisterSubState(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgStart);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME,
             BUFFER_DESC);

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -113,15 +113,17 @@ void DetectHttpRawHeaderRegister(void)
             PrefilterMpmHttpHeaderRawResponseRegister, NULL, ALPROTO_HTTP1,
             0); /* progress handled in register */
 
-    DetectAppLayerInspectEngineRegister("http_raw_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
-    DetectAppLayerInspectEngineRegister("http_raw_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_raw_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_raw_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
-    DetectAppLayerMpmRegister("http_raw_header", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
-    DetectAppLayerMpmRegister("http_raw_header", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_raw_header", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_raw_header", SIG_FLAG_TOCLIENT, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_raw_header",
             "raw http headers");

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -116,10 +116,11 @@ void DetectHttpRequestLineRegister(void)
     DetectAppLayerMpmRegister("http_request_line", SIG_FLAG_TOSERVER, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_LINE);
 
-    DetectAppLayerInspectEngineRegister("http_request_line", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgData, DetectEngineInspectBufferGeneric, GetData2);
-    DetectAppLayerMpmRegister("http_request_line", SIG_FLAG_TOSERVER, 2,
-            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2ProgData);
+    DetectAppLayerInspectEngineRegisterSubState("http_request_line", ALPROTO_HTTP2,
+            SIG_FLAG_TOSERVER, HTTP2TxTypeStream, HTTP2ProgData, DetectEngineInspectBufferGeneric,
+            GetData2);
+    DetectAppLayerMpmRegisterSubState("http_request_line", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream, HTTP2ProgData);
 
     DetectBufferTypeSetDescriptionByName("http_request_line",
             "http request line");

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -115,10 +115,11 @@ void DetectHttpResponseLineRegister(void)
     DetectAppLayerMpmRegister("http_response_line", SIG_FLAG_TOCLIENT, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_HTTP1, HTP_RESPONSE_PROGRESS_LINE);
 
-    DetectAppLayerInspectEngineRegister("http_response_line", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgData, DetectEngineInspectBufferGeneric, GetData2);
-    DetectAppLayerMpmRegister("http_response_line", SIG_FLAG_TOCLIENT, 2,
-            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2ProgData);
+    DetectAppLayerInspectEngineRegisterSubState("http_response_line", ALPROTO_HTTP2,
+            SIG_FLAG_TOCLIENT, HTTP2TxTypeStream, HTTP2ProgData, DetectEngineInspectBufferGeneric,
+            GetData2);
+    DetectAppLayerMpmRegisterSubState("http_response_line", SIG_FLAG_TOCLIENT, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream, HTTP2ProgData);
 
     DetectBufferTypeSetDescriptionByName("http_response_line",
             "http response line");

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -107,11 +107,12 @@ void DetectHttpStatCodeRegister (void)
     DetectAppLayerMpmRegister("http_stat_code", SIG_FLAG_TOCLIENT, 4, PrefilterGenericMpmRegister,
             GetData, ALPROTO_HTTP1, HTP_RESPONSE_PROGRESS_LINE);
 
-    DetectAppLayerInspectEngineRegister("http_stat_code", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_stat_code", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
-    DetectAppLayerMpmRegister("http_stat_code", SIG_FLAG_TOCLIENT, 4, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_stat_code", SIG_FLAG_TOCLIENT, 4,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_stat_code",
             "http response status code");

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -117,10 +117,11 @@ void DetectHttpStatMsgRegister (void)
     DetectAppLayerMpmRegister("http_stat_msg", SIG_FLAG_TOCLIENT, 3, PrefilterGenericMpmRegister,
             GetData, ALPROTO_HTTP1, HTP_RESPONSE_PROGRESS_LINE);
 
-    DetectAppLayerInspectEngineRegister("http_stat_msg", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
-    DetectAppLayerMpmRegister("http_stat_msg", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgStart);
+    DetectAppLayerInspectEngineRegisterSubState("http_stat_msg", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerMpmRegisterSubState("http_stat_msg", SIG_FLAG_TOCLIENT, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgStart);
 
     DetectBufferTypeSetDescriptionByName("http_stat_msg",
             "http response status message");

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -118,10 +118,10 @@ void DetectHttpStatMsgRegister (void)
             GetData, ALPROTO_HTTP1, HTP_RESPONSE_PROGRESS_LINE);
 
     DetectAppLayerInspectEngineRegisterSubState("http_stat_msg", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2TxTypeStream, HTTP2ProgStart, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2TxTypeStream, HTTP2ProgStarted, DetectEngineInspectBufferGeneric, GetData2);
     DetectAppLayerMpmRegisterSubState("http_stat_msg", SIG_FLAG_TOCLIENT, 2,
             PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
-            HTTP2ProgStart);
+            HTTP2ProgStarted);
 
     DetectBufferTypeSetDescriptionByName("http_stat_msg",
             "http response status message");

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -107,11 +107,12 @@ void DetectHttpUARegister(void)
     DetectAppLayerMpmRegister("http_user_agent", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_HEADERS);
 
-    DetectAppLayerInspectEngineRegister("http_user_agent", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_user_agent", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
-    DetectAppLayerMpmRegister("http_user_agent", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_user_agent", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_user_agent",
             "http user agent");

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -113,11 +113,11 @@ void DetectHttpUriRegister (void)
     DetectAppLayerMpmRegister("http_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_LINE);
 
-    DetectAppLayerInspectEngineRegister("http_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
-    DetectAppLayerMpmRegister("http_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_uri",
             "http request uri");
@@ -151,11 +151,12 @@ void DetectHttpUriRegister (void)
             GetRawData, ALPROTO_HTTP1, HTP_REQUEST_PROGRESS_LINE);
 
     // no difference between raw and decoded uri for HTTP2
-    DetectAppLayerInspectEngineRegister("http_raw_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerInspectEngineRegisterSubState("http_raw_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
 
-    DetectAppLayerMpmRegister("http_raw_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+    DetectAppLayerMpmRegisterSubState("http_raw_uri", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_raw_uri",
             "raw http uri");

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -183,29 +183,40 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_HEADERNAME].flags |=
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER;
 
-    DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgHeaders, SCHttp2TxGetHeaderName, 2);
-    DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, SCHttp2TxGetHeaderName, 2);
+    /* registration for for Stream Tx Sub State */
+    DetectAppLayerMultiRegisterSubState("http2:header_name", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, SCHttp2TxGetHeaderName, 2);
+    DetectAppLayerMultiRegisterSubState("http2:header_name", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgHeaders, SCHttp2TxGetHeaderName, 2);
 
-    DetectBufferTypeSupportsMultiInstance("http2_header_name");
-    DetectBufferTypeSetDescriptionByName("http2_header_name",
-                                         "HTTP2 header name");
-    g_http2_header_buffer_id = DetectBufferTypeGetByName("http2_header_name");
+    DetectBufferTypeSupportsMultiInstance("http2:header_name");
+    DetectBufferTypeSetDescriptionByName("http2:header_name", "HTTP2 header name");
+    g_http2_header_buffer_id = DetectBufferTypeGetByName("http2:header_name");
 
-    DetectAppLayerInspectEngineRegister(
-            "http2", ALPROTO_HTTP2, SIG_FLAG_TOSERVER, 0, DetectEngineInspectGenericList, NULL);
-    DetectAppLayerInspectEngineRegister(
-            "http2", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectGenericList, NULL);
+    g_http2_match_buffer_id = DetectBufferTypeRegister("http2:start");
+    /* registration for for Stream Tx Sub State */
+    DetectAppLayerInspectEngineRegisterSubState("http2:start", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, 0, DetectEngineInspectGenericList, NULL);
+    DetectAppLayerInspectEngineRegisterSubState("http2:start", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, 0, DetectEngineInspectGenericList, NULL);
+    /* registration for for Global Tx Sub State */
+    DetectAppLayerInspectEngineRegisterSubState("http2:start", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeGlobal, 0, DetectEngineInspectGenericList, NULL);
+    DetectAppLayerInspectEngineRegisterSubState("http2:start", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeGlobal, 0, DetectEngineInspectGenericList, NULL);
 
-    g_http2_match_buffer_id = DetectBufferTypeRegister("http2");
+    g_http2_complete_buffer_id = DetectBufferTypeRegister("http2:complete");
 
-    DetectAppLayerInspectEngineRegister("http2_complete", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgComplete, DetectEngineInspectGenericList, NULL);
-    DetectAppLayerInspectEngineRegister("http2_complete", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2ProgComplete, DetectEngineInspectGenericList, NULL);
-
-    g_http2_complete_buffer_id = DetectBufferTypeRegister("http2_complete");
+    /* registration for for Stream Tx Sub State */
+    DetectAppLayerInspectEngineRegisterSubState("http2:complete", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeStream, HTTP2ProgComplete, DetectEngineInspectGenericList, NULL);
+    DetectAppLayerInspectEngineRegisterSubState("http2:complete", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeStream, HTTP2ProgComplete, DetectEngineInspectGenericList, NULL);
+    /* registration for for Global Tx Sub State */
+    DetectAppLayerInspectEngineRegisterSubState("http2:complete", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2TxTypeGlobal, HTTP2ProgGlobalComplete, DetectEngineInspectGenericList, NULL);
+    DetectAppLayerInspectEngineRegisterSubState("http2:complete", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2TxTypeGlobal, HTTP2ProgGlobalComplete, DetectEngineInspectGenericList, NULL);
 }
 
 /**

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1388,6 +1388,7 @@ static int SigParseProtoHookApp(
         Signature *s, const char *proto_hook, const char *p, const char *in_h)
 {
     char hook[64];
+    char generic_hook_name[256];
     strlcpy(hook, in_h, sizeof(hook));
     const char *h = hook;
     const char *t = NULL;
@@ -1425,6 +1426,12 @@ static int SigParseProtoHookApp(
             SCLogError("sub states currently only supported for http2");
             return -1;
         }
+        /* FW hook LTE mode */
+        if (*h == '<') {
+            h++;
+            SCLogDebug("hook and prior hooks: '%s'", h);
+            s->flags |= SIG_FLAG_FW_HOOK_LTE;
+        }
         const uint8_t max_state = AppLayerParserGetSubStateCompletion(
                 s->alproto, sub_state); // TODO allow different completion per direction?
         if (strcmp(h, "request_started") == 0) {
@@ -1457,7 +1464,14 @@ static int SigParseProtoHookApp(
                 s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_tc);
             }
         }
+        snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:%s:generic", p, t, h);
     } else {
+        /* FW hook LTE mode */
+        if (*h == '<') {
+            h++;
+            SCLogDebug("hook and prior hooks: '%s'", h);
+            s->flags |= SIG_FLAG_FW_HOOK_LTE;
+        }
         SCLogDebug("h:'%s'", h);
         if (strcmp(h, "request_started") == 0) {
             s->flags |= SIG_FLAG_TOSERVER;
@@ -1494,11 +1508,10 @@ static int SigParseProtoHookApp(
                 s->init_data->hook = SetAppHook(s->alproto, sub_state, (uint8_t)progress_tc);
             }
         }
+        snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", p, h);
     }
+    SCLogDebug("generic_hook_name %s", generic_hook_name);
 
-    /* use in_h to include sub state */
-    char generic_hook_name[128];
-    snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", p, in_h);
     int list = DetectBufferTypeGetByName(generic_hook_name);
     if (list < 0) {
         SCLogError("no list registered as %s for hook %s", generic_hook_name, proto_hook);
@@ -1569,14 +1582,6 @@ static int SigParseProto(Signature *s, const char *protostr)
                 if (strlen(h) == 0) {
                     SCLogError("invalid protocol specification '%s'", proto);
                     return -1;
-                }
-
-                /* FW hook LTE mode */
-                SCLogDebug("hook '%s'", h);
-                if (*h == '<') {
-                    h++;
-                    SCLogDebug("hook and prior hooks: '%s'", h);
-                    s->flags |= SIG_FLAG_FW_HOOK_LTE;
                 }
                 if (SigParseProtoHookApp(s, protostr, p, h) < 0) {
                     SCLogError("protocol \"%s\" does not support hook \"%s\"", p, h);

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3928,6 +3928,33 @@ void DetectSetupParseRegexes(const char *parse_str, DetectParseRegex *detect_par
     }
 }
 
+static uint32_t AppPolicyHashFunc(HashTable *ht, void *data, uint16_t datalen)
+{
+    const struct DetectFirewallAppPolicy *p = data;
+    /* use a prime-mix hash */
+    uint32_t hash = p->alproto * 65537 + p->sub_state * 257 + p->progress * 5 +
+                    (p->direction == STREAM_TOSERVER);
+    hash ^= (hash >> 10) ^ (hash >> 20);
+    return hash % ht->array_size;
+}
+
+static char AppPolicyCompareFunc(void *data1, uint16_t datalen1, void *data2, uint16_t datalen2)
+{
+    const struct DetectFirewallAppPolicy *p1 = data1;
+    const struct DetectFirewallAppPolicy *p2 = data2;
+
+    if (p1 == NULL || p2 == NULL)
+        return 0;
+
+    return p1->direction == p2->direction && p1->alproto == p2->alproto &&
+           p1->sub_state == p2->sub_state && p1->progress == p2->progress;
+}
+
+static void AppPolicyHashFree(void *data)
+{
+    struct DetectFirewallAppPolicy *p = data;
+    SCFree(p);
+}
 static uint32_t PolicySignatureHashFunc(HashTable *ht, void *data, uint16_t datalen)
 {
     const Signature *s = data;
@@ -4108,7 +4135,7 @@ static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *p
 static int DoParseAppSubStatePolicy(const char *prefix, const AppProto app_proto,
         const uint8_t sub_state, const char *sub_state_name, const uint8_t state,
         const char *hookname, const uint8_t complete_state, const int direction,
-        struct DetectFirewallPolicies *fw_policies, struct DetectFirewallAppPolicy *app_fw_policies)
+        struct DetectFirewallPolicies *fw_policies)
 {
     char policy_name[256];
     BUG_ON(sub_state_name == NULL);
@@ -4131,18 +4158,33 @@ static int DoParseAppSubStatePolicy(const char *prefix, const AppProto app_proto
         FatalError("internal error: failed to assemble firewall policy config string");
     }
 
-    struct DetectFirewallPolicy *pol;
-    if (direction == STREAM_TOSERVER)
-        pol = &fw_policies->http2_substates[sub_state - 1].ts[state];
-    else
-        pol = &fw_policies->http2_substates[sub_state - 1].tc[state];
+    struct DetectFirewallAppPolicy *app_pol = SCCalloc(1, sizeof(*app_pol));
+    if (app_pol == NULL)
+        return -1;
 
-    r = DoParsePolicy(policy_name, pol);
+    app_pol->alproto = app_proto;
+    app_pol->sub_state = sub_state;
+    app_pol->progress = state;
+    app_pol->direction = (uint8_t)direction;
+    /* init to drop:flow by default, will be overwritten by DoParsePolicy if there
+     * is a config for this hook. */
+    app_pol->policy.action = ACTION_DROP;
+    app_pol->policy.action_scope = ACTION_SCOPE_FLOW;
+
+    r = DoParsePolicy(policy_name, &app_pol->policy);
+    if (r < 0) {
+        SCFree(app_pol);
+        return -1;
+    }
+
+    if (HashTableAdd(fw_policies->app_policies, app_pol, 0) != 0) {
+        FatalError("internal error: insert policy into hash table");
+    }
     /* for policies with an alert action, create a policy sig */
-    if (r == 1 && pol->action & ACTION_ALERT) {
+    if (r == 1 && app_pol->policy.action & ACTION_ALERT) {
         SCLogDebug("adding policy signature");
         return AddAppPolicySignature(fw_policies->policy_signatures, direction, app_proto, app_name,
-                state, hookname, pol);
+                state, hookname, &app_pol->policy);
     }
     SCLogDebug("r %d", r);
     return r;
@@ -4150,7 +4192,7 @@ static int DoParseAppSubStatePolicy(const char *prefix, const AppProto app_proto
 
 static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const char *hookname,
         const uint8_t state, const uint8_t complete_state, const int direction,
-        struct DetectFirewallPolicies *fw_policies, struct DetectFirewallAppPolicy *app_fw_policies)
+        struct DetectFirewallPolicies *fw_policies)
 {
     char policy_name[256];
     const char *in_name = hookname;
@@ -4184,12 +4226,20 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
         FatalError("internal error: failed to assemble firewall policy config string");
     }
 
-    struct DetectFirewallPolicy *pol;
-    if (direction == STREAM_TOSERVER)
-        pol = &app_fw_policies[app_proto].ts[state];
-    else
-        pol = &app_fw_policies[app_proto].tc[state];
-    r = DoParsePolicy(policy_name, pol);
+    struct DetectFirewallAppPolicy *app_pol = SCCalloc(1, sizeof(*app_pol));
+    if (app_pol == NULL)
+        return -1;
+
+    app_pol->alproto = app_proto;
+    app_pol->sub_state = 0;
+    app_pol->progress = state;
+    app_pol->direction = (uint8_t)direction;
+    /* init to drop:flow by default, will be overwritten by DoParsePolicy if there
+     * is a config for this hook. */
+    app_pol->policy.action = ACTION_DROP;
+    app_pol->policy.action_scope = ACTION_SCOPE_FLOW;
+
+    r = DoParsePolicy(policy_name, &app_pol->policy);
     if (r == 0 && in_name != NULL) {
         if (state == 0) {
             if (direction == STREAM_TOSERVER)
@@ -4209,32 +4259,46 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
             FatalError("internal error: failed to assemble firewall policy config string");
         }
 
-        r = DoParsePolicy(policy_name, pol);
+        r = DoParsePolicy(policy_name, &app_pol->policy);
+    }
+    if (r < 0) {
+        SCFree(app_pol);
+        return -1;
+    }
+
+    if (HashTableAdd(fw_policies->app_policies, app_pol, 0) != 0) {
+        FatalError("internal error: insert policy into hash table");
     }
 
     /* for policies with an alert action, create a policy sig */
-    if (r == 1 && pol->action & ACTION_ALERT) {
+    if (r == 1 && app_pol->policy.action & ACTION_ALERT) {
         SCLogDebug("adding policy signature");
         return AddAppPolicySignature(fw_policies->policy_signatures, direction, app_proto, app_name,
-                state, hookname, pol);
+                state, hookname, &app_pol->policy);
     }
+
     return r;
 }
 
 /** \brief allocate and initialize to default values the policies table */
 int DetectFirewallInitDefaultPolicies(DetectEngineCtx *de_ctx)
 {
-    struct DetectFirewallPolicies *fw_policies = SCCalloc(
-            1, sizeof(*fw_policies) + g_alproto_max * sizeof(struct DetectFirewallAppPolicy));
+    struct DetectFirewallPolicies *fw_policies = SCCalloc(1, sizeof(*fw_policies));
     if (fw_policies == NULL)
         return -1;
-    struct DetectFirewallAppPolicy *app_fw_policies = fw_policies->app;
-    if (app_fw_policies == NULL)
-        goto error;
     fw_policies->policy_signatures = HashTableInit(
             512, PolicySignatureHashFunc, PolicySignatureCompareFunc, PolicySignatureHashFree);
-    if (fw_policies->policy_signatures == NULL)
-        goto error;
+    if (fw_policies->policy_signatures == NULL) {
+        SCFree(fw_policies);
+        return -1;
+    }
+    fw_policies->app_policies =
+            HashTableInit(512, AppPolicyHashFunc, AppPolicyCompareFunc, AppPolicyHashFree);
+    if (fw_policies->app_policies == NULL) {
+        HashTableFree(fw_policies->policy_signatures);
+        SCFree(fw_policies);
+        return -1;
+    }
 
     fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER].action = ACTION_DROP;
     fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER].action_scope = ACTION_SCOPE_PACKET;
@@ -4245,31 +4309,8 @@ int DetectFirewallInitDefaultPolicies(DetectEngineCtx *de_ctx)
     fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM].action = ACTION_ACCEPT;
     fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM].action_scope = ACTION_SCOPE_HOOK;
 
-    for (AppProto a = 0; a < g_alproto_max; a++) {
-        for (int i = 0; i < 48; i++) {
-            app_fw_policies[a].ts[i].action = ACTION_DROP;
-            app_fw_policies[a].ts[i].action_scope = ACTION_SCOPE_FLOW;
-            app_fw_policies[a].tc[i].action = ACTION_DROP;
-            app_fw_policies[a].tc[i].action_scope = ACTION_SCOPE_FLOW;
-        }
-    }
-
-    /* TODO hard coded for HTTP/2 for now */
-    for (int s = 0; s < 2; s++) {
-        for (int i = 0; i < 48; i++) {
-            fw_policies->http2_substates[s].ts[i].action = ACTION_DROP;
-            fw_policies->http2_substates[s].ts[i].action_scope = ACTION_SCOPE_FLOW;
-            fw_policies->http2_substates[s].tc[i].action = ACTION_DROP;
-            fw_policies->http2_substates[s].tc[i].action_scope = ACTION_SCOPE_FLOW;
-        }
-    }
-
     de_ctx->fw_policies = fw_policies;
     return 0;
-
-error:
-    SCFree(fw_policies);
-    return -1;
 }
 
 int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
@@ -4283,9 +4324,6 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
 
     struct DetectFirewallPolicies *fw_policies = de_ctx->fw_policies;
     if (fw_policies == NULL)
-        return -1;
-    struct DetectFirewallAppPolicy *app_fw_policies = fw_policies->app;
-    if (app_fw_policies == NULL)
         return -1;
 
     r = snprintf(policy_name, sizeof(policy_name), "%s.packet-filter", prefix);
@@ -4352,7 +4390,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
                     SCLogDebug("protocol %s: sub state:%s state:%s", AppProtoToString(a),
                             sub_state_name, state_name);
                     if (DoParseAppSubStatePolicy(prefix, a, s, sub_state_name, state, state_name,
-                                max_state, STREAM_TOSERVER, fw_policies, app_fw_policies) < 0)
+                                max_state, STREAM_TOSERVER, fw_policies) < 0)
                         return -1;
                 }
                 /* to_client */
@@ -4365,7 +4403,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
                     SCLogDebug("protocol %s: to_client: sub state:%s state:%s", AppProtoToString(a),
                             sub_state_name, state_name);
                     if (DoParseAppSubStatePolicy(prefix, a, s, sub_state_name, state, state_name,
-                                max_state, STREAM_TOCLIENT, fw_policies, app_fw_policies) < 0)
+                                max_state, STREAM_TOCLIENT, fw_policies) < 0)
                         return -1;
                 }
             }
@@ -4377,7 +4415,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
                 const char *name =
                         AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOSERVER);
                 if (DoParseAppPolicy(prefix, a, name, state, complete_state_ts, STREAM_TOSERVER,
-                            fw_policies, app_fw_policies) < 0)
+                            fw_policies) < 0)
                     return -1;
             }
             const uint8_t complete_state_tc =
@@ -4387,7 +4425,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
                 const char *name =
                         AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOCLIENT);
                 if (DoParseAppPolicy(prefix, a, name, state, complete_state_tc, STREAM_TOCLIENT,
-                            fw_policies, app_fw_policies) < 0)
+                            fw_policies) < 0)
                     return -1;
             }
         }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1161,65 +1161,131 @@ void DetectRegisterAppLayerHookLists(void)
             alproto_name = "http1";
         SCLogDebug("alproto %u/%s", a, alproto_name);
 
-        const uint8_t max_progress_ts =
-                AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOSERVER);
-        const uint8_t max_progress_tc =
-                AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOCLIENT);
+        if (AppLayerParserSupportsSubStates(a)) {
+            uint8_t max_sub_state = AppLayerParserGetMaxSubState(a);
+            SCLogDebug("%s: max sub state for %u is %u", AppProtoToString(a), a, max_sub_state);
+            for (uint8_t s = 1; s <= max_sub_state; s++) {
+                const uint8_t max_state = AppLayerParserGetSubStateCompletion(
+                        a, s); // TODO allow different completion per direction?
+                const char *sub_state_name = AppLayerParserGetSubStateName(a, s);
+                if (sub_state_name == NULL)
+                    continue;
 
-        char ts_tx_started[64];
-        snprintf(ts_tx_started, sizeof(ts_tx_started), "%s:request_started:generic", alproto_name);
-        DetectAppLayerInspectEngineRegister(
-                ts_tx_started, a, SIG_FLAG_TOSERVER, 0, DetectEngineInspectGenericList, NULL);
-        SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, "request_name", ts_tx_started,
-                (uint32_t)strlen(ts_tx_started));
+                char ts_tx_started[64];
+                snprintf(ts_tx_started, sizeof(ts_tx_started), "%s:%s:request_started:generic",
+                        alproto_name, sub_state_name);
+                DetectAppLayerInspectEngineRegisterSubState(ts_tx_started, a, SIG_FLAG_TOSERVER, s,
+                        0, DetectEngineInspectGenericList, NULL);
 
-        char tc_tx_started[64];
-        snprintf(tc_tx_started, sizeof(tc_tx_started), "%s:response_started:generic", alproto_name);
-        DetectAppLayerInspectEngineRegister(
-                tc_tx_started, a, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectGenericList, NULL);
-        SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, "response_name", tc_tx_started,
-                (uint32_t)strlen(tc_tx_started));
+                char tc_tx_started[64];
+                snprintf(tc_tx_started, sizeof(tc_tx_started), "%s:%s:response_started:generic",
+                        alproto_name, sub_state_name);
+                DetectAppLayerInspectEngineRegisterSubState(tc_tx_started, a, SIG_FLAG_TOCLIENT, s,
+                        0, DetectEngineInspectGenericList, NULL);
 
-        char ts_tx_complete[64];
-        snprintf(ts_tx_complete, sizeof(ts_tx_complete), "%s:request_complete:generic",
-                alproto_name);
-        DetectAppLayerInspectEngineRegister(ts_tx_complete, a, SIG_FLAG_TOSERVER, max_progress_ts,
-                DetectEngineInspectGenericList, NULL);
-        SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, "request_name", ts_tx_complete,
-                (uint32_t)strlen(ts_tx_complete));
+                char ts_tx_complete[64];
+                snprintf(ts_tx_complete, sizeof(ts_tx_complete), "%s:%s:request_complete:generic",
+                        alproto_name, sub_state_name);
+                DetectAppLayerInspectEngineRegisterSubState(ts_tx_complete, a, SIG_FLAG_TOSERVER, s,
+                        max_state, DetectEngineInspectGenericList, NULL);
 
-        char tc_tx_complete[64];
-        snprintf(tc_tx_complete, sizeof(tc_tx_complete), "%s:response_complete:generic",
-                alproto_name);
-        DetectAppLayerInspectEngineRegister(tc_tx_complete, a, SIG_FLAG_TOCLIENT, max_progress_tc,
-                DetectEngineInspectGenericList, NULL);
-        SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, "response_name", tc_tx_complete,
-                (uint32_t)strlen(tc_tx_complete));
+                char tc_tx_complete[64];
+                snprintf(tc_tx_complete, sizeof(tc_tx_complete), "%s:%s:response_complete:generic",
+                        alproto_name, sub_state_name);
+                DetectAppLayerInspectEngineRegisterSubState(tc_tx_complete, a, SIG_FLAG_TOCLIENT, s,
+                        max_state, DetectEngineInspectGenericList, NULL);
 
-        for (uint8_t p = 0; p <= max_progress_ts; p++) {
-            const char *name = AppLayerParserGetStateNameById(
-                    IPPROTO_TCP /* TODO no ipproto */, a, p, STREAM_TOSERVER);
-            if (name != NULL && !IsBuiltIn(name)) {
-                char list_name[64];
-                snprintf(list_name, sizeof(list_name), "%s:%s:generic", alproto_name, name);
-                SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, name, list_name,
-                        (uint32_t)strlen(list_name));
+                /* to_server */
+                for (uint8_t state = 0; state <= max_state; state++) {
+                    const char *state_name =
+                            AppLayerParserGetSubStateProgressName(a, s, state, STREAM_TOSERVER);
+                    BUG_ON(state_name == NULL);
 
-                DetectAppLayerInspectEngineRegister(
-                        list_name, a, SIG_FLAG_TOSERVER, p, DetectEngineInspectGenericList, NULL);
+                    if (state_name != NULL && !IsBuiltIn(state_name)) {
+                        char list_name[64];
+                        snprintf(list_name, sizeof(list_name), "%s:%s:%s:generic", alproto_name,
+                                sub_state_name, state_name);
+                        DetectAppLayerInspectEngineRegisterSubState(list_name, a, SIG_FLAG_TOSERVER,
+                                s, state, DetectEngineInspectGenericList, NULL);
+                    }
+                }
+                /* to_client */
+                for (uint8_t state = 0; state <= max_state; state++) {
+                    const char *state_name =
+                            AppLayerParserGetSubStateProgressName(a, s, state, STREAM_TOCLIENT);
+                    BUG_ON(state_name == NULL);
+                    if (state_name != NULL && !IsBuiltIn(state_name)) {
+                        char list_name[64];
+                        snprintf(list_name, sizeof(list_name), "%s:%s:%s:generic", alproto_name,
+                                sub_state_name, state_name);
+                        DetectAppLayerInspectEngineRegisterSubState(list_name, a, SIG_FLAG_TOCLIENT,
+                                s, state, DetectEngineInspectGenericList, NULL);
+                    }
+                }
             }
-        }
-        for (uint8_t p = 0; p <= max_progress_tc; p++) {
-            const char *name = AppLayerParserGetStateNameById(
-                    IPPROTO_TCP /* TODO no ipproto */, a, p, STREAM_TOCLIENT);
-            if (name != NULL && !IsBuiltIn(name)) {
-                char list_name[64];
-                snprintf(list_name, sizeof(list_name), "%s:%s:generic", alproto_name, name);
-                SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, name, list_name,
-                        (uint32_t)strlen(list_name));
+        } else {
+            const uint8_t max_progress_ts =
+                    AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOSERVER);
+            const uint8_t max_progress_tc =
+                    AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOCLIENT);
 
-                DetectAppLayerInspectEngineRegister(
-                        list_name, a, SIG_FLAG_TOCLIENT, p, DetectEngineInspectGenericList, NULL);
+            char ts_tx_started[64];
+            snprintf(ts_tx_started, sizeof(ts_tx_started), "%s:request_started:generic",
+                    alproto_name);
+            DetectAppLayerInspectEngineRegister(
+                    ts_tx_started, a, SIG_FLAG_TOSERVER, 0, DetectEngineInspectGenericList, NULL);
+            SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, "request_name", ts_tx_started,
+                    (uint32_t)strlen(ts_tx_started));
+
+            char tc_tx_started[64];
+            snprintf(tc_tx_started, sizeof(tc_tx_started), "%s:response_started:generic",
+                    alproto_name);
+            DetectAppLayerInspectEngineRegister(
+                    tc_tx_started, a, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectGenericList, NULL);
+            SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, "response_name", tc_tx_started,
+                    (uint32_t)strlen(tc_tx_started));
+
+            char ts_tx_complete[64];
+            snprintf(ts_tx_complete, sizeof(ts_tx_complete), "%s:request_complete:generic",
+                    alproto_name);
+            DetectAppLayerInspectEngineRegister(ts_tx_complete, a, SIG_FLAG_TOSERVER,
+                    max_progress_ts, DetectEngineInspectGenericList, NULL);
+            SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, "request_name", ts_tx_complete,
+                    (uint32_t)strlen(ts_tx_complete));
+
+            char tc_tx_complete[64];
+            snprintf(tc_tx_complete, sizeof(tc_tx_complete), "%s:response_complete:generic",
+                    alproto_name);
+            DetectAppLayerInspectEngineRegister(tc_tx_complete, a, SIG_FLAG_TOCLIENT,
+                    max_progress_tc, DetectEngineInspectGenericList, NULL);
+            SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, "response_name", tc_tx_complete,
+                    (uint32_t)strlen(tc_tx_complete));
+
+            for (uint8_t p = 0; p <= max_progress_ts; p++) {
+                const char *name = AppLayerParserGetStateNameById(
+                        IPPROTO_TCP /* TODO no ipproto */, a, p, STREAM_TOSERVER);
+                if (name != NULL && !IsBuiltIn(name)) {
+                    char list_name[64];
+                    snprintf(list_name, sizeof(list_name), "%s:%s:generic", alproto_name, name);
+                    SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, name, list_name,
+                            (uint32_t)strlen(list_name));
+
+                    DetectAppLayerInspectEngineRegister(list_name, a, SIG_FLAG_TOSERVER, p,
+                            DetectEngineInspectGenericList, NULL);
+                }
+            }
+            for (uint8_t p = 0; p <= max_progress_tc; p++) {
+                const char *name = AppLayerParserGetStateNameById(
+                        IPPROTO_TCP /* TODO no ipproto */, a, p, STREAM_TOCLIENT);
+                if (name != NULL && !IsBuiltIn(name)) {
+                    char list_name[64];
+                    snprintf(list_name, sizeof(list_name), "%s:%s:generic", alproto_name, name);
+                    SCLogDebug("- hook %s:%s list %s (%u)", alproto_name, name, list_name,
+                            (uint32_t)strlen(list_name));
+
+                    DetectAppLayerInspectEngineRegister(list_name, a, SIG_FLAG_TOCLIENT, p,
+                            DetectEngineInspectGenericList, NULL);
+                }
             }
         }
     }
@@ -1356,44 +1422,80 @@ static int SigParseProtoHookApp(
                 return -1;
             }
         }
-    }
-
-    SCLogDebug("h:'%s'", h);
-    if (strcmp(h, "request_started") == 0) {
-        s->flags |= SIG_FLAG_TOSERVER;
-        s->init_data->hook = SetAppHook(
-                s->alproto, sub_state, 0); // state 0 should be the starting state in each protocol.
-    } else if (strcmp(h, "response_started") == 0) {
-        s->flags |= SIG_FLAG_TOCLIENT;
-        s->init_data->hook = SetAppHook(
-                s->alproto, sub_state, 0); // state 0 should be the starting state in each protocol.
-    } else if (strcmp(h, "request_complete") == 0) {
-        s->flags |= SIG_FLAG_TOSERVER;
-        s->init_data->hook = SetAppHook(s->alproto, sub_state,
-                AppLayerParserGetStateProgressCompletionStatus(s->alproto, STREAM_TOSERVER));
-    } else if (strcmp(h, "response_complete") == 0) {
-        s->flags |= SIG_FLAG_TOCLIENT;
-        s->init_data->hook = SetAppHook(s->alproto, sub_state,
-                AppLayerParserGetStateProgressCompletionStatus(s->alproto, STREAM_TOCLIENT));
-    } else {
-        const int progress_ts = AppLayerParserGetStateIdByName(
-                IPPROTO_TCP /* TODO */, s->alproto, h, STREAM_TOSERVER);
-        if (progress_ts >= 0) {
+        const uint8_t max_state = AppLayerParserGetSubStateCompletion(
+                s->alproto, sub_state); // TODO allow different completion per direction?
+        if (strcmp(h, "request_started") == 0) {
             s->flags |= SIG_FLAG_TOSERVER;
-            s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_ts);
-        } else {
-            const int progress_tc = AppLayerParserGetStateIdByName(
-                    IPPROTO_TCP /* TODO */, s->alproto, h, STREAM_TOCLIENT);
-            if (progress_tc < 0) {
-                return -1;
-            }
+            s->init_data->hook = SetAppHook(s->alproto, sub_state,
+                    0); // state 0 should be the starting state in each protocol.
+        } else if (strcmp(h, "response_started") == 0) {
             s->flags |= SIG_FLAG_TOCLIENT;
-            s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_tc);
+            s->init_data->hook = SetAppHook(s->alproto, sub_state,
+                    0); // state 0 should be the starting state in each protocol.
+        } else if (strcmp(h, "request_complete") == 0) {
+            s->flags |= SIG_FLAG_TOSERVER;
+            s->init_data->hook = SetAppHook(s->alproto, sub_state, max_state);
+        } else if (strcmp(h, "response_complete") == 0) {
+            s->flags |= SIG_FLAG_TOCLIENT;
+            s->init_data->hook = SetAppHook(s->alproto, sub_state, max_state);
+        } else {
+            const int8_t progress_ts =
+                    AppLayerParserGetSubStateProgressId(s->alproto, sub_state, h, STREAM_TOSERVER);
+            if (progress_ts >= 0) {
+                s->flags |= SIG_FLAG_TOSERVER;
+                s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_ts);
+            } else {
+                const int8_t progress_tc = AppLayerParserGetSubStateProgressId(
+                        s->alproto, sub_state, h, STREAM_TOCLIENT);
+                if (progress_tc < 0) {
+                    return -1;
+                }
+                s->flags |= SIG_FLAG_TOCLIENT;
+                s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_tc);
+            }
+        }
+    } else {
+        SCLogDebug("h:'%s'", h);
+        if (strcmp(h, "request_started") == 0) {
+            s->flags |= SIG_FLAG_TOSERVER;
+            s->init_data->hook = SetAppHook(s->alproto, sub_state,
+                    0); // state 0 should be the starting state in each protocol.
+        } else if (strcmp(h, "response_started") == 0) {
+            s->flags |= SIG_FLAG_TOCLIENT;
+            s->init_data->hook = SetAppHook(s->alproto, sub_state,
+                    0); // state 0 should be the starting state in each protocol.
+        } else if (strcmp(h, "request_complete") == 0) {
+            s->flags |= SIG_FLAG_TOSERVER;
+            s->init_data->hook = SetAppHook(s->alproto, sub_state,
+                    AppLayerParserGetStateProgressCompletionStatus(s->alproto, STREAM_TOSERVER));
+        } else if (strcmp(h, "response_complete") == 0) {
+            s->flags |= SIG_FLAG_TOCLIENT;
+            s->init_data->hook = SetAppHook(s->alproto, sub_state,
+                    AppLayerParserGetStateProgressCompletionStatus(s->alproto, STREAM_TOCLIENT));
+        } else {
+            const int progress_ts = AppLayerParserGetStateIdByName(
+                    IPPROTO_TCP /* TODO */, s->alproto, h, STREAM_TOSERVER);
+            if (progress_ts >= 0) {
+                if (progress_ts >= 48) {
+                    return -1;
+                }
+                s->flags |= SIG_FLAG_TOSERVER;
+                s->init_data->hook = SetAppHook(s->alproto, sub_state, (uint8_t)progress_ts);
+            } else {
+                const int progress_tc = AppLayerParserGetStateIdByName(
+                        IPPROTO_TCP /* TODO */, s->alproto, h, STREAM_TOCLIENT);
+                if (progress_tc < 0 || progress_tc >= 48) {
+                    return -1;
+                }
+                s->flags |= SIG_FLAG_TOCLIENT;
+                s->init_data->hook = SetAppHook(s->alproto, sub_state, (uint8_t)progress_tc);
+            }
         }
     }
 
+    /* use in_h to include sub state */
     char generic_hook_name[64];
-    snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", p, h);
+    snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", p, in_h);
     int list = DetectBufferTypeGetByName(generic_hook_name);
     if (list < 0) {
         SCLogError("no list registered as %s for hook %s", generic_hook_name, proto_hook);

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1304,11 +1304,12 @@ static int SigParseProtoHookPkt(Signature *s, const char *proto_hook, const char
     return 0;
 }
 
-static SignatureHook SetAppHook(const AppProto alproto, uint8_t progress)
+static SignatureHook SetAppHook(const AppProto alproto, uint8_t sub_state, uint8_t progress)
 {
     SignatureHook h = {
         .type = SIGNATURE_HOOK_TYPE_APP,
         .t.app.alproto = alproto,
+        .t.app.sub_state = sub_state,
         .t.app.app_progress = progress,
     };
     return h;
@@ -1317,31 +1318,59 @@ static SignatureHook SetAppHook(const AppProto alproto, uint8_t progress)
 /**
  * \param proto_hook string of protocol and hook, e.g. dns:request_complete
  */
-static int SigParseProtoHookApp(Signature *s, const char *proto_hook, const char *p, const char *h)
+static int SigParseProtoHookApp(
+        Signature *s, const char *proto_hook, const char *p, const char *in_h)
 {
+    char hook[33];
+    strlcpy(hook, in_h, 33);
+    const char *h = hook;
+    const char *t = NULL;
+    uint8_t sub_state = 0;
+
+    bool has_type = strchr(hook, ':') != NULL;
+    if (has_type) {
+        char *rem = NULL;
+        t = strtok_r(hook, ":", &rem);
+        h = rem;
+        SCLogDebug("h: '%s' t: '%s'", h, t);
+    }
+    if (h == NULL || strlen(h) == 0) {
+        SCLogError("invalid hook specification '%s'", hook);
+        return -1;
+    }
+
+    if (t != NULL) {
+        if (strlen(t) == 0) {
+            SCLogError("invalid tx type specification '%s'", hook);
+            return -1;
+        }
+
+        /* TODO handle substate here */
+    }
+
     SCLogDebug("h:'%s'", h);
     if (strcmp(h, "request_started") == 0) {
         s->flags |= SIG_FLAG_TOSERVER;
-        s->init_data->hook =
-                SetAppHook(s->alproto, 0); // state 0 should be the starting state in each protocol.
+        s->init_data->hook = SetAppHook(
+                s->alproto, sub_state, 0); // state 0 should be the starting state in each protocol.
     } else if (strcmp(h, "response_started") == 0) {
         s->flags |= SIG_FLAG_TOCLIENT;
-        s->init_data->hook =
-                SetAppHook(s->alproto, 0); // state 0 should be the starting state in each protocol.
+        s->init_data->hook = SetAppHook(
+                s->alproto, sub_state, 0); // state 0 should be the starting state in each protocol.
     } else if (strcmp(h, "request_complete") == 0) {
         s->flags |= SIG_FLAG_TOSERVER;
-        s->init_data->hook = SetAppHook(s->alproto,
+        s->init_data->hook = SetAppHook(s->alproto, sub_state,
                 AppLayerParserGetStateProgressCompletionStatus(s->alproto, STREAM_TOSERVER));
     } else if (strcmp(h, "response_complete") == 0) {
         s->flags |= SIG_FLAG_TOCLIENT;
-        s->init_data->hook = SetAppHook(s->alproto,
+        s->init_data->hook = SetAppHook(s->alproto, sub_state,
                 AppLayerParserGetStateProgressCompletionStatus(s->alproto, STREAM_TOCLIENT));
     } else {
         const int progress_ts = AppLayerParserGetStateIdByName(
                 IPPROTO_TCP /* TODO */, s->alproto, h, STREAM_TOSERVER);
         if (progress_ts >= 0) {
             s->flags |= SIG_FLAG_TOSERVER;
-            s->init_data->hook = SetAppHook(s->alproto, (uint8_t)progress_ts);
+            s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_ts);
         } else {
             const int progress_tc = AppLayerParserGetStateIdByName(
                     IPPROTO_TCP /* TODO */, s->alproto, h, STREAM_TOCLIENT);
@@ -1349,7 +1378,7 @@ static int SigParseProtoHookApp(Signature *s, const char *proto_hook, const char
                 return -1;
             }
             s->flags |= SIG_FLAG_TOCLIENT;
-            s->init_data->hook = SetAppHook(s->alproto, (uint8_t)progress_tc);
+            s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_tc);
         }
     }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -4000,6 +4000,49 @@ static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *p
     return 1;
 }
 
+static int DoParseAppSubStatePolicy(const char *prefix, const AppProto app_proto,
+        const uint8_t sub_state, const char *sub_state_name, const uint8_t state,
+        const char *hookname, const uint8_t complete_state, const int direction,
+        struct DetectFirewallPolicies *fw_policies, struct DetectFirewallAppPolicy *app_fw_policies)
+{
+    char policy_name[256];
+    BUG_ON(sub_state_name == NULL);
+    BUG_ON(hookname == NULL);
+
+    char *nname = SCStrdup(hookname);
+    if (nname == NULL)
+        return -1;
+    for (int i = 0; nname[i] != '\0'; i++) {
+        if (nname[i] == '_')
+            nname[i] = '-';
+    }
+
+    const char *app_name = AppProtoToString(app_proto);
+    int r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s.%s", prefix, app_name,
+            sub_state_name, nname);
+    SCLogDebug("policy_name %s", policy_name);
+    SCFree(nname);
+    if (r < 0 || (size_t)r >= sizeof(policy_name)) {
+        FatalError("internal error: failed to assemble firewall policy config string");
+    }
+
+    struct DetectFirewallPolicy *pol;
+    if (direction == STREAM_TOSERVER)
+        pol = &fw_policies->http2_substates[sub_state - 1].ts[state];
+    else
+        pol = &fw_policies->http2_substates[sub_state - 1].tc[state];
+
+    r = DoParsePolicy(policy_name, pol);
+    /* for policies with an alert action, create a policy sig */
+    if (r == 1 && pol->action & ACTION_ALERT) {
+        SCLogDebug("adding policy signature");
+        return AddAppPolicySignature(fw_policies->policy_signatures, direction, app_proto, app_name,
+                state, hookname, pol);
+    }
+    SCLogDebug("r %d", r);
+    return r;
+}
+
 static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const char *hookname,
         const uint8_t state, const uint8_t complete_state, const int direction,
         struct DetectFirewallPolicies *fw_policies, struct DetectFirewallAppPolicy *app_fw_policies)
@@ -4105,6 +4148,17 @@ int DetectFirewallInitDefaultPolicies(DetectEngineCtx *de_ctx)
             app_fw_policies[a].tc[i].action_scope = ACTION_SCOPE_FLOW;
         }
     }
+
+    /* TODO hard coded for HTTP/2 for now */
+    for (int s = 0; s < 2; s++) {
+        for (int i = 0; i < 48; i++) {
+            fw_policies->http2_substates[s].ts[i].action = ACTION_DROP;
+            fw_policies->http2_substates[s].ts[i].action_scope = ACTION_SCOPE_FLOW;
+            fw_policies->http2_substates[s].tc[i].action = ACTION_DROP;
+            fw_policies->http2_substates[s].tc[i].action_scope = ACTION_SCOPE_FLOW;
+        }
+    }
+
     de_ctx->fw_policies = fw_policies;
     return 0;
 
@@ -4170,27 +4224,69 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
         if (!AppProtoIsValid(a))
             continue;
 
-        const uint8_t complete_state_ts =
-                (const uint8_t)AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOSERVER);
-        for (uint8_t state = 0; state <= complete_state_ts; state++) {
-            const char *name =
-                    AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOSERVER);
-            if (DoParseAppPolicy(prefix, a, name, state, complete_state_ts, STREAM_TOSERVER,
-                        fw_policies, app_fw_policies) < 0)
-                return -1;
-        }
+        if (AppLayerParserSupportsSubStates(a)) {
+            uint8_t max_sub_state = AppLayerParserGetMaxSubState(a);
+            SCLogDebug("%s: max sub state for %u is %u", AppProtoToString(a), a, max_sub_state);
+            for (uint8_t s = 1; s <= max_sub_state; s++) {
+                SCLogDebug("%s: checking sub state %u", AppProtoToString(a), s);
 
-        const uint8_t complete_state_tc =
-                (const uint8_t)AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOCLIENT);
-        for (uint8_t state = 0; state <= complete_state_tc; state++) {
-            const char *name =
-                    AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOCLIENT);
-            if (DoParseAppPolicy(prefix, a, name, state, complete_state_tc, STREAM_TOCLIENT,
-                        fw_policies, app_fw_policies) < 0)
-                return -1;
+                const char *sub_state_name = AppLayerParserGetSubStateName(a, s);
+                if (sub_state_name == NULL)
+                    continue;
+
+                // iterate the states belonging to the sub state
+                const uint8_t max_state = AppLayerParserGetSubStateCompletion(
+                        a, s); // TODO allow different completion per direction?
+                /* to_server */
+                for (uint8_t state = 0; state <= max_state; state++) {
+                    SCLogDebug("protocol %s: sub state:%s state:%u", AppProtoToString(a),
+                            sub_state_name, state);
+                    const char *state_name =
+                            AppLayerParserGetSubStateProgressName(a, s, state, STREAM_TOSERVER);
+                    BUG_ON(state_name == NULL);
+                    SCLogDebug("protocol %s: sub state:%s state:%s", AppProtoToString(a),
+                            sub_state_name, state_name);
+                    if (DoParseAppSubStatePolicy(prefix, a, s, sub_state_name, state, state_name,
+                                max_state, STREAM_TOSERVER, fw_policies, app_fw_policies) < 0)
+                        return -1;
+                }
+                /* to_client */
+                for (uint8_t state = 0; state <= max_state; state++) {
+                    SCLogDebug("protocol %s: to_client: sub state:%s state:%u", AppProtoToString(a),
+                            sub_state_name, state);
+                    const char *state_name =
+                            AppLayerParserGetSubStateProgressName(a, s, state, STREAM_TOCLIENT);
+                    BUG_ON(state_name == NULL);
+                    SCLogDebug("protocol %s: to_client: sub state:%s state:%s", AppProtoToString(a),
+                            sub_state_name, state_name);
+                    if (DoParseAppSubStatePolicy(prefix, a, s, sub_state_name, state, state_name,
+                                max_state, STREAM_TOCLIENT, fw_policies, app_fw_policies) < 0)
+                        return -1;
+                }
+            }
+        } else {
+            const uint8_t complete_state_ts =
+                    (const uint8_t)AppLayerParserGetStateProgressCompletionStatus(
+                            a, STREAM_TOSERVER);
+            for (uint8_t state = 0; state <= complete_state_ts; state++) {
+                const char *name =
+                        AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOSERVER);
+                if (DoParseAppPolicy(prefix, a, name, state, complete_state_ts, STREAM_TOSERVER,
+                            fw_policies, app_fw_policies) < 0)
+                    return -1;
+            }
+            const uint8_t complete_state_tc =
+                    (const uint8_t)AppLayerParserGetStateProgressCompletionStatus(
+                            a, STREAM_TOCLIENT);
+            for (uint8_t state = 0; state <= complete_state_tc; state++) {
+                const char *name =
+                        AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOCLIENT);
+                if (DoParseAppPolicy(prefix, a, name, state, complete_state_tc, STREAM_TOCLIENT,
+                            fw_policies, app_fw_policies) < 0)
+                    return -1;
+            }
         }
     }
-
     return 0;
 }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1387,8 +1387,8 @@ static SignatureHook SetAppHook(const AppProto alproto, uint8_t sub_state, uint8
 static int SigParseProtoHookApp(
         Signature *s, const char *proto_hook, const char *p, const char *in_h)
 {
-    char hook[33];
-    strlcpy(hook, in_h, 33);
+    char hook[64];
+    strlcpy(hook, in_h, sizeof(hook));
     const char *h = hook;
     const char *t = NULL;
     uint8_t sub_state = 0;
@@ -1497,7 +1497,7 @@ static int SigParseProtoHookApp(
     }
 
     /* use in_h to include sub state */
-    char generic_hook_name[64];
+    char generic_hook_name[128];
     snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", p, in_h);
     int list = DetectBufferTypeGetByName(generic_hook_name);
     if (list < 0) {
@@ -1536,11 +1536,11 @@ void DetectListSupportedProtocols(void)
 static int SigParseProto(Signature *s, const char *protostr)
 {
     SCEnter();
-    if (strlen(protostr) > 32)
+    if (strlen(protostr) >= 64)
         return -1;
 
-    char proto[33];
-    strlcpy(proto, protostr, 33);
+    char proto[64];
+    strlcpy(proto, protostr, sizeof(proto));
     const char *p = proto;
     const char *h = NULL;
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2869,6 +2869,8 @@ static int SigValidateCheckBuffers(
                 if (!(AppProtoEqualsStrict(s->alproto, app->alproto))) {
                     continue;
                 }
+                if (app->sub_state != s->init_data->hook.t.app.sub_state)
+                    continue;
             } else {
                 if (!(AppProtoEquals(s->alproto, app->alproto) || s->alproto == 0)) {
                     continue;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3953,35 +3953,12 @@ static char AppPolicyCompareFunc(void *data1, uint16_t datalen1, void *data2, ui
 static void AppPolicyHashFree(void *data)
 {
     struct DetectFirewallAppPolicy *p = data;
+    Signature *s = p->alert_signature;
+    if (s != NULL) {
+        SCFree(s->msg);
+        SCFree(s);
+    }
     SCFree(p);
-}
-static uint32_t PolicySignatureHashFunc(HashTable *ht, void *data, uint16_t datalen)
-{
-    const Signature *s = data;
-    const int dir = 1 + (s->flags & SIG_FLAG_TOSERVER) != 0; // 2 for ts, 1 for tc
-    uint32_t hash = s->alproto * s->app_progress_hook * dir;
-    hash = hash % ht->array_size;
-    return hash;
-}
-
-static char PolicySignatureCompareFunc(
-        void *data1, uint16_t datalen1, void *data2, uint16_t datalen2)
-{
-    const Signature *s1 = data1;
-    const Signature *s2 = data2;
-
-    if (s1 == NULL || s2 == NULL)
-        return 0;
-
-    return s1->flags == s2->flags && s1->alproto == s2->alproto &&
-           s1->app_progress_hook == s2->app_progress_hook;
-}
-
-static void PolicySignatureHashFree(void *data)
-{
-    Signature *s = data;
-    SCFree(s->msg);
-    SCFree(s);
 }
 
 const char *ActionScopeToString(enum ActionScope s)
@@ -4073,9 +4050,7 @@ static int AddPktPolicySignature(struct DetectFirewallPolicies *fw_policies,
     return 0;
 }
 
-static int AddAppPolicySignature(HashTable *ht, const int direction, const AppProto alproto,
-        const char *app_name, const uint8_t hook, const char *hookname,
-        struct DetectFirewallPolicy *pol)
+static int AddAppPolicySignature(struct DetectFirewallAppPolicy *pol)
 {
     Signature *s = SCCalloc(1, sizeof(*s)); // SigAlloc does way more than we need
     if (s == NULL)
@@ -4087,11 +4062,11 @@ static int AddAppPolicySignature(HashTable *ht, const int direction, const AppPr
         SCFree(s);
         return -1;
     }
-    s->app_progress_hook = hook;
-    s->action = pol->action;
-    s->action_scope = pol->action_scope;
-    s->alproto = alproto;
-    s->flags = (direction == STREAM_TOSERVER) ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;
+    s->app_progress_hook = pol->progress;
+    s->action = pol->policy.action;
+    s->action_scope = pol->policy.action_scope;
+    s->alproto = pol->alproto;
+    s->flags = (pol->direction == STREAM_TOSERVER) ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;
     s->flags |= SIG_FLAG_FIREWALL;
     s->type = SIG_TYPE_APP_TX;
     s->detect_table = DETECT_TABLE_APP_FILTER;
@@ -4100,11 +4075,7 @@ static int AddAppPolicySignature(HashTable *ht, const int direction, const AppPr
     s->gid = 1;
     s->prio = 3;
 
-    if (HashTableAdd(ht, s, 0) != 0) {
-        SCFree(s->msg);
-        SCFree(s);
-        return -1;
-    }
+    pol->alert_signature = s;
     SCLogDebug("added to hash");
     return 0;
 }
@@ -4183,8 +4154,7 @@ static int DoParseAppSubStatePolicy(const char *prefix, const AppProto app_proto
     /* for policies with an alert action, create a policy sig */
     if (r == 1 && app_pol->policy.action & ACTION_ALERT) {
         SCLogDebug("adding policy signature");
-        return AddAppPolicySignature(fw_policies->policy_signatures, direction, app_proto, app_name,
-                state, hookname, &app_pol->policy);
+        return AddAppPolicySignature(app_pol);
     }
     SCLogDebug("r %d", r);
     return r;
@@ -4273,8 +4243,7 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
     /* for policies with an alert action, create a policy sig */
     if (r == 1 && app_pol->policy.action & ACTION_ALERT) {
         SCLogDebug("adding policy signature");
-        return AddAppPolicySignature(fw_policies->policy_signatures, direction, app_proto, app_name,
-                state, hookname, &app_pol->policy);
+        return AddAppPolicySignature(app_pol);
     }
 
     return r;
@@ -4286,16 +4255,9 @@ int DetectFirewallInitDefaultPolicies(DetectEngineCtx *de_ctx)
     struct DetectFirewallPolicies *fw_policies = SCCalloc(1, sizeof(*fw_policies));
     if (fw_policies == NULL)
         return -1;
-    fw_policies->policy_signatures = HashTableInit(
-            512, PolicySignatureHashFunc, PolicySignatureCompareFunc, PolicySignatureHashFree);
-    if (fw_policies->policy_signatures == NULL) {
-        SCFree(fw_policies);
-        return -1;
-    }
     fw_policies->app_policies =
             HashTableInit(512, AppPolicyHashFunc, AppPolicyCompareFunc, AppPolicyHashFree);
     if (fw_policies->app_policies == NULL) {
-        HashTableFree(fw_policies->policy_signatures);
         SCFree(fw_policies);
         return -1;
     }
@@ -4431,22 +4393,6 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
         }
     }
     return 0;
-}
-
-Signature *DetectFirewallGetPolicySignature(struct DetectFirewallPolicies *fw_policies,
-        const AppProto alproto, const int direction, const uint8_t hook)
-{
-    if (fw_policies != NULL && fw_policies->policy_signatures != NULL) {
-        Signature lookup;
-        lookup.alproto = alproto;
-        lookup.flags = SIG_FLAG_FIREWALL |
-                       (direction == STREAM_TOSERVER ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT);
-        lookup.app_progress_hook = hook;
-
-        Signature *s = HashTableLookup(fw_policies->policy_signatures, &lookup, 0);
-        return s;
-    }
-    return NULL;
 }
 
 /*

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1479,7 +1479,7 @@ static int SigParseProtoHookApp(
             const int progress_ts = AppLayerParserGetStateIdByName(
                     IPPROTO_TCP /* TODO */, s->alproto, h, STREAM_TOSERVER);
             if (progress_ts >= 0) {
-                if (progress_ts >= 48) {
+                if (progress_ts >= APP_LAYER_MAX_PROGRESS) {
                     return -1;
                 }
                 s->flags |= SIG_FLAG_TOSERVER;
@@ -1487,7 +1487,7 @@ static int SigParseProtoHookApp(
             } else {
                 const int progress_tc = AppLayerParserGetStateIdByName(
                         IPPROTO_TCP /* TODO */, s->alproto, h, STREAM_TOCLIENT);
-                if (progress_tc < 0 || progress_tc >= 48) {
+                if (progress_tc < 0 || progress_tc >= APP_LAYER_MAX_PROGRESS) {
                     return -1;
                 }
                 s->flags |= SIG_FLAG_TOCLIENT;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1406,11 +1406,17 @@ static int SigParseProtoHookApp(
         return -1;
     }
 
-    if (t != NULL) {
-        if (strlen(t) == 0) {
+    /* first see if we get a proto:substate only */
+    const bool support_substate = AppLayerParserSupportsSubStates(s->alproto);
+    if (t != NULL || (t == NULL && support_substate)) {
+        if (t != NULL && strlen(t) == 0) {
             SCLogError("invalid tx type specification '%s'", hook);
             return -1;
         }
+        if (t == NULL) {
+            t = h;
+        }
+
         if (strcmp(p, "http2") == 0 || strcmp(p, "doh2") == 0) {
             if (strcmp(t, "stream") == 0) {
                 sub_state = HTTP2TxTypeStream;
@@ -1426,45 +1432,52 @@ static int SigParseProtoHookApp(
             SCLogError("sub states currently only supported for http2 and doh2");
             return -1;
         }
-        /* FW hook LTE mode */
-        if (*h == '<') {
-            h++;
-            SCLogDebug("hook and prior hooks: '%s'", h);
-            s->flags |= SIG_FLAG_FW_HOOK_LTE;
-        }
-        const uint8_t max_state = AppLayerParserGetSubStateCompletion(
-                s->alproto, sub_state); // TODO allow different completion per direction?
-        if (strcmp(h, "request_started") == 0) {
-            s->flags |= SIG_FLAG_TOSERVER;
-            s->init_data->hook = SetAppHook(s->alproto, sub_state,
-                    0); // state 0 should be the starting state in each protocol.
-        } else if (strcmp(h, "response_started") == 0) {
-            s->flags |= SIG_FLAG_TOCLIENT;
-            s->init_data->hook = SetAppHook(s->alproto, sub_state,
-                    0); // state 0 should be the starting state in each protocol.
-        } else if (strcmp(h, "request_complete") == 0) {
-            s->flags |= SIG_FLAG_TOSERVER;
-            s->init_data->hook = SetAppHook(s->alproto, sub_state, max_state);
-        } else if (strcmp(h, "response_complete") == 0) {
-            s->flags |= SIG_FLAG_TOCLIENT;
-            s->init_data->hook = SetAppHook(s->alproto, sub_state, max_state);
+
+        if (t == h) {
+            /* no hook, just proto:substate */
+            s->init_data->hook.t.app.sub_state = sub_state;
+            s->init_data->hook.t.app.alproto = s->alproto;
         } else {
-            const int8_t progress_ts =
-                    AppLayerParserGetSubStateProgressId(s->alproto, sub_state, h, STREAM_TOSERVER);
-            if (progress_ts >= 0) {
-                s->flags |= SIG_FLAG_TOSERVER;
-                s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_ts);
-            } else {
-                const int8_t progress_tc = AppLayerParserGetSubStateProgressId(
-                        s->alproto, sub_state, h, STREAM_TOCLIENT);
-                if (progress_tc < 0) {
-                    return -1;
-                }
-                s->flags |= SIG_FLAG_TOCLIENT;
-                s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_tc);
+            /* FW hook LTE mode */
+            if (*h == '<') {
+                h++;
+                SCLogDebug("hook and prior hooks: '%s'", h);
+                s->flags |= SIG_FLAG_FW_HOOK_LTE;
             }
+            const uint8_t max_state = AppLayerParserGetSubStateCompletion(
+                    s->alproto, sub_state); // TODO allow different completion per direction?
+            if (strcmp(h, "request_started") == 0) {
+                s->flags |= SIG_FLAG_TOSERVER;
+                s->init_data->hook = SetAppHook(s->alproto, sub_state,
+                        0); // state 0 should be the starting state in each protocol.
+            } else if (strcmp(h, "response_started") == 0) {
+                s->flags |= SIG_FLAG_TOCLIENT;
+                s->init_data->hook = SetAppHook(s->alproto, sub_state,
+                        0); // state 0 should be the starting state in each protocol.
+            } else if (strcmp(h, "request_complete") == 0) {
+                s->flags |= SIG_FLAG_TOSERVER;
+                s->init_data->hook = SetAppHook(s->alproto, sub_state, max_state);
+            } else if (strcmp(h, "response_complete") == 0) {
+                s->flags |= SIG_FLAG_TOCLIENT;
+                s->init_data->hook = SetAppHook(s->alproto, sub_state, max_state);
+            } else {
+                const int8_t progress_ts = AppLayerParserGetSubStateProgressId(
+                        s->alproto, sub_state, h, STREAM_TOSERVER);
+                if (progress_ts >= 0) {
+                    s->flags |= SIG_FLAG_TOSERVER;
+                    s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_ts);
+                } else {
+                    const int8_t progress_tc = AppLayerParserGetSubStateProgressId(
+                            s->alproto, sub_state, h, STREAM_TOCLIENT);
+                    if (progress_tc < 0) {
+                        return -1;
+                    }
+                    s->flags |= SIG_FLAG_TOCLIENT;
+                    s->init_data->hook = SetAppHook(s->alproto, sub_state, progress_tc);
+                }
+            }
+            snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:%s:generic", p, t, h);
         }
-        snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:%s:generic", p, t, h);
     } else {
         if (AppLayerParserSupportsSubStates(s->alproto)) {
             SCLogError(
@@ -1516,20 +1529,22 @@ static int SigParseProtoHookApp(
         }
         snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:generic", p, h);
     }
-    SCLogDebug("generic_hook_name %s", generic_hook_name);
+    if (strlen(generic_hook_name) > 0) {
+        SCLogDebug("generic_hook_name %s", generic_hook_name);
 
-    int list = DetectBufferTypeGetByName(generic_hook_name);
-    if (list < 0) {
-        SCLogError("no list registered as %s for hook %s", generic_hook_name, proto_hook);
-        return -1;
+        int list = DetectBufferTypeGetByName(generic_hook_name);
+        if (list < 0) {
+            SCLogError("no list registered as %s for hook %s", generic_hook_name, proto_hook);
+            return -1;
+        }
+        s->init_data->hook.sm_list = list;
+
+        SCLogDebug("protocol:%s hook:%s: type:%s alproto:%u hook:%d", p, h,
+                SignatureHookTypeToString(s->init_data->hook.type),
+                s->init_data->hook.t.app.alproto, s->init_data->hook.t.app.app_progress);
     }
-    s->init_data->hook.sm_list = list;
-
-    SCLogDebug("protocol:%s hook:%s: type:%s alproto:%u hook:%d", p, h,
-            SignatureHookTypeToString(s->init_data->hook.type), s->init_data->hook.t.app.alproto,
-            s->init_data->hook.t.app.app_progress);
-
     s->app_progress_hook = s->init_data->hook.t.app.app_progress;
+    s->app_sub_state = s->init_data->hook.t.app.sub_state;
     return 0;
 }
 
@@ -2875,6 +2890,13 @@ static int SigValidateCheckBuffers(
                 if (!(AppProtoEquals(s->alproto, app->alproto) || s->alproto == 0)) {
                     continue;
                 }
+
+                /* Signature::sub_state check: 0 here means we don't check. E.g.
+                 * `alert http2 ... http2.frametype...` would apply to both stream
+                 * and global sub states. */
+                if (s->app_sub_state != 0 && s->app_sub_state != app->sub_state) {
+                    continue;
+                }
             }
 
             SCLogDebug("engine %s dir %d alproto %d",
@@ -4076,6 +4098,7 @@ static int AddAppPolicySignature(struct DetectFirewallAppPolicy *pol)
         return -1;
     }
     s->app_progress_hook = pol->progress;
+    s->app_sub_state = pol->sub_state;
     s->action = pol->policy.action;
     s->action_scope = pol->policy.action_scope;
     s->alproto = pol->alproto;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1411,19 +1411,19 @@ static int SigParseProtoHookApp(
             SCLogError("invalid tx type specification '%s'", hook);
             return -1;
         }
-        if (strcmp(p, "http2") == 0) {
+        if (strcmp(p, "http2") == 0 || strcmp(p, "doh2") == 0) {
             if (strcmp(t, "stream") == 0) {
                 sub_state = HTTP2TxTypeStream;
             } else if (strcmp(t, "global") == 0) {
                 sub_state = HTTP2TxTypeGlobal;
             } else {
-                SCLogError("unknown http/2 tx type specification '%s': valid values are 'stream' "
+                SCLogError("unknown %s tx type specification '%s': valid values are 'stream' "
                            "and 'global'",
-                        hook);
+                        p, hook);
                 return -1;
             }
         } else {
-            SCLogError("sub states currently only supported for http2");
+            SCLogError("sub states currently only supported for http2 and doh2");
             return -1;
         }
         /* FW hook LTE mode */
@@ -1466,6 +1466,12 @@ static int SigParseProtoHookApp(
         }
         snprintf(generic_hook_name, sizeof(generic_hook_name), "%s:%s:%s:generic", p, t, h);
     } else {
+        if (AppLayerParserSupportsSubStates(s->alproto)) {
+            SCLogError(
+                    "protocol %s requires a substate specification: %s:<sub_state>:%s", p, p, hook);
+            return -1;
+        }
+
         /* FW hook LTE mode */
         if (*h == '<') {
             h++;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1421,6 +1421,9 @@ static int SigParseProtoHookApp(
                         hook);
                 return -1;
             }
+        } else {
+            SCLogError("sub states currently only supported for http2");
+            return -1;
         }
         const uint8_t max_state = AppLayerParserGetSubStateCompletion(
                 s->alproto, sub_state); // TODO allow different completion per direction?

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1344,8 +1344,18 @@ static int SigParseProtoHookApp(
             SCLogError("invalid tx type specification '%s'", hook);
             return -1;
         }
-
-        /* TODO handle substate here */
+        if (strcmp(p, "http2") == 0) {
+            if (strcmp(t, "stream") == 0) {
+                sub_state = HTTP2TxTypeStream;
+            } else if (strcmp(t, "global") == 0) {
+                sub_state = HTTP2TxTypeGlobal;
+            } else {
+                SCLogError("unknown http/2 tx type specification '%s': valid values are 'stream' "
+                           "and 'global'",
+                        hook);
+                return -1;
+            }
+        }
     }
 
     SCLogDebug("h:'%s'", h);

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2866,7 +2866,7 @@ static int SigValidateCheckBuffers(
             if (s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {
                 /* only allow rules to use the hook for engines at that
                  * exact progress for now. */
-                if (app->alproto != s->alproto) {
+                if (!(AppProtoEqualsStrict(s->alproto, app->alproto))) {
                     continue;
                 }
             } else {

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -122,7 +122,5 @@ struct DetectFirewallPolicy;
 void DetectFirewallPolicyToString(const struct DetectFirewallPolicy *p, char *out, size_t out_size);
 int DetectFirewallInitDefaultPolicies(DetectEngineCtx *);
 int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *);
-Signature *DetectFirewallGetPolicySignature(struct DetectFirewallPolicies *fw_policies,
-        const AppProto alproto, const int direction, const uint8_t hook);
 
 #endif /* SURICATA_DETECT_PARSE_H */

--- a/src/detect.c
+++ b/src/detect.c
@@ -771,7 +771,7 @@ static void DetectRulePacketAppendAlert(const DetectEngineCtx *de_ctx,
                     alert_flags |= PACKET_ALERT_FLAG_TX_GUESSED;
                 }
                 txd->guessed_applayer_logged++;
-                AlertQueueAppendAppTxFromPacket(det_ctx, s, p, tx_id, alert_flags);
+                AlertQueueAppendAppTxFromPacket(det_ctx, s, p, tx_id, txd->tx_type, alert_flags);
                 return;
             }
         }
@@ -1719,13 +1719,14 @@ struct DetectFirewallAppTxState {
 };
 
 static inline void DetectRunAppendDefaultAppPolicyAlert(DetectEngineThreadCtx *det_ctx, Packet *p,
-        const bool apply_to_packet, const uint64_t tx_id, const struct DetectFirewallAppPolicy *ap)
+        const bool apply_to_packet, const DetectTransaction *tx,
+        const struct DetectFirewallAppPolicy *ap)
 {
     if (EngineModeIsFirewall()) {
         const Signature *s = ap->alert_signature;
         BUG_ON(s == NULL);
         uint8_t alert_flags = apply_to_packet ? PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET : 0;
-        AlertQueueAppendAppTx(det_ctx, s, p, tx_id, alert_flags);
+        AlertQueueAppendAppTx(det_ctx, s, p, tx->tx_id, tx->tx_type, alert_flags);
     }
 }
 
@@ -1763,7 +1764,7 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
             p->flow->flags |= FLOW_ACTION_BY_FIREWALL;
         }
         if (policy->action & ACTION_ALERT) {
-            DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, true, tx->tx_id, ap);
+            DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, true, tx, ap);
         }
     } else if (policy->action & ACTION_ACCEPT) {
         /* should the accept be applied to the packet?
@@ -1796,7 +1797,7 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
 
         if (policy->action & ACTION_ALERT) {
             SCLogDebug("policy alert, do the append");
-            DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, apply_to_packet, tx->tx_id, ap);
+            DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, apply_to_packet, tx, ap);
         } else if (apply_to_packet) {
             SCLogDebug("default accept: last_tx");
             DetectRunAppendDefaultAccept(det_ctx, p);
@@ -2221,10 +2222,10 @@ static void DetectRunTxFirewallRuleFullMatch(DetectEngineThreadCtx *det_ctx, con
         if (fw_accept_to_packet) {
             SCLogDebug("packet %" PRIu64 ": apply accept to packet", PcapPacketCntGet(p));
             SCLogDebug("accept:(tx|hook): should be applied to the packet");
-            AlertQueueAppendAppTx(
-                    det_ctx, s, p, tx->tx_id, PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET);
+            AlertQueueAppendAppTx(det_ctx, s, p, tx->tx_id, tx->tx_type,
+                    PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET);
         } else {
-            AlertQueueAppendAppTx(det_ctx, s, p, tx->tx_id, 0);
+            AlertQueueAppendAppTx(det_ctx, s, p, tx->tx_id, tx->tx_type, 0);
         }
         DetectRunTxFirewallApplyAccept(det_ctx, p, flow_flags, s, tx, fw_state);
     } else if (s->action & ACTION_DROP) {
@@ -2236,10 +2237,10 @@ static void DetectRunTxFirewallRuleFullMatch(DetectEngineThreadCtx *det_ctx, con
             f->flags |= FLOW_ACTION_BY_FIREWALL;
         }
         SCLogDebug("append alert");
-        AlertQueueAppendAppTx(det_ctx, s, p, tx->tx_id, 0);
+        AlertQueueAppendAppTx(det_ctx, s, p, tx->tx_id, tx->tx_type, 0);
     } else {
         SCLogDebug("append alert");
-        AlertQueueAppendAppTx(det_ctx, s, p, tx->tx_id, 0);
+        AlertQueueAppendAppTx(det_ctx, s, p, tx->tx_id, tx->tx_type, 0);
     }
 }
 
@@ -2615,7 +2616,7 @@ static void DetectRunTx(ThreadVars *tv,
                         "%p/%" PRIu64 " sig %u (%u) matched", tx.tx_ptr, tx.tx_id, s->id, s->iid);
 
                 if ((s->flags & SIG_FLAG_FIREWALL) == 0) {
-                    AlertQueueAppendAppTx(det_ctx, s, p, tx.tx_id, 0);
+                    AlertQueueAppendAppTx(det_ctx, s, p, tx.tx_id, tx.tx_type, 0);
                 } else {
                     DetectRunTxFirewallRuleFullMatch(det_ctx, s, &tx, &fw_state, f, p, flow_flags);
                 }
@@ -2832,7 +2833,15 @@ static void DetectRunFrames(ThreadVars *tv, DetectEngineCtx *de_ctx, DetectEngin
                     const uint8_t alert_flags =
                             (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_FRAME);
                     if (frame->flags & FRAME_FLAG_TX_ID_SET) {
-                        AlertQueueAppendAppTx(det_ctx, s, p, frame->tx_id, alert_flags);
+                        const uint8_t ipproto = p->proto;
+                        uint8_t sub_state = 0;
+                        void *tx = AppLayerParserGetTx(
+                                ipproto, alproto, p->flow->alstate, frame->tx_id);
+                        if (tx) {
+                            AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx);
+                            sub_state = txd->tx_type;
+                        }
+                        AlertQueueAppendAppTx(det_ctx, s, p, frame->tx_id, sub_state, alert_flags);
                     } else {
                         AlertQueueAppendPacket(det_ctx, s, p, alert_flags);
                     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1257,19 +1257,34 @@ DetectRunTxSortHelper(const void *a, const void *b)
 #define TRACE_SID_TXS(sid,txs,...)
 #endif
 
-// Get inner transaction for engine
+/** \internal
+ *  \brief get correct transaction pointer
+ *
+ *  Gets an encapsulated DNS transaction in the DOH2 case.
+ *
+ *  Returns NULL is the TX is not to be inspected by this engine.
+ */
 void *DetectGetInnerTx(void *tx_ptr, AppProto alproto, AppProto engine_alproto, uint8_t flow_flags)
 {
+    SCLogDebug("pre: tx_ptr %p flow::alproto %s engine::alproto %s", tx_ptr,
+            AppProtoToString(alproto), AppProtoToString(engine_alproto));
     if (unlikely(alproto == ALPROTO_DOH2)) {
-        if (engine_alproto == ALPROTO_DNS) {
-            // need to get the dns tx pointer
-            tx_ptr = SCDoH2GetDnsTx(tx_ptr, flow_flags);
-        } else if (engine_alproto != ALPROTO_HTTP2 && engine_alproto != ALPROTO_UNKNOWN) {
-            // incompatible engine->alproto with flow alproto
-            tx_ptr = NULL;
+        switch (engine_alproto) {
+            case ALPROTO_DOH2:
+                /* need to get the dns tx pointer */
+                tx_ptr = SCDoH2GetDnsTx(tx_ptr, flow_flags);
+                break;
+            case ALPROTO_HTTP2:
+            case ALPROTO_UNKNOWN:
+                /* tx_ptr is untouched, so use outer (HTTP/2) layer */
+                break;
+            default:
+                /* any other protocol is a mismatch with DOH2 */
+                tx_ptr = NULL;
+                break;
         }
     } else if (engine_alproto != alproto && engine_alproto != ALPROTO_UNKNOWN) {
-        // incompatible engine->alproto with flow alproto
+        /* incompatible engine->alproto with flow alproto */
         tx_ptr = NULL;
     }
     return tx_ptr;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1744,22 +1744,31 @@ static inline void DetectRunAppendDefaultAppPolicyAlert(DetectEngineThreadCtx *d
  *  \note alproto and progress are unused right now, will be used
  *        to look up configurable default policies later
  */
-static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
+static struct DetectFirewallPolicy DetectFirewallApplyDefaultAppPolicy(
         DetectEngineThreadCtx *det_ctx, const struct DetectFirewallPolicies *policies,
         const DetectTransaction *tx, Packet *p, const AppProto alproto, const uint8_t direction,
         const uint8_t progress)
 {
+    const uint8_t dir_flags = direction & (STREAM_TOSERVER | STREAM_TOCLIENT);
+
     SCLogDebug("packet %" PRIu64 ": tx type %u", PcapPacketCntGet(p), tx->tx_type);
 
+    const struct DetectFirewallPolicy drop_policy = { .action = ACTION_DROP,
+        .action_scope = ACTION_SCOPE_FLOW };
     const struct DetectFirewallAppPolicy lookup = {
-        .alproto = alproto, .sub_state = tx->tx_type, .progress = progress, .direction = direction
+        .alproto = alproto, .sub_state = tx->tx_type, .progress = progress, .direction = dir_flags
     };
+    const struct DetectFirewallPolicy *policy = NULL;
     const struct DetectFirewallAppPolicy *ap =
             HashTableLookup(policies->app_policies, (void *)&lookup, 0);
-    /* table should be fully populated, so this should not be able to fail */
+    /* table should be fully populated, so this should not be able to fail.
+     * However as it continues to confuse tooling, at a fallback. */
     DEBUG_VALIDATE_BUG_ON(ap == NULL);
-    const struct DetectFirewallPolicy *policy = &ap->policy;
-
+    if (likely(ap != NULL)) {
+        policy = &ap->policy;
+    } else {
+        policy = &drop_policy;
+    }
     if (policy->action & ACTION_DROP) {
         SCLogDebug("dropping packet PKT_DROP_REASON_FW_DEFAULT_APP_POLICY");
         PacketDrop(p, policy->action, PKT_DROP_REASON_FW_DEFAULT_APP_POLICY);
@@ -1811,7 +1820,7 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
         /* should be unreachable */
         DEBUG_VALIDATE_BUG_ON(1);
     }
-    return policy;
+    return *policy;
 }
 
 /** \internal
@@ -1847,27 +1856,27 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
                 PcapPacketCntGet(p), direction & STREAM_TOSERVER ? "toserver" : "toclient", hook,
                 BOOL2STR(apply_to_packet));
 
-        const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
+        const struct DetectFirewallPolicy policy = DetectFirewallApplyDefaultAppPolicy(
                 det_ctx, policies, tx, p, alproto, direction, hook);
-        SCLogDebug("fw: hook:%u policy:%02x apply_to_packet:%s", hook, policy->action,
+        SCLogDebug("fw: hook:%u policy:%02x apply_to_packet:%s", hook, policy.action,
                 BOOL2STR(apply_to_packet));
-        if (policy->action & ACTION_DROP) {
-            SCLogDebug("fw: action %02x", policy->action);
+        if (policy.action & ACTION_DROP) {
+            SCLogDebug("fw: action %02x", policy.action);
             return DETECT_TX_FW_FC_BREAK;
 
-        } else if (policy->action & ACTION_ACCEPT) {
-            SCLogDebug("fw: accept hook %u action %02x", hook, policy->action);
+        } else if (policy.action & ACTION_ACCEPT) {
+            SCLogDebug("fw: accept hook %u action %02x", hook, policy.action);
 
             /* accepting flow, so skip rest of the fw rules */
-            if (policy->action_scope == ACTION_SCOPE_FLOW) {
+            if (policy.action_scope == ACTION_SCOPE_FLOW) {
                 SCLogDebug("fw: accept flow");
                 return DETECT_TX_FW_FC_SKIP;
 
                 /* accepting flow, so skip rest of the fw rules for this tx */
-            } else if (policy->action_scope == ACTION_SCOPE_TX) {
+            } else if (policy.action_scope == ACTION_SCOPE_TX) {
                 return DETECT_TX_FW_FC_SKIP;
 
-            } else if (policy->action_scope == ACTION_SCOPE_HOOK) {
+            } else if (policy.action_scope == ACTION_SCOPE_HOOK) {
                 /* we're done */
                 if (apply_to_packet) {
                     return DETECT_TX_FW_FC_SKIP;
@@ -2301,10 +2310,10 @@ static int DetectRunTxFirewallRuleNoMatch(DetectEngineThreadCtx *det_ctx, const 
          * we have to invoke the default policy. We only check the current rule hook.
          * DROP is immediate, flow control for various accept options is handled by
          * the DetectRunTxPreCheckFirewallPolicy function for the next rule. */
-        const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(det_ctx,
+        const struct DetectFirewallPolicy policy = DetectFirewallApplyDefaultAppPolicy(det_ctx,
                 det_ctx->de_ctx->fw_policies, tx, p, s->alproto, flow_flags, s->app_progress_hook);
-        SCLogDebug("fw_last_for_progress policy %02x", policy->action);
-        if (policy->action & ACTION_DROP) {
+        SCLogDebug("fw_last_for_progress policy %02x", policy.action);
+        if (policy.action & ACTION_DROP) {
             return 1;
         }
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1741,19 +1741,39 @@ static inline void DetectRunAppendDefaultAppPolicyAlert(DetectEngineThreadCtx *d
  *        to look up configurable default policies later
  */
 static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
-        DetectEngineThreadCtx *det_ctx, const struct DetectFirewallAppPolicy *policies,
+        DetectEngineThreadCtx *det_ctx, const struct DetectFirewallPolicies *policies,
         const DetectTransaction *tx, Packet *p, const AppProto alproto, const uint8_t direction,
         const uint8_t progress)
 {
     const struct DetectFirewallPolicy *policy;
-    if (direction & STREAM_TOSERVER) {
-        policy = &policies[alproto].ts[progress];
-        SCLogDebug("packet %" PRIu64 ", hook:%u, toserver, policy: action %02x scope %u",
-                PcapPacketCntGet(p), progress, policy->action, policy->action_scope);
+    SCLogDebug("packet %" PRIu64 ": tx type %u", PcapPacketCntGet(p), tx->tx_type);
+    if (tx->tx_type != 0) {
+        // TODO hard coded to HTTP/2 for now
+        BUG_ON(alproto != ALPROTO_HTTP2);
+        if (direction & STREAM_TOSERVER) {
+            policy = &policies->http2_substates[tx->tx_type - 1].ts[progress];
+            SCLogDebug("packet %" PRIu64
+                       ", sub_state:%u, hook:%u, toserver, policy: action %02x scope %u",
+                    PcapPacketCntGet(p), tx->tx_type, progress, policy->action,
+                    policy->action_scope);
+        } else {
+            policy = &policies->http2_substates[tx->tx_type - 1].tc[progress];
+            SCLogDebug("packet %" PRIu64
+                       ", sub_state:%u, hook:%u, toclient, policy: action %02x scope %u",
+                    PcapPacketCntGet(p), tx->tx_type, progress, policy->action,
+                    policy->action_scope);
+        }
+
     } else {
-        policy = &policies[alproto].tc[progress];
-        SCLogDebug("packet %" PRIu64 ", hook:%u, toclient, policy: action %02x scope %u",
-                PcapPacketCntGet(p), progress, policy->action, policy->action_scope);
+        if (direction & STREAM_TOSERVER) {
+            policy = &policies->app[alproto].ts[progress];
+            SCLogDebug("packet %" PRIu64 ", hook:%u, toserver, policy: action %02x scope %u",
+                    PcapPacketCntGet(p), progress, policy->action, policy->action_scope);
+        } else {
+            policy = &policies->app[alproto].tc[progress];
+            SCLogDebug("packet %" PRIu64 ", hook:%u, toclient, policy: action %02x scope %u",
+                    PcapPacketCntGet(p), progress, policy->action, policy->action_scope);
+        }
     }
 
     if (policy->action & ACTION_DROP) {
@@ -1825,7 +1845,7 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
  *  \retval DETECT_TX_FW_FC_OK no action needed
  */
 static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
-        DetectEngineThreadCtx *det_ctx, const struct DetectFirewallAppPolicy *policies,
+        DetectEngineThreadCtx *det_ctx, const struct DetectFirewallPolicies *policies,
         DetectTransaction *tx, Packet *p, const AppProto alproto, const uint8_t direction,
         const uint8_t start_hook, const uint8_t end_hook)
 {
@@ -1846,7 +1866,7 @@ static enum DetectTxFirewallFlowControl DetectFirewallApplyDefaultPolicies(
                 BOOL2STR(apply_to_packet));
 
         const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(
-                det_ctx, det_ctx->de_ctx->fw_policies->app, tx, p, alproto, direction, hook);
+                det_ctx, policies, tx, p, alproto, direction, hook);
         SCLogDebug("fw: hook:%u policy:%02x apply_to_packet:%s", hook, policy->action,
                 BOOL2STR(apply_to_packet));
         if (policy->action & ACTION_DROP) {
@@ -1961,9 +1981,9 @@ static enum DetectTxFirewallFlowControl DetectRunTxPreCheckFirewallPolicy(
                 s->app_progress_hook, tx->detect_progress, tx->detect_progress_orig);
         /* if this rule was after the state we expected meaning that there are
          * no rules for that state. Invoke the default policies. */
-        enum DetectTxFirewallFlowControl r = DetectFirewallApplyDefaultPolicies(det_ctx,
-                det_ctx->de_ctx->fw_policies->app, tx, p, s->alproto, direction,
-                tx->detect_progress_orig, s->app_progress_hook - 1);
+        enum DetectTxFirewallFlowControl r =
+                DetectFirewallApplyDefaultPolicies(det_ctx, det_ctx->de_ctx->fw_policies, tx, p,
+                        s->alproto, direction, tx->detect_progress_orig, s->app_progress_hook - 1);
         if (r != DETECT_TX_FW_FC_OK) {
             /* both SKIP and BREAK mean: no more fw rules to inspect.
              * SKIP applies to just this TX.
@@ -2124,8 +2144,8 @@ static void DetectRunTxFirewallApplyAccept(DetectEngineThreadCtx *det_ctx, Packe
                                               ? tx->tx_end_state
                                               : MIN(tx->tx_end_state, s->app_progress_hook + 1);
             enum DetectTxFirewallFlowControl r =
-                    DetectFirewallApplyDefaultPolicies(det_ctx, det_ctx->de_ctx->fw_policies->app,
-                            tx, p, s->alproto, direction, s->app_progress_hook + 1, last_hook);
+                    DetectFirewallApplyDefaultPolicies(det_ctx, det_ctx->de_ctx->fw_policies, tx, p,
+                            s->alproto, direction, s->app_progress_hook + 1, last_hook);
             if (r == DETECT_TX_FW_FC_BREAK) {
                 fw_state->fw_skip_app_filter = true;
                 return;
@@ -2187,8 +2207,8 @@ static int DetectTxFirewallNoRulesApplyPolicies(DetectEngineThreadCtx *det_ctx, 
             SCLogDebug("tx.detect_progress_orig %u tx.tx_progress %u", tx->detect_progress_orig,
                     tx->tx_progress);
             enum DetectTxFirewallFlowControl r =
-                    DetectFirewallApplyDefaultPolicies(det_ctx, det_ctx->de_ctx->fw_policies->app,
-                            tx, p, alproto, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT),
+                    DetectFirewallApplyDefaultPolicies(det_ctx, det_ctx->de_ctx->fw_policies, tx, p,
+                            alproto, flow_flags & (STREAM_TOSERVER | STREAM_TOCLIENT),
                             tx->detect_progress_orig, tx->tx_progress);
             SCLogDebug("r %u", r);
             if (r == DETECT_TX_FW_FC_BREAK)
@@ -2299,9 +2319,8 @@ static int DetectRunTxFirewallRuleNoMatch(DetectEngineThreadCtx *det_ctx, const 
          * we have to invoke the default policy. We only check the current rule hook.
          * DROP is immediate, flow control for various accept options is handled by
          * the DetectRunTxPreCheckFirewallPolicy function for the next rule. */
-        const struct DetectFirewallPolicy *policy =
-                DetectFirewallApplyDefaultAppPolicy(det_ctx, det_ctx->de_ctx->fw_policies->app, tx,
-                        p, s->alproto, flow_flags, s->app_progress_hook);
+        const struct DetectFirewallPolicy *policy = DetectFirewallApplyDefaultAppPolicy(det_ctx,
+                det_ctx->de_ctx->fw_policies, tx, p, s->alproto, flow_flags, s->app_progress_hook);
         SCLogDebug("fw_last_for_progress policy %02x", policy->action);
         if (policy->action & ACTION_DROP) {
             return 1;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1719,12 +1719,10 @@ struct DetectFirewallAppTxState {
 };
 
 static inline void DetectRunAppendDefaultAppPolicyAlert(DetectEngineThreadCtx *det_ctx, Packet *p,
-        const bool apply_to_packet, const int direction, const uint64_t tx_id,
-        const AppProto alproto, const uint8_t hook)
+        const bool apply_to_packet, const uint64_t tx_id, const struct DetectFirewallAppPolicy *ap)
 {
     if (EngineModeIsFirewall()) {
-        Signature *s = DetectFirewallGetPolicySignature(
-                det_ctx->de_ctx->fw_policies, alproto, direction, hook);
+        const Signature *s = ap->alert_signature;
         BUG_ON(s == NULL);
         uint8_t alert_flags = apply_to_packet ? PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET : 0;
         AlertQueueAppendAppTx(det_ctx, s, p, tx_id, alert_flags);
@@ -1765,8 +1763,7 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
             p->flow->flags |= FLOW_ACTION_BY_FIREWALL;
         }
         if (policy->action & ACTION_ALERT) {
-            DetectRunAppendDefaultAppPolicyAlert(
-                    det_ctx, p, true, direction, tx->tx_id, alproto, progress);
+            DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, true, tx->tx_id, ap);
         }
     } else if (policy->action & ACTION_ACCEPT) {
         /* should the accept be applied to the packet?
@@ -1799,8 +1796,7 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
 
         if (policy->action & ACTION_ALERT) {
             SCLogDebug("policy alert, do the append");
-            DetectRunAppendDefaultAppPolicyAlert(
-                    det_ctx, p, apply_to_packet, direction, tx->tx_id, alproto, progress);
+            DetectRunAppendDefaultAppPolicyAlert(det_ctx, p, apply_to_packet, tx->tx_id, ap);
         } else if (apply_to_packet) {
             SCLogDebug("default accept: last_tx");
             DetectRunAppendDefaultAccept(det_ctx, p);

--- a/src/detect.c
+++ b/src/detect.c
@@ -1349,6 +1349,11 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
         if (!(inspect_flags & BIT_U32(engine->id)) &&
                 (direction == engine->dir || ((s->flags & SIG_FLAG_TXBOTHDIR) && direction == 1))) {
 
+            DEBUG_VALIDATE_BUG_ON(
+                    AppLayerParserSupportsSubStates(engine->alproto) && engine->sub_state == 0);
+            DEBUG_VALIDATE_BUG_ON(
+                    !AppLayerParserSupportsSubStates(engine->alproto) && engine->sub_state != 0);
+
             if (engine->alproto != ALPROTO_UNKNOWN && // app-layer-events is registered for each
                                                       // proto this way
                     tx->tx_type != engine->sub_state) {

--- a/src/detect.c
+++ b/src/detect.c
@@ -1564,12 +1564,12 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
 static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alproto,
         const uint64_t tx_id, void *tx_ptr, const int tx_end_state, const uint8_t flow_flags)
 {
-    DEBUG_VALIDATE_BUG_ON(tx_end_state >= 48);
+    DEBUG_VALIDATE_BUG_ON(tx_end_state >= APP_LAYER_MAX_PROGRESS);
 
     AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx_ptr);
     const uint8_t tx_progress =
             (uint8_t)AppLayerParserGetStateProgress(ipproto, alproto, tx_ptr, flow_flags);
-    DEBUG_VALIDATE_BUG_ON(tx_progress >= 48);
+    DEBUG_VALIDATE_BUG_ON(tx_progress >= APP_LAYER_MAX_PROGRESS);
 
     const uint8_t e_tx_end_state = txd->tx_type == 0                ? (uint8_t)tx_end_state
                                    : (flow_flags & STREAM_TOSERVER) ? txd->tx_type_eop_ts

--- a/src/detect.c
+++ b/src/detect.c
@@ -1731,7 +1731,7 @@ static inline void DetectRunAppendDefaultAppPolicyAlert(DetectEngineThreadCtx *d
         const Signature *s = ap->alert_signature;
         BUG_ON(s == NULL);
         uint8_t alert_flags = apply_to_packet ? PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET : 0;
-        AlertQueueAppendAppTx(det_ctx, s, p, tx->tx_id, tx->tx_type, alert_flags);
+        AlertQueueAppendAppTxFromPacket(det_ctx, s, p, tx->tx_id, tx->tx_type, alert_flags);
     }
 }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -1328,14 +1328,33 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
     const DetectEngineAppInspectionEngine *engine = s->app_inspect;
     do {
         TRACE_SID_TXS(s->id, tx, "engine %p inspect_flags %x", engine, inspect_flags);
+
         // also if it is not the same direction, but
         // this is a transactional signature, and we are toclient
         if (!(inspect_flags & BIT_U32(engine->id)) &&
                 (direction == engine->dir || ((s->flags & SIG_FLAG_TXBOTHDIR) && direction == 1))) {
 
+            if (engine->alproto != ALPROTO_UNKNOWN && // app-layer-events is registered for each
+                                                      // proto this way
+                    tx->tx_type != engine->sub_state) {
+                TRACE_SID_TXS(s->id, tx,
+                        "skip because engine alproto %s sub_state %u != tx_type %u (engine "
+                        "progress %u)",
+                        AppProtoToString(engine->alproto), engine->sub_state, tx->tx_type,
+                        engine->progress);
+                engine = engine->next;
+                continue;
+            }
+            TRACE_SID_TXS(s->id, tx,
+                    "inspecting engine alproto %s sub_state %u == tx_type %u (engine progress %u)",
+                    AppProtoToString(engine->alproto), engine->sub_state, tx->tx_type,
+                    engine->progress);
+
             void *tx_ptr = DetectGetInnerTx(tx->tx_ptr, f->alproto, engine->alproto, flow_flags);
             if (tx_ptr == NULL) {
+                TRACE_SID_TXS(s->id, tx, "no tx_ptr after DetectGetInnerTx");
                 if (engine->alproto != ALPROTO_UNKNOWN) {
+                    TRACE_SID_TXS(s->id, tx, "no tx_ptr skip engine");
                     /* special case: file_data on 'alert tcp' will have engines
                      * in the list that are not for us. */
                     engine = engine->next;
@@ -1344,6 +1363,7 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
                     tx_ptr = tx->tx_ptr;
                 }
             }
+            TRACE_SID_TXS(s->id, tx, "tx_ptr %p", tx_ptr);
 
             /* engines are sorted per progress, except that the one with
              * mpm/prefilter enabled is first */
@@ -1434,6 +1454,8 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
             break;
         } else if (!(inspect_flags & BIT_U32(engine->id)) && s->flags & SIG_FLAG_TXBOTHDIR &&
                    direction != engine->dir) {
+            TRACE_SID_TXS(s->id, tx, "handle bidir engine");
+
             // for transactional rules, the engines on the opposite direction
             // are ordered by progress on the different side
             // so we have a two mixed-up lists, and we skip the elements
@@ -1517,7 +1539,7 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
 
 #define NO_TX                                                                                      \
     {                                                                                              \
-        NULL, 0, NULL, NULL, 0, 0, 0, 0, false,                                                    \
+        NULL, 0, NULL, NULL, 0, 0, 0, 0, false, 0,                                                 \
     }
 
 /** \internal
@@ -1530,11 +1552,16 @@ static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alpro
     DEBUG_VALIDATE_BUG_ON(tx_end_state >= 48);
 
     AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx_ptr);
-    const int tx_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx_ptr, flow_flags);
+    const uint8_t tx_progress =
+            (uint8_t)AppLayerParserGetStateProgress(ipproto, alproto, tx_ptr, flow_flags);
     DEBUG_VALIDATE_BUG_ON(tx_progress >= 48);
 
+    const uint8_t e_tx_end_state = txd->tx_type == 0                ? (uint8_t)tx_end_state
+                                   : (flow_flags & STREAM_TOSERVER) ? txd->tx_type_eop_ts
+                                                                    : txd->tx_type_eop_tc;
+
     bool updated = (flow_flags & STREAM_TOSERVER) ? txd->updated_ts : txd->updated_tc;
-    if (!updated && tx_progress < tx_end_state && ((flow_flags & STREAM_EOF) == 0)) {
+    if (!updated && tx_progress < e_tx_end_state && ((flow_flags & STREAM_EOF) == 0)) {
         DetectTransaction no_tx = NO_TX;
         return no_tx;
     }
@@ -1555,6 +1582,10 @@ static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alpro
         return no_tx;
     }
 
+    if (txd->tx_type != 0) {
+        SCLogDebug("using tx_type %u", txd->tx_type);
+    }
+
     const uint8_t detect_progress =
             (flow_flags & STREAM_TOSERVER) ? txd->detect_progress_ts : txd->detect_progress_tc;
 
@@ -1570,8 +1601,9 @@ static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alpro
         .detect_progress = detect_progress,
         .detect_progress_orig = detect_progress,
         .tx_progress = (uint8_t)tx_progress,
-        .tx_end_state = (uint8_t)tx_end_state,
+        .tx_end_state = e_tx_end_state,
         .is_last = false,
+        .tx_type = txd->tx_type,
     };
     return tx;
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1745,36 +1745,16 @@ static const struct DetectFirewallPolicy *DetectFirewallApplyDefaultAppPolicy(
         const DetectTransaction *tx, Packet *p, const AppProto alproto, const uint8_t direction,
         const uint8_t progress)
 {
-    const struct DetectFirewallPolicy *policy;
     SCLogDebug("packet %" PRIu64 ": tx type %u", PcapPacketCntGet(p), tx->tx_type);
-    if (tx->tx_type != 0) {
-        // TODO hard coded to HTTP/2 for now
-        BUG_ON(alproto != ALPROTO_HTTP2);
-        if (direction & STREAM_TOSERVER) {
-            policy = &policies->http2_substates[tx->tx_type - 1].ts[progress];
-            SCLogDebug("packet %" PRIu64
-                       ", sub_state:%u, hook:%u, toserver, policy: action %02x scope %u",
-                    PcapPacketCntGet(p), tx->tx_type, progress, policy->action,
-                    policy->action_scope);
-        } else {
-            policy = &policies->http2_substates[tx->tx_type - 1].tc[progress];
-            SCLogDebug("packet %" PRIu64
-                       ", sub_state:%u, hook:%u, toclient, policy: action %02x scope %u",
-                    PcapPacketCntGet(p), tx->tx_type, progress, policy->action,
-                    policy->action_scope);
-        }
 
-    } else {
-        if (direction & STREAM_TOSERVER) {
-            policy = &policies->app[alproto].ts[progress];
-            SCLogDebug("packet %" PRIu64 ", hook:%u, toserver, policy: action %02x scope %u",
-                    PcapPacketCntGet(p), progress, policy->action, policy->action_scope);
-        } else {
-            policy = &policies->app[alproto].tc[progress];
-            SCLogDebug("packet %" PRIu64 ", hook:%u, toclient, policy: action %02x scope %u",
-                    PcapPacketCntGet(p), progress, policy->action, policy->action_scope);
-        }
-    }
+    const struct DetectFirewallAppPolicy lookup = {
+        .alproto = alproto, .sub_state = tx->tx_type, .progress = progress, .direction = direction
+    };
+    const struct DetectFirewallAppPolicy *ap =
+            HashTableLookup(policies->app_policies, (void *)&lookup, 0);
+    /* table should be fully populated, so this should not be able to fail */
+    DEBUG_VALIDATE_BUG_ON(ap == NULL);
+    const struct DetectFirewallPolicy *policy = &ap->policy;
 
     if (policy->action & ACTION_DROP) {
         SCLogDebug("dropping packet PKT_DROP_REASON_FW_DEFAULT_APP_POLICY");

--- a/src/detect.h
+++ b/src/detect.h
@@ -930,12 +930,12 @@ struct DetectFirewallPolicy {
     uint8_t action_scope; /**< same as Signature::action_scope. Scope argument for the action. */
 };
 
-/** Application layer firewall policies per hook. */
 struct DetectFirewallAppPolicy {
-    /** policy per hook/progress value (max 48) for toserver direction. */
-    struct DetectFirewallPolicy ts[48];
-    /** policy per hook/progress value (max 48) for toclient direction. */
-    struct DetectFirewallPolicy tc[48];
+    AppProto alproto;
+    uint8_t sub_state;
+    uint8_t progress;
+    uint8_t direction;
+    struct DetectFirewallPolicy policy;
 };
 
 struct DetectFirewallPolicies {
@@ -946,11 +946,8 @@ struct DetectFirewallPolicies {
     /* hash table with a Signature object per default policy that has `alert` enabled. */
     HashTable *policy_signatures;
 
-    /* hard coded for now: http2 substates. Index at substate - 1. */
-    struct DetectFirewallAppPolicy http2_substates[2];
-
-    /** app layer policies, one per alproto */
-    struct DetectFirewallAppPolicy app[];
+    /* hash table with policies, hashed by alproto, sub_state, progress and direction */
+    HashTable *app_policies;
 };
 
 /* Flow states:

--- a/src/detect.h
+++ b/src/detect.h
@@ -936,15 +936,15 @@ struct DetectFirewallAppPolicy {
     uint8_t progress;
     uint8_t direction;
     struct DetectFirewallPolicy policy;
+    /* signature that will be logged if the policy includes "alert". Will
+     * be set to NULL if alert is not part of the policy. */
+    Signature *alert_signature;
 };
 
 struct DetectFirewallPolicies {
     /** policy for packet_filter, pre_flow, pre_stream hooks */
     struct DetectFirewallPolicy pkt[DETECT_FIREWALL_POLICY_SIZE];
     Signature *pkt_policy_signatures[DETECT_FIREWALL_POLICY_SIZE];
-
-    /* hash table with a Signature object per default policy that has `alert` enabled. */
-    HashTable *policy_signatures;
 
     /* hash table with policies, hashed by alproto, sub_state, progress and direction */
     HashTable *app_policies;

--- a/src/detect.h
+++ b/src/detect.h
@@ -424,6 +424,7 @@ typedef struct DetectEngineAppInspectionEngine_ {
     uint16_t sm_list;
     uint16_t sm_list_base; /**< base buffer being transformed */
     uint8_t progress;
+    uint8_t sub_state; /**< matches tx type */
 
     struct {
         union {
@@ -578,6 +579,8 @@ typedef struct SignatureHook_ {
     union {
         struct {
             AppProto alproto;
+            /** sub state for a specific transaction type or 0 if not used */
+            uint8_t sub_state;
             /** progress value of the app-layer hook specified in the rule. Sets the app_proto
              *  specific progress value. */
             uint8_t app_progress;
@@ -792,6 +795,7 @@ typedef struct DetectBufferMpmRegistry_ {
             };
             AppProto alproto;
             uint8_t tx_min_progress;
+            uint8_t sub_state;
         } app_v2;
 
         /* pkt matching: use if type == DETECT_BUFFER_MPM_TYPE_PKT */
@@ -1589,6 +1593,8 @@ typedef struct PrefilterEngineList_ {
 
     SignatureMask pkt_mask; /**< mask for pkt engines */
 
+    uint8_t sub_state;
+
     enum SignatureHookPkt pkt_hook;
 
     /** Context for matching. Might be MpmCtx for MPM engines, other ctx'
@@ -1622,9 +1628,12 @@ typedef struct PrefilterEngine_ {
             SignatureMask mask; /**< mask for pkt engines */
             uint8_t hook;       /**< enum SignatureHookPkt */
         } pkt;
-        /** Minimal Tx progress we need before running the engine. Only used
-         *  with Tx Engine. Set to -1 for all states. */
-        int8_t tx_min_progress;
+        struct {
+            /** Minimal Tx progress we need before running the engine. Only used
+             *  with Tx Engine. Set to -1 for all states. */
+            int8_t tx_min_progress;
+            uint8_t sub_state;
+        } app;
         uint8_t frame_type;
     } ctx;
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -946,6 +946,9 @@ struct DetectFirewallPolicies {
     /* hash table with a Signature object per default policy that has `alert` enabled. */
     HashTable *policy_signatures;
 
+    /* hard coded for now: http2 substates. Index at substate - 1. */
+    struct DetectFirewallAppPolicy http2_substates[2];
+
     /** app layer policies, one per alproto */
     struct DetectFirewallAppPolicy app[];
 };

--- a/src/detect.h
+++ b/src/detect.h
@@ -713,6 +713,8 @@ typedef struct Signature_ {
 
     /** firewall: progress value for this signature */
     uint8_t app_progress_hook;
+    /** tx type to match against. If 0 a sig can match multiple (e.g. http2.frametype) */
+    uint8_t app_sub_state;
 
     DetectMatchAddressIPv4 *addr_dst_match4;
     DetectMatchAddressIPv4 *addr_src_match4;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -324,74 +324,61 @@ static void AlertAddPayload(AlertJsonOutputCtx *json_output_ctx, SCJsonBuilder *
     }
 }
 
+static void AlertAddAppLayerStates(const Packet *p, const AppProto alproto, const uint8_t sub_state,
+        void *tx, SCJsonBuilder *jb)
+{
+    const int ts = AppLayerParserGetStateProgress(p->flow->proto, alproto, tx, STREAM_TOSERVER);
+    const int tc = AppLayerParserGetStateProgress(p->flow->proto, alproto, tx, STREAM_TOCLIENT);
+    SCJbSetString(jb, "ts_progress",
+            AppLayerParserGetStateNameById(p->flow->proto, alproto, ts, STREAM_TOSERVER));
+    SCJbSetString(jb, "tc_progress",
+            AppLayerParserGetStateNameById(p->flow->proto, alproto, tc, STREAM_TOCLIENT));
+    if (sub_state) {
+        const char *sname = AppLayerParserGetSubStateName(alproto, sub_state);
+        if (sname != NULL) {
+            SCJbSetString(jb, "sub_state", sname);
+        }
+    }
+}
+
 static void AlertAddAppLayer(const Packet *p, SCJsonBuilder *jb, const uint64_t tx_id,
         const uint8_t sub_state, const uint16_t option_flags)
 {
     const AppProto proto = SCFlowGetAppProtocol(p->flow);
     EveJsonSimpleAppLayerLogger *al = SCEveJsonSimpleGetLogger(proto);
+    void *state = FlowGetAppState(p->flow);
+    void *tx = NULL;
+    if (state) {
+        tx = AppLayerParserGetTx(p->flow->proto, proto, state, tx_id);
+    }
+    if (tx == NULL)
+        return;
+
+    AlertAddAppLayerStates(p, proto, sub_state, tx, jb);
+
     SCJsonBuilderMark mark = { 0, 0, 0 };
     if (al && al->LogTx) {
-        void *state = FlowGetAppState(p->flow);
-        if (state) {
-            void *tx = AppLayerParserGetTx(p->flow->proto, proto, state, tx_id);
-            if (tx) {
-                const int ts =
-                        AppLayerParserGetStateProgress(p->flow->proto, proto, tx, STREAM_TOSERVER);
-                const int tc =
-                        AppLayerParserGetStateProgress(p->flow->proto, proto, tx, STREAM_TOCLIENT);
-                SCJbSetString(jb, "ts_progress",
-                        AppLayerParserGetStateNameById(p->flow->proto, proto, ts, STREAM_TOSERVER));
-                SCJbSetString(jb, "tc_progress",
-                        AppLayerParserGetStateNameById(p->flow->proto, proto, tc, STREAM_TOCLIENT));
-                if (sub_state) {
-                    const char *sname = AppLayerParserGetSubStateName(proto, sub_state);
-                    if (sname != NULL) {
-                        SCJbSetString(jb, "sub_state", sname);
+        SCJbGetMark(jb, &mark);
+        switch (proto) {
+            // first check some protocols need special options for alerts logging
+            case ALPROTO_WEBSOCKET:
+                if (option_flags &
+                        (LOG_JSON_WEBSOCKET_PAYLOAD | LOG_JSON_WEBSOCKET_PAYLOAD_BASE64)) {
+                    const bool pp = (option_flags & LOG_JSON_WEBSOCKET_PAYLOAD) != 0;
+                    const bool pb64 = (option_flags & LOG_JSON_WEBSOCKET_PAYLOAD_BASE64) != 0;
+                    if (!SCWebSocketLogDetails(tx, jb, pp, pb64)) {
+                        SCJbRestoreMark(jb, &mark);
                     }
+                    // nothing more to log or do
+                    return;
                 }
-
-                SCJbGetMark(jb, &mark);
-                switch (proto) {
-                    // first check some protocols need special options for alerts logging
-                    case ALPROTO_WEBSOCKET:
-                        if (option_flags &
-                                (LOG_JSON_WEBSOCKET_PAYLOAD | LOG_JSON_WEBSOCKET_PAYLOAD_BASE64)) {
-                            bool pp = (option_flags & LOG_JSON_WEBSOCKET_PAYLOAD) != 0;
-                            bool pb64 = (option_flags & LOG_JSON_WEBSOCKET_PAYLOAD_BASE64) != 0;
-                            if (!SCWebSocketLogDetails(tx, jb, pp, pb64)) {
-                                SCJbRestoreMark(jb, &mark);
-                            }
-                            // nothing more to log or do
-                            return;
-                        }
-                }
-                if (!al->LogTx(tx, jb)) {
-                    SCJbRestoreMark(jb, &mark);
-                }
-            }
+        }
+        if (!al->LogTx(tx, jb)) {
+            SCJbRestoreMark(jb, &mark);
         }
         return;
     }
-    void *state = FlowGetAppState(p->flow);
-    if (state) {
-        void *tx = AppLayerParserGetTx(p->flow->proto, proto, state, tx_id);
-        if (tx) {
-            const int ts =
-                    AppLayerParserGetStateProgress(p->flow->proto, proto, tx, STREAM_TOSERVER);
-            const int tc =
-                    AppLayerParserGetStateProgress(p->flow->proto, proto, tx, STREAM_TOCLIENT);
-            SCJbSetString(jb, "ts_progress",
-                    AppLayerParserGetStateNameById(p->flow->proto, proto, ts, STREAM_TOSERVER));
-            SCJbSetString(jb, "tc_progress",
-                    AppLayerParserGetStateNameById(p->flow->proto, proto, tc, STREAM_TOCLIENT));
-            if (sub_state) {
-                const char *sname = AppLayerParserGetSubStateName(proto, sub_state);
-                if (sname != NULL) {
-                    SCJbSetString(jb, "sub_state", sname);
-                }
-            }
-        }
-    }
+
     switch (proto) {
         case ALPROTO_HTTP1:
             // TODO: Could result in an empty http object being logged.
@@ -455,26 +442,20 @@ static void AlertAddAppLayer(const Packet *p, SCJsonBuilder *jb, const uint64_t 
                 SCJbRestoreMark(jb, &mark);
             }
             break;
-        case ALPROTO_DCERPC: {
-            if (state) {
-                void *tx = AppLayerParserGetTx(p->flow->proto, proto, state, tx_id);
-                if (tx) {
-                    SCJbGetMark(jb, &mark);
-                    SCJbOpenObject(jb, "dcerpc");
-                    if (p->proto == IPPROTO_TCP) {
-                        if (!SCDcerpcLogJsonRecordTcp(state, tx, jb)) {
-                            SCJbRestoreMark(jb, &mark);
-                        }
-                    } else {
-                        if (!SCDcerpcLogJsonRecordUdp(state, tx, jb)) {
-                            SCJbRestoreMark(jb, &mark);
-                        }
-                    }
-                    SCJbClose(jb);
+        case ALPROTO_DCERPC:
+            SCJbGetMark(jb, &mark);
+            SCJbOpenObject(jb, "dcerpc");
+            if (p->proto == IPPROTO_TCP) {
+                if (!SCDcerpcLogJsonRecordTcp(state, tx, jb)) {
+                    SCJbRestoreMark(jb, &mark);
+                }
+            } else {
+                if (!SCDcerpcLogJsonRecordUdp(state, tx, jb)) {
+                    SCJbRestoreMark(jb, &mark);
                 }
             }
+            SCJbClose(jb);
             break;
-        }
         default:
             break;
     }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -324,8 +324,8 @@ static void AlertAddPayload(AlertJsonOutputCtx *json_output_ctx, SCJsonBuilder *
     }
 }
 
-static void AlertAddAppLayer(
-        const Packet *p, SCJsonBuilder *jb, const uint64_t tx_id, const uint16_t option_flags)
+static void AlertAddAppLayer(const Packet *p, SCJsonBuilder *jb, const uint64_t tx_id,
+        const uint8_t sub_state, const uint16_t option_flags)
 {
     const AppProto proto = SCFlowGetAppProtocol(p->flow);
     EveJsonSimpleAppLayerLogger *al = SCEveJsonSimpleGetLogger(proto);
@@ -343,6 +343,13 @@ static void AlertAddAppLayer(
                         AppLayerParserGetStateNameById(p->flow->proto, proto, ts, STREAM_TOSERVER));
                 SCJbSetString(jb, "tc_progress",
                         AppLayerParserGetStateNameById(p->flow->proto, proto, tc, STREAM_TOCLIENT));
+                if (sub_state) {
+                    const char *sname = AppLayerParserGetSubStateName(proto, sub_state);
+                    if (sname != NULL) {
+                        SCJbSetString(jb, "sub_state", sname);
+                    }
+                }
+
                 SCJbGetMark(jb, &mark);
                 switch (proto) {
                     // first check some protocols need special options for alerts logging
@@ -377,6 +384,12 @@ static void AlertAddAppLayer(
                     AppLayerParserGetStateNameById(p->flow->proto, proto, ts, STREAM_TOSERVER));
             SCJbSetString(jb, "tc_progress",
                     AppLayerParserGetStateNameById(p->flow->proto, proto, tc, STREAM_TOCLIENT));
+            if (sub_state) {
+                const char *sname = AppLayerParserGetSubStateName(proto, sub_state);
+                if (sname != NULL) {
+                    SCJbSetString(jb, "sub_state", sname);
+                }
+            }
         }
     }
     switch (proto) {
@@ -762,7 +775,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         if (p->flow != NULL) {
             if (pa->flags & PACKET_ALERT_FLAG_TX) {
                 if (json_output_ctx->flags & LOG_JSON_APP_LAYER) {
-                    AlertAddAppLayer(p, jb, pa->tx_id, json_output_ctx->flags);
+                    AlertAddAppLayer(p, jb, pa->tx_id, pa->sub_state, json_output_ctx->flags);
                 }
                 /* including fileinfo data is configured by the metadata setting */
                 if (json_output_ctx->flags & LOG_JSON_RULE_METADATA) {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -329,15 +329,22 @@ static void AlertAddAppLayerStates(const Packet *p, const AppProto alproto, cons
 {
     const int ts = AppLayerParserGetStateProgress(p->flow->proto, alproto, tx, STREAM_TOSERVER);
     const int tc = AppLayerParserGetStateProgress(p->flow->proto, alproto, tx, STREAM_TOCLIENT);
-    SCJbSetString(jb, "ts_progress",
-            AppLayerParserGetStateNameById(p->flow->proto, alproto, ts, STREAM_TOSERVER));
-    SCJbSetString(jb, "tc_progress",
-            AppLayerParserGetStateNameById(p->flow->proto, alproto, tc, STREAM_TOCLIENT));
-    if (sub_state) {
+    if (sub_state == 0) {
+        SCJbSetString(jb, "ts_progress",
+                AppLayerParserGetStateNameById(p->flow->proto, alproto, ts, STREAM_TOSERVER));
+        SCJbSetString(jb, "tc_progress",
+                AppLayerParserGetStateNameById(p->flow->proto, alproto, tc, STREAM_TOCLIENT));
+    } else {
         const char *sname = AppLayerParserGetSubStateName(alproto, sub_state);
         if (sname != NULL) {
             SCJbSetString(jb, "sub_state", sname);
         }
+        SCJbSetString(jb, "ts_progress",
+                AppLayerParserGetSubStateProgressName(
+                        alproto, sub_state, (uint8_t)ts, STREAM_TOSERVER));
+        SCJbSetString(jb, "tc_progress",
+                AppLayerParserGetSubStateProgressName(
+                        alproto, sub_state, (uint8_t)tc, STREAM_TOCLIENT));
     }
 }
 

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -694,7 +694,11 @@ void JsonDnsLogRegister (void)
 
 void JsonDoh2LogRegister(void)
 {
-    OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", "JsonDoH2Log", "eve-log.doh2",
-            JsonDnsLogInitCtxSub, ALPROTO_DOH2, JsonDoh2Logger, LogDnsLogThreadInit,
+    OutputRegisterTxSubModuleWithProgressSubState(LOGGER_JSON_TX, "eve-log", "JsonDoH2Log::stream",
+            "eve-log.doh2", JsonDnsLogInitCtxSub, ALPROTO_DOH2, HTTP2TxTypeStream, JsonDoh2Logger,
+            HTTP2ProgData, HTTP2ProgData, LogDnsLogThreadInit, LogDnsLogThreadDeinit);
+    OutputRegisterTxSubModuleWithProgressSubState(LOGGER_JSON_TX, "eve-log", "LogDoh2Log::global",
+            "eve-log.doh2", JsonDnsLogInitCtxSub, ALPROTO_DOH2, HTTP2TxTypeGlobal, JsonDoh2Logger,
+            HTTP2ProgGlobalComplete, HTTP2ProgGlobalComplete, LogDnsLogThreadInit,
             LogDnsLogThreadDeinit);
 }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -266,9 +266,9 @@ bool AlertJsonDoh2(void *txptr, SCJsonBuilder *js)
         SCJbRestoreMark(js, &mark);
     }
     // then log one DNS tx if any, preferring the answer
-    void *tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DNS, STREAM_TOCLIENT);
+    void *tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DOH2, STREAM_TOCLIENT);
     if (tx_dns == NULL) {
-        tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DNS, STREAM_TOSERVER);
+        tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DOH2, STREAM_TOSERVER);
     }
     bool r2 = false;
     if (tx_dns) {
@@ -287,9 +287,9 @@ static int JsonDoh2Logger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     LogDnsLogThread *td = (LogDnsLogThread *)thread_data;
     LogDnsFileCtx *dnslog_ctx = td->dnslog_ctx;
 
-    void *tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DNS, STREAM_TOCLIENT);
+    void *tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DOH2, STREAM_TOCLIENT);
     if (tx_dns == NULL) {
-        tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DNS, STREAM_TOSERVER);
+        tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DOH2, STREAM_TOSERVER);
     }
 
     /* DOH2 is always logged in flow direction, as its driven by the scope of an

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -405,9 +405,9 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
     AppLayerGetTxIterState state;
     memset(&state, 0, sizeof(state));
 
-    const int complete_ts =
+    const int default_complete_ts =
             AppLayerParserGetStateProgressCompletionStatus(alproto, STREAM_TOSERVER);
-    const int complete_tc =
+    const int default_complete_tc =
             AppLayerParserGetStateProgressCompletionStatus(alproto, STREAM_TOCLIENT);
     while (1) {
         AppLayerGetTxIterTuple ires = IterFunc(ipproto, alproto, alstate, tx_id, total_txs, &state);
@@ -418,6 +418,14 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
         SCLogDebug("STARTING tx_id %" PRIu64 ", tx %p", tx_id, tx);
 
         AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx);
+        int complete_ts, complete_tc;
+        if (txd->tx_type == 0) {
+            complete_ts = default_complete_ts;
+            complete_tc = default_complete_tc;
+        } else {
+            complete_ts = txd->tx_type_eop_ts;
+            complete_tc = txd->tx_type_eop_tc;
+        }
 
         const int tx_progress_ts =
                 AppLayerParserGetStateProgress(ipproto, alproto, tx, ts_disrupt_flags);

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -48,6 +48,7 @@ typedef struct OutputTxLoggerThreadData_ {
  * log module (e.g. fast.log) with different output ctx'. */
 typedef struct OutputTxLogger_ {
     AppProto alproto;
+    uint8_t sub_state;
     TxLogger LogFunc;
     TxLoggerCondition LogCondition;
     void *initdata;
@@ -63,10 +64,13 @@ typedef struct OutputTxLogger_ {
 
 static OutputTxLogger **list = NULL;
 
-int SCOutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto, TxLogger LogFunc,
-        void *initdata, int tc_log_progress, int ts_log_progress, TxLoggerCondition LogCondition,
-        ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit)
+static int SCOutputRegisterTxLoggerInternal(LoggerId id, const char *name, AppProto alproto,
+        const uint8_t sub_state, TxLogger LogFunc, void *initdata, int tc_log_progress,
+        int ts_log_progress, TxLoggerCondition LogCondition, ThreadInitFunc ThreadInit,
+        ThreadDeinitFunc ThreadDeinit)
 {
+    BUG_ON(sub_state > 0 && (tc_log_progress < 0 || ts_log_progress < 0));
+
     if (list == NULL) {
         list = SCCalloc(g_alproto_max, sizeof(OutputTxLogger *));
         if (unlikely(list == NULL)) {
@@ -85,6 +89,7 @@ int SCOutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto, Tx
         return -1;
 
     op->alproto = alproto;
+    op->sub_state = sub_state;
     op->LogFunc = LogFunc;
     op->LogCondition = LogCondition;
     op->initdata = initdata;
@@ -129,6 +134,23 @@ int SCOutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto, Tx
 
     SCLogDebug("OutputRegisterTxLogger happy");
     return 0;
+}
+
+int SCOutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto, TxLogger LogFunc,
+        void *initdata, int tc_log_progress, int ts_log_progress, TxLoggerCondition LogCondition,
+        ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit)
+{
+    return SCOutputRegisterTxLoggerInternal(id, name, alproto, 0, LogFunc, initdata,
+            tc_log_progress, ts_log_progress, LogCondition, ThreadInit, ThreadDeinit);
+}
+
+int SCOutputRegisterTxLoggerForSubState(LoggerId id, const char *name, AppProto alproto,
+        const uint8_t sub_state, TxLogger LogFunc, void *initdata, int tc_log_progress,
+        int ts_log_progress, TxLoggerCondition LogCondition, ThreadInitFunc ThreadInit,
+        ThreadDeinitFunc ThreadDeinit)
+{
+    return SCOutputRegisterTxLoggerInternal(id, name, alproto, sub_state, LogFunc, initdata,
+            tc_log_progress, ts_log_progress, LogCondition, ThreadInit, ThreadDeinit);
 }
 
 extern bool g_file_logger_enabled;
@@ -274,8 +296,8 @@ struct Ctx {
 
 static void OutputTxLogCallLoggers(ThreadVars *tv, OutputTxLoggerThreadData *op_thread_data,
         const OutputTxLogger *logger, const OutputLoggerThreadStore *store, Packet *p, Flow *f,
-        void *alstate, void *tx, const uint64_t tx_id, const AppProto alproto, const bool eof,
-        const int tx_progress_ts, const int tx_progress_tc, struct Ctx *ctx)
+        void *alstate, void *tx, const uint64_t tx_id, AppLayerTxData *txd, const AppProto alproto,
+        const bool eof, const int tx_progress_ts, const int tx_progress_tc, struct Ctx *ctx)
 {
     DEBUG_VALIDATE_BUG_ON(logger == NULL && store != NULL);
     DEBUG_VALIDATE_BUG_ON(logger != NULL && store == NULL);
@@ -294,6 +316,13 @@ static void OutputTxLogCallLoggers(ThreadVars *tv, OutputTxLoggerThreadData *op_
 
             SCLogDebug("pcap_cnt %" PRIu64 ", tx_id %" PRIu64 " logger %d. EOF %s",
                     PcapPacketCntGet(p), tx_id, logger->logger_id, eof ? "true" : "false");
+
+            if (logger->sub_state != txd->tx_type) {
+                SCLogDebug("logger:%s flow:%s: skip logger for wrong sub state: logger %u tx %u",
+                        AppProtoToString(logger->alproto), AppProtoToString(alproto),
+                        logger->sub_state, txd->tx_type);
+                goto next_logger;
+            }
 
             if (eof) {
                 SCLogDebug("EOF, so log now");
@@ -503,8 +532,8 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
         struct Ctx ctx = { .tx_logged = txd->logged, .tx_logged_old = txd->logged };
         SCLogDebug("logger: expect %08x, have %08x", logger_expectation, ctx.tx_logged);
 
-        OutputTxLogCallLoggers(tv, op_thread_data, logger, store, p, f, alstate, tx, tx_id, alproto,
-                eof, tx_progress_ts, tx_progress_tc, &ctx);
+        OutputTxLogCallLoggers(tv, op_thread_data, logger, store, p, f, alstate, tx, tx_id, txd,
+                alproto, eof, tx_progress_ts, tx_progress_tc, &ctx);
 
         SCLogDebug("logger: expect %08x, have %08x", logger_expectation, ctx.tx_logged);
         if (ctx.tx_logged != ctx.tx_logged_old) {

--- a/src/output-tx.h
+++ b/src/output-tx.h
@@ -77,6 +77,9 @@ typedef bool (*TxLoggerCondition)(
 int SCOutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto, TxLogger LogFunc,
         void *, int tc_log_progress, int ts_log_progress, TxLoggerCondition LogCondition,
         ThreadInitFunc, ThreadDeinitFunc);
+int SCOutputRegisterTxLoggerForSubState(LoggerId id, const char *name, AppProto alproto,
+        const uint8_t sub_state, TxLogger LogFunc, void *, int tc_log_progress, int ts_log_progress,
+        TxLoggerCondition LogCondition, ThreadInitFunc, ThreadDeinitFunc);
 
 /** Internal function: private API. */
 void OutputTxLoggerRegister (void);

--- a/src/output.c
+++ b/src/output.c
@@ -300,9 +300,9 @@ error:
 }
 
 static void OutputRegisterTxSubModuleWrapper(LoggerId id, const char *parent_name, const char *name,
-        const char *conf_name, OutputInitSubFunc InitFunc, AppProto alproto, TxLogger TxLogFunc,
-        int tc_log_progress, int ts_log_progress, TxLoggerCondition TxLogCondition,
-        ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit)
+        const char *conf_name, OutputInitSubFunc InitFunc, AppProto alproto,
+        const uint8_t sub_state, TxLogger TxLogFunc, int tc_log_progress, int ts_log_progress,
+        TxLoggerCondition TxLogCondition, ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit)
 {
     if (unlikely(TxLogFunc == NULL)) {
         goto error;
@@ -321,6 +321,7 @@ static void OutputRegisterTxSubModuleWrapper(LoggerId id, const char *parent_nam
     module->TxLogFunc = TxLogFunc;
     module->TxLogCondition = TxLogCondition;
     module->alproto = alproto;
+    module->sub_state = sub_state;
     module->tc_log_progress = tc_log_progress;
     module->ts_log_progress = ts_log_progress;
     module->ThreadInit = ThreadInit;
@@ -353,8 +354,8 @@ void OutputRegisterTxSubModuleWithCondition(LoggerId id, const char *parent_name
         const char *conf_name, OutputInitSubFunc InitFunc, AppProto alproto, TxLogger TxLogFunc,
         TxLoggerCondition TxLogCondition, ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit)
 {
-    OutputRegisterTxSubModuleWrapper(id, parent_name, name, conf_name, InitFunc, alproto, TxLogFunc,
-            -1, -1, TxLogCondition, ThreadInit, ThreadDeinit);
+    OutputRegisterTxSubModuleWrapper(id, parent_name, name, conf_name, InitFunc, alproto, 0,
+            TxLogFunc, -1, -1, TxLogCondition, ThreadInit, ThreadDeinit);
 }
 
 /**
@@ -378,8 +379,17 @@ void OutputRegisterTxSubModuleWithProgress(LoggerId id, const char *parent_name,
         int tc_log_progress, int ts_log_progress, ThreadInitFunc ThreadInit,
         ThreadDeinitFunc ThreadDeinit)
 {
-    OutputRegisterTxSubModuleWrapper(id, parent_name, name, conf_name, InitFunc, alproto, TxLogFunc,
-            tc_log_progress, ts_log_progress, NULL, ThreadInit, ThreadDeinit);
+    OutputRegisterTxSubModuleWrapper(id, parent_name, name, conf_name, InitFunc, alproto, 0,
+            TxLogFunc, tc_log_progress, ts_log_progress, NULL, ThreadInit, ThreadDeinit);
+}
+
+void OutputRegisterTxSubModuleWithProgressSubState(LoggerId id, const char *parent_name,
+        const char *name, const char *conf_name, OutputInitSubFunc InitFunc, AppProto alproto,
+        const uint8_t sub_state, TxLogger TxLogFunc, uint8_t tc_log_progress,
+        uint8_t ts_log_progress, ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit)
+{
+    OutputRegisterTxSubModuleWrapper(id, parent_name, name, conf_name, InitFunc, alproto, sub_state,
+            TxLogFunc, tc_log_progress, ts_log_progress, NULL, ThreadInit, ThreadDeinit);
 }
 
 /**
@@ -402,8 +412,8 @@ void OutputRegisterTxSubModule(LoggerId id, const char *parent_name, const char 
         const char *conf_name, OutputInitSubFunc InitFunc, AppProto alproto, TxLogger TxLogFunc,
         ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit)
 {
-    OutputRegisterTxSubModuleWrapper(id, parent_name, name, conf_name, InitFunc, alproto, TxLogFunc,
-            -1, -1, NULL, ThreadInit, ThreadDeinit);
+    OutputRegisterTxSubModuleWrapper(id, parent_name, name, conf_name, InitFunc, alproto, 0,
+            TxLogFunc, -1, -1, NULL, ThreadInit, ThreadDeinit);
 }
 
 /**
@@ -1087,9 +1097,14 @@ void OutputRegisterLoggers(void)
     JsonSmtpLogRegister();
     /* http log */
     JsonHttpLogRegister();
-    OutputRegisterTxSubModuleWithProgress(LOGGER_JSON_TX, "eve-log", "LogHttp2Log", "eve-log.http2",
-            OutputJsonLogInitSub, ALPROTO_HTTP2, JsonGenericDirFlowLogger, HTTP2ProgClosed,
-            HTTP2ProgClosed, JsonLogThreadInit, JsonLogThreadDeinit);
+    OutputRegisterTxSubModuleWithProgressSubState(LOGGER_JSON_TX, "eve-log", "LogHttp2Log::stream",
+            "eve-log.http2", OutputJsonLogInitSub, ALPROTO_HTTP2, HTTP2TxTypeStream,
+            JsonGenericDirFlowLogger, HTTP2ProgClosed, HTTP2ProgClosed, JsonLogThreadInit,
+            JsonLogThreadDeinit);
+    OutputRegisterTxSubModuleWithProgressSubState(LOGGER_JSON_TX, "eve-log", "LogHttp2Log::global",
+            "eve-log.http2", OutputJsonLogInitSub, ALPROTO_HTTP2, HTTP2TxTypeGlobal,
+            JsonGenericDirFlowLogger, HTTP2ProgGlobalComplete, HTTP2ProgGlobalComplete,
+            JsonLogThreadInit, JsonLogThreadDeinit);
     /* tls log */
     JsonTlsLogRegister();
     LogTlsStoreRegister();

--- a/src/output.h
+++ b/src/output.h
@@ -74,6 +74,7 @@ typedef struct OutputModule_ {
     SCStreamingLogger StreamingLogFunc;
     StatsLogger StatsLogFunc;
     AppProto alproto;
+    uint8_t sub_state;
     enum SCOutputStreamingType stream_type;
     int tc_log_progress;
     int ts_log_progress;
@@ -121,6 +122,10 @@ void OutputRegisterTxSubModuleWithProgress(LoggerId id, const char *parent_name,
         const char *conf_name, OutputInitSubFunc InitFunc, AppProto alproto, TxLogger TxLogFunc,
         int tc_log_progress, int ts_log_progress, ThreadInitFunc ThreadInit,
         ThreadDeinitFunc ThreadDeinit);
+void OutputRegisterTxSubModuleWithProgressSubState(LoggerId id, const char *parent_name,
+        const char *name, const char *conf_name, OutputInitSubFunc InitFunc, AppProto alproto,
+        const uint8_t sub_state, TxLogger TxLogFunc, uint8_t tc_log_progress,
+        uint8_t ts_log_progress, ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit);
 
 void OutputRegisterFileSubModule(LoggerId id, const char *parent_name, const char *name,
         const char *conf_name, OutputInitSubFunc InitFunc, SCFileLogger FileLogFunc,

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -631,10 +631,18 @@ static void SetupOutput(
         SCOutputRegisterPacketLogger(module->logger_id, module->name, module->PacketLogFunc,
                 module->PacketConditionFunc, output_ctx, module->ThreadInit, module->ThreadDeinit);
     } else if (module->TxLogFunc) {
-        SCLogDebug("%s is a tx logger", module->name);
-        SCOutputRegisterTxLogger(module->logger_id, module->name, module->alproto,
-                module->TxLogFunc, output_ctx, module->tc_log_progress, module->ts_log_progress,
-                module->TxLogCondition, module->ThreadInit, module->ThreadDeinit);
+        if (module->sub_state == 0) {
+            SCLogDebug("%s is a tx logger", module->name);
+            SCOutputRegisterTxLogger(module->logger_id, module->name, module->alproto,
+                    module->TxLogFunc, output_ctx, module->tc_log_progress, module->ts_log_progress,
+                    module->TxLogCondition, module->ThreadInit, module->ThreadDeinit);
+        } else {
+            SCLogDebug("%s is a tx logger for sub state %u", module->name, module->sub_state);
+            SCOutputRegisterTxLoggerForSubState(module->logger_id, module->name, module->alproto,
+                    module->sub_state, module->TxLogFunc, output_ctx, module->tc_log_progress,
+                    module->ts_log_progress, module->TxLogCondition, module->ThreadInit,
+                    module->ThreadDeinit);
+        }
         /* Not used with wild card loggers */
         if (module->alproto != ALPROTO_UNKNOWN) {
             logger_bits[module->alproto] |= BIT_U32(module->logger_id);


### PR DESCRIPTION
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3168

Work in progress branch on https://redmine.openinfosecfoundation.org/issues/8386

Defines 2 sub-states for HTTP2:
- "stream" for the regular HTTP-style request/responses
- "global" for the stream id 0 settings
Each has it's own state machine.

Issues/open questions:
- stream has a closed (data end of stream reached) and complete (both sides closed). This is because after the end of stream is reached, we can still receive window updates. But since this doesn't always happen, we often get no traffic on "complete". So a rule like `accept:tx http2:stream:request_complete ...` is not reliable. Not sure yet how to handle this.
- should `http.uri; absent;` or `http.uri; content:!"/index"` causes matches on the global txs? I think no, but this is a behavior changes vs main.
- I wonder if the DOH2 TX should be it's own sub type, perhaps even instead of a alproto?

For review:
- overhauls DNS over HTTP/2: forces all keywords to explicitly register for DOH2.

TODO
- complete registration logic
- docs
- commit cleanups
- CI (probably)