### PR TITLE
Xdp tunnel 7674 v17

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2959,7 +2959,7 @@ jobs:
       - uses: ./.github/actions/install-cbindgen
       - run: tar xf prep/suricata-verify.tar.gz
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
+      - run: CFLAGS="${DEFAULT_CFLAGS} -DAFPACKET_TEST_REPLAY" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
       - run: make -j ${{ env.CPUS }}
       - run: make check
       - name: Running suricata-verify

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2895,6 +2895,79 @@ jobs:
       # DPDK configuration checks
       - run: ./qa/live/dpdk/dpdk-testsuite.sh
 
+  ubuntu-xdp:
+    name: Ubuntu (xdp)
+    runs-on: ubuntu-latest
+    needs: [prepare-deps]
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
+      - run: sudo apt update
+      - run: |
+          sudo apt -y install \
+              autoconf \
+              automake \
+              build-essential \
+              cmake \
+              curl \
+              git \
+              hwloc \
+              libhwloc-dev \
+              jq \
+              make \
+              libpcre3 \
+              libpcre3-dbg \
+              libpcre3-dev \
+              libpcre2-dev \
+              libtool \
+              libpcap-dev \
+              libnet1-dev \
+              libyaml-0-2 \
+              libyaml-dev \
+              libcap-ng-dev \
+              libcap-ng0 \
+              libjansson-dev \
+              libjansson4 \
+              libnuma-dev \
+              liblz4-dev \
+              libssl-dev \
+              pkg-config \
+              python3 \
+              python3-yaml \
+              tcpreplay \
+              zlib1g \
+              zlib1g-dev \
+              clang \
+              libxdp-dev
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: prep
+          path: prep
+      - name: Install Rust
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $(grep rust-version rust/Cargo.toml.in|sed 's/\"//g'|awk '{print $3}') -y
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: ./autogen.sh
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
+      - run: make -j ${{ env.CPUS }}
+      - run: make check
+      - name: Running suricata-verify
+        run: python3 ./suricata-verify/run.py -q --debug-failed
+      - run: ulimit -a
+      - name: Running suricata-verify live tests
+        run: sudo python3 ./suricata-verify/run.py --live --debug-failed
+
   debian-12:
     name: Debian 12 (xdp)
     runs-on: ubuntu-latest

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -3095,6 +3095,26 @@ default.
 Using this default setting, flows will be associated only if the compared packet
 headers are encapsulated in the same number of headers.
 
+Tunnels
+~~~~~~~
+
+If your packets sources are multiple tunnels encapsulating the traffic,
+you can configure the ``decoder.tunnels`` section to assign a tunnel
+identifier to each of these tunnels.
+
+These tunnel identifiers are used in flow hashing to be able to distinguish
+the same-looking flow (same 5-tuple) from different tunnels, meaning it
+is in fact a different subnetwork (like a VLAN identifier).
+
+This section is a list of tunnels with the following parameters:
+::
+
+    - id: 1
+      type: erspan2 # or vxlan
+      src: 192.168.1.1
+      dst: 192.168.1.3
+      session: 123 # erspan span id or vxlan vni
+
 Advanced Options
 ----------------
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -3115,6 +3115,10 @@ This section is a list of tunnels with the following parameters:
       dst: 192.168.1.3
       session: 123 # erspan span id or vxlan vni
 
+It is also recommended to define ``decoder.tunnels-ifaces`` list of interfaces
+receiving tunneled traffic. The traffic received on these interfaces that do
+not belong to a defined tunnel will be skipped.
+
 Advanced Options
 ----------------
 

--- a/ebpf/xdp_filter.c
+++ b/ebpf/xdp_filter.c
@@ -23,6 +23,10 @@
 #include <linux/if_ether.h>
 #include <linux/if_packet.h>
 #include <linux/if_vlan.h>
+/* Workaround to avoid the need of 32bit headers */
+#define _LINUX_IF_H
+#define IFNAMSIZ 16
+#include <linux/if_tunnel.h>
 #include <linux/ip.h>
 #include <linux/ipv6.h>
 #include <linux/tcp.h>
@@ -66,6 +70,13 @@ struct vlan_hdr {
     __u16	h_vlan_encapsulated_proto;
 };
 
+struct flowtunnel_keys {
+    __u32 src;
+    __u32 dst;
+    __u32 session : 24;
+    __u8 tunnel : 8;
+};
+
 struct flowv4_keys {
     __u32 src;
     __u32 dst;
@@ -75,7 +86,8 @@ struct flowv4_keys {
     };
     __u8 ip_proto:1;
     __u16 vlan0:15;
-    __u16 vlan1;
+    __u8 tunnel : 1;
+    __u16 vlan1_or_tunnel_id : 15;
 };
 
 struct flowv6_keys {
@@ -87,13 +99,29 @@ struct flowv6_keys {
     };
     __u8 ip_proto:1;
     __u16 vlan0:15;
-    __u16 vlan1;
+    __u8 tunnel : 1;
+    __u16 vlan1_or_tunnel_id : 15;
 };
 
 struct pair {
     __u64 packets;
     __u64 bytes;
 };
+
+struct flowtunnel_id {
+    __u16 tunnel_id;
+};
+
+struct {
+#if USE_PERCPU_HASH
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+#else
+    __uint(type, BPF_MAP_TYPE_HASH);
+#endif
+    __type(key, struct flowtunnel_keys);
+    __type(value, struct flowtunnel_id);
+    __uint(max_entries, 256);
+} flow_table_tunnels SEC(".maps");
 
 struct {
 #if USE_PERCPU_HASH
@@ -232,7 +260,8 @@ static __always_inline int get_dport(void *trans_data, void *data_end,
     }
 }
 
