### PR TITLE
decode/ipv6: bound hop-by-hop option to the option area

### DIFF
--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -304,8 +304,10 @@ static void DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, 
                     /* length field for each opt */
                     uint8_t ip6_optlen = *(ptr + 1);
 
-                    /* see if the optlen from the packet fits the total optslen */
-                    if ((offset + 1 + ip6_optlen) > optslen) {
+                    /* see if the optlen from the packet fits the total optslen.
+                     * the option occupies 2 header bytes (type + len) plus
+                     * ip6_optlen data bytes, so its data must end within optslen. */
+                    if ((offset + 2 + ip6_optlen) > optslen) {
                         ENGINE_SET_INVALID_EVENT(p, IPV6_EXTHDR_INVALID_OPTLEN);
                         break;
                     }


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in doc/userguide/) to reflect the changes made
- [ ] I have updated the JSON schema (in etc/schema.json) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:

The TLV loop for IPv6 hop-by-hop and destination option headers gates each option on `(offset + 1 + ip6_optlen) > optslen`. An option is two header bytes (type, length) plus `ip6_optlen` data bytes, so the value ends at `offset + 1 + ip6_optlen` and the bound has to be `offset + 2 + ip6_optlen`. Before: an option that declares its data running one byte past the option area is accepted, and the Router Alert / Jumbo / Home Address `memcpy` then copies `sizeof(value)` bytes ending one byte past the area; when the header sits at the tail of the IPv6 payload that read goes past the payload.

After: the option is rejected with `IPV6_EXTHDR_INVALID_OPTLEN`, matching how the IPv4 option loop already bounds a full option against the remaining length. The check stays next to the read so each option type does not need its own guard. Added `DecodeIPV6HopOptLenTest01`, which fails on the current tree and passes with this change.
