### PR TITLE
Revert "af-packet: speed up thread sync during startup"

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -607,7 +607,7 @@ void TmModuleDecodeAFPRegister (void)
     tmm_modules[TMM_DECODEAFP].flags = TM_FLAG_DECODE_TM;
 }
 
-static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose, const bool peer_update);
+static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose);
 
 static inline void AFPDumpCounters(AFPThreadVars *ptv)
 {
@@ -1282,7 +1282,7 @@ static int AFPTryReopen(AFPThreadVars *ptv)
     /* ref cnt 0, we can close the old socket */
     AFPCloseSocket(ptv);
 
-    int afp_activate_r = AFPCreateSocket(ptv, ptv->iface, 0, false);
+    int afp_activate_r = AFPCreateSocket(ptv, ptv->iface, 0);
     if (afp_activate_r != 0) {
         if (ptv->down_count % AFP_DOWN_COUNTER_INTERVAL == 0) {
             SCLogWarning("%s: can't reopen interface", ptv->iface);
@@ -1326,7 +1326,7 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
                 break;
             }
         }
-        r = AFPCreateSocket(ptv, ptv->iface, 1, true);
+        r = AFPCreateSocket(ptv, ptv->iface, 1);
         if (r < 0) {
             switch (-r) {
                 case AFP_FATAL_ERROR:
@@ -1337,6 +1337,7 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
                             "%s: failed to init socket for interface, retrying soon", ptv->iface);
             }
         }
+        AFPPeersListReachedInc();
     }
     if (ptv->afp_state == AFP_STATE_UP) {
         SCLogDebug("Thread %s using socket %d", tv->name, ptv->socket);
@@ -1938,8 +1939,7 @@ static TmEcode SetEbpfFilter(AFPThreadVars *ptv)
 }
 #endif
 
-/** \param peer_update increment peers reached */
-static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose, const bool peer_update)
+static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
 {
     int r;
     int ret = AFP_FATAL_ERROR;
@@ -2064,10 +2064,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose, const
         }
     }
 #endif
-    /* bind() done, allow next thread to continue */
-    if (peer_update) {
-        AFPPeersListReachedInc();
-    }
+
     ret = AFPSetupRing(ptv, devname);
     if (ret != 0)
         goto socket_err;


### PR DESCRIPTION
This reverts commit 923ad6af7709c9eca6f0f5856ee267845b425ae5.

Several issues have been reported:

1. non-deterministic thread to queue mapping (privately reported)

2. race condition causing IPS mode to loose packets, or get stuck completely, ticket 8667.

Ticket: #8667.
(cherry picked from commit 2b19f86ee6b8962d32ced4acd7d81dc6fb4d22d8)