-static int __always_inline filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, __u16 vlan0, __u16 vlan1)
+static int __always_inline filter_ipv4_final(
+        struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, __u16 vlan0, __u16 vlan1)
 {
     struct iphdr *iph = data + nh_off;
     int dport;
@@ -280,7 +309,8 @@ static int __always_inline filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_
     tuple.port16[1] = (__u16)dport;
 
     tuple.vlan0 = vlan0;
-    tuple.vlan1 = vlan1;
+    tuple.tunnel = (vlan1 & 0x8000) != 0;
+    tuple.vlan1_or_tunnel_id = vlan1 & 0x7FFF;
 
     value = bpf_map_lookup_elem(&flow_table_v4, &tuple);
 #if 0
@@ -421,7 +451,8 @@ static int __always_inline filter_ipv6(struct xdp_md *ctx, void *data, __u64 nh_
     tuple.port16[1] = dport;
 
     tuple.vlan0 = vlan0;
-    tuple.vlan1 = vlan1;
+    tuple.tunnel = (vlan1 & 0x8000) != 0;
+    tuple.vlan1_or_tunnel_id = vlan1 & 0x7FFF;
 
     value = bpf_map_lookup_elem(&flow_table_v6, &tuple);
     if (value) {
@@ -480,6 +511,130 @@ static int __always_inline filter_ipv6(struct xdp_md *ctx, void *data, __u64 nh_
 
     return XDP_PASS;
 #endif
+}
+
+static int __always_inline filter_erspan(
+        struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, struct iphdr *iph)
+{
+    struct erspan_hdr {
+        __be16 ver_vlan;
+        __be16 flags_spanid;
+        __be32 padding;
+    };
+    __u16 vlan0 = 0;
+    __u16 vlan1 = 0;
+    struct flowtunnel_keys tuple;
+    __u16 h_proto;
+    __u16 flags_spanid;
+    struct flowtunnel_id *value;
+
+    struct erspan_hdr *erhdr = (struct erspan_hdr *)(data + nh_off);
+    if ((void *)(erhdr + 1) > data_end)
+        return XDP_PASS;
+
+    if ((erhdr->ver_vlan & 0xF0) != 0x10) {
+        // only handle ERSPAN 2
+        return XDP_PASS;
+    }
+    flags_spanid = erhdr->flags_spanid;
+    if ((flags_spanid & 0x1800) == 0x800) {
+        // do not handle ISL encapsulated
+        return XDP_PASS;
+    }
+
+    tuple.tunnel = 1; // DECODE_TUNNEL_ERSPANII
+    tuple.src = iph->saddr;
+    tuple.dst = iph->daddr;
+    tuple.session = flags_spanid & 0x3FF;
+    value = bpf_map_lookup_elem(&flow_table_tunnels, &tuple);
+    if (!value) {
+        // unknown tunnel
+        return XDP_PASS;
+    }
+    vlan1 = 0x8000 | value->tunnel_id;
+
+    nh_off += 8;
+    if (data + nh_off + sizeof(struct ethhdr) > data_end)
+        return XDP_PASS;
+
+    struct ethhdr *eth = data + nh_off;
+    nh_off += sizeof(*eth);
+
+    h_proto = eth->h_proto;
+
+#if VLAN_TRACKING
+    if ((flags_spanid & 0x1800) == 0x1000) {
+        vlan0 = erhdr->ver_vlan & 0xFFF;
+    }
+#endif
+    if ((flags_spanid & 0x1800) == 0x1800 && (h_proto == __constant_htons(ETH_P_8021Q) ||
+                                                     h_proto == __constant_htons(ETH_P_8021AD))) {
+        struct vlan_hdr *vhdr;
+
+        if (data + nh_off + sizeof(struct vlan_hdr) > data_end)
+            return XDP_PASS;
+        vhdr = data + nh_off;
+        nh_off += sizeof(struct vlan_hdr);
+        h_proto = vhdr->h_vlan_encapsulated_proto;
+#if VLAN_TRACKING
+        vlan0 = vhdr->h_vlan_TCI & 0x0fff;
+#endif
+    }
+    if (h_proto == __constant_htons(ETH_P_IP))
+        return filter_ipv4_final(ctx, data, nh_off, data_end, vlan0, vlan1);
+    else if (h_proto == __constant_htons(ETH_P_IPV6))
+        return filter_ipv6(ctx, data, nh_off, data_end, vlan0, vlan1);
+    return XDP_PASS;
+}
+
+static int __always_inline filter_gre(
+        struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, struct iphdr *iph)
+{
+    struct gre_hdr {
+        __be16 flags;
+        __be16 proto;
+    };
+    __u16 proto;
+
+    struct gre_hdr *grhdr = (struct gre_hdr *)(data + nh_off);
+
+    if ((void *)(grhdr + 1) > data_end)
+        return XDP_PASS;
+
+    // only GRE version 0 without routing
+    if (grhdr->flags & (GRE_VERSION | GRE_ROUTING))
+        return XDP_PASS;
+
+    nh_off += 4;
+    if (grhdr->flags & GRE_CSUM)
+        nh_off += 4;
+    if (grhdr->flags & GRE_KEY)
+        nh_off += 4;
+    if (grhdr->flags & GRE_SEQ)
+        nh_off += 4;
+    if (data + nh_off > data_end)
+        return XDP_PASS;
+
+    proto = grhdr->proto;
+    // only handle erspan over gre
+    if (proto == __constant_htons(ETH_P_ERSPAN)) {
+        return filter_erspan(ctx, data, nh_off, data_end, iph);
+    }
+    return XDP_PASS;
+}
+
+static int __always_inline filter_ipv4(
+        struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, __u16 vlan0, __u16 vlan1)
+{
+    struct iphdr *iph = data + nh_off;
+    if ((void *)(iph + 1) > data_end)
+        return XDP_PASS;
+
+    if (iph->protocol == IPPROTO_GRE) {
+        nh_off += sizeof(struct iphdr);
+        return filter_gre(ctx, data, nh_off, data_end, iph);
+    }
+    return filter_ipv4_final(ctx, data, nh_off, data_end, vlan0, vlan1);
 }
 
 int SEC("xdp") xdp_hashfilter(struct xdp_md *ctx)

--- a/ebpf/xdp_filter.c
+++ b/ebpf/xdp_filter.c
@@ -65,6 +65,9 @@
  * also be used as workaround of some hardware offload issue */
 #define VLAN_TRACKING    1
 
+/* vxlan port configurable */
+#define VXLAN_PORT 4789
+
 struct vlan_hdr {
     __u16	h_vlan_TCI;
     __u16	h_vlan_encapsulated_proto;
@@ -623,6 +626,92 @@ static int __always_inline filter_gre(
     return XDP_PASS;
 }
 
+struct vxlanhdr {
+    __be16 flags;
+    __be16 gdp;
+    __u8 vni0;
+    __u8 vni1;
+    __u8 vni2;
+    __u8 res;
+};
+
+static int __always_inline filter_vxlan(
+        struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, struct iphdr *iph)
+{
+    __u16 vlan0 = 0;
+    __u16 vlan1;
+    __u16 h_proto;
+    struct flowtunnel_keys tuple;
+    struct flowtunnel_id *value;
+
+    struct vxlanhdr *vh = (struct vxlanhdr *)(data + nh_off);
+
+    tuple.tunnel = 3; // DECODE_TUNNEL_VXLAN
+    tuple.src = iph->saddr;
+    tuple.dst = iph->daddr;
+    tuple.session = vh->vni2 | (vh->vni1 << 8) | (vh->vni0 << 16);
+    value = bpf_map_lookup_elem(&flow_table_tunnels, &tuple);
+    if (!value) {
+        // unknown tunnel
+        return XDP_PASS;
+    }
+    vlan1 = 0x8000 | value->tunnel_id;
+    nh_off += sizeof(*vh);
+
+    struct ethhdr *eth = data + nh_off;
+    nh_off += sizeof(*eth);
+    h_proto = eth->h_proto;
+
+    if (h_proto == __constant_htons(ETH_P_8021Q) || h_proto == __constant_htons(ETH_P_8021AD)) {
+        struct vlan_hdr *vhdr;
+
+        if (data + nh_off + sizeof(struct vlan_hdr) > data_end)
+            return XDP_PASS;
+        vhdr = data + nh_off;
+        nh_off += sizeof(struct vlan_hdr);
+        h_proto = vhdr->h_vlan_encapsulated_proto;
+#if VLAN_TRACKING
+        vlan0 = vhdr->h_vlan_TCI & 0x0fff;
+#endif
+    }
+
+    if (h_proto == __constant_htons(ETH_P_IP))
+        return filter_ipv4_final(ctx, data, nh_off, data_end, vlan0, vlan1);
+    else if (h_proto == __constant_htons(ETH_P_IPV6))
+        return filter_ipv6(ctx, data, nh_off, data_end, vlan0, vlan1);
+    return XDP_PASS;
+}
+
+static int __always_inline is_vxlan(void *data, __u64 nh_off, void *data_end)
+{
+    if (data + nh_off + sizeof(struct iphdr) + sizeof(struct udphdr) + sizeof(struct vxlanhdr) +
+                    sizeof(struct ethhdr) >
+            data_end) {
+        return 0;
+    }
+    struct udphdr *uh = (struct udphdr *)(data + nh_off + sizeof(struct iphdr));
+    if (uh->dest != __constant_ntohs(VXLAN_PORT)) {
+        return 0;
+    }
+    struct vxlanhdr *vh =
+            (struct vxlanhdr *)(data + nh_off + sizeof(struct iphdr) + sizeof(struct udphdr));
+    // check vni is present and reserved is 0
+    if ((vh->flags & 0xDEFF) == 8 && vh->res == 0) {
+        return 0;
+    }
+    // check ethernet type is handled
+    struct ethhdr *eth = (struct ethhdr *)(data + nh_off + sizeof(struct iphdr) +
+                                           sizeof(struct udphdr) + sizeof(struct vxlanhdr));
+    if (eth->h_proto == __constant_htons(ETH_P_8021Q) ||
+            eth->h_proto == __constant_htons(ETH_P_8021AD) ||
+            eth->h_proto == __constant_htons(ETH_P_IP) ||
+            eth->h_proto == __constant_htons(ETH_P_IPV6)) {
+        return 1;
+    }
+
+    return 0;
+}
+
 static int __always_inline filter_ipv4(
         struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, __u16 vlan0, __u16 vlan1)
 {
@@ -633,6 +722,9 @@ static int __always_inline filter_ipv4(
     if (iph->protocol == IPPROTO_GRE) {
         nh_off += sizeof(struct iphdr);
         return filter_gre(ctx, data, nh_off, data_end, iph);
+    } else if (iph->protocol == IPPROTO_UDP && is_vxlan(data, nh_off, data_end)) {
+        nh_off += sizeof(struct iphdr) + sizeof(struct udphdr);
+        return filter_vxlan(ctx, data, nh_off, data_end, iph);
     }
     return filter_ipv4_final(ctx, data, nh_off, data_end, vlan0, vlan1);
 }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -9475,8 +9475,16 @@
                 },
                 "src_port": {
                     "type": "integer"
+                },
+                "tunnel_id": {
+                    "type": "integer",
+                    "description": "If any, the tunnel identifier defined in suricata.yaml decoder.tunnels section"
                 }
             }
+        },
+        "tunnel_id": {
+            "type": "integer",
+            "description": "if any, the tunnel identifier defined in suricata.yaml decoder.tunnels section"
         },
         "tx_guessed": {
             "type": "boolean",

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -29,6 +29,7 @@ use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::ptr;
 use std::str;
+use std::str::FromStr;
 use suricata_sys::sys::SCConfGetChildValue;
 use suricata_sys::sys::SCConfGetChildValueBool;
 use suricata_sys::sys::SCConfGetFirstNode;
@@ -57,13 +58,47 @@ pub use suricata_ffi::conf::{conf_get, conf_get_bool};
 
 /// Wrap a Suricata ConfNode and expose some of its methods with a
 /// Rust friendly interface.
+#[derive(Copy, Clone)]
 pub struct ConfNode {
     pub conf: *const SCConfNode,
+}
+
+pub(crate) struct ConfNodeIter {
+    node: ConfNode,
+    start: bool,
+}
+
+impl Iterator for ConfNodeIter {
+    type Item = ConfNode;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let r = if self.start {
+            self.start = false;
+            self.node.first()
+        } else {
+            self.node.next()
+        };
+        if let Some(n) = r {
+            self.node = n;
+            return Some(self.node);
+        }
+        r
+    }
 }
 
 impl ConfNode {
     pub fn wrap(conf: *const SCConfNode) -> Self {
         return Self { conf };
+    }
+
+    // Return the value of key as T like u16.
+    pub(crate) fn get_child_from<T: FromStr>(&self, key: &str) -> Option<T> {
+        if let Some(n) = self.get_child_node(key) {
+            if let Ok(r) = T::from_str(n.value()) {
+                return Some(r);
+            }
+        }
+        return None;
     }
 
     pub fn get_child_node(&self, key: &str) -> Option<ConfNode> {
@@ -75,6 +110,13 @@ impl ConfNode {
             None
         } else {
             Some(ConfNode::wrap(node))
+        }
+    }
+
+    pub(crate) fn iter(&self) -> ConfNodeIter {
+        ConfNodeIter {
+            node: *self,
+            start: true,
         }
     }
 

--- a/rust/src/decode.rs
+++ b/rust/src/decode.rs
@@ -1,0 +1,134 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! Decode module.
+
+use crate::conf::conf_get_node;
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use suricata_sys::sys::SCPacketTunnelProto;
+
+pub const PKT_TUNNEL_UNKNOWN: u16 = u16::MAX;
+
+fn decoder_tunnel_proto(s: Option<&str>) -> Option<SCPacketTunnelProto> {
+    return match s {
+        Some("erspan2") => Some(SCPacketTunnelProto::DECODE_TUNNEL_ERSPANII),
+        Some("vxlan") => Some(SCPacketTunnelProto::DECODE_TUNNEL_VXLAN),
+        _ => None,
+    };
+}
+
+fn decoder_ipv4(o: Option<&str>) -> Option<u32> {
+    if let Some(s) = o {
+        if let Ok(i) = s.parse::<Ipv4Addr>() {
+            return Some(u32::from_be_bytes(i.octets()));
+        }
+    }
+    return None;
+}
+
+#[repr(C)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct flowtunnel_keys {
+    src: u32,
+    dst: u32,
+    // would be nice to have this field u24, like C __u32 session : 24; __u8 tunnel : 8;
+    session: u32, // erspan spanid or vxlan vni
+    tunnel_proto: u8,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn DecodeTunnelsConfig() -> *mut HashMap<flowtunnel_keys, u16> {
+    let mut r = HashMap::new();
+    if let Some(n) = conf_get_node("decoder.tunnels") {
+        for nodeu in n.iter() {
+            // Get all the fields with their right types
+            let nid = nodeu.get_child_from::<u16>("id");
+            if nid.is_none() {
+                SCLogWarning!("missing id for decoder tunnel");
+                continue;
+            }
+            let nid = nid.unwrap();
+
+            let ntype = nodeu.get_child_value("type");
+            let tunnel_proto = decoder_tunnel_proto(ntype);
+            if tunnel_proto.is_none() {
+                SCLogWarning!("unknown type for decoder tunnel {:?}", ntype);
+                continue;
+            }
+            let tunnel_proto = tunnel_proto.unwrap() as u8;
+
+            let session = nodeu.get_child_from::<u32>("session");
+            if session.is_none() {
+                SCLogWarning!("missing session for decoder tunnel");
+                continue;
+            }
+            let session = session.unwrap();
+
+            let nsrc = nodeu.get_child_value("src");
+            let src = decoder_ipv4(nsrc);
+            if src.is_none() {
+                SCLogWarning!("invalid ipv4 src for decoder tunnel {:?}", nsrc);
+                continue;
+            }
+            let src = src.unwrap();
+
+            let ndst = nodeu.get_child_value("dst");
+            let dst = decoder_ipv4(ndst);
+            if dst.is_none() {
+                SCLogWarning!("invalid ipv4 src for decoder tunnel {:?}", ndst);
+                continue;
+            }
+            let dst = dst.unwrap();
+
+            // Finally insert the tunnel in the map
+            let k = flowtunnel_keys {
+                src,
+                dst,
+                session,
+                tunnel_proto,
+            };
+            r.insert(k, nid);
+        }
+    } else {
+        // no decoder.tunnels section in conf
+        return std::ptr::null_mut();
+    }
+    return Box::into_raw(Box::new(r));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn DecodeTunnelsFree(map: *mut HashMap<flowtunnel_keys, u16>) {
+    if !map.is_null() {
+        let _ = Box::from_raw(map); // Automatically dropped at end of scope
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn DecodeTunnelsId(
+    map: *mut HashMap<flowtunnel_keys, u16>, key: flowtunnel_keys,
+) -> u16 {
+    if map.is_null() {
+        return PKT_TUNNEL_UNKNOWN;
+    }
+
+    let map = &*map;
+    match map.get(&key) {
+        Some(value) => *value,
+        None => PKT_TUNNEL_UNKNOWN,
+    }
+}

--- a/rust/src/decode.rs
+++ b/rust/src/decode.rs
@@ -19,6 +19,7 @@
 
 use crate::conf::conf_get_node;
 use std::collections::HashMap;
+use std::ffi::c_void;
 use std::net::Ipv4Addr;
 use suricata_sys::sys::SCPacketTunnelProto;
 
@@ -131,4 +132,47 @@ pub unsafe extern "C" fn DecodeTunnelsId(
         Some(value) => *value,
         None => PKT_TUNNEL_UNKNOWN,
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn DecodeTunnelsIterStart(
+    map: *mut HashMap<flowtunnel_keys, u16>,
+) -> *mut c_void {
+    if map.is_null() {
+        return std::ptr::null_mut();
+    }
+    let map = &*map;
+    return Box::into_raw(Box::new(map.iter())) as *mut _;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn DecodeTunnelsMapIter(
+    iter: *mut c_void, key: &mut flowtunnel_keys, value: &mut u16,
+) -> bool {
+    if iter.is_null() {
+        return false;
+    }
+    let iter = cast_pointer!(
+        iter,
+        std::collections::hash_map::Iter<'static, flowtunnel_keys, u16>
+    );
+    match iter.next() {
+        Some((k, v)) => {
+            *key = k.clone();
+            *value = *v;
+            return true;
+        }
+        None => {
+            return false;
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn DecodeTunnelsMapIterEnd(iter: *mut c_void) {
+    let iter = cast_pointer!(
+        iter,
+        std::collections::hash_map::Iter<'static, flowtunnel_keys, u16>
+    );
+    let _ = Box::from_raw(iter);
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -72,6 +72,8 @@ pub mod core;
 #[macro_use]
 pub mod debug;
 
+pub mod decode;
+
 pub mod common;
 pub mod conf;
 pub mod jsonbuilder;

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -1243,6 +1243,23 @@ extern "C" {
 extern "C" {
     pub fn SCBasicSearchNocaseIndex(arg1: *const u8, arg2: u32, arg3: *const u8, arg4: u16) -> u32;
 }
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum SCPacketTunnelProto {
+    DECODE_TUNNEL_ETHERNET = 0,
+    DECODE_TUNNEL_ERSPANII = 1,
+    DECODE_TUNNEL_ERSPANI = 2,
+    DECODE_TUNNEL_VXLAN = 3,
+    DECODE_TUNNEL_VLAN = 4,
+    DECODE_TUNNEL_IPV4 = 5,
+    DECODE_TUNNEL_IPV6 = 6,
+    #[doc = "< separate protocol for stricter error handling"]
+    DECODE_TUNNEL_IPV6_TEREDO = 7,
+    DECODE_TUNNEL_PPP = 8,
+    DECODE_TUNNEL_NSH = 9,
+    DECODE_TUNNEL_ARP = 10,
+    DECODE_TUNNEL_UNSET = 11,
+}
 pub type ProbingParserFPtr = ::std::option::Option<
     unsafe extern "C" fn(
         f: *const Flow,

--- a/src/bindgen.h
+++ b/src/bindgen.h
@@ -34,6 +34,7 @@
 
 #include "app-layer-protos.h"
 #include "suricata-plugin.h"
+
 // do not export struct fields only used for debug validation
 // do this after suricata-plugin.h which needs autoconf.h to define SC_PACKAGE_VERSION
 #undef DEBUG_VALIDATION
@@ -51,6 +52,8 @@
 #include "util-mpm.h"
 #include "util-var.h"
 #include "util-spm-bs.h"
+
+#include "decode.h"
 
 #include "app-layer-detect-proto.h"
 #include "app-layer-parser.h"

--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -107,7 +107,7 @@ int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
         p->vlan_id[p->vlan_idx] = vlan_id;
         p->vlan_idx++;
     }
-
+    PacketSetTunnelId(p, SCNtohs(ehdr->flags_spanid) & 0x03ff);
     return DecodeEthernet(tv, dtv, p, pkt + sizeof(ErspanHdr), len - sizeof(ErspanHdr));
 }
 

--- a/src/decode-vxlan.c
+++ b/src/decode-vxlan.c
@@ -135,6 +135,17 @@ void DecodeVXLANConfig(void)
     }
 }
 
+// Just get the tunnel id (for the flow hash)
+// Then pass on to ethernet decoder on next layer
+int DecodeVXLANtunnel(
+        ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
+{
+    const VXLANHeader *vxlanh = (const VXLANHeader *)pkt;
+    uint32_t vni = (vxlanh->vni[0] << 16) + (vxlanh->vni[1] << 8) + (vxlanh->vni[2]);
+    PacketSetTunnelId(p, vni);
+    return DecodeEthernet(tv, dtv, p, pkt + VXLAN_HEADER_LEN, len - VXLAN_HEADER_LEN);
+}
+
 /** \param pkt payload data directly above UDP header
  *  \param len length in bytes of pkt
  *
@@ -214,8 +225,9 @@ int DecodeVXLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
     /* Set-up and process inner packet if it is a supported ethertype */
     if (eth_ok) {
-        Packet *tp = PacketTunnelPktSetup(
-                tv, dtv, p, pkt + VXLAN_HEADER_LEN, len - VXLAN_HEADER_LEN, DECODE_TUNNEL_VXLAN);
+        // do not advance in packet, as we will need child packet to read vxlan header
+        // to compute its tunnel_id before computing its hash
+        Packet *tp = PacketTunnelPktSetup(tv, dtv, p, pkt, len, DECODE_TUNNEL_VXLAN);
         if (tp != NULL) {
             PKT_SET_SRC(tp, PKT_SRC_DECODER_VXLAN);
             PacketEnqueueNoLock(&tv->decode_pq, tp);

--- a/src/decode.c
+++ b/src/decode.c
@@ -397,7 +397,7 @@ inline int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
  *  \retval p the pseudo packet or NULL if out of memory
  */
 Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *parent,
-                             const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto)
+        const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto)
 {
     int ret;
 
@@ -435,6 +435,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     }
     /* tell new packet it's part of a tunnel */
     p->ttype = PacketTunnelChild;
+    p->tproto = (uint8_t)proto;
 
     ret = DecodeTunnel(tv, dtv, p, GET_PKT_DATA(p),
                        GET_PKT_LEN(p), proto);

--- a/src/decode.c
+++ b/src/decode.c
@@ -402,6 +402,11 @@ void PacketSetTunnelId(Packet *p, uint32_t session)
     p->tunnel_id = DecodeTunnelsId(decode_tunnels_map, k);
 }
 
+void *DecodeTunnelsGetMapIter(void)
+{
+    return DecodeTunnelsIterStart(decode_tunnels_map);
+}
+
 /**
  *  \brief Setup a pseudo packet (tunnel)
  *
@@ -441,6 +446,10 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     p->tenant_id = parent->tenant_id;
     p->livedev_id = parent->livedev_id;
 
+#ifdef HAVE_PACKET_EBPF
+    // need to copy BypassPacketsFlow callback and such
+    AFPReadCopyBypass(p, parent);
+#endif
     /* set the root ptr to the lowest layer */
     if (parent->root != NULL) {
         p->root = parent->root;

--- a/src/decode.c
+++ b/src/decode.c
@@ -71,6 +71,7 @@
 #include "util-profiling.h"
 #include "util-validate.h"
 #include "util-debug.h"
+#include "util-device-private.h"
 #include "util-exception-policy.h"
 #include "action-globals.h"
 
@@ -225,6 +226,14 @@ void PacketFree(Packet *p)
     SCFree(p);
 }
 
+static bool PacketIsInTunnelIface(Packet *p)
+{
+    LiveDevice *dev = LiveDeviceGetById(p->livedev_id);
+    if (dev) {
+        return dev->skip_non_tunnel;
+    }
+    return false;
+}
 /**
  * \brief Finalize decoding of a packet
  *
@@ -236,6 +245,10 @@ void PacketDecodeFinalize(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
     if (p->flags & PKT_IS_INVALID) {
         StatsCounterIncr(&tv->stats, dtv->counter_invalid);
+    }
+    if (p->tunnel_id == 0 && PacketIsInTunnelIface(p)) {
+        // skips non-tunnel packets
+        p->flags |= PKT_SKIP_WORK;
     }
 }
 
@@ -390,8 +403,12 @@ static void *decode_tunnels_map;
 
 void PacketSetTunnelId(Packet *p, uint32_t session)
 {
+    bool packet_in_tunnel_iface = PacketIsInTunnelIface(p);
     if (decode_tunnels_map == NULL || p->root == NULL || !PacketIsIPv4(p->root)) {
         p->tunnel_id = PKT_TUNNEL_UNKNOWN;
+        if (packet_in_tunnel_iface) {
+            p->flags |= PKT_SKIP_WORK;
+        }
         return;
     }
     struct flowtunnel_keys k = {};
@@ -400,6 +417,9 @@ void PacketSetTunnelId(Packet *p, uint32_t session)
     k.session = session;
     k.tunnel_proto = (uint8_t)p->tproto;
     p->tunnel_id = DecodeTunnelsId(decode_tunnels_map, k);
+    if (packet_in_tunnel_iface && p->tunnel_id == PKT_TUNNEL_UNKNOWN) {
+        p->flags |= PKT_SKIP_WORK;
+    }
 }
 
 void *DecodeTunnelsGetMapIter(void)
@@ -1175,6 +1195,20 @@ void DecodeGlobalConfig(void)
     DecodeVXLANConfig();
     DecodeERSPANConfig();
     decode_tunnels_map = DecodeTunnelsConfig();
+    SCConfNode *tunnel_ifaces_node = SCConfGetNode("decoder.tunnel-ifaces");
+    if (tunnel_ifaces_node != NULL) {
+        SCConfNode *child = NULL;
+        TAILQ_FOREACH (child, &tunnel_ifaces_node->head, next) {
+            if (child->val != NULL) {
+                LiveDevice *ld = LiveGetDevice(child->val);
+                if (ld != NULL) {
+                    ld->skip_non_tunnel = true;
+                } else {
+                    SCLogWarning("%s is not a registered device", child->val);
+                }
+            }
+        }
+    }
     intmax_t value = 0;
     if (SCConfGetInt("decoder.max-layers", &value) == 1) {
         if (value < 0 || value > UINT8_MAX) {

--- a/src/decode.c
+++ b/src/decode.c
@@ -180,10 +180,10 @@ void PacketAlertFree(PacketAlert *pa_array)
 }
 
 static int DecodeTunnel(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t,
-        enum DecodeTunnelProto) WARN_UNUSED;
+        enum SCPacketTunnelProto) WARN_UNUSED;
 
 static int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt,
-        uint32_t len, enum DecodeTunnelProto proto)
+        uint32_t len, enum SCPacketTunnelProto proto)
 {
     switch (proto) {
         case DECODE_TUNNEL_PPP:
@@ -204,7 +204,7 @@ static int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const 
         case DECODE_TUNNEL_ERSPANI:
             return DecodeERSPANTypeI(tv, dtv, p, pkt, len);
         case DECODE_TUNNEL_VXLAN:
-            return DecodeEthernet(tv, dtv, p, pkt, len);
+            return DecodeVXLANtunnel(tv, dtv, p, pkt, len);
         case DECODE_TUNNEL_NSH:
             return DecodeNSH(tv, dtv, p, pkt, len);
         case DECODE_TUNNEL_ARP:
@@ -386,6 +386,22 @@ inline int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
     return PacketCopyDataOffset(p, 0, pktdata, pktlen);
 }
 
+static void *decode_tunnels_map;
+
+void PacketSetTunnelId(Packet *p, uint32_t session)
+{
+    if (decode_tunnels_map == NULL || p->root == NULL || !PacketIsIPv4(p->root)) {
+        p->tunnel_id = PKT_TUNNEL_UNKNOWN;
+        return;
+    }
+    struct flowtunnel_keys k = {};
+    k.src = htonl(GET_IPV4_SRC_ADDR_U32(p->root));
+    k.dst = htonl(GET_IPV4_DST_ADDR_U32(p->root));
+    k.session = session;
+    k.tunnel_proto = (uint8_t)p->tproto;
+    p->tunnel_id = DecodeTunnelsId(decode_tunnels_map, k);
+}
+
 /**
  *  \brief Setup a pseudo packet (tunnel)
  *
@@ -397,7 +413,7 @@ inline int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
  *  \retval p the pseudo packet or NULL if out of memory
  */
 Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *parent,
-        const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto)
+        const uint8_t *pkt, uint32_t len, enum SCPacketTunnelProto proto)
 {
     int ret;
 
@@ -614,6 +630,7 @@ void DecodeUnregisterCounters(void)
         g_counter_table = NULL;
     }
     SCMutexUnlock(&g_counter_table_mutex);
+    DecodeTunnelsFree(decode_tunnels_map);
 }
 
 static bool IsDefragMemcapExceptionPolicyStatsValid(enum ExceptionPolicy policy)
@@ -1148,6 +1165,7 @@ void DecodeGlobalConfig(void)
     DecodeGeneveConfig();
     DecodeVXLANConfig();
     DecodeERSPANConfig();
+    decode_tunnels_map = DecodeTunnelsConfig();
     intmax_t value = 0;
     if (SCConfGetInt("decoder.max-layers", &value) == 1) {
         if (value < 0 || value > UINT8_MAX) {

--- a/src/decode.h
+++ b/src/decode.h
@@ -1318,7 +1318,8 @@ void DecodeUnregisterCounters(void);
 /** Packet is part of established stream */
 #define PKT_STREAM_EST BIT_U32(6)
 
-// vacancy
+/** Flag to indicate that worker to skip the packet */
+#define PKT_SKIP_WORK BIT_U32(7)
 
 #define PKT_HAS_FLOW   BIT_U32(8)
 /** Pseudo packet to end the stream */

--- a/src/decode.h
+++ b/src/decode.h
@@ -1190,6 +1190,8 @@ void DecodeUpdatePacketCounters(ThreadVars *tv,
                                 const DecodeThreadVars *dtv, const Packet *p);
 const char *PacketDropReasonToString(enum PacketDropReason r);
 
+void *DecodeTunnelsGetMapIter(void);
+
 /* decoder functions */
 int DecodeEthernet(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeSll(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);

--- a/src/decode.h
+++ b/src/decode.h
@@ -557,6 +557,9 @@ typedef struct Packet_
     /* tunnel type: none, root or child */
     uint8_t ttype; // enum PacketTunnelType
 
+    /* tunnel protocol */
+    uint8_t tproto; // enum DecodeTunnelProto
+
     /* Pkt Flags */
     uint32_t flags;
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -24,6 +24,22 @@
 #ifndef SURICATA_DECODE_H
 #define SURICATA_DECODE_H
 
+enum SCPacketTunnelProto {
+    DECODE_TUNNEL_ETHERNET,
+    DECODE_TUNNEL_ERSPANII,
+    DECODE_TUNNEL_ERSPANI,
+    DECODE_TUNNEL_VXLAN,
+    DECODE_TUNNEL_VLAN,
+    DECODE_TUNNEL_IPV4,
+    DECODE_TUNNEL_IPV6,
+    DECODE_TUNNEL_IPV6_TEREDO, /**< separate protocol for stricter error handling */
+    DECODE_TUNNEL_PPP,
+    DECODE_TUNNEL_NSH,
+    DECODE_TUNNEL_ARP,
+    DECODE_TUNNEL_UNSET
+};
+
+#ifndef SURICATA_BINDGEN_H
 //#define DBG_THREADS
 #define COUNTERS
 
@@ -539,6 +555,11 @@ typedef struct Packet_
      * has the exact same tuple as the lower levels */
     uint8_t recursion_level;
 
+    /* tunnel id if any, PKT_TUNNEL_UNKNOWN if unknown, 0 if none
+     * tunnel ids are configured in suricata.yaml decoder.tunnels section
+     */
+    uint16_t tunnel_id;
+
     uint16_t vlan_id[VLAN_MAX_LAYERS];
     uint8_t vlan_idx;
 
@@ -558,7 +579,7 @@ typedef struct Packet_
     uint8_t ttype; // enum PacketTunnelType
 
     /* tunnel protocol */
-    uint8_t tproto; // enum DecodeTunnelProto
+    uint8_t tproto; // enum SCPacketTunnelProto
 
     /* Pkt Flags */
     uint32_t flags;
@@ -1142,23 +1163,9 @@ static inline void PacketTunnelSetVerdicted(Packet *p)
     p->tunnel_verdicted = true;
 }
 
-enum DecodeTunnelProto {
-    DECODE_TUNNEL_ETHERNET,
-    DECODE_TUNNEL_ERSPANII,
-    DECODE_TUNNEL_ERSPANI,
-    DECODE_TUNNEL_VXLAN,
-    DECODE_TUNNEL_VLAN,
-    DECODE_TUNNEL_IPV4,
-    DECODE_TUNNEL_IPV6,
-    DECODE_TUNNEL_IPV6_TEREDO, /**< separate protocol for stricter error handling */
-    DECODE_TUNNEL_PPP,
-    DECODE_TUNNEL_NSH,
-    DECODE_TUNNEL_ARP,
-    DECODE_TUNNEL_UNSET
-};
-
 Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *parent,
-                             const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto);
+        const uint8_t *pkt, uint32_t len, enum SCPacketTunnelProto proto);
+void PacketSetTunnelId(Packet *p, uint32_t session);
 Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, uint8_t proto);
 void PacketDefragPktSetupParent(Packet *parent);
 void DecodeRegisterPerfCounters(DecodeThreadVars *, ThreadVars *);
@@ -1207,6 +1214,7 @@ int DecodeETag(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint
 int DecodeIEEE8021ah(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeGeneve(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeVXLAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
+int DecodeVXLANtunnel(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeMPLS(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeERSPAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeERSPANTypeI(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
@@ -1559,6 +1567,7 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
     }
     return true;
 }
+#endif // SURICATA_BINDGEN_H
 
 uint64_t PcapPacketCntGet(const Packet *p);
 void PcapPacketCntSet(Packet *p, uint64_t pcap_cnt);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -102,6 +102,7 @@ static DetectEngineMasterCtx g_master_de_ctx = { SCMUTEX_INITIALIZER,
 static uint32_t TenantIdHash(HashTable *h, void *data, uint16_t data_len);
 static char TenantIdCompare(void *d1, uint16_t d1_len, void *d2, uint16_t d2_len);
 static void TenantIdFree(void *d);
+static uint32_t DetectEngineTenantGetIdFromTunnel(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromPcap(const void *ctx, const Packet *p);
@@ -3382,6 +3383,10 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
             det_ctx->TenantGetId = DetectEngineTenantGetIdFromLivedev;
             SCLogDebug("TENANT_SELECTOR_LIVEDEV");
             break;
+        case TENANT_SELECTOR_TUNNEL:
+            det_ctx->TenantGetId = DetectEngineTenantGetIdFromTunnel;
+            SCLogDebug("TENANT_SELECTOR_TUNNEL");
+            break;
         case TENANT_SELECTOR_DIRECT:
             det_ctx->TenantGetId = DetectEngineTenantGetIdFromPcap;
             SCLogDebug("TENANT_SELECTOR_DIRECT");
@@ -4322,6 +4327,57 @@ int DetectEngineReloadTenantsBlocking(const int reload_cnt)
     return 0;
 }
 
+static int DetectEngineMultiTenantSetupLoadTunnelMappings(
+        const SCConfNode *mappings_root_node, bool failure_fatal)
+{
+    SCConfNode *mapping_node = NULL;
+
+    int mapping_cnt = 0;
+    if (mappings_root_node != NULL) {
+        TAILQ_FOREACH (mapping_node, &mappings_root_node->head, next) {
+            SCConfNode *tenant_id_node = SCConfNodeLookupChild(mapping_node, "tenant-id");
+            if (tenant_id_node == NULL)
+                goto bad_mapping;
+            SCConfNode *tunnel_id_node = SCConfNodeLookupChild(mapping_node, "tunnel-id");
+            if (tunnel_id_node == NULL)
+                goto bad_mapping;
+
+            uint32_t tenant_id = 0;
+            if (StringParseUint32(&tenant_id, 10, (uint16_t)strlen(tenant_id_node->val),
+                        tenant_id_node->val) < 0) {
+                SCLogError("tenant-id  "
+                           "of %s is invalid",
+                        tenant_id_node->val);
+                goto bad_mapping;
+            }
+
+            uint16_t tunnel_id = 0;
+            if (StringParseUint16(&tunnel_id, 10, (uint16_t)strlen(tunnel_id_node->val),
+                        tunnel_id_node->val) < 0) {
+                SCLogError("tunnel id  "
+                           "of %s is invalid",
+                        tunnel_id_node->val);
+                goto bad_mapping;
+            }
+
+            if (DetectEngineTenantRegisterTunnel(tenant_id, tunnel_id) != 0) {
+                goto error;
+            }
+            SCLogConfig("tunnel %u connected to tenant-id %u", tunnel_id, tenant_id);
+            mapping_cnt++;
+            continue;
+
+        bad_mapping:
+            if (failure_fatal)
+                goto error;
+        }
+    }
+    return mapping_cnt;
+
+error:
+    return 0;
+}
+
 static int DetectEngineMultiTenantSetupLoadLivedevMappings(
         const SCConfNode *mappings_root_node, bool failure_fatal)
 {
@@ -4480,6 +4536,8 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
 
             } else if (strcmp(handler, "direct") == 0) {
                 tenant_selector = master->tenant_selector = TENANT_SELECTOR_DIRECT;
+            } else if (strcmp(handler, "tunnel") == 0) {
+                tenant_selector = master->tenant_selector = TENANT_SELECTOR_TUNNEL;
             } else if (strcmp(handler, "device") == 0) {
                 tenant_selector = master->tenant_selector = TENANT_SELECTOR_LIVEDEV;
                 if (EngineModeIsIPS()) {
@@ -4520,6 +4578,17 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
                     } else {
                         SCLogWarning("no multi-detect mappings defined");
                     }
+                }
+            }
+        } else if (tenant_selector == TENANT_SELECTOR_TUNNEL) {
+            int mapping_cnt = DetectEngineMultiTenantSetupLoadTunnelMappings(
+                    mappings_root_node, failure_fatal);
+            if (mapping_cnt == 0) {
+                if (failure_fatal) {
+                    SCLogError("no multi-detect mappings defined");
+                    goto error;
+                } else {
+                    SCLogWarning("no multi-detect mappings defined");
                 }
             }
         } else if (tenant_selector == TENANT_SELECTOR_LIVEDEV) {
@@ -4651,6 +4720,26 @@ static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet
     return ld->tenant_id;
 }
 
+static uint32_t DetectEngineTenantGetIdFromTunnel(const void *ctx, const Packet *p)
+{
+    const DetectEngineThreadCtx *det_ctx = ctx;
+
+    if (p->tunnel_id == 0 || p->tunnel_id == PKT_TUNNEL_UNKNOWN)
+        return 0;
+
+    if (det_ctx == NULL || det_ctx->tenant_array == NULL || det_ctx->tenant_array_size == 0)
+        return 0;
+
+    /* not very efficient, but for now we're targeting only limited amounts.
+     * Can use hash/tree approach later. */
+    for (uint32_t x = 0; x < det_ctx->tenant_array_size; x++) {
+        if (det_ctx->tenant_array[x].traffic_id == p->tunnel_id)
+            return det_ctx->tenant_array[x].tenant_id;
+    }
+
+    return 0;
+}
+
 static int DetectEngineTenantRegisterSelector(
         enum DetectEngineTenantSelectors selector, uint32_t tenant_id, uint32_t traffic_id)
 {
@@ -4732,6 +4821,12 @@ int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id)
 {
     return DetectEngineTenantRegisterSelector(
             TENANT_SELECTOR_LIVEDEV, tenant_id, (uint32_t)device_id);
+}
+
+int DetectEngineTenantRegisterTunnel(uint32_t tenant_id, uint16_t tunnel_id)
+{
+    return DetectEngineTenantRegisterSelector(
+            TENANT_SELECTOR_TUNNEL, tenant_id, (uint32_t)tunnel_id);
 }
 
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id)

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -121,6 +121,7 @@ int DetectEngineReloadTenantBlocking(uint32_t tenant_id, const char *yaml, int r
 int DetectEngineReloadTenantsBlocking(const int reload_cnt);
 
 int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id);
+int DetectEngineTenantRegisterTunnel(uint32_t tenant_id, uint16_t tunnel_id);
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantRegisterPcapFile(uint32_t tenant_id);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1697,12 +1697,12 @@ typedef struct SigGroupHead_ {
 
 } SigGroupHead;
 
-enum DetectEngineTenantSelectors
-{
-    TENANT_SELECTOR_UNKNOWN = 0,    /**< not set */
-    TENANT_SELECTOR_DIRECT,         /**< method provides direct tenant id */
-    TENANT_SELECTOR_VLAN,           /**< map vlan to tenant id */
-    TENANT_SELECTOR_LIVEDEV,        /**< map livedev to tenant id */
+enum DetectEngineTenantSelectors {
+    TENANT_SELECTOR_UNKNOWN = 0, /**< not set */
+    TENANT_SELECTOR_DIRECT,      /**< method provides direct tenant id */
+    TENANT_SELECTOR_VLAN,        /**< map vlan to tenant id */
+    TENANT_SELECTOR_LIVEDEV,     /**< map livedev to tenant id */
+    TENANT_SELECTOR_TUNNEL,      /**< map tunnel id to tenant id */
 };
 
 typedef struct DetectEngineTenantMapping_ {

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -114,6 +114,35 @@ typedef struct FlowHashKey6_ {
     };
 } FlowHashKey6;
 
+static inline void FlowHashIp4Fill(FlowHashKey4 *fhk, const Packet *p)
+{
+    fhk->proto = p->proto;
+    /* g_recurlvl_mask sets the recursion_level to 0 if
+     * decoder.recursion-level.use-for-tracking is disabled.
+     */
+    fhk->recur = (uint8_t)p->recursion_level & g_recurlvl_mask;
+    /* g_livedev_mask sets the livedev ids to 0 if livedev.use-for-tracking
+     * is disabled. */
+    uint16_t devid = p->livedev_id;
+    fhk->livedev = devid & g_livedev_mask;
+    /* g_vlan_mask sets the vlan_ids to 0 if vlan.use-for-tracking
+     * is disabled. */
+    fhk->vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
+    fhk->vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
+    fhk->vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+}
+
+static inline void FlowHashIp6Fill(FlowHashKey6 *fhk, const Packet *p)
+{
+    fhk->proto = p->proto;
+    fhk->recur = (uint8_t)p->recursion_level & g_recurlvl_mask;
+    uint16_t devid = p->livedev_id;
+    fhk->livedev = devid & g_livedev_mask;
+    fhk->vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
+    fhk->vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
+    fhk->vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+}
+
 uint32_t FlowGetIpPairProtoHash(const Packet *p)
 {
     uint32_t hash = 0;
@@ -129,17 +158,7 @@ uint32_t FlowGetIpPairProtoHash(const Packet *p)
         fhk.ports[0] = 0xfedc;
         fhk.ports[1] = 0xba98;
 
-        fhk.proto = (uint8_t)p->proto;
-        fhk.livedev = p->livedev_id & g_livedev_mask;
-        /* g_recurlvl_mask sets the recursion_level to 0 if
-         * decoder.recursion-level.use-for-tracking is disabled.
-         */
-        fhk.recur = (uint8_t)p->recursion_level & g_recurlvl_mask;
-        /* g_vlan_mask sets the vlan_ids to 0 if vlan.use-for-tracking
-         * is disabled. */
-        fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
-        fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
-        fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+        FlowHashIp4Fill(&fhk, p);
 
         hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
     } else if (PacketIsIPv6(p)) {
@@ -168,12 +187,8 @@ uint32_t FlowGetIpPairProtoHash(const Packet *p)
 
         fhk.ports[0] = 0xfedc;
         fhk.ports[1] = 0xba98;
-        fhk.proto = (uint8_t)p->proto;
-        fhk.livedev = p->livedev_id & g_livedev_mask;
-        fhk.recur = (uint8_t)p->recursion_level & g_recurlvl_mask;
-        fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
-        fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
-        fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+
+        FlowHashIp6Fill(&fhk, p);
 
         hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
     }
@@ -209,20 +224,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.ports[1-pi] = p->sp;
             fhk.ports[pi] = p->dp;
 
-            fhk.proto = p->proto;
-            /* g_recurlvl_mask sets the recursion_level to 0 if
-             * decoder.recursion-level.use-for-tracking is disabled.
-             */
-            fhk.recur = p->recursion_level & g_recurlvl_mask;
-            /* g_livedev_mask sets the livedev ids to 0 if livedev.use-for-tracking
-             * is disabled. */
-            uint16_t devid = p->livedev_id;
-            fhk.livedev = devid & g_livedev_mask;
-            /* g_vlan_mask sets the vlan_ids to 0 if vlan.use-for-tracking
-             * is disabled. */
-            fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
-            fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
-            fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+            FlowHashIp4Fill(&fhk, p);
 
             hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
 
@@ -239,13 +241,8 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.ports[1 - pi] = p->l4.vars.icmpv4.emb_sport;
             fhk.ports[pi] = p->l4.vars.icmpv4.emb_dport;
 
+            FlowHashIp4Fill(&fhk, p);
             fhk.proto = ICMPV4_GET_EMB_PROTO(p);
-            fhk.recur = p->recursion_level & g_recurlvl_mask;
-            uint16_t devid = p->livedev_id;
-            fhk.livedev = devid & g_livedev_mask;
-            fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
-            fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
-            fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
 
             hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
 
@@ -256,13 +253,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.addrs[ai] = p->dst.addr_data32[0];
             fhk.ports[0] = 0xfeed;
             fhk.ports[1] = 0xbeef;
-            fhk.proto = p->proto;
-            fhk.recur = p->recursion_level & g_recurlvl_mask;
-            uint16_t devid = p->livedev_id;
-            fhk.livedev = devid & g_livedev_mask;
-            fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
-            fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
-            fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+            FlowHashIp4Fill(&fhk, p);
 
             hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
         }
@@ -291,13 +282,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
         const int pi = (p->sp > p->dp);
         fhk.ports[1-pi] = p->sp;
         fhk.ports[pi] = p->dp;
-        fhk.proto = p->proto;
-        fhk.recur = p->recursion_level & g_recurlvl_mask;
-        uint16_t devid = p->livedev_id;
-        fhk.livedev = devid & g_livedev_mask;
-        fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
-        fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
-        fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+        FlowHashIp6Fill(&fhk, p);
 
         hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
     }
@@ -410,6 +395,11 @@ static inline bool CmpLiveDevIds(const uint16_t id1, const uint16_t id2)
     return (((id1 ^ id2) & g_livedev_mask) == 0);
 }
 
+#define CmpFlowMisc(x, y)                                                                          \
+    (((x)->proto == (y)->proto) &&                                                                 \
+            ((x)->recursion_level == (y)->recursion_level || g_recurlvl_mask == 0) &&              \
+            CmpVlanIds((x)->vlan_id, (y)->vlan_id))
+
 /* Since two or more flows can have the same hash key, we need to compare
  * the flow with the current packet or flow key. */
 static inline bool CmpFlowPacket(const Flow *f, const Packet *p)
@@ -419,9 +409,7 @@ static inline bool CmpFlowPacket(const Flow *f, const Packet *p)
     const uint32_t *p_src = p->src.address.address_un_data32;
     const uint32_t *p_dst = p->dst.address.address_un_data32;
     return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, p_src, p_dst, p->sp, p->dp) &&
-           f->proto == p->proto &&
-           (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev_id, f->livedev_id);
+           CmpFlowMisc(f, p) && CmpLiveDevIds(p->livedev_id, f->livedev_id);
 }
 
 static inline bool CmpFlowKey(const Flow *f, const FlowKey *k)
@@ -431,9 +419,7 @@ static inline bool CmpFlowKey(const Flow *f, const FlowKey *k)
     const uint32_t *k_src = k->src.address.address_un_data32;
     const uint32_t *k_dst = k->dst.address.address_un_data32;
     return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, k_src, k_dst, k->sp, k->dp) &&
-           f->proto == k->proto &&
-           (f->recursion_level == k->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, k->vlan_id) && CmpLiveDevIds(f->livedev_id, k->livedev_id);
+           CmpFlowMisc(f, k) && CmpLiveDevIds(f->livedev_id, k->livedev_id);
 }
 
 static inline bool CmpAddrsAndICMPTypes(const uint32_t src1[4],
@@ -458,9 +444,7 @@ static inline bool CmpFlowICMPPacket(const Flow *f, const Packet *p)
     const uint32_t *p_dst = p->dst.address.address_un_data32;
     return CmpAddrsAndICMPTypes(f_src, f_dst, f->icmp_s.type, f->icmp_d.type, p_src, p_dst,
                    p->icmp_s.type, p->icmp_d.type) &&
-           f->proto == p->proto &&
-           (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev_id, f->livedev_id);
+           CmpFlowMisc(f, p) && CmpLiveDevIds(p->livedev_id, f->livedev_id);
 }
 
 /**
@@ -524,9 +508,8 @@ static inline int FlowCompareESP(Flow *f, const Packet *p)
     const uint32_t *p_src = p->src.address.address_un_data32;
     const uint32_t *p_dst = p->dst.address.address_un_data32;
 
-    return CmpAddrs(f_src, p_src) && CmpAddrs(f_dst, p_dst) && f->proto == p->proto &&
-           (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-           CmpVlanIds(f->vlan_id, p->vlan_id) && f->esp.spi == ESP_GET_SPI(PacketGetESP(p)) &&
+    return CmpAddrs(f_src, p_src) && CmpAddrs(f_dst, p_dst) && CmpFlowMisc(f, p) &&
+           f->esp.spi == ESP_GET_SPI(PacketGetESP(p)) &&
            CmpLiveDevIds(p->livedev_id, f->livedev_id);
 }
 

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -93,7 +93,7 @@ typedef struct FlowHashKey4_ {
             uint8_t recur;
             uint16_t livedev;
             uint16_t vlan_id[VLAN_MAX_LAYERS];
-            uint16_t pad[1];
+            uint16_t tunnel_id;
         };
         const uint32_t u32[6];
     };
@@ -108,7 +108,7 @@ typedef struct FlowHashKey6_ {
             uint8_t recur;
             uint16_t livedev;
             uint16_t vlan_id[VLAN_MAX_LAYERS];
-            uint16_t pad[1];
+            uint16_t tunnel_id;
         };
         const uint32_t u32[12];
     };
@@ -130,6 +130,7 @@ static inline void FlowHashIp4Fill(FlowHashKey4 *fhk, const Packet *p)
     fhk->vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
     fhk->vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
     fhk->vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+    fhk->tunnel_id = p->tunnel_id;
 }
 
 static inline void FlowHashIp6Fill(FlowHashKey6 *fhk, const Packet *p)
@@ -141,15 +142,14 @@ static inline void FlowHashIp6Fill(FlowHashKey6 *fhk, const Packet *p)
     fhk->vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
     fhk->vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
     fhk->vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+    fhk->tunnel_id = p->tunnel_id;
 }
 
 uint32_t FlowGetIpPairProtoHash(const Packet *p)
 {
     uint32_t hash = 0;
     if (PacketIsIPv4(p)) {
-        FlowHashKey4 fhk = {
-            .pad[0] = 0,
-        };
+        FlowHashKey4 fhk = {};
 
         int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);
         fhk.addrs[1 - ai] = p->src.addr_data32[0];
@@ -162,9 +162,7 @@ uint32_t FlowGetIpPairProtoHash(const Packet *p)
 
         hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
     } else if (PacketIsIPv6(p)) {
-        FlowHashKey6 fhk = {
-            .pad[0] = 0,
-        };
+        FlowHashKey6 fhk = {};
         if (FlowHashRawAddressIPv6GtU32(p->src.addr_data32, p->dst.addr_data32)) {
             fhk.src[0] = p->src.addr_data32[0];
             fhk.src[1] = p->src.addr_data32[1];
@@ -214,7 +212,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
 
     if (PacketIsIPv4(p)) {
         if (PacketIsTCP(p) || PacketIsUDP(p)) {
-            FlowHashKey4 fhk = { .pad[0] = 0 };
+            FlowHashKey4 fhk = {};
 
             int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);
             fhk.addrs[1-ai] = p->src.addr_data32[0];
@@ -231,7 +229,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
         } else if (ICMPV4_DEST_UNREACH_IS_VALID(p)) {
             uint32_t psrc = IPV4_GET_RAW_IPSRC_U32(PacketGetICMPv4EmbIPv4(p));
             uint32_t pdst = IPV4_GET_RAW_IPDST_U32(PacketGetICMPv4EmbIPv4(p));
-            FlowHashKey4 fhk = { .pad[0] = 0 };
+            FlowHashKey4 fhk = {};
 
             const int ai = (psrc > pdst);
             fhk.addrs[1-ai] = psrc;
@@ -247,7 +245,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
             hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
 
         } else {
-            FlowHashKey4 fhk = { .pad[0] = 0 };
+            FlowHashKey4 fhk = {};
             const int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);
             fhk.addrs[1-ai] = p->src.addr_data32[0];
             fhk.addrs[ai] = p->dst.addr_data32[0];
@@ -258,7 +256,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
             hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
         }
     } else if (PacketIsIPv6(p)) {
-        FlowHashKey6 fhk = { .pad[0] = 0 };
+        FlowHashKey6 fhk = {};
         if (FlowHashRawAddressIPv6GtU32(p->src.addr_data32, p->dst.addr_data32)) {
             fhk.src[0] = p->src.addr_data32[0];
             fhk.src[1] = p->src.addr_data32[1];
@@ -303,9 +301,7 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
     uint32_t hash = 0;
 
     if (fk->src.family == AF_INET) {
-        FlowHashKey4 fhk = {
-            .pad[0] = 0,
-        };
+        FlowHashKey4 fhk = {};
         int ai = (fk->src.address.address_un_data32[0] > fk->dst.address.address_un_data32[0]);
         fhk.addrs[1-ai] = fk->src.address.address_un_data32[0];
         fhk.addrs[ai] = fk->dst.address.address_un_data32[0];
@@ -320,12 +316,11 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
         fhk.vlan_id[0] = fk->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = fk->vlan_id[1] & g_vlan_mask;
         fhk.vlan_id[2] = fk->vlan_id[2] & g_vlan_mask;
+        fhk.tunnel_id = fk->tunnel_id;
 
         hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
     } else {
-        FlowHashKey6 fhk = {
-            .pad[0] = 0,
-        };
+        FlowHashKey6 fhk = {};
         if (FlowHashRawAddressIPv6GtU32(fk->src.address.address_un_data32,
                     fk->dst.address.address_un_data32)) {
             fhk.src[0] = fk->src.address.address_un_data32[0];
@@ -356,6 +351,7 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
         fhk.vlan_id[0] = fk->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = fk->vlan_id[1] & g_vlan_mask;
         fhk.vlan_id[2] = fk->vlan_id[2] & g_vlan_mask;
+        fhk.tunnel_id = fk->tunnel_id;
 
         hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
     }
@@ -398,7 +394,8 @@ static inline bool CmpLiveDevIds(const uint16_t id1, const uint16_t id2)
 #define CmpFlowMisc(x, y)                                                                          \
     (((x)->proto == (y)->proto) &&                                                                 \
             ((x)->recursion_level == (y)->recursion_level || g_recurlvl_mask == 0) &&              \
-            CmpVlanIds((x)->vlan_id, (y)->vlan_id))
+            CmpVlanIds((x)->vlan_id, (y)->vlan_id)) &&                                             \
+            ((x)->tunnel_id == (y)->tunnel_id)
 
 /* Since two or more flows can have the same hash key, we need to compare
  * the flow with the current packet or flow key. */
@@ -468,7 +465,8 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                 f->sp == p->l4.vars.icmpv4.emb_sport && f->dp == p->l4.vars.icmpv4.emb_dport &&
                 f->proto == ICMPV4_GET_EMB_PROTO(p) &&
                 (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-                CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev_id, f->livedev_id)) {
+                CmpVlanIds(f->vlan_id, p->vlan_id) && f->tunnel_id == p->tunnel_id &&
+                CmpLiveDevIds(p->livedev_id, f->livedev_id)) {
             return 1;
 
         /* check the less likely case where the ICMP error was a response to
@@ -478,7 +476,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                    f->dp == p->l4.vars.icmpv4.emb_sport && f->sp == p->l4.vars.icmpv4.emb_dport &&
                    f->proto == ICMPV4_GET_EMB_PROTO(p) &&
                    (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-                   CmpVlanIds(f->vlan_id, p->vlan_id) &&
+                   CmpVlanIds(f->vlan_id, p->vlan_id) && f->tunnel_id == p->tunnel_id &&
                    CmpLiveDevIds(p->livedev_id, f->livedev_id)) {
             return 1;
         }
@@ -1098,7 +1096,7 @@ Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t ha
     }
     f->proto = key->proto;
     memcpy(&f->vlan_id[0], &key->vlan_id[0], sizeof(f->vlan_id));
-    ;
+    f->tunnel_id = key->tunnel_id;
     f->src.addr_data32[0] = key->src.addr_data32[0];
     f->src.addr_data32[1] = key->src.addr_data32[1];
     f->src.addr_data32[2] = key->src.addr_data32[2];

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -130,6 +130,7 @@ uint32_t FlowGetIpPairProtoHash(const Packet *p)
         fhk.ports[1] = 0xba98;
 
         fhk.proto = (uint8_t)p->proto;
+        fhk.livedev = p->livedev_id & g_livedev_mask;
         /* g_recurlvl_mask sets the recursion_level to 0 if
          * decoder.recursion-level.use-for-tracking is disabled.
          */
@@ -168,6 +169,7 @@ uint32_t FlowGetIpPairProtoHash(const Packet *p)
         fhk.ports[0] = 0xfedc;
         fhk.ports[1] = 0xba98;
         fhk.proto = (uint8_t)p->proto;
+        fhk.livedev = p->livedev_id & g_livedev_mask;
         fhk.recur = (uint8_t)p->recursion_level & g_recurlvl_mask;
         fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -152,6 +152,7 @@ void FlowInit(ThreadVars *tv, Flow *f, const Packet *p)
 
     f->proto = p->proto;
     f->recursion_level = p->recursion_level;
+    f->tunnel_id = p->tunnel_id;
     memcpy(&f->vlan_id[0], &p->vlan_id[0], sizeof(f->vlan_id));
     f->vlan_idx = p->vlan_idx;
 

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -569,6 +569,9 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
 
     SCLogDebug("packet %" PRIu64, PcapPacketCntGet(p));
 
+    if (p->flags & PKT_SKIP_WORK) {
+        return TM_ECODE_OK;
+    }
     /* handle Flow */
     if (det_ctx != NULL && det_ctx->de_ctx->PreFlowHook != NULL) {
         const uint8_t action = det_ctx->de_ctx->PreFlowHook(tv, det_ctx, p);

--- a/src/flow.h
+++ b/src/flow.h
@@ -311,6 +311,7 @@ typedef struct FlowKey_
     uint8_t recursion_level;
     uint16_t livedev_id;
     uint16_t vlan_id[VLAN_MAX_LAYERS];
+    uint16_t tunnel_id;
 } FlowKey;
 
 typedef struct FlowAddress_ {
@@ -375,6 +376,7 @@ typedef struct Flow_
     };
     uint8_t proto; /**< ip proto of the flow */
     uint8_t recursion_level;
+    uint16_t tunnel_id;
     uint16_t vlan_id[VLAN_MAX_LAYERS];
 
     uint8_t vlan_idx;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -301,6 +301,9 @@ static void AlertJsonTunnel(const Packet *p, SCJsonBuilder *js, OutputJsonCommon
     SCJbSetUint(js, "dest_port", addr.dp);
     SCJbSetString(js, "proto", addr.proto);
 
+    if (p->tunnel_id > 0 && p->tunnel_id != PKT_TUNNEL_UNKNOWN) {
+        SCJbSetUint(js, "tunnel_id", p->tunnel_id);
+    }
     SCJbSetUint(js, "depth", p->recursion_level);
     uint64_t pcap_cnt = PcapPacketCntGet(p->root);
     if (pcap_cnt != 0) {

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -155,6 +155,9 @@ static SCJsonBuilder *CreateEveHeaderFromFlow(const Flow *f, OutputJsonCommonSet
         SCJbSetUint(jb, "ip_v", 6);
     }
 
+    if (f->tunnel_id > 0 && f->tunnel_id != PKT_TUNNEL_UNKNOWN) {
+        SCJbSetUint(jb, "tunnel_id", f->tunnel_id);
+    }
     if (SCProtoNameValid(f->proto)) {
         SCJbSetString(jb, "proto", known_proto[f->proto]);
     } else {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -895,7 +895,9 @@ SCJsonBuilder *CreateEveHeader(const Packet *p, enum SCOutputJsonLogDirection di
     } else if (PacketIsIPv6(p)) {
         SCJbSetUint(js, "ip_v", 6);
     }
-
+    if (p->tunnel_id > 0 && p->tunnel_id != PKT_TUNNEL_UNKNOWN) {
+        SCJbSetUint(js, "tunnel_id", p->tunnel_id);
+    }
     /* icmp */
     switch (p->proto) {
         case IPPROTO_ICMP:

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -595,7 +595,13 @@ static void *ParseAFPConfig(const char *iface)
         SCLogError("%s: XDP support is not built-in", iface);
 #endif
     }
-
+#ifdef AFPACKET_TEST_REPLAY
+    if ((SCConfGetChildValueIntWithDefault(if_root, if_default, "max-packets", &value)) == 1) {
+        aconf->max_packets = (uint32_t)value;
+    } else {
+        aconf->max_packets = 0;
+    }
+#endif
     if ((SCConfGetChildValueIntWithDefault(if_root, if_default, "buffer-size", &value)) == 1) {
         aconf->buffer_size = (int)value;
     } else {

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -584,6 +584,7 @@ static void *ParseAFPConfig(const char *iface)
                         /* It will just set CPU count to 0 */
                         EBPFBuildCPUSet(NULL, aconf->iface);
                     }
+                    EBPFLoadTunnels(aconf->iface, aconf->ebpf_t_config.cpus_count);
                 }
                 /* we have a peer and we use bypass so we can set up XDP iface redirect */
                 if (aconf->out_iface) {

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2245,6 +2245,13 @@ static int AFPSetFlowStorage(Packet *p, int map_fd, void *key0, void* key1,
     return 1;
 }
 
+#define FlowKeyIpFill(k, p)                                                                        \
+    {                                                                                              \
+        (k)->ip_proto = ((p)->proto == IPPROTO_TCP) ? 1 : 0;                                       \
+        (k)->vlan0 = (p)->vlan_id[0];                                                              \
+        (k)->vlan1 = (p)->vlan_id[1];                                                              \
+    }
+
 /**
  * Bypass function for AF_PACKET capture in eBPF mode
  *
@@ -2292,16 +2299,9 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[0]->src = htonl(GET_IPV4_SRC_ADDR_U32(p));
         keys[0]->dst = htonl(GET_IPV4_DST_ADDR_U32(p));
+        FlowKeyIpFill(keys[0], p);
         keys[0]->port16[0] = p->sp;
         keys[0]->port16[1] = p->dp;
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
-
-        if (p->proto == IPPROTO_TCP) {
-            keys[0]->ip_proto = 1;
-        } else {
-            keys[0]->ip_proto = 0;
-        }
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[0],
                               p->afp_v.nr_cpus) == 0) {
             LiveDevAddBypassFail(dev, 1, AF_INET);
@@ -2319,10 +2319,7 @@ static int AFPBypassCallback(Packet *p)
         keys[1]->dst = htonl(GET_IPV4_SRC_ADDR_U32(p));
         keys[1]->port16[0] = p->dp;
         keys[1]->port16[1] = p->sp;
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
-
-        keys[1]->ip_proto = keys[0]->ip_proto;
+        FlowKeyIpFill(keys[1], p);
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
             EBPFDeleteKey(p->afp_v.v4_map_fd, keys[0]);
@@ -2353,14 +2350,7 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[0]->port16[0] = p->sp;
         keys[0]->port16[1] = p->dp;
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
-
-        if (p->proto == IPPROTO_TCP) {
-            keys[0]->ip_proto = 1;
-        } else {
-            keys[0]->ip_proto = 0;
-        }
+        FlowKeyIpFill(keys[0], p);
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[0],
                               p->afp_v.nr_cpus) == 0) {
             LiveDevAddBypassFail(dev, 1, AF_INET6);
@@ -2380,10 +2370,7 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[1]->port16[0] = p->dp;
         keys[1]->port16[1] = p->sp;
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
-
-        keys[1]->ip_proto = keys[0]->ip_proto;
+        FlowKeyIpFill(keys[1], p);
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
             EBPFDeleteKey(p->afp_v.v6_map_fd, keys[0]);
@@ -2448,13 +2435,7 @@ static int AFPXDPBypassCallback(Packet *p)
          * (as in eBPF filter) so we need to pass from host to network order */
         keys[0]->port16[0] = htons(p->sp);
         keys[0]->port16[1] = htons(p->dp);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
-        if (p->proto == IPPROTO_TCP) {
-            keys[0]->ip_proto = 1;
-        } else {
-            keys[0]->ip_proto = 0;
-        }
+        FlowKeyIpFill(keys[0], p);
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[0],
                               p->afp_v.nr_cpus) == 0) {
             LiveDevAddBypassFail(dev, 1, AF_INET);
@@ -2472,9 +2453,7 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[1]->dst = p->src.addr_data32[0];
         keys[1]->port16[0] = htons(p->dp);
         keys[1]->port16[1] = htons(p->sp);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
-        keys[1]->ip_proto = keys[0]->ip_proto;
+        FlowKeyIpFill(keys[1], p);
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
             EBPFDeleteKey(p->afp_v.v4_map_fd, keys[0]);
@@ -2504,13 +2483,7 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         keys[0]->port16[0] = htons(p->sp);
         keys[0]->port16[1] = htons(p->dp);
-        keys[0]->vlan0 = p->vlan_id[0];
-        keys[0]->vlan1 = p->vlan_id[1];
-        if (p->proto == IPPROTO_TCP) {
-            keys[0]->ip_proto = 1;
-        } else {
-            keys[0]->ip_proto = 0;
-        }
+        FlowKeyIpFill(keys[0], p);
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[0],
                               p->afp_v.nr_cpus) == 0) {
             LiveDevAddBypassFail(dev, 1, AF_INET6);
@@ -2530,9 +2503,7 @@ static int AFPXDPBypassCallback(Packet *p)
         }
         keys[1]->port16[0] = htons(p->dp);
         keys[1]->port16[1] = htons(p->sp);
-        keys[1]->vlan0 = p->vlan_id[0];
-        keys[1]->vlan1 = p->vlan_id[1];
-        keys[1]->ip_proto = keys[0]->ip_proto;
+        FlowKeyIpFill(keys[1], p);
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
             EBPFDeleteKey(p->afp_v.v6_map_fd, keys[0]);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -356,7 +356,9 @@ typedef struct AFPThreadVars_
     int ebpf_filter_fd;
     struct ebpf_timeout_config ebpf_t_config;
 #endif
-
+#ifdef AFPACKET_TEST_REPLAY
+    uint32_t max_packets;
+#endif
 } AFPThreadVars;
 
 static TmEcode ReceiveAFPThreadInit(ThreadVars *, const void *, void **);
@@ -1441,6 +1443,11 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
         } else if (r > 0) {
             StatsCounterIncr(&ptv->tv->stats, ptv->capture_afp_poll_data);
             r = AFPReadFunc(ptv);
+#ifdef AFPACKET_TEST_REPLAY
+            if (ptv->max_packets > 0 && ptv->pkts >= ptv->max_packets) {
+                suricata_ctl_flags |= SURICATA_STOP;
+            }
+#endif
             switch (r) {
                 case AFP_READ_OK:
                     /* Trigger one dump of stats every second */
@@ -2586,6 +2593,9 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, const void *initdata, void **data)
     ptv->promisc = afpconfig->promisc;
     ptv->checksum_mode = afpconfig->checksum_mode;
     ptv->bpf_filter = NULL;
+#ifdef AFPACKET_TEST_REPLAY
+    ptv->max_packets = afpconfig->max_packets;
+#endif
 
     ptv->threads = 1;
 #ifdef HAVE_PACKET_FANOUT

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -60,6 +60,7 @@
 #include "flow-storage.h"
 #include "util-validate.h"
 #include "action-globals.h"
+#include "rust.h"
 
 #ifdef HAVE_AF_PACKET
 
@@ -740,6 +741,16 @@ static inline int AFPSuriFailure(AFPThreadVars *ptv, union thdr h)
     }
     SCReturnInt(AFP_SURI_FAILURE);
 }
