### PR TITLE
detect: use only one non-prefilter frame for prefilter

### DIFF
--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -1023,6 +1023,12 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
                     tx_non_pf = true;
                 }
             }
+            if (frame_non_pf) {
+                // we found a frame, do not look for other buffers
+                // which may include the same frame + transform
+                // but we only want 1 per signature
+                break;
+            }
         }
         /* handle hook only rules */
         if (!tx_non_pf && s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8590

Describe changes:
- detect: use only one non-prefilter frame for prefilter

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3179
