### PR TITLE
flow: accessors and and more rust bindings - v3


### DIFF
--- a/doc/userguide/devguide/extending/flow-lifecycle-callbacks.rst
+++ b/doc/userguide/devguide/extending/flow-lifecycle-callbacks.rst
@@ -104,20 +104,21 @@ The Rust wrappers register closures or function items and return
 
 .. code-block:: rust
 
-   use suricata_ffi::flow::{self, Flow, Packet};
+   use suricata_ffi::flow::{self, Flow};
    use suricata_ffi::thread::ThreadVars;
+   use suricata_sys::sys::Packet;
    use suricata_ffi::SCLogNotice;
 
-   fn flow_init(_tv: &mut ThreadVars, f: *mut Flow, _p: *const Packet) {
-       SCLogNotice!("flow initialized: {:p}", f);
+   fn flow_init(_tv: &mut ThreadVars, f: &mut Flow, _p: *const Packet) {
+       SCLogNotice!("flow initialized: {:p}", f.as_ptr());
    }
 
-   fn flow_update(_tv: &mut ThreadVars, f: *mut Flow, p: *mut Packet) {
-       SCLogNotice!("flow updated: {:p} packet: {:p}", f, p);
+   fn flow_update(_tv: &mut ThreadVars, f: &mut Flow, p: *mut Packet) {
+       SCLogNotice!("flow updated: {:p} packet: {:p}", f.as_ptr(), p);
    }
 
-   fn flow_finish(_tv: &mut ThreadVars, f: *mut Flow) {
-       SCLogNotice!("flow finished: {:p}", f);
+   fn flow_finish(_tv: &mut ThreadVars, f: &mut Flow) {
+       SCLogNotice!("flow finished: {:p}", f.as_ptr());
    }
 
    fn register_flow_callbacks() -> Result<(), &'static str> {

--- a/doc/userguide/devguide/extending/flow-lifecycle-callbacks.rst
+++ b/doc/userguide/devguide/extending/flow-lifecycle-callbacks.rst
@@ -131,3 +131,45 @@ The Rust wrappers register closures or function items and return
 The raw pointers passed into callbacks are only valid for the duration
 of the callback invocation and must not be stored. Rust callbacks must
 not panic.
+
+Flow Storage
+============
+
+``flow::FlowStorage<T>`` provides typed, per-flow storage backed by
+Suricata's flow storage API. Each registered slot holds an independent value
+of type ``T`` for every flow.
+
+Register a slot once during initialization with
+``FlowStorage::<T>::register``. Registration must happen before Suricata
+finalizes its storage registration, which is the case during plugin
+initialization.
+
+.. code-block:: rust
+
+   use suricata_ffi::flow::{self, Flow, FlowStorage};
+   use suricata_ffi::thread::ThreadVars;
+   use suricata_sys::sys::Packet;
+
+   #[derive(Default)]
+   struct FlowState {
+       packets: u64,
+   }
+
+   fn register(storage: FlowStorage<FlowState>) -> Result<(), &'static str> {
+       flow::register_update_callback(move |tv, f, p| on_flow_update(storage, tv, f, p))
+   }
+
+Values are owned by Suricata's flow storage and are dropped automatically when
+the flow's storage is freed.
+
+.. code-block:: rust
+
+   fn on_flow_init(storage: FlowStorage<FlowState>, _tv: &mut ThreadVars, f: &mut Flow, _p: *const Packet) {
+       let _ = storage.get_or_insert_with(f, FlowState::default);
+   }
+
+   fn on_flow_update(storage: FlowStorage<FlowState>, _tv: &mut ThreadVars, f: &mut Flow, _p: *mut Packet) {
+       if let Some(state) = storage.get_mut(f) {
+           state.packets += 1;
+       }
+   }

--- a/examples/plugins/c-custom-loggers/custom-logger.c
+++ b/examples/plugins/c-custom-loggers/custom-logger.c
@@ -56,21 +56,29 @@ static int CustomFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
 
     if ((SCFlowGetFlags(f) & FLOW_DIR_REVERSED) == 0) {
         if (SCFlowIsIPv4(f)) {
-            PrintInet(AF_INET, (const void *)&(f->src.addr_data32[0]), src_ip, sizeof(src_ip));
-            PrintInet(AF_INET, (const void *)&(f->dst.addr_data32[0]), dst_ip, sizeof(dst_ip));
+            PrintInet(AF_INET, (const void *)&(SCFlowGetSourceAddressPtr(f)->addr_data32[0]),
+                    src_ip, sizeof(src_ip));
+            PrintInet(AF_INET, (const void *)&(SCFlowGetDestinationAddressPtr(f)->addr_data32[0]),
+                    dst_ip, sizeof(dst_ip));
         } else if (SCFlowIsIPv6(f)) {
-            PrintInet(AF_INET6, (const void *)&(f->src.address), src_ip, sizeof(src_ip));
-            PrintInet(AF_INET6, (const void *)&(f->dst.address), dst_ip, sizeof(dst_ip));
+            PrintInet(AF_INET6, (const void *)&(SCFlowGetSourceAddressPtr(f)->address), src_ip,
+                    sizeof(src_ip));
+            PrintInet(AF_INET6, (const void *)&(SCFlowGetDestinationAddressPtr(f)->address), dst_ip,
+                    sizeof(dst_ip));
         }
         sp = SCFlowGetSourcePort(f);
         dp = SCFlowGetDestinationPort(f);
     } else {
         if (SCFlowIsIPv4(f)) {
-            PrintInet(AF_INET, (const void *)&(f->dst.addr_data32[0]), src_ip, sizeof(src_ip));
-            PrintInet(AF_INET, (const void *)&(f->src.addr_data32[0]), dst_ip, sizeof(dst_ip));
+            PrintInet(AF_INET, (const void *)&(SCFlowGetDestinationAddressPtr(f)->addr_data32[0]),
+                    src_ip, sizeof(src_ip));
+            PrintInet(AF_INET, (const void *)&(SCFlowGetSourceAddressPtr(f)->addr_data32[0]),
+                    dst_ip, sizeof(dst_ip));
         } else if (SCFlowIsIPv6(f)) {
-            PrintInet(AF_INET6, (const void *)&(f->dst.address), src_ip, sizeof(src_ip));
-            PrintInet(AF_INET6, (const void *)&(f->src.address), dst_ip, sizeof(dst_ip));
+            PrintInet(AF_INET6, (const void *)&(SCFlowGetDestinationAddressPtr(f)->address), src_ip,
+                    sizeof(src_ip));
+            PrintInet(AF_INET6, (const void *)&(SCFlowGetSourceAddressPtr(f)->address), dst_ip,
+                    sizeof(dst_ip));
         }
         sp = SCFlowGetDestinationPort(f);
         dp = SCFlowGetSourcePort(f);

--- a/examples/plugins/c-custom-loggers/custom-logger.c
+++ b/examples/plugins/c-custom-loggers/custom-logger.c
@@ -21,6 +21,7 @@
 #include "output-packet.h"
 #include "output-flow.h"
 #include "output-tx.h"
+#include "flow.h"
 #include "util-print.h"
 #include "output.h"
 
@@ -53,26 +54,26 @@ static int CustomFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     char src_ip[46] = { 0 }, dst_ip[46] = { 0 };
     Port sp, dp;
 
-    if ((f->flags & FLOW_DIR_REVERSED) == 0) {
-        if (FLOW_IS_IPV4(f)) {
+    if ((SCFlowGetFlags(f) & FLOW_DIR_REVERSED) == 0) {
+        if (SCFlowIsIPv4(f)) {
             PrintInet(AF_INET, (const void *)&(f->src.addr_data32[0]), src_ip, sizeof(src_ip));
             PrintInet(AF_INET, (const void *)&(f->dst.addr_data32[0]), dst_ip, sizeof(dst_ip));
-        } else if (FLOW_IS_IPV6(f)) {
+        } else if (SCFlowIsIPv6(f)) {
             PrintInet(AF_INET6, (const void *)&(f->src.address), src_ip, sizeof(src_ip));
             PrintInet(AF_INET6, (const void *)&(f->dst.address), dst_ip, sizeof(dst_ip));
         }
-        sp = f->sp;
-        dp = f->dp;
+        sp = SCFlowGetSourcePort(f);
+        dp = SCFlowGetDestinationPort(f);
     } else {
-        if (FLOW_IS_IPV4(f)) {
+        if (SCFlowIsIPv4(f)) {
             PrintInet(AF_INET, (const void *)&(f->dst.addr_data32[0]), src_ip, sizeof(src_ip));
             PrintInet(AF_INET, (const void *)&(f->src.addr_data32[0]), dst_ip, sizeof(dst_ip));
-        } else if (FLOW_IS_IPV6(f)) {
+        } else if (SCFlowIsIPv6(f)) {
             PrintInet(AF_INET6, (const void *)&(f->dst.address), src_ip, sizeof(src_ip));
             PrintInet(AF_INET6, (const void *)&(f->src.address), dst_ip, sizeof(dst_ip));
         }
-        sp = f->dp;
-        dp = f->sp;
+        sp = SCFlowGetDestinationPort(f);
+        dp = SCFlowGetSourcePort(f);
     }
 
     SCLogNotice("Flow: %s:%u -> %s:%u", src_ip, sp, dst_ip, dp);

--- a/examples/plugins/rust/src/mod.rs
+++ b/examples/plugins/rust/src/mod.rs
@@ -1,11 +1,11 @@
 use std::ptr::null_mut;
 
 use suricata_ffi::eve::{self, SCJsonBuilder};
-use suricata_ffi::flow;
+use suricata_ffi::flow::{self, Flow};
 use suricata_ffi::jsonbuilder::JsonBuilder;
 use suricata_ffi::thread::{self, ThreadStorage, ThreadVars};
 use suricata_ffi::{SCLogError, SCLogNotice, SCLogWarning};
-use suricata_sys::sys::{self, Flow, Packet, SCEveRegisterCallback, SCPlugin};
+use suricata_sys::sys::{self, Packet, SCEveRegisterCallback, SCPlugin};
 
 /// Per-thread state stored in Suricata thread storage.
 #[derive(Default)]
@@ -59,7 +59,7 @@ fn register_thread_callbacks(storage: ThreadStorage<ThreadState>) -> Result<(), 
 unsafe extern "C" fn log_eve_raw(
     _tv: *mut sys::ThreadVars,
     _p: *const Packet,
-    _f: *mut Flow,
+    _f: *mut sys::Flow,
     jb: *mut SCJsonBuilder,
     _user: *mut std::os::raw::c_void,
 ) {
@@ -72,12 +72,12 @@ unsafe extern "C" fn log_eve_raw(
 fn log_eve_wrapped(
     _tv: &mut ThreadVars,
     _p: *const Packet,
-    f: *mut Flow,
+    f: Option<&mut Flow>,
     jb: &mut JsonBuilder,
 ) -> Result<(), suricata_ffi::jsonbuilder::Error> {
     jb.open_object("rust_wrapped")?;
     jb.set_string("example", "eve-callback")?;
-    jb.set_string("has_flow", if f.is_null() { "false" } else { "true" })?;
+    jb.set_string("has_flow", if f.is_some() { "true" } else { "false" })?;
     jb.close()?;
     Ok(())
 }
@@ -96,7 +96,7 @@ fn on_thread_init(storage: ThreadStorage<ThreadState>, tv: &mut ThreadVars) {
 fn log_flow_init(
     storage: ThreadStorage<ThreadState>,
     tv: &mut ThreadVars,
-    f: *mut Flow,
+    f: &mut Flow,
     _p: *const Packet,
 ) {
     // Count flows seen by this thread using the per-thread storage.
@@ -112,21 +112,21 @@ fn log_flow_init(
     };
     SCLogNotice!(
         "rust example flow init callback: flow={:p}, thread_flows={}",
-        f,
+        f.as_ptr(),
         flows
     );
 }
 
-fn log_flow_update(_tv: &mut ThreadVars, _f: *mut Flow, _p: *mut Packet) {
+fn log_flow_update(_tv: &mut ThreadVars, f: &mut Flow, _p: *mut Packet) {
     SCLogNotice!(
         "rust example flow update callback: flow={:p}, packet={:p}",
-        _f,
+        f.as_ptr(),
         _p
     );
 }
 
-fn log_flow_finish(_tv: &mut ThreadVars, _f: *mut Flow) {
-    SCLogNotice!("rust example flow finish callback: flow={:p}", _f);
+fn log_flow_finish(_tv: &mut ThreadVars, f: &mut Flow) {
+    SCLogNotice!("rust example flow finish callback: flow={:p}", f.as_ptr());
 }
 
 #[no_mangle]

--- a/examples/plugins/rust/src/mod.rs
+++ b/examples/plugins/rust/src/mod.rs
@@ -98,8 +98,32 @@ fn log_eve_wrapped(
     jb.set_string("example", "eve-callback")?;
     jb.set_string("has_flow", if f.is_some() { "true" } else { "false" })?;
 
-    // If we have a flow, log something from flow storage.
+    // If we have a flow, show the `Flow` wrapper accessors and log something
+    // from flow storage.
     if let Some(f) = f {
+        let src_ip = f
+            .source_address()
+            .map(|addr| addr.to_string())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let dst_ip = f
+            .destination_address()
+            .map(|addr| addr.to_string())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let toserver = f.to_server_packet_count();
+        let toclient = f.to_client_packet_count();
+
+        jb.open_object("flow_accessors")?;
+        jb.set_string("src_ip", &src_ip)?;
+        jb.set_uint("src_port", f.source_port() as u64)?;
+        jb.set_string("dest_ip", &dst_ip)?;
+        jb.set_uint("dest_port", f.destination_port() as u64)?;
+        jb.set_uint("ip_proto", f.ip_protocol() as u64)?;
+        jb.set_uint("app_proto", f.app_protocol() as u64)?;
+        jb.set_uint("toserver_pkts", toserver as u64)?;
+        jb.set_uint("toclient_pkts", toclient as u64)?;
+        jb.set_uint("last_seen", f.last_time().as_secs())?;
+        jb.close()?;
+
         if let Some(state) = flow_storage.get(f) {
             jb.set_uint("flow_packets", state.packets)?;
         }

--- a/examples/plugins/rust/src/mod.rs
+++ b/examples/plugins/rust/src/mod.rs
@@ -1,7 +1,7 @@
 use std::ptr::null_mut;
 
 use suricata_ffi::eve::{self, SCJsonBuilder};
-use suricata_ffi::flow::{self, Flow};
+use suricata_ffi::flow::{self, Flow, FlowStorage};
 use suricata_ffi::jsonbuilder::JsonBuilder;
 use suricata_ffi::thread::{self, ThreadStorage, ThreadVars};
 use suricata_ffi::{SCLogError, SCLogNotice, SCLogWarning};
@@ -11,6 +11,12 @@ use suricata_sys::sys::{self, Packet, SCEveRegisterCallback, SCPlugin};
 #[derive(Default)]
 struct ThreadState {
     flows: u64,
+}
+
+/// Per-flow state stored in Suricata flow storage.
+#[derive(Default)]
+struct FlowState {
+    packets: u64,
 }
 
 unsafe extern "C" fn init() {
@@ -26,11 +32,18 @@ unsafe extern "C" fn init() {
             return;
         }
     };
+    let flow_storage = match FlowStorage::<FlowState>::register("rust-example-flow") {
+        Ok(storage) => storage,
+        Err(err) => {
+            SCLogError!("Failed to register rust example flow storage: {}", err);
+            return;
+        }
+    };
 
-    if let Err(err) = register_eve_callbacks() {
+    if let Err(err) = register_eve_callbacks(flow_storage) {
         SCLogError!("Failed to register rust example EVE callbacks: {}", err);
     }
-    if let Err(err) = register_flow_callbacks(thread_storage) {
+    if let Err(err) = register_flow_callbacks(thread_storage, flow_storage) {
         SCLogError!("Failed to register rust example flow callbacks: {}", err);
     }
     if let Err(err) = register_thread_callbacks(thread_storage) {
@@ -38,17 +51,22 @@ unsafe extern "C" fn init() {
     }
 }
 
-fn register_eve_callbacks() -> Result<(), &'static str> {
+fn register_eve_callbacks(flow_storage: FlowStorage<FlowState>) -> Result<(), &'static str> {
     if !unsafe { SCEveRegisterCallback(Some(log_eve_raw), null_mut()) } {
         return Err("Failed to register raw EVE callback");
     }
-    eve::register_callback(log_eve_wrapped)
+    eve::register_callback(move |tv, p, f, jb| log_eve_wrapped(flow_storage, tv, p, f, jb))
 }
 
-fn register_flow_callbacks(storage: ThreadStorage<ThreadState>) -> Result<(), &'static str> {
-    flow::register_init_callback(move |tv, f, p| log_flow_init(storage, tv, f, p))?;
-    flow::register_update_callback(log_flow_update)?;
-    flow::register_finish_callback(log_flow_finish)?;
+fn register_flow_callbacks(
+    thread_storage: ThreadStorage<ThreadState>,
+    flow_storage: FlowStorage<FlowState>,
+) -> Result<(), &'static str> {
+    flow::register_init_callback(move |tv, f, p| {
+        log_flow_init(thread_storage, flow_storage, tv, f, p)
+    })?;
+    flow::register_update_callback(move |tv, f, p| log_flow_update(flow_storage, tv, f, p))?;
+    flow::register_finish_callback(move |tv, f| log_flow_finish(flow_storage, tv, f))?;
     Ok(())
 }
 
@@ -70,6 +88,7 @@ unsafe extern "C" fn log_eve_raw(
 }
 
 fn log_eve_wrapped(
+    flow_storage: FlowStorage<FlowState>,
     _tv: &mut ThreadVars,
     _p: *const Packet,
     f: Option<&mut Flow>,
@@ -78,6 +97,13 @@ fn log_eve_wrapped(
     jb.open_object("rust_wrapped")?;
     jb.set_string("example", "eve-callback")?;
     jb.set_string("has_flow", if f.is_some() { "true" } else { "false" })?;
+
+    // If we have a flow, log something from flow storage.
+    if let Some(f) = f {
+        if let Some(state) = flow_storage.get(f) {
+            jb.set_uint("flow_packets", state.packets)?;
+        }
+    }
     jb.close()?;
     Ok(())
 }
@@ -94,13 +120,14 @@ fn on_thread_init(storage: ThreadStorage<ThreadState>, tv: &mut ThreadVars) {
 }
 
 fn log_flow_init(
-    storage: ThreadStorage<ThreadState>,
+    thread_storage: ThreadStorage<ThreadState>,
+    flow_storage: FlowStorage<FlowState>,
     tv: &mut ThreadVars,
     f: &mut Flow,
     _p: *const Packet,
 ) {
     // Count flows seen by this thread using the per-thread storage.
-    let flows = match storage.get_mut(tv) {
+    let flows = match thread_storage.get_mut(tv) {
         Some(state) => {
             state.flows += 1;
             state.flows
@@ -110,6 +137,10 @@ fn log_flow_init(
             0
         }
     };
+    // Initialize the per-flow storage for this flow.
+    if let Err(err) = flow_storage.get_or_insert_with(f, FlowState::default) {
+        SCLogError!("failed to initialize rust example flow storage: {}", err);
+    }
     SCLogNotice!(
         "rust example flow init callback: flow={:p}, thread_flows={}",
         f.as_ptr(),
@@ -117,16 +148,37 @@ fn log_flow_init(
     );
 }
 
-fn log_flow_update(_tv: &mut ThreadVars, f: &mut Flow, _p: *mut Packet) {
+fn log_flow_update(
+    flow_storage: FlowStorage<FlowState>,
+    _tv: &mut ThreadVars,
+    f: &mut Flow,
+    _p: *mut Packet,
+) {
+    // Count packets seen on this flow using the per-flow storage.
+    let packets = match flow_storage.get_mut(f) {
+        Some(state) => {
+            state.packets += 1;
+            state.packets
+        }
+        None => {
+            SCLogWarning!("rust example flow storage was not initialized");
+            0
+        }
+    };
     SCLogNotice!(
-        "rust example flow update callback: flow={:p}, packet={:p}",
+        "rust example flow update callback: flow={:p}, flow_packets={}",
         f.as_ptr(),
-        _p
+        packets
     );
 }
 
-fn log_flow_finish(_tv: &mut ThreadVars, f: &mut Flow) {
-    SCLogNotice!("rust example flow finish callback: flow={:p}", f.as_ptr());
+fn log_flow_finish(flow_storage: FlowStorage<FlowState>, _tv: &mut ThreadVars, f: &mut Flow) {
+    let packets = flow_storage.get(f).map(|state| state.packets).unwrap_or(0);
+    SCLogNotice!(
+        "rust example flow finish callback: flow={:p}, flow_packets={}",
+        f.as_ptr(),
+        packets
+    );
 }
 
 #[no_mangle]

--- a/plugins/ndpi/ndpi.c
+++ b/plugins/ndpi/ndpi.c
@@ -121,7 +121,10 @@ static void OnFlowInit(ThreadVars *tv, Flow *f, const Packet *p, void *_data)
 
     memset(flowctx->ndpi_flow, 0, SIZEOF_FLOW_STRUCT);
     flowctx->detection_completed = false;
-    SCFlowSetStorageById(f, flow_storage_id, flowctx);
+    if (SCFlowSetStorageById(f, flow_storage_id, flowctx) != 0) {
+        SCLogDebug("Failed to set nDPI flow storage");
+        FlowStorageFree(flowctx);
+    }
 }
 
 static void OnFlowUpdate(ThreadVars *tv, Flow *f, Packet *p, void *_data)

--- a/plugins/ndpi/ndpi.c
+++ b/plugins/ndpi/ndpi.c
@@ -24,6 +24,7 @@
 
 #include "detect-engine-helper.h"
 #include "detect-parse.h"
+#include "flow.h"
 #include "flow-callbacks.h"
 #include "flow-storage.h"
 #include "output-eve.h"
@@ -129,9 +130,11 @@ static void OnFlowInit(ThreadVars *tv, Flow *f, const Packet *p, void *_data)
 
 static void OnFlowUpdate(ThreadVars *tv, Flow *f, Packet *p, void *_data)
 {
+    const uint8_t flow_proto = SCFlowGetIPProtocol(f);
+
     /* Ignore packets that have a different protocol than the
      * flow. This can happen with ICMP unreachable packets. */
-    if (p->proto != f->proto) {
+    if (p->proto != flow_proto) {
         return;
     }
 
@@ -169,9 +172,10 @@ static void OnFlowUpdate(ThreadVars *tv, Flow *f, Packet *p, void *_data)
                     flowctx->detection_completed = true;
             }
         } else {
-            uint16_t max_num_pkts = (f->proto == IPPROTO_UDP) ? 8 : 24;
+            uint16_t max_num_pkts = (flow_proto == IPPROTO_UDP) ? 8 : 24;
 
-            if ((f->todstpktcnt + f->tosrcpktcnt) > max_num_pkts) {
+            if ((SCFlowGetToServerPacketCount(f) + SCFlowGetToClientPacketCount(f)) >
+                    max_num_pkts) {
                 uint8_t proto_guessed;
 
                 flowctx->detected_l7_protocol =

--- a/plugins/ndpi/ndpi.c
+++ b/plugins/ndpi/ndpi.c
@@ -71,13 +71,11 @@ static inline struct NdpiThreadContext *NdpiGetThreadContext(ThreadVars *tv)
 
 /**
  * Safe helper to get nDPI flow context. Returns NULL if the flow
- * or its storage is not available. Guards against the case where
- * f->storage is NULL (uninitialized flow) which would crash inside
- * SCStorageGetById.
+ * context is not available.
  */
 static inline struct NdpiFlowContext *NdpiGetFlowContext(const Flow *f)
 {
-    if (unlikely(f == NULL || flow_storage_id.id < 0 || f->storage == NULL))
+    if (unlikely(f == NULL || flow_storage_id.id < 0))
         return NULL;
     return SCFlowGetStorageById(f, flow_storage_id);
 }
@@ -107,11 +105,6 @@ static void OnFlowInit(ThreadVars *tv, Flow *f, const Packet *p, void *_data)
 {
     if (unlikely(f == NULL))
         return;
-
-    if (unlikely(f->storage == NULL)) {
-        SCLogDebug("Flow %p has no storage, skipping nDPI init", f);
-        return;
-    }
 
     struct NdpiFlowContext *flowctx = SCCalloc(1, sizeof(*flowctx));
     if (flowctx == NULL) {

--- a/rust/ffi/src/eve.rs
+++ b/rust/ffi/src/eve.rs
@@ -23,8 +23,9 @@ use suricata_sys::sys::{
     SCEveFileTypeThreadDeinitFunc, SCEveFileTypeThreadInitFunc, SCEveFileTypeWriteFunc,
     SCEveRegisterCallback, SCRegisterEveFileType,
 };
-pub use suricata_sys::sys::{Flow, Packet, SCEveUserCallbackFn, SCJsonBuilder};
+pub use suricata_sys::sys::{Packet, SCEveUserCallbackFn, SCJsonBuilder};
 
+use crate::flow::Flow;
 use crate::thread::ThreadVars;
 
 pub struct EveFileType {
@@ -82,7 +83,7 @@ impl EveFileType {
 /// The callback receives:
 /// - `tv`: the `ThreadVars` for the thread performing the logging
 /// - `p`: the `Packet`, if available
-/// - `f`: the `Flow`, if available
+/// - `f`: the `Flow`, if available (`None` when no flow is associated)
 /// - `jb`: the JSON builder for the current EVE record
 ///
 /// This API is intended for plugin and library users.
@@ -115,7 +116,7 @@ where
     F: Fn(
             &mut ThreadVars,
             *const Packet,
-            *mut Flow,
+            Option<&mut Flow>,
             &mut crate::jsonbuilder::JsonBuilder,
         ) -> Result<(), crate::jsonbuilder::Error>
         + Send
@@ -136,13 +137,13 @@ where
 /// Internal wrapper used to adapt the C EVE callback to a Rust
 /// closure callback.
 unsafe extern "C" fn callback_wrapper<F>(
-    tv: *mut sys::ThreadVars, p: *const Packet, f: *mut Flow, jb: *mut SCJsonBuilder,
+    tv: *mut sys::ThreadVars, p: *const Packet, f: *mut sys::Flow, jb: *mut SCJsonBuilder,
     user: *mut c_void,
 ) where
     F: Fn(
             &mut ThreadVars,
             *const Packet,
-            *mut Flow,
+            Option<&mut Flow>,
             &mut crate::jsonbuilder::JsonBuilder,
         ) -> Result<(), crate::jsonbuilder::Error>
         + Send
@@ -151,9 +152,14 @@ unsafe extern "C" fn callback_wrapper<F>(
 {
     let callback = &*(user as *const F);
     let mut tv = ThreadVars::from_ptr(tv);
+    let mut flow = if f.is_null() {
+        None
+    } else {
+        Some(Flow::from_ptr(f))
+    };
     let mut jb = crate::jsonbuilder::JsonBuilder::from_raw(jb);
     let mark = jb.get_mark();
-    if callback(&mut tv, p, f, &mut jb).is_err() {
+    if callback(&mut tv, p, flow.as_mut(), &mut jb).is_err() {
         let _ = jb.restore_mark(&mark);
     }
 }

--- a/rust/ffi/src/flow.rs
+++ b/rust/ffi/src/flow.rs
@@ -69,7 +69,7 @@ impl<'a> Flow<'a> {
 /// The callback must not panic.
 pub fn register_init_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(&mut ThreadVars, *mut sys::Flow, *const Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, &mut Flow, *const Packet) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCFlowRegisterInitCallback(Some(init_callback_wrapper::<F>), user) } {
@@ -98,7 +98,7 @@ where
 /// The callback must not panic.
 pub fn register_update_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(&mut ThreadVars, *mut sys::Flow, *mut Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, &mut Flow, *mut Packet) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCFlowRegisterUpdateCallback(Some(update_callback_wrapper::<F>), user) } {
@@ -125,7 +125,7 @@ where
 /// The callback must not panic.
 pub fn register_finish_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(&mut ThreadVars, *mut sys::Flow) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, &mut Flow) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCFlowRegisterFinishCallback(Some(finish_callback_wrapper::<F>), user) } {
@@ -141,29 +141,32 @@ where
 unsafe extern "C" fn init_callback_wrapper<F>(
     tv: *mut sys::ThreadVars, f: *mut sys::Flow, p: *const Packet, user: *mut c_void,
 ) where
-    F: Fn(&mut ThreadVars, *mut sys::Flow, *const Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, &mut Flow, *const Packet) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
     let mut tv = ThreadVars::from_ptr(tv);
-    callback(&mut tv, f, p);
+    let mut f = Flow::from_ptr(f);
+    callback(&mut tv, &mut f, p);
 }
 
 unsafe extern "C" fn update_callback_wrapper<F>(
     tv: *mut sys::ThreadVars, f: *mut sys::Flow, p: *mut Packet, user: *mut c_void,
 ) where
-    F: Fn(&mut ThreadVars, *mut sys::Flow, *mut Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, &mut Flow, *mut Packet) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
     let mut tv = ThreadVars::from_ptr(tv);
-    callback(&mut tv, f, p);
+    let mut f = Flow::from_ptr(f);
+    callback(&mut tv, &mut f, p);
 }
 
 unsafe extern "C" fn finish_callback_wrapper<F>(
     tv: *mut sys::ThreadVars, f: *mut sys::Flow, user: *mut c_void,
 ) where
-    F: Fn(&mut ThreadVars, *mut sys::Flow) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, &mut Flow) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
     let mut tv = ThreadVars::from_ptr(tv);
-    callback(&mut tv, f);
+    let mut f = Flow::from_ptr(f);
+    callback(&mut tv, &mut f);
 }

--- a/rust/ffi/src/flow.rs
+++ b/rust/ffi/src/flow.rs
@@ -17,7 +17,9 @@
 
 use std::ffi::CString;
 use std::marker::PhantomData;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::os::raw::c_void;
+use std::time::Duration;
 
 use suricata_sys::sys::{
     self, Packet, SCFlowGetStorageById, SCFlowRegisterFinishCallback, SCFlowRegisterInitCallback,
@@ -57,6 +59,87 @@ impl<'a> Flow<'a> {
     /// Return the underlying raw `Flow` pointer for mutable access.
     fn as_mut_ptr(&mut self) -> *mut sys::Flow {
         self.flow
+    }
+
+    /// Return the time of the last flow update as a `Duration` since the epoch.
+    pub fn last_time(&self) -> Duration {
+        let mut secs: u64 = 0;
+        let mut usecs: u64 = 0;
+        unsafe {
+            sys::SCFlowGetLastTimeAsParts(self.as_ptr(), &mut secs, &mut usecs);
+        }
+        Duration::new(secs, usecs as u32 * 1000)
+    }
+
+    /// Return the flow flags.
+    pub fn flags(&self) -> u64 {
+        unsafe { sys::SCFlowGetFlags(self.as_ptr()) }
+    }
+
+    /// Return true if the flow is IPv4.
+    pub fn is_ipv4(&self) -> bool {
+        unsafe { sys::SCFlowIsIPv4(self.as_ptr()) }
+    }
+
+    /// Return true if the flow is IPv6.
+    pub fn is_ipv6(&self) -> bool {
+        unsafe { sys::SCFlowIsIPv6(self.as_ptr()) }
+    }
+
+    /// Return the flow IP protocol.
+    pub fn ip_protocol(&self) -> u8 {
+        unsafe { sys::SCFlowGetIPProtocol(self.as_ptr()) }
+    }
+
+    /// Return the flow app-layer protocol.
+    pub fn app_protocol(&self) -> sys::AppProto {
+        unsafe { sys::SCFlowGetAppProtocol(self.as_ptr()) }
+    }
+
+    /// Return the flow source port.
+    pub fn source_port(&self) -> u16 {
+        unsafe { sys::SCFlowGetSourcePort(self.as_ptr()) }
+    }
+
+    /// Return the flow destination port.
+    pub fn destination_port(&self) -> u16 {
+        unsafe { sys::SCFlowGetDestinationPort(self.as_ptr()) }
+    }
+
+    /// Return the flow source address.
+    pub fn source_address(&self) -> Option<IpAddr> {
+        let ptr = unsafe { sys::SCFlowGetSourceAddressPtr(self.as_ptr()) };
+        self.address_from_ptr(ptr)
+    }
+
+    /// Return the flow destination address.
+    pub fn destination_address(&self) -> Option<IpAddr> {
+        let ptr = unsafe { sys::SCFlowGetDestinationAddressPtr(self.as_ptr()) };
+        self.address_from_ptr(ptr)
+    }
+
+    /// Return the number of packets seen to-server.
+    pub fn to_server_packet_count(&self) -> u32 {
+        unsafe { sys::SCFlowGetToServerPacketCount(self.as_ptr()) }
+    }
+
+    /// Return the number of packets seen to-client.
+    pub fn to_client_packet_count(&self) -> u32 {
+        unsafe { sys::SCFlowGetToClientPacketCount(self.as_ptr()) }
+    }
+
+    fn address_from_ptr(&self, ptr: *const sys::SCFlowAddress) -> Option<IpAddr> {
+        let address = unsafe { ptr.as_ref()? };
+        let bytes = unsafe { address.address.address_un_data8 };
+        if self.is_ipv4() {
+            Some(IpAddr::V4(Ipv4Addr::new(
+                bytes[0], bytes[1], bytes[2], bytes[3],
+            )))
+        } else if self.is_ipv6() {
+            Some(IpAddr::V6(Ipv6Addr::from(bytes)))
+        } else {
+            None
+        }
     }
 }
 

--- a/rust/ffi/src/flow.rs
+++ b/rust/ffi/src/flow.rs
@@ -15,12 +15,13 @@
  * 02110-1301, USA.
  */
 
+use std::ffi::CString;
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 
 use suricata_sys::sys::{
-    self, Packet, SCFlowRegisterFinishCallback, SCFlowRegisterInitCallback,
-    SCFlowRegisterUpdateCallback,
+    self, Packet, SCFlowGetStorageById, SCFlowRegisterFinishCallback, SCFlowRegisterInitCallback,
+    SCFlowRegisterUpdateCallback, SCFlowSetStorageById, SCFlowStorageId, SCFlowStorageRegister,
 };
 
 use crate::thread::ThreadVars;
@@ -51,6 +52,118 @@ impl<'a> Flow<'a> {
     /// Return the underlying raw `Flow` pointer for read-only access.
     pub fn as_ptr(&self) -> *const sys::Flow {
         self.flow
+    }
+
+    /// Return the underlying raw `Flow` pointer for mutable access.
+    fn as_mut_ptr(&mut self) -> *mut sys::Flow {
+        self.flow
+    }
+}
+
+/// A typed handle to a per-flow storage slot.
+///
+/// `FlowStorage<T>` wraps the `SCFlowStorageId` returned when registering flow
+/// storage with Suricata. Values are stored as a `Box<T>` owned by Suricata's
+/// flow storage and are dropped automatically when the flow's storage is freed.
+///
+/// The handle only holds the storage id, so it is `Copy` and `Send`/`Sync`
+/// regardless of `T`, and can be passed by value into the callbacks that need
+/// it.
+pub struct FlowStorage<T> {
+    id: SCFlowStorageId,
+    _marker: PhantomData<fn() -> T>,
+}
+
+// Manual `Copy`/`Clone` impls so the handle is copyable regardless of whether
+// `T` is; it only holds the storage id.
+impl<T> Clone for FlowStorage<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for FlowStorage<T> {}
+
+impl<T: Send + 'static> FlowStorage<T> {
+    /// Register a new flow storage slot for values of type `T`.
+    ///
+    /// `name` must be unique among registered flow storage. Registration has to
+    /// happen during initialization, before Suricata finalizes storage
+    /// registration (`SCStorageFinalize`).
+    ///
+    /// Returns an error if `name` contains an interior nul byte or if Suricata
+    /// rejects the registration.
+    pub fn register(name: &str) -> Result<Self, &'static str> {
+        let name = CString::new(name).map_err(|_| "flow storage name contains a nul byte")?;
+        let id = unsafe { SCFlowStorageRegister(name.as_ptr(), Some(Self::free)) };
+        if id.id < 0 {
+            return Err("Failed to register flow storage");
+        }
+
+        // Suricata keeps the storage name pointer in its storage mapping for
+        // the lifetime of the process, so the CString is intentionally leaked.
+        std::mem::forget(name);
+
+        Ok(Self {
+            id,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Return a reference to the value stored for `f`, if any.
+    pub fn get<'f>(&self, f: &'f Flow<'_>) -> Option<&'f T> {
+        let ptr = unsafe { SCFlowGetStorageById(f.as_ptr(), self.id) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { &*(ptr as *const T) })
+        }
+    }
+
+    /// Return a mutable reference to the value stored for `f`, if any.
+    pub fn get_mut<'f>(&self, f: &'f mut Flow<'_>) -> Option<&'f mut T> {
+        let ptr = unsafe { SCFlowGetStorageById(f.as_ptr(), self.id) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { &mut *(ptr as *mut T) })
+        }
+    }
+
+    /// Return a mutable reference to the value stored for `f`, inserting the
+    /// value produced by `init` if none is present yet.
+    pub fn get_or_insert_with<'f>(
+        &self, f: &'f mut Flow<'_>, init: impl FnOnce() -> T,
+    ) -> Result<&'f mut T, &'static str> {
+        let ptr = unsafe { SCFlowGetStorageById(f.as_ptr(), self.id) };
+        if !ptr.is_null() {
+            return Ok(unsafe { &mut *(ptr as *mut T) });
+        }
+
+        // `SCFlowSetStorageById` overwrites the slot without freeing any
+        // previous value; we only reach here when the slot is empty.
+        let ptr = Box::into_raw(Box::new(init()));
+        let rc = unsafe { SCFlowSetStorageById(f.as_mut_ptr(), self.id, ptr.cast()) };
+        if rc != 0 {
+            unsafe {
+                drop(Box::from_raw(ptr));
+            }
+            return Err("Failed to set flow storage");
+        }
+
+        Ok(unsafe { &mut *ptr })
+    }
+
+    /// Free callback registered with Suricata flow storage that drops the
+    /// `Box<T>` backing a stored value.
+    unsafe extern "C" fn free(ptr: *mut c_void) {
+        if !ptr.is_null() {
+            // The drop runs across an FFI boundary, so guard against unwinding
+            // into C if `T`'s `Drop` panics.
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                drop(Box::from_raw(ptr as *mut T));
+            }));
+        }
     }
 }
 

--- a/rust/ffi/src/flow.rs
+++ b/rust/ffi/src/flow.rs
@@ -15,14 +15,44 @@
  * 02110-1301, USA.
  */
 
+use std::marker::PhantomData;
 use std::os::raw::c_void;
 
 use suricata_sys::sys::{
-    self, Flow, Packet, SCFlowRegisterFinishCallback, SCFlowRegisterInitCallback,
+    self, Packet, SCFlowRegisterFinishCallback, SCFlowRegisterInitCallback,
     SCFlowRegisterUpdateCallback,
 };
 
 use crate::thread::ThreadVars;
+
+/// A safe wrapper around a Suricata `sys::Flow` pointer.
+///
+/// A wrapper around `sys::Flow` that carries a lifetime tied to the callback
+/// invocation it was created for, so the borrow checker prevents it from being
+/// stored beyond the call.
+pub struct Flow<'a> {
+    flow: *mut sys::Flow,
+    _marker: PhantomData<&'a mut sys::Flow>,
+}
+
+impl<'a> Flow<'a> {
+    /// Wrap a raw `Flow` pointer.
+    ///
+    /// # Safety
+    ///
+    /// `flow` must be a valid `Flow` pointer provided by Suricata.
+    pub unsafe fn from_ptr(flow: *mut sys::Flow) -> Self {
+        Self {
+            flow,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Return the underlying raw `Flow` pointer for read-only access.
+    pub fn as_ptr(&self) -> *const sys::Flow {
+        self.flow
+    }
+}
 
 /// Register a flow initialization callback.
 ///
@@ -39,7 +69,7 @@ use crate::thread::ThreadVars;
 /// The callback must not panic.
 pub fn register_init_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(&mut ThreadVars, *mut Flow, *const Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut sys::Flow, *const Packet) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCFlowRegisterInitCallback(Some(init_callback_wrapper::<F>), user) } {
@@ -68,7 +98,7 @@ where
 /// The callback must not panic.
 pub fn register_update_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(&mut ThreadVars, *mut Flow, *mut Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut sys::Flow, *mut Packet) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCFlowRegisterUpdateCallback(Some(update_callback_wrapper::<F>), user) } {
@@ -95,7 +125,7 @@ where
 /// The callback must not panic.
 pub fn register_finish_callback<F>(callback: F) -> Result<(), &'static str>
 where
-    F: Fn(&mut ThreadVars, *mut Flow) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut sys::Flow) + Send + Sync + 'static,
 {
     let user = Box::into_raw(Box::new(callback)) as *mut c_void;
     if unsafe { SCFlowRegisterFinishCallback(Some(finish_callback_wrapper::<F>), user) } {
@@ -109,9 +139,9 @@ where
 }
 
 unsafe extern "C" fn init_callback_wrapper<F>(
-    tv: *mut sys::ThreadVars, f: *mut Flow, p: *const Packet, user: *mut c_void,
+    tv: *mut sys::ThreadVars, f: *mut sys::Flow, p: *const Packet, user: *mut c_void,
 ) where
-    F: Fn(&mut ThreadVars, *mut Flow, *const Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut sys::Flow, *const Packet) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
     let mut tv = ThreadVars::from_ptr(tv);
@@ -119,9 +149,9 @@ unsafe extern "C" fn init_callback_wrapper<F>(
 }
 
 unsafe extern "C" fn update_callback_wrapper<F>(
-    tv: *mut sys::ThreadVars, f: *mut Flow, p: *mut Packet, user: *mut c_void,
+    tv: *mut sys::ThreadVars, f: *mut sys::Flow, p: *mut Packet, user: *mut c_void,
 ) where
-    F: Fn(&mut ThreadVars, *mut Flow, *mut Packet) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut sys::Flow, *mut Packet) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
     let mut tv = ThreadVars::from_ptr(tv);
@@ -129,9 +159,9 @@ unsafe extern "C" fn update_callback_wrapper<F>(
 }
 
 unsafe extern "C" fn finish_callback_wrapper<F>(
-    tv: *mut sys::ThreadVars, f: *mut Flow, user: *mut c_void,
+    tv: *mut sys::ThreadVars, f: *mut sys::Flow, user: *mut c_void,
 ) where
-    F: Fn(&mut ThreadVars, *mut Flow) + Send + Sync + 'static,
+    F: Fn(&mut ThreadVars, *mut sys::Flow) + Send + Sync + 'static,
 {
     let callback = &*(user as *const F);
     let mut tv = ThreadVars::from_ptr(tv);

--- a/rust/ffi/src/jsonbuilder.rs
+++ b/rust/ffi/src/jsonbuilder.rs
@@ -22,8 +22,8 @@
 use std::ffi::{CString, NulError};
 
 use suricata_sys::sys::{
-    SCJbClose, SCJbGetMark, SCJbOpenObject, SCJbRestoreMark, SCJbSetFormatted, SCJbSetString,
-    SCJsonBuilder, SCJsonBuilderMark,
+    SCJbClose, SCJbGetMark, SCJbOpenObject, SCJbRestoreMark, SCJbSetFloat, SCJbSetFormatted,
+    SCJbSetInt, SCJbSetString, SCJbSetUint, SCJsonBuilder, SCJsonBuilderMark,
 };
 
 // TODO: Map suricata::jsonbuilder::JsonBuilder errors as well,
@@ -91,6 +91,33 @@ impl JsonBuilder {
         let key = CString::new(key)?;
         let val = CString::new(val.escape_default().to_string())?;
         if unsafe { SCJbSetString(self.jb, key.as_ptr(), val.as_ptr()) } {
+            Ok(self)
+        } else {
+            Err(Error::Other)
+        }
+    }
+
+    pub fn set_uint(&mut self, key: &str, val: u64) -> Result<&mut Self, Error> {
+        let key = CString::new(key)?;
+        if unsafe { SCJbSetUint(self.jb, key.as_ptr(), val) } {
+            Ok(self)
+        } else {
+            Err(Error::Other)
+        }
+    }
+
+    pub fn set_int(&mut self, key: &str, val: i64) -> Result<&mut Self, Error> {
+        let key = CString::new(key)?;
+        if unsafe { SCJbSetInt(self.jb, key.as_ptr(), val) } {
+            Ok(self)
+        } else {
+            Err(Error::Other)
+        }
+    }
+
+    pub fn set_float(&mut self, key: &str, val: f64) -> Result<&mut Self, Error> {
+        let key = CString::new(key)?;
+        if unsafe { SCJbSetFloat(self.jb, key.as_ptr(), val) } {
             Ok(self)
         } else {
             Err(Error::Other)

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -1906,6 +1906,38 @@ extern "C" {
     #[doc = " \\internal\n\n Run all registered flow init callbacks."]
     pub fn SCFlowRunFinishCallbacks(tv: *mut ThreadVars, f: *mut Flow);
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct SCFlowStorageId {
+    pub id: ::std::os::raw::c_int,
+}
+extern "C" {
+    pub fn SCFlowStorageSize() -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn SCFlowGetStorageById(h: *const Flow, id: SCFlowStorageId)
+        -> *mut ::std::os::raw::c_void;
+}
+extern "C" {
+    pub fn SCFlowSetStorageById(
+        h: *mut Flow, id: SCFlowStorageId, ptr: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SCFlowFreeStorageById(h: *mut Flow, id: SCFlowStorageId);
+}
+extern "C" {
+    pub fn SCFlowFreeStorage(h: *mut Flow);
+}
+extern "C" {
+    pub fn SCRegisterFlowStorageTests();
+}
+extern "C" {
+    pub fn SCFlowStorageRegister(
+        name: *const ::std::os::raw::c_char,
+        Free: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
+    ) -> SCFlowStorageId;
+}
 #[doc = " \\brief Function type for thread intialization callbacks.\n\n Once registered by SCThreadRegisterInitCallback, this function will\n be called for every thread being initialized during Suricata\n startup.\n\n \\param tv The ThreadVars struct that has just been initialized.\n \\param user The user data provided when registering the callback."]
 pub type SCThreadInitCallbackFn = ::std::option::Option<
     unsafe extern "C" fn(tv: *mut ThreadVars, user: *mut ::std::os::raw::c_void),

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -1787,6 +1787,37 @@ extern "C" {
         f: *const Flow, dir: ::std::os::raw::c_int, id: FrameId, tx_id: u64,
     );
 }
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct SCFlowAddress_ {
+    pub address: SCFlowAddress___bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union SCFlowAddress___bindgen_ty_1 {
+    pub address_un_data32: [u32; 4usize],
+    pub address_un_data16: [u16; 8usize],
+    pub address_un_data8: [u8; 16usize],
+}
+impl Default for SCFlowAddress___bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl Default for SCFlowAddress_ {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type SCFlowAddress = SCFlowAddress_;
 extern "C" {
     pub fn SCFlowGetLastTimeAsParts(flow: *const Flow, secs: *mut u64, usecs: *mut u64);
 }
@@ -1794,10 +1825,31 @@ extern "C" {
     pub fn SCFlowGetFlags(flow: *const Flow) -> u64;
 }
 extern "C" {
+    pub fn SCFlowIsIPv4(flow: *const Flow) -> bool;
+}
+extern "C" {
+    pub fn SCFlowIsIPv6(flow: *const Flow) -> bool;
+}
+extern "C" {
+    pub fn SCFlowGetIPProtocol(flow: *const Flow) -> u8;
+}
+extern "C" {
     pub fn SCFlowGetSourcePort(flow: *const Flow) -> u16;
 }
 extern "C" {
     pub fn SCFlowGetDestinationPort(flow: *const Flow) -> u16;
+}
+extern "C" {
+    pub fn SCFlowGetSourceAddressPtr(flow: *const Flow) -> *const SCFlowAddress;
+}
+extern "C" {
+    pub fn SCFlowGetDestinationAddressPtr(flow: *const Flow) -> *const SCFlowAddress;
+}
+extern "C" {
+    pub fn SCFlowGetToServerPacketCount(flow: *const Flow) -> u32;
+}
+extern "C" {
+    pub fn SCFlowGetToClientPacketCount(flow: *const Flow) -> u32;
 }
 extern "C" {
     pub fn SCFlowGetAppProtocol(f: *const Flow) -> AppProto;

--- a/src/bindgen.h
+++ b/src/bindgen.h
@@ -62,6 +62,7 @@
 
 #include "flow-bindgen.h"
 #include "flow-callbacks.h"
+#include "flow-storage.h"
 
 #include "thread-callbacks.h"
 #include "thread-storage.h"

--- a/src/detect.c
+++ b/src/detect.c
@@ -29,7 +29,6 @@
 #include "decode.h"
 #include "packet.h"
 #include "flow.h"
-#include "flow-bindgen.h"
 #include "stream-tcp.h"
 #include "app-layer.h"
 #include "app-layer-parser.h"

--- a/src/flow-bindgen.h
+++ b/src/flow-bindgen.h
@@ -23,8 +23,13 @@ typedef struct Flow_ Flow;
 
 void SCFlowGetLastTimeAsParts(const Flow *flow, uint64_t *secs, uint64_t *usecs);
 uint64_t SCFlowGetFlags(const Flow *flow);
+bool SCFlowIsIPv4(const Flow *flow);
+bool SCFlowIsIPv6(const Flow *flow);
+uint8_t SCFlowGetIPProtocol(const Flow *flow);
 uint16_t SCFlowGetSourcePort(const Flow *flow);
 uint16_t SCFlowGetDestinationPort(const Flow *flow);
+uint32_t SCFlowGetToServerPacketCount(const Flow *flow);
+uint32_t SCFlowGetToClientPacketCount(const Flow *flow);
 AppProto SCFlowGetAppProtocol(const Flow *f);
 
 #endif /* SURICATA_FLOW_BINDGEN_H */

--- a/src/flow-bindgen.h
+++ b/src/flow-bindgen.h
@@ -21,6 +21,14 @@
 /* forward declaration for macset include */
 typedef struct Flow_ Flow;
 
+typedef struct SCFlowAddress_ {
+    union {
+        uint32_t address_un_data32[4]; /* type-specific field */
+        uint16_t address_un_data16[8]; /* type-specific field */
+        uint8_t address_un_data8[16];  /* type-specific field */
+    } address;
+} SCFlowAddress;
+
 void SCFlowGetLastTimeAsParts(const Flow *flow, uint64_t *secs, uint64_t *usecs);
 uint64_t SCFlowGetFlags(const Flow *flow);
 bool SCFlowIsIPv4(const Flow *flow);
@@ -28,6 +36,8 @@ bool SCFlowIsIPv6(const Flow *flow);
 uint8_t SCFlowGetIPProtocol(const Flow *flow);
 uint16_t SCFlowGetSourcePort(const Flow *flow);
 uint16_t SCFlowGetDestinationPort(const Flow *flow);
+const SCFlowAddress *SCFlowGetSourceAddressPtr(const Flow *flow);
+const SCFlowAddress *SCFlowGetDestinationAddressPtr(const Flow *flow);
 uint32_t SCFlowGetToServerPacketCount(const Flow *flow);
 uint32_t SCFlowGetToClientPacketCount(const Flow *flow);
 AppProto SCFlowGetAppProtocol(const Flow *f);

--- a/src/flow-storage.c
+++ b/src/flow-storage.c
@@ -25,10 +25,7 @@
  * Flow wrapper around storage api
  */
 
-#include "suricata-common.h"
 #include "flow-storage.h"
-#include "flow-hash.h"
-#include "flow-util.h"
 #include "util-storage.h"
 #include "util-unittest.h"
 
@@ -66,6 +63,8 @@ SCFlowStorageId SCFlowStorageRegister(const char *name, void (*Free)(void *))
 }
 
 #ifdef UNITTESTS
+
+#include "flow-util.h"
 
 static void StorageTestFree(void *x)
 {

--- a/src/flow-storage.h
+++ b/src/flow-storage.h
@@ -26,7 +26,9 @@
 #ifndef SURICATA_FLOW_STORAGE_H
 #define SURICATA_FLOW_STORAGE_H
 
+#ifndef SURICATA_BINDGEN_H
 #include "flow.h"
+#endif
 
 typedef struct SCFlowStorageId {
     int id;

--- a/src/flow.c
+++ b/src/flow.c
@@ -1237,6 +1237,30 @@ uint16_t SCFlowGetSourcePort(const Flow *flow)
     return flow->sp;
 }
 
+/**
+ * \brief Return true if the flow is IPv4.
+ */
+bool SCFlowIsIPv4(const Flow *flow)
+{
+    return FLOW_IS_IPV4(flow);
+}
+
+/**
+ * \brief Return true if the flow is IPv6.
+ */
+bool SCFlowIsIPv6(const Flow *flow)
+{
+    return FLOW_IS_IPV6(flow);
+}
+
+/**
+ * \brief Get flow IP protocol.
+ */
+uint8_t SCFlowGetIPProtocol(const Flow *flow)
+{
+    return flow->proto;
+}
+
 AppProto SCFlowGetAppProtocol(const Flow *f)
 {
     return f->alproto;
@@ -1252,6 +1276,22 @@ AppProto SCFlowGetAppProtocol(const Flow *f)
 uint16_t SCFlowGetDestinationPort(const Flow *flow)
 {
     return flow->dp;
+}
+
+/**
+ * \brief Get the number of packets seen toserver.
+ */
+uint32_t SCFlowGetToServerPacketCount(const Flow *flow)
+{
+    return flow->todstpktcnt;
+}
+
+/**
+ * \brief Get the number of packets seen toclient.
+ */
+uint32_t SCFlowGetToClientPacketCount(const Flow *flow)
+{
+    return flow->tosrcpktcnt;
 }
 
 /**

--- a/src/flow.c
+++ b/src/flow.c
@@ -1237,6 +1237,22 @@ uint16_t SCFlowGetSourcePort(const Flow *flow)
 }
 
 /**
+ * \brief Get flow source address.
+ */
+const SCFlowAddress *SCFlowGetSourceAddressPtr(const Flow *flow)
+{
+    return &flow->src;
+}
+
+/**
+ * \brief Get flow destination address.
+ */
+const SCFlowAddress *SCFlowGetDestinationAddressPtr(const Flow *flow)
+{
+    return &flow->dst;
+}
+
+/**
  * \brief Return true if the flow is IPv4.
  */
 bool SCFlowIsIPv4(const Flow *flow)

--- a/src/flow.c
+++ b/src/flow.c
@@ -36,7 +36,6 @@
 #include "util-time.h"
 
 #include "flow.h"
-#include "flow-bindgen.h"
 #include "flow-queue.h"
 #include "flow-hash.h"
 #include "flow-util.h"

--- a/src/flow.h
+++ b/src/flow.h
@@ -35,6 +35,7 @@ typedef struct SCFlowStorageId SCFlowStorageId;
 #include "util-optimize.h"
 #include "util-validate.h"
 #include "app-layer-protos.h"
+#include "flow-bindgen.h"
 
 /* Part of the flow structure, so we declare it here.
  * The actual declaration is in app-layer-parser.c */

--- a/src/flow.h
+++ b/src/flow.h
@@ -314,13 +314,13 @@ typedef struct FlowKey_
     uint16_t vlan_id[VLAN_MAX_LAYERS];
 } FlowKey;
 
-typedef struct FlowAddress_ {
+typedef struct SCFlowAddress_ {
     union {
         uint32_t       address_un_data32[4]; /* type-specific field */
         uint16_t       address_un_data16[8]; /* type-specific field */
         uint8_t        address_un_data8[16]; /* type-specific field */
     } address;
-} FlowAddress;
+} SCFlowAddress;
 
 #define addr_data32 address.address_un_data32
 #define addr_data16 address.address_un_data16
@@ -355,7 +355,7 @@ typedef struct Flow_
 {
     /* flow "header", used for hashing and flow lookup. Static after init,
      * so safe to look at without lock */
-    FlowAddress src, dst;
+    SCFlowAddress src, dst;
     union {
         Port sp;        /**< tcp/udp source port */
         struct {

--- a/src/flow.h
+++ b/src/flow.h
@@ -314,18 +314,6 @@ typedef struct FlowKey_
     uint16_t vlan_id[VLAN_MAX_LAYERS];
 } FlowKey;
 
-typedef struct SCFlowAddress_ {
-    union {
-        uint32_t       address_un_data32[4]; /* type-specific field */
-        uint16_t       address_un_data16[8]; /* type-specific field */
-        uint8_t        address_un_data8[16]; /* type-specific field */
-    } address;
-} SCFlowAddress;
-
-#define addr_data32 address.address_un_data32
-#define addr_data16 address.address_un_data16
-#define addr_data8  address.address_un_data8
-
 typedef unsigned short FlowStateType;
 
 /** Local Thread ID */

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -28,7 +28,6 @@
 #include "packet.h"
 #include "detect.h"
 #include "flow.h"
-#include "flow-bindgen.h"
 #include "conf.h"
 
 #include "stream.h"

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -51,7 +51,7 @@
 
 #include "output-json.h"
 #include "output-json-email-common.h"
-#include "flow-bindgen.h"
+#include "flow.h"
 
 #define LOG_EMAIL_DEFAULT       0
 #define LOG_EMAIL_EXTENDED      (1<<0)

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -66,7 +66,7 @@
 #include "app-layer-htp-xff.h"
 #include "util-memcmp.h"
 #include "stream-tcp-reassemble.h"
-#include "flow-bindgen.h"
+#include "flow.h"
 
 typedef struct OutputFileCtx_ {
     uint32_t file_cnt;


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8599
Ticket: https://redmine.openinfosecfoundation.org/issues/8447
Ticket: https://redmine.openinfosecfoundation.org/issues/8632

Includes https://github.com/OISF/suricata/pull/15541 with changes as my main
motivation was to complete a Rust safe flow struct with accessor methods.

In summary:
- Add flow access methods, update NDPI and example C plugin to use these
- Add Rust flow wrapper, with accessor methods on the wrapper
- Add flow storage bindings to Rust
- Use storage, and flow accessor functions in Rust example plugin

This gets us very close to allowing NDPI plugins in Rust (even they use some C
or a C lib). Packet accessors would be next.