+
+#ifdef HAVE_PACKET_EBPF
+void AFPReadCopyBypass(Packet *dst, Packet *src)
+{
+    dst->BypassPacketsFlow = src->BypassPacketsFlow;
+    dst->afp_v.v4_map_fd = src->afp_v.v4_map_fd;
+    dst->afp_v.v6_map_fd = src->afp_v.v6_map_fd;
+    dst->afp_v.nr_cpus = src->afp_v.nr_cpus;
+}
+#endif
 
 static inline void AFPReadApplyBypass(const AFPThreadVars *ptv, Packet *p)
 {
@@ -2245,11 +2256,20 @@ static int AFPSetFlowStorage(Packet *p, int map_fd, void *key0, void* key1,
     return 1;
 }
 
+// unsupported by ebpf : tunnel with multiple layers of vlans inside
 #define FlowKeyIpFill(k, p)                                                                        \
     {                                                                                              \
         (k)->ip_proto = ((p)->proto == IPPROTO_TCP) ? 1 : 0;                                       \
         (k)->vlan0 = (p)->vlan_id[0];                                                              \
-        (k)->vlan1 = (p)->vlan_id[1];                                                              \
+        if ((p)->tunnel_id) {                                                                      \
+            if ((p)->vlan_id[1]) {                                                                 \
+                return 0;                                                                          \
+            }                                                                                      \
+            (k)->tunnel = 1;                                                                       \
+            (k)->vlan1_or_tunnel_id = (p)->tunnel_id;                                              \
+        } else {                                                                                   \
+            (k)->vlan1_or_tunnel_id = (p)->vlan_id[1];                                             \
+        }                                                                                          \
     }
 
 /**
@@ -2280,10 +2300,9 @@ static int AFPBypassCallback(Packet *p)
     if (p->flow == NULL) {
         return 0;
     }
-    /* Bypassing tunneled packets is currently not supported
-     * because we can't discard the inner packet only due to
-     * primitive parsing in eBPF */
-    if (PacketIsTunnel(p)) {
+    /* Bypassing tunneled packets is now supported based on the
+     * configured tunnel with their ids */
+    if (p->tunnel_id == PKT_TUNNEL_UNKNOWN) {
         return 0;
     }
     LiveDevice *dev = LiveDeviceGetById(p->livedev_id);
@@ -2411,10 +2430,9 @@ static int AFPXDPBypassCallback(Packet *p)
     if (p->flow == NULL) {
         return 0;
     }
-    /* Bypassing tunneled packets is currently not supported
-     * because we can't discard the inner packet only due to
-     * primitive parsing in eBPF */
-    if (PacketIsTunnel(p)) {
+    /* Bypassing tunneled packets is now supported based on the
+     * configured tunnel with their ids */
+    if (p->tunnel_id == PKT_TUNNEL_UNKNOWN) {
         return 0;
     }
     LiveDevice *dev = LiveDeviceGetById(p->livedev_id);

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -121,6 +121,9 @@ typedef struct AFPIfaceConfig_
 #ifdef HAVE_PACKET_EBPF
     struct ebpf_timeout_config ebpf_t_config;
 #endif
+#ifdef AFPACKET_TEST_REPLAY
+    uint32_t max_packets;
+#endif
     SC_ATOMIC_DECLARE(unsigned int, ref);
     void (*DerefFunc)(void *);
 } AFPIfaceConfig;

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -204,4 +204,9 @@ int AFPGetLinkType(const char *ifname);
 
 int AFPIsFanoutSupported(uint16_t cluster_id);
 
+#ifdef HAVE_PACKET_EBPF
+typedef struct Packet_ Packet;
+void AFPReadCopyBypass(Packet *dst, Packet *src);
+#endif
+
 #endif /* SURICATA_SOURCE_AFP_H */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -844,6 +844,9 @@ static void PrintBuildInfo(void)
 #ifdef HAVE_PACKET_EBPF
     strlcat(features, "EBPF ", sizeof(features));
 #endif
+#ifdef AFPACKET_TEST_REPLAY
+    strlcat(features, "AFPACKET_TEST_REPLAY ", sizeof(features));
+#endif
 #ifdef PROFILE_LOCKING
     strlcat(features, "PROFILE_LOCKING ", sizeof(features));
 #endif

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -841,6 +841,9 @@ static void PrintBuildInfo(void)
 #ifdef PROFILING
     strlcat(features, "PROFILING ", sizeof(features));
 #endif
+#ifdef HAVE_PACKET_EBPF
+    strlcat(features, "EBPF ", sizeof(features));
+#endif
 #ifdef PROFILE_LOCKING
     strlcat(features, "PROFILE_LOCKING ", sizeof(features));
 #endif

--- a/src/util-device-private.h
+++ b/src/util-device-private.h
@@ -34,6 +34,7 @@ typedef struct LiveDevice_ {
     char dev_short[MAX_DEVNAME + 1];
     int mtu; /* MTU of the device */
     bool tenant_id_set;
+    bool skip_non_tunnel;
 
     uint16_t id;
 

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -58,8 +58,6 @@
 
 #define BPF_MAP_MAX_COUNT 16
 
-#define BYPASSED_FLOW_TIMEOUT   60
-
 static SCLiveDevStorageId g_livedev_storage_id = { .id = -1 };
 static SCFlowStorageId g_flow_storage_id = { .id = -1 };
 

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -55,6 +55,7 @@
 #include <bpf/bpf.h>
 #include <net/if.h>
 #include "autoconf.h"
+#include "rust.h"
 
 #define BPF_MAP_MAX_COUNT 16
 
@@ -179,7 +180,7 @@ static int EBPFLoadPinnedMapsFile(LiveDevice *livedev, const char *file)
 
 static int EBPFLoadPinnedMaps(LiveDevice *livedev, struct ebpf_timeout_config *config)
 {
-    int fd_v4 = -1, fd_v6 = -1;
+    int fd_v4 = -1, fd_v6 = -1, fd_tunnel = -1;
 
     /* First try to load the eBPF check map and return if found */
     if (config->pinned_maps_name) {
@@ -203,6 +204,9 @@ static int EBPFLoadPinnedMaps(LiveDevice *livedev, struct ebpf_timeout_config *c
             SCLogWarning("Found a flow_table_v4 map but no flow_table_v6 map");
             return fd_v6;
         }
+
+        /* Get flow tunnel table if it exists */
+        fd_tunnel = EBPFLoadPinnedMapsFile(livedev, "flow_table_tunnels");
     }
 
     struct bpf_maps_info *bpf_map_data = SCCalloc(1, sizeof(*bpf_map_data));
@@ -223,6 +227,14 @@ static int EBPFLoadPinnedMaps(LiveDevice *livedev, struct ebpf_timeout_config *c
             goto alloc_error;
         }
         bpf_map_data->last = 2;
+        if (fd_tunnel > 0) {
+            bpf_map_data->array[2].fd = fd_tunnel;
+            bpf_map_data->array[2].name = SCStrdup("flow_table_tunnels");
+            if (bpf_map_data->array[2].name == NULL) {
+                goto alloc_error;
+            }
+            bpf_map_data->last++;
+        }
     } else {
         bpf_map_data->last = 0;
     }
@@ -420,6 +432,12 @@ int EBPFLoadFile(const char *iface, const char *path, const char * section,
         if (strcmp(bpf_map__name(map), "flow_table_v6") == 0) {
             if (bpf_map__key_size(map) != sizeof(struct flowv6_keys)) {
                 SCLogError("Incompatible flow_table_v6");
+                break;
+            }
+        }
+        if (strcmp(bpf_map__name(map), "flow_table_tunnels") == 0) {
+            if (bpf_map__key_size(map) != sizeof(struct flowtunnel_keys_ebpf)) {
+                SCLogError("Incompatible flow_table_tunnels");
                 break;
             }
         }
@@ -758,7 +776,11 @@ static int EBPFForEachFlowV4Table(ThreadVars *th_v, LiveDevice *dev, const char 
         flow_key.dst.addr_data32[2] = 0;
         flow_key.dst.addr_data32[3] = 0;
         flow_key.vlan_id[0] = next_key.vlan0;
-        flow_key.vlan_id[1] = next_key.vlan1;
+        if (next_key.tunnel) {
+            flow_key.tunnel_id = next_key.vlan1_or_tunnel_id;
+        } else {
+            flow_key.vlan_id[1] = next_key.vlan1_or_tunnel_id;
+        }
         if (next_key.ip_proto == 1) {
             flow_key.proto = IPPROTO_TCP;
         } else {
@@ -876,7 +898,11 @@ static int EBPFForEachFlowV6Table(ThreadVars *th_v,
             flow_key.dst.addr_data32[3] = ntohl(next_key.dst[3]);
         }
         flow_key.vlan_id[0] = next_key.vlan0;
-        flow_key.vlan_id[1] = next_key.vlan1;
+        if (next_key.tunnel) {
+            flow_key.tunnel_id = next_key.vlan1_or_tunnel_id;
+        } else {
+            flow_key.vlan_id[1] = next_key.vlan1_or_tunnel_id;
+        }
         if (next_key.ip_proto == 1) {
             flow_key.proto = IPPROTO_TCP;
         } else {
@@ -972,6 +998,38 @@ static void EBPFRedirectMapAddCPU(int i, void *data)
     } else {
         g_redirect_iface_cpu_counter++;
     }
+}
+
+void EBPFLoadTunnels(const char *iface, unsigned int nr_cpus)
+{
+    BPF_DECLARE_PERCPU(struct flowtunnel_id, value, nr_cpus);
+
+    int mapfd = EBPFGetMapFDByName(iface, "flow_table_tunnels");
+    if (mapfd < 0) {
+        return;
+    }
+    struct flowtunnel_keys key;
+    struct flowtunnel_keys_ebpf *key_ebpf = SCCalloc(1, sizeof(struct flowtunnel_keys_ebpf));
+    if (key_ebpf == NULL) {
+        return;
+    }
+    uint16_t tunnel_id;
+    void *iter = DecodeTunnelsGetMapIter();
+
+    while (DecodeTunnelsMapIter(iter, &key, &tunnel_id)) {
+        for (unsigned int i = 0; i < nr_cpus; i++) {
+            BPF_PERCPU(value, i).tunnel_id = tunnel_id;
+        }
+        key_ebpf->src = key.src;
+        key_ebpf->dst = key.dst;
+        key_ebpf->session = key.session;
+        key_ebpf->tunnel_proto = key.tunnel_proto;
+        if (bpf_map_update_elem(mapfd, key_ebpf, value, BPF_NOEXIST) != 0) {
+            SCLogError("Can't update eBPF tunnels map: %s (%d)", strerror(errno), errno);
+            return;
+        }
+    }
+    DecodeTunnelsMapIterEnd(iter);
 }
 
 void EBPFBuildCPUSet(SCConfNode *node, char *iface)

--- a/src/util-ebpf.h
+++ b/src/util-ebpf.h
@@ -34,6 +34,12 @@
 #define XDP_FLAGS_DRV_MODE		(1U << 2)
 #define XDP_FLAGS_HW_MODE		(1U << 3)
 
+struct flowtunnel_keys_ebpf {
+    __be32 src;
+    __be32 dst;
+    __u32 session : 24; // vni or spanid
+    __u8 tunnel_proto : 8;
+};
 
 struct flowv4_keys {
     __be32 src;
@@ -44,7 +50,8 @@ struct flowv4_keys {
     };
     __u8 ip_proto:1;
     __u16 vlan0:15;
-    __u16 vlan1;
+    __u8 tunnel : 1;
+    __u16 vlan1_or_tunnel_id : 15;
 };
 
 struct flowv6_keys {
@@ -56,12 +63,17 @@ struct flowv6_keys {
     };
     __u8 ip_proto:1;
     __u16 vlan0:15;
-    __u16 vlan1;
+    __u8 tunnel : 1;
+    __u16 vlan1_or_tunnel_id : 15;
 };
 
 struct pair {
     uint64_t packets;
     uint64_t bytes;
+};
+
+struct flowtunnel_id {
+    uint16_t tunnel_id;
 };
 
 typedef struct EBPFBypassData_ {
@@ -87,6 +99,8 @@ void EBPFRegisterExtension(void);
 void EBPFBuildCPUSet(SCConfNode *node, char *iface);
 
 int EBPFSetPeerIface(const char *iface, const char *out_iface);
+
+void EBPFLoadTunnels(const char *iface, unsigned int nr_cpus);
 
 int EBPFUpdateFlow(Flow *f, Packet *p, void *data);
 bool EBPFBypassUpdate(Flow *f, void *data, time_t tsec);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1809,6 +1809,14 @@ decoder:
   # has put the headers on, like when using netmap driver pickup.
   recursion-level:
     use-for-tracking: true
+  # If your packets sources are tunnels encapsulating the traffic,
+  # you can list here these tunnels and assign identifiers to them.
+  # tunnels:
+  #  - id: 1
+  #    type: erspan2
+  #    src: 192.168.1.1
+  #    dst: 192.168.1.3
+  #    session: 123
 
 ##
 ## Performance tuning and profiling


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7674

Describe changes:
- introduces configurable tunnel_id to distinguish same-looking (same 5-tuple) flows encapsulated in different tunnels
- adds a config option to "skip" the packets that are not part of a tunnel on interfaces receiving tunneled traffic
- handle xdp bypass of these encapsulated flows
- use this new tunnel_id as a multi-tenant selector
- EBPF is now in suricata --build-info list of features
- ebpf: remove unused macro
- test: new afpacket max-packets feature

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3186

https://github.com/OISF/suricata/pull/15603 with new SV PR

On top of first https://github.com/OISF/suricata/pull/15446