### PR TITLE
docs: allow enabling dark mode for RtD - v1

### DIFF
--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -40,6 +40,9 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # ones.
 extensions = []
 
+# Allow users to switch to dark mode
+default_dark_mode = False
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/doc/userguide/requirements.txt
+++ b/doc/userguide/requirements.txt
@@ -1,1 +1,2 @@
 sphinx_rtd_theme
+sphinx_rtd_dark_mode


### PR DESCRIPTION
Add option to enable dark mode for Read the Docs.
Keeping light mode as default, since that's what we have now.

The place where the user changes it is a bit... obfuscated by the versions menu. But it's there 😅 

Docs built: https://suri-rtd-test.readthedocs.io/en/dark-docs-v1/

<img width="371" height="272" alt="image" src="https://github.com/user-attachments/assets/76c6e9c8-5a5c-43de-b867-7069d78873f1" />

<img width="1916" height="995" alt="image" src="https://github.com/user-attachments/assets/ff5f633c-9a7f-4ad0-ad32-472e4b8227b5" />
