### PR TITLE
doc: requirements for rtd aren't changed - v2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
 
 python:
   install:
-    - requirements: doc/userguide/bundle.txt
+    - requirements: doc/userguide/requirements.txt
 
 sphinx:
   builder: html


### PR DESCRIPTION
Python's naming conflict shouldn't affect the read the docs requirements file, so don't rename that one.

Previous PR: #15692 

Changes: don't change read the docs' requirements file -- thus, last PR's changes are not needed.

Built docs: https://suri-rtd-test.readthedocs.io/en/fix-docs-requirements-v2/