### PR TITLE
detect/bsize: apply as content depth

### DIFF
--- a/doc/userguide/rules/rule-types.rst
+++ b/doc/userguide/rules/rule-types.rst
@@ -274,6 +274,39 @@ There is a work-in-progress to add information about this to the ``engine-analys
 report (ticket `#7456 <https://redmine.openinfosecfoundation.org/issues/7456>`_).
 
 
+.. _engine-analysis-notes-warnings:
+
+Notes and Warnings
+------------------
+
+When the JSON rule analysis is enabled (``engine-analysis.rules: yes``), each
+rule in ``rules.json`` may carry two optional arrays of free-form strings:
+
+``warnings``
+    Conditions that are likely to make the rule behave in a surprising way, for
+    example a firewall ``packet:filter`` table with no ``accept`` rules, where
+    the default policy will be applied instead.
+
+``notes``
+    Informational hints. These cover both optimizations the engine applied to
+    the rule and suggestions for expressing the rule more efficiently.
+
+Each array is only present when the rule has at least one entry. The strings
+are meant to be self-explanatory; some examples of ``notes`` are:
+
+- ``'within' option for pattern w/o previous content was converted to 'depth'``
+- ``'bsize' on the buffer was applied as a 'depth' to this content`` -- the
+  engine derived a content ``depth`` from a ``bsize`` on the same buffer, so the
+  pattern search is bounded to the buffer length.
+- ``buffer '<name>' pins a single content to the whole buffer with
+  'startswith'/'endswith'; 'bsize:<len>' is an equivalent that also prefilters
+  on length`` -- a suggestion to replace the anchored form with a single
+  ``bsize`` keyword.
+- ``buffer '<name>' uses multiple 'bsize' keywords; a single bsize range
+  (bsize:lo<>hi) expresses a bounded length more clearly`` -- a suggestion to
+  collapse several ``bsize`` keywords on one buffer into one range.
+
+
 Signatures per Type
 -------------------
 

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -50,48 +50,45 @@ static void DetectBsizeRegisterTests (void);
 bool DetectBsizeValidateContentCallback(const Signature *s, const SignatureInitDataBuffer *b)
 {
     uint64_t bsize;
-    int retval = -1;
-    const DetectU64Data *bsz;
-    for (const SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
-        if (sm->type == DETECT_BSIZE) {
-            bsz = (const DetectU64Data *)sm->ctx;
-            retval = SigParseGetMaxBsize(bsz, &bsize);
-            break;
-        }
-    }
-
-    if (retval == -1) {
+    if (!SigBsizeBufferMaxBound(b, &bsize, NULL)) {
         return true;
     }
 
-    uint64_t needed;
-    if (retval == 0) {
-        int len, offset;
-        SigParseRequiredContentSize(s, bsize, b->head, &len, &offset);
-        SCLogDebug("bsize: %" PRIu64 "; len: %d; offset: %d [%s]", bsize, len, offset, s->sig_str);
-        needed = len;
-        if ((uint64_t)len > bsize) {
-            goto value_error;
-        }
-        if ((uint64_t)(len + offset) > bsize) {
-            needed += offset;
-            goto value_error;
-        }
+    int len, offset;
+    SigParseRequiredContentSize(s, bsize, b->head, &len, &offset);
+    SCLogDebug("bsize: %" PRIu64 "; len: %d; offset: %d [%s]", bsize, len, offset, s->sig_str);
+    uint64_t needed = len;
+    if ((uint64_t)len > bsize) {
+        goto value_error;
+    }
+    if ((uint64_t)(len + offset) > bsize) {
+        needed += offset;
+        goto value_error;
     }
 
     return true;
-value_error:
-    if (bsz->mode == DETECT_UINT_RA) {
+value_error: {
+    /* find the bsize that set the tightest bound, to describe it in the error */
+    const DetectU64Data *bsz = NULL;
+    for (const SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
+        uint64_t cur;
+        if (sm->type == DETECT_BSIZE &&
+                SigParseGetMaxBsize((const DetectU64Data *)sm->ctx, &cur) == 0 && cur == bsize) {
+            bsz = (const DetectU64Data *)sm->ctx;
+            break;
+        }
+    }
+    if (bsz != NULL && bsz->mode == DETECT_UINT_RA) {
         SCLogError("signature can't match as required content length %" PRIu64
                    " exceeds bsize range: %" PRIu64 "-%" PRIu64,
                 needed, bsz->arg1, bsz->arg2);
     } else {
         SCLogError("signature can't match as required content length %" PRIu64
-                   " exceeds bsize value: "
-                   "%" PRIu64,
-                needed, bsz->arg1);
+                   " exceeds bsize value: %" PRIu64,
+                needed, bsz != NULL ? bsz->arg1 : bsize);
     }
     return false;
+}
 }
 
 /**

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2022 Open Information Security Foundation
+/* Copyright (C) 2017-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -42,6 +42,7 @@
 static int DetectBsizeSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectBsizeFree (DetectEngineCtx *, void *);
 static int SigParseGetMaxBsize(const DetectU64Data *bsz, uint64_t *bsize);
+static bool SigBsizeBufferMaxBound(const SignatureInitDataBuffer *b, uint64_t *bound, bool *exact);
 #ifdef UNITTESTS
 static void DetectBsizeRegisterTests (void);
 #endif
@@ -175,6 +176,117 @@ static int SigParseGetMaxBsize(const DetectU64Data *bsz, uint64_t *bsize)
             SCReturnInt(-2);
     }
     SCReturnInt(-1);
+}
+
+/**
+ * \brief find the tightest usable bsize upper bound for a buffer
+ *
+ * A buffer may carry more than one bsize; the buffer must satisfy them all, so
+ * the tightest (smallest) usable upper bound applies. bsize:>N yields no upper
+ * bound and is ignored.
+ *
+ * \param b buffer to scan
+ * \param bound set to the smallest usable upper bound on success
+ * \param exact if non-NULL, set to true when that bound comes from an exact
+ *              bsize (bsize:N)
+ * \retval true a usable upper bound was found
+ * \retval false no bsize with a usable upper bound (e.g. only bsize:>N)
+ */
+static bool SigBsizeBufferMaxBound(const SignatureInitDataBuffer *b, uint64_t *bound, bool *exact)
+{
+    uint64_t b_min = UINT64_MAX;
+    bool found = false;
+    bool is_exact = false;
+    for (const SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
+        if (sm->type != DETECT_BSIZE)
+            continue;
+
+        const DetectU64Data *bsz = (const DetectU64Data *)sm->ctx;
+        uint64_t cur;
+        if (SigParseGetMaxBsize(bsz, &cur) != 0)
+            continue;
+        if (cur < b_min) {
+            b_min = cur;
+            is_exact = (bsz->mode == DETECT_UINT_EQ);
+        }
+        found = true;
+    }
+
+    if (!found)
+        return false;
+
+    *bound = b_min;
+    if (exact != NULL)
+        *exact = is_exact;
+    return true;
+}
+
+/**
+ * \brief apply each buffer's bsize upper bound to its content matches
+ *
+ * When a buffer carries a bsize keyword that yields a usable upper bound
+ * (bsize:N, bsize:<N or bsize:N<>M), every content in that buffer can be
+ * constrained to that depth: the content can't match beyond the end of the
+ * buffer, and the buffer is at most \c bsize bytes long. This lets the mpm and
+ * content inspection bound their search instead of scanning the whole buffer,
+ * mirroring the dsize and urilen optimizations.
+ *
+ * As a stronger case, when an exact bsize (bsize:N) equals the length of a lone
+ * content in the buffer, that content must span the whole buffer: it both
+ * starts and ends it. Mark it startswith/endswith so the mpm anchoring and the
+ * endswith inspection short-circuit apply, as Victor described in #4226.
+ *
+ * \param s signature whose buffers are processed
+ */
+void DetectBsizeApplyToContent(const Signature *s)
+{
+    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
+        const SignatureInitDataBuffer *b = &s->init_data->buffers[x];
+
+        uint64_t bsize;
+        bool exact;
+        if (!SigBsizeBufferMaxBound(b, &bsize, &exact))
+            continue;
+
+        /* depth is a uint16_t; a larger bound can't be expressed as a depth */
+        if (bsize > UINT16_MAX)
+            continue;
+
+        uint32_t content_cnt = 0;
+        DetectContentData *single = NULL;
+        for (SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
+            if (sm->type != DETECT_CONTENT)
+                continue;
+
+            DetectContentData *cd = (DetectContentData *)sm->ctx;
+            if (cd == NULL)
+                continue;
+
+            content_cnt++;
+            single = cd;
+
+            if (cd->depth == 0 || cd->depth > (uint16_t)bsize) {
+                cd->depth = (uint16_t)bsize;
+                cd->flags |= DETECT_CONTENT_DEPTH;
+                cd->flags |= DETECT_CONTENT_BSIZE2DEPTH;
+                SCLogDebug("updated %u, content %u to have depth %u because of bsize.", s->id,
+                        cd->id, cd->depth);
+            }
+        }
+
+        /* exact bsize matching a lone content's length: the content fills the
+         * buffer, so it starts and ends it. Skip if the content is anchored
+         * elsewhere or negated, where that doesn't hold. */
+        if (content_cnt == 1 && exact && single->content_len == (uint16_t)bsize &&
+                (single->flags & (DETECT_CONTENT_OFFSET | DETECT_CONTENT_DISTANCE |
+                                         DETECT_CONTENT_WITHIN | DETECT_CONTENT_NEGATED)) == 0) {
+            single->depth = single->content_len;
+            single->flags |=
+                    DETECT_CONTENT_DEPTH | DETECT_CONTENT_STARTS_WITH | DETECT_CONTENT_ENDS_WITH;
+            SCLogDebug("updated %u, content %u to startswith/endswith because of exact bsize %u.",
+                    s->id, single->id, (uint16_t)bsize);
+        }
+    }
 }
 
 /**

--- a/src/detect-bsize.h
+++ b/src/detect-bsize.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2023 Open Information Security Foundation
+/* Copyright (C) 2017-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -27,5 +27,6 @@
 void DetectBsizeRegister(void);
 int DetectBsizeMatch(const SigMatchCtx *ctx, const uint64_t buffer_size, bool eof);
 bool DetectBsizeValidateContentCallback(const Signature *s, const SignatureInitDataBuffer *);
+void DetectBsizeApplyToContent(const Signature *s);
 
 #endif /* SURICATA_DETECT_BSIZE_H */

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -61,6 +61,7 @@
 #define DETECT_CONTENT_MPM              BIT_U32(20)
 #define DETECT_CONTENT_WITHIN2DEPTH     BIT_U32(21)
 #define DETECT_CONTENT_DISTANCE2OFFSET  BIT_U32(22)
+#define DETECT_CONTENT_BSIZE2DEPTH      BIT_U32(23)
 
 /** a relative match to this content is next, used in matching phase */
 #define DETECT_CONTENT_RELATIVE_NEXT    (DETECT_CONTENT_WITHIN_NEXT|DETECT_CONTENT_DISTANCE_NEXT)

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2025 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -767,6 +767,10 @@ static void DumpMatches(RuleAnalyzer *ctx, SCJsonBuilder *js, const SigMatchData
                 if (cd->flags & DETECT_CONTENT_DISTANCE2OFFSET) {
                     AnalyzerNote(ctx, (char *)"'distance' option for pattern w/o previous content "
                                               "was converted to 'offset'");
+                }
+                if (cd->flags & DETECT_CONTENT_BSIZE2DEPTH) {
+                    AnalyzerNote(ctx, (char *)"'bsize' on the buffer was applied as a 'depth' to "
+                                              "this content");
                 }
                 SCJbClose(js);
                 break;

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1108,6 +1108,56 @@ static void DumpMatches(RuleAnalyzer *ctx, SCJsonBuilder *js, const SigMatchData
     SCJbClose(js);
 }
 
+/**
+ * \brief suggest 'bsize' where a buffer is already pinned to an exact length
+ *
+ * A single content marked both 'startswith' and 'endswith' must span the whole
+ * buffer, so its length is fixed at the content length. ('endswith' also covers
+ * the 'isdataat:!1,relative' form, which the parser folds into the same flag.)
+ * 'bsize:<len>' expresses that in one keyword and lets the engine prefilter on
+ * buffer length. This is a high-signal hint: it only fires when the rule has
+ * already encoded a fixed length the long way.
+ */
+static void AnalyzerSuggestBsize(RuleAnalyzer *ctx, const char *buffer, const SigMatchData *smd)
+{
+    if (smd == NULL)
+        return;
+
+    uint32_t content_cnt = 0;
+    uint32_t bsize_cnt = 0;
+    const DetectContentData *cd = NULL;
+    for (const SigMatchData *smv = smd;; smv++) {
+        if (smv->type == DETECT_CONTENT) {
+            content_cnt++;
+            cd = (const DetectContentData *)smv->ctx;
+        } else if (smv->type == DETECT_BSIZE) {
+            bsize_cnt++;
+        }
+        if (smv->is_last)
+            break;
+    }
+
+    if (bsize_cnt > 1) {
+        AnalyzerNote(ctx,
+                (char *)"buffer '%s' uses multiple 'bsize' keywords; a single bsize range "
+                        "(bsize:lo<>hi) expresses a bounded length more clearly",
+                buffer);
+    }
+
+    if (content_cnt != 1 || bsize_cnt != 0 || cd == NULL)
+        return;
+
+    const uint32_t anchored = DETECT_CONTENT_STARTS_WITH | DETECT_CONTENT_ENDS_WITH;
+    if ((cd->flags & anchored) != anchored)
+        return;
+
+    AnalyzerNote(ctx,
+            (char *)"buffer '%s' pins a single content to the whole buffer with "
+                    "'startswith'/'endswith'; 'bsize:%u' is an equivalent that also prefilters on "
+                    "length",
+            buffer, cd->content_len);
+}
+
 SCMutex g_rules_analyzer_write_m = SCMUTEX_INITIALIZER;
 void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
 {
@@ -1457,6 +1507,8 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
             }
             DumpMatches(&ctx, ctx.js, app->smd);
             SCJbClose(ctx.js);
+            if (app->sm_list != DETECT_SM_LIST_PMATCH && app->v2.transforms == NULL)
+                AnalyzerSuggestBsize(&ctx, name, app->smd);
             if (app->mpm) {
                 app_mpm = app;
             }

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2025 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -33,6 +33,7 @@
 #include "detect-engine-threshold.h"
 
 #include "detect-dsize.h"
+#include "detect-bsize.h"
 #include "detect-tcp-flags.h"
 #include "detect-flow.h"
 #include "detect-config.h"
@@ -1858,6 +1859,7 @@ int SigPrepareStage1(DetectEngineCtx *de_ctx)
         SignatureCreateMask(s);
         DetectContentPropagateLimits(s);
         SigParseApplyDsizeToContent(s);
+        DetectBsizeApplyToContent(s);
 
         RuleSetScore(s);
 


### PR DESCRIPTION
Continuation of #15596

Optimize content checks by using `bsize` as an upper bound, similar to what `dsize` and `urilen` do. This will improve performance on large buffers. Small buffers will see less, if any, performance boost.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/4226

Performance varies 
Describe changes:
-Use `bsize` as an upper bound and apply it as a `depth` so inspection is bounded.
- Have engine-analysis suggest `bsize` values when it can reliably do so.
- Extend documentation with the engine-analysis recommendation.

Updates
- When `--strict-rule-keywords` is used, the usage of mult. bsize keywords on a single buffer are rejected.
- Address review comments from #15996

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3155

## Benchmark: `bsize` applied as content `depth`

Measured with a standalone profiling harness (paired rules: each scenario has a `bsize`-form rule and the hand-written equivalent), run over three captures. Reproduction kit (script + synthetic pcap) attached separately.

**Definitions**

- **base** — Suricata `master` (no `bsize`-as-depth optimization).
- **opt** — this branch (`bsize` upper bound applied as content `depth`; for an exact `bsize` equal to a lone content's length, the content is also marked `startswith`+`endswith`).
- **anchored** — the hand-written equivalent that pins the content to the buffer with `startswith; endswith` (what the optimization derives automatically for the exact case).
- **plain** — the same content with no length constraint at all (a floating match).
- **cost ratio** — the profiled cost of the `bsize`-form rule ÷ the cost of its hand-written equivalent, computed *within the same run*. `~1.0` means the `bsize` rule reached parity with the manual form; `>1.0` means it is still paying extra. The within-run ratio cancels run-to-run and cross-binary tick noise.
- **check counts** — how often each `bsize` rule is evaluated. A drop from base to opt means the depth bound made the MPM prefilter more selective, so the rule runs less often.

### 1. Synthetic capture (uniform bodies — isolates the anchoring path)

| scenario (cost ratio, ~1.0 == parity) | base | opt |
|---|--:|--:|
| A  file.data (large)   bsize/depth | 1.44 | 1.51 |
| B  user_agent (small)  bsize/depth | 1.40 | 1.45 |
| C  http.method (exact) bsize/anchored | 2.00 | 2.45 |
| D  http.uri (exact)    bsize/anchored | 2.42 | 1.35 |
| D  http.uri (exact)    bsize/plain | 1.77 | 0.90 |

| bsize-rule check counts (rule evaluations) | base | opt |
|---|--:|--:|
| A  file.data (large)   bsize | 100 | 100 |
| B  user_agent (small)  bsize | 200 | 200 |
| C  http.method (exact) bsize | 100 | 100 |
| D  http.uri (exact)    bsize | 300 | 300 |

### 2. `smallFlows.pcap` (real mixed traffic, ~9 MB)

| scenario (cost ratio, ~1.0 == parity) | base | opt |
|---|--:|--:|
| A  file.data (large)   bsize/depth | 2.27 | 0.93 |
| B  user_agent (small)  bsize/depth | 1.54 | 1.55 |
| C  http.method (exact) bsize/anchored | 1.78 | 2.00 |
| D  http.uri (exact)    bsize/anchored | 2.04 | 1.15 |
| D  http.uri (exact)    bsize/plain | 1.56 | 0.81 |

| bsize-rule check counts (rule evaluations) | base | opt |
|---|--:|--:|
| A  file.data (large)   bsize | 699 | 396 |
| B  user_agent (small)  bsize | 525 | 525 |
| C  http.method (exact) bsize | 533 | 533 |
| D  http.uri (exact)    bsize | 544 | 544 |

### 3. `bigFlows.pcap` (real mixed traffic, ~368 MB)

| scenario (cost ratio, ~1.0 == parity) | base | opt |
|---|--:|--:|
| A  file.data (large)   bsize/depth | 2.56 | 1.17 |
| B  user_agent (small)  bsize/depth | 1.62 | 1.66 |
| C  http.method (exact) bsize/anchored | 1.90 | 2.05 |
| D  http.uri (exact)    bsize/anchored | 2.15 | 1.16 |
| D  http.uri (exact)    bsize/plain | 1.54 | 0.79 |

| bsize-rule check counts (rule evaluations) | base | opt |
|---|--:|--:|
| A  file.data (large)   bsize | 7006 | 3759 |
| B  user_agent (small)  bsize | 6403 | 6403 |
| C  http.method (exact) bsize | 6414 | 6414 |
| D  http.uri (exact)    bsize | 6603 | 6603 |

### Reading the results

The **anchoring win (D)** reproduces on every capture: the `bsize`-form rule drops from ~2x the cost of the manually-anchored equivalent to ~1.15x, and to *cheaper than* an unconstrained content (0.79–0.90x of plain).

The **`file.data` depth win (A)** is prefilter-driven and only shows on realistic traffic. On the synthetic capture the bodies are uniform, so the fast-pattern can't become more selective and A is flat (check counts identical, 100/100). On real traffic the depth bound roughly halves how often the rule is evaluated — smallFlows 699→396 (ratio 2.27→0.93), bigFlows 7006→3759 (ratio 2.56→1.17).

**B** (small `user_agent`) and **C** (fixed-length `http.method`) are flat by design: the buffer is tiny or always equals the pinned length, so neither the depth bound nor the `endswith` short-circuit has room to help. Their check counts are unchanged.

#### 
* bigFlows.pcap too large to attach

[bsize-bench.pcap.gz](https://github.com/user-attachments/files/29097874/bsize-bench.pcap.gz)
[bsize-bench.rules.gz](https://github.com/user-attachments/files/29097875/bsize-bench.rules.gz)
[smallFlows.pcap.gz](https://github.com/user-attachments/files/29097876/smallFlows.pcap.gz)
