### PR TITLE
fuzz: forbid usage of pcre with \X backport8

### DIFF
--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -708,6 +708,21 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
     if (capture_names == NULL || strlen(capture_names) == 0)
         opts |= PCRE2_NO_AUTO_CAPTURE;
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    // forbid use of \X Unicode extended grapheme cluster as slow
+    bool escape = false;
+    for (size_t i = 0; i < strlen(re); i++) {
+        if (escape) {
+            if (re[i] == 'X') {
+                goto error;
+            }
+            escape = false;
+        } else if (re[i] == '\\') {
+            escape = true;
+        }
+    }
+
+#endif
     pd->parse_regex.regex =
             pcre2_compile((PCRE2_SPTR8)re, PCRE2_ZERO_TERMINATED, opts, &en, &eo2, NULL);
     if (pd->parse_regex.regex == NULL && en == 115) { // reference to nonexistent subpattern


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8634

Describe changes:
- backport of #15651, clean cherry-pick