### PR TITLE
Detect integers allmulti 7929 v9.3

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -3067,6 +3067,7 @@ jobs:
         env:
           DISTCHECK_CONFIGURE_FLAGS: "--enable-unittests --enable-debug --enable-geoip --enable-profiling --enable-profiling-locks --enable-dpdk --enable-ebpf --enable-ebpf-build"
       - run: python3 scripts/check-dist-rules.py
+      - run: python3 scripts/check-uint-keywords.py
       - run: test -e doc/userguide/suricata.1
       - run: test -e doc/userguide/userguide.pdf
       - name: Building Rust documentation

--- a/doc/userguide/rules/enip-keyword.rst
+++ b/doc/userguide/rules/enip-keyword.rst
@@ -86,6 +86,8 @@ It uses a 32-bit unsigned integer as value.
 
 enip.cip_instance uses an :ref:`unsigned 32-bits integer <rules-integer-keywords>`.
 
+enip.cip_instance is also a :ref:`multi-integer <multi-integers>`.
+
 Examples::
 
   enip.cip_instance:1;
@@ -98,6 +100,8 @@ Match on the cip class in CIP request path.
 It uses a 32-bit unsigned integer as value.
 
 enip.cip_class uses an :ref:`unsigned 32-bits integer <rules-integer-keywords>`.
+
+enip.cip_class is also a :ref:`multi-integer <multi-integers>`.
 
 This allows to match without needing to match on cip.service.
 

--- a/doc/userguide/rules/enip-keyword.rst
+++ b/doc/userguide/rules/enip-keyword.rst
@@ -71,6 +71,8 @@ This allows to match without needing to match on cip.service.
 
 enip.cip_attribute uses an :ref:`unsigned 32-bits integer <rules-integer-keywords>`.
 
+enip.cip_attribute is also a :ref:`multi-integer <multi-integers>`.
+
 Examples::
 
   enip.cip_attribute:1;

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -1612,7 +1612,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         AppLayerTxMatch: Some(cip_status_match),
         Setup: Some(cip_status_setup),
         Free: Some(cip_status_free),
-        flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT,
+        flags: SIGMATCH_INFO_UINT8,
     };
     G_ENIP_CIP_STATUS_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_ENIP_CIP_STATUS_BUFFER_ID = SCDetectHelperBufferProgressRegister(
@@ -1645,7 +1645,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         AppLayerTxMatch: Some(cip_extendedstatus_match),
         Setup: Some(cip_extendedstatus_setup),
         Free: Some(cip_extendedstatus_free),
-        flags: SIGMATCH_INFO_UINT16 | SIGMATCH_INFO_MULTI_UINT,
+        flags: SIGMATCH_INFO_UINT16,
     };
     G_ENIP_CIP_EXTENDEDSTATUS_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_ENIP_CIP_EXTENDEDSTATUS_BUFFER_ID = SCDetectHelperBufferProgressRegister(

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -32,9 +32,10 @@ use super::parser::{
 
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
-    detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU16Free, SCDetectU16Match,
-    SCDetectU16Parse, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse, SCDetectU8Free,
-    SCDetectU8Match, SCDetectU8Parse,
+    detect_match_uint, detect_parse_uint_enum, detect_uint_match_at_index, DetectUintArrayData,
+    DetectUintData, DetectUintIndex, SCDetectU16Free, SCDetectU16Match, SCDetectU16Parse,
+    SCDetectU32ArrayFree, SCDetectU32ArrayParse, SCDetectU32Free, SCDetectU32Match,
+    SCDetectU32Parse, SCDetectU8Free, SCDetectU8Match, SCDetectU8Parse,
 };
 use crate::detect::{
     helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
@@ -328,49 +329,63 @@ fn enip_tx_has_cip_segment(
     return 0;
 }
 
-fn enip_cip_match_attribute(d: &CipData, ctx: &DetectUintData<u32>) -> std::os::raw::c_int {
+fn enip_cip_match_attribute(d: &CipData, ctx: &DetectUintArrayData<u32>, done: bool) -> std::os::raw::c_int {
     if let CipDir::Request(req) = &d.cipdir {
+        let mut vals = Vec::new();
         for seg in req.path.iter() {
-            if seg.segment_type >> 2 == 12 && detect_match_uint(ctx, seg.value) {
-                return 1;
+            if seg.segment_type >> 2 == 12 {
+                if ctx.index != DetectUintIndex::Any {
+                    vals.push(seg.value);
+                } else if detect_match_uint(&ctx.du, seg.value) {
+                    return 1;
+                }
             }
         }
         match &req.payload {
             EnipCipRequestPayload::GetAttributeList(ga) => {
                 for attrg in ga.attr_list.iter() {
-                    if detect_match_uint(ctx, (*attrg).into()) {
+                    if ctx.index != DetectUintIndex::Any {
+                        vals.push((*attrg).into());
+                    } else if detect_match_uint(&ctx.du, (*attrg).into()) {
                         return 1;
                     }
                 }
             }
             EnipCipRequestPayload::SetAttributeList(sa) => {
                 if let Some(val) = sa.first_attr {
-                    if detect_match_uint(ctx, val.into()) {
+                    if ctx.index != DetectUintIndex::Any {
+                        vals.push(val.into());
+                    } else if detect_match_uint(&ctx.du, val.into()) {
                         return 1;
                     }
                 }
             }
             EnipCipRequestPayload::Multiple(m) => {
                 for p in m.packet_list.iter() {
-                    if enip_cip_match_attribute(p, ctx) == 1 {
+                    // treat each array independently
+                    if enip_cip_match_attribute(p, ctx, done) == 1 {
                         return 1;
                     }
                 }
             }
             _ => {}
         }
+        if ctx.index != DetectUintIndex::Any {
+            return detect_uint_match_at_index::<u32, u32>(&vals, ctx, |v| Some(*v), done);
+        }
     }
     return 0;
 }
 
 fn enip_tx_has_cip_attribute(
-    tx: &EnipTransaction, ctx: &DetectUintData<u32>,
+    tx: &EnipTransaction, ctx: &DetectUintArrayData<u32>,
 ) -> std::os::raw::c_int {
     if let Some(pdu) = &tx.request {
         if let EnipPayload::Cip(c) = &pdu.payload {
             for item in c.items.iter() {
                 if let EnipItemPayload::Data(d) = &item.payload {
-                    return enip_cip_match_attribute(&d.cip, ctx);
+                    // there should be only one EnipItemPayload item
+                    return enip_cip_match_attribute(&d.cip, ctx, tx.done);
                 }
             }
         }
@@ -554,7 +569,7 @@ unsafe extern "C" fn cip_attribute_setup(
     if SCDetectSignatureSetAppProto(s, ALPROTO_ENIP) != 0 {
         return -1;
     }
-    let ctx = SCDetectU32Parse(raw) as *mut c_void;
+    let ctx = SCDetectU32ArrayParse(raw) as *mut c_void;
     if ctx.is_null() {
         return -1;
     }
@@ -578,14 +593,14 @@ unsafe extern "C" fn cip_attribute_match(
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
     let tx = cast_pointer!(tx, EnipTransaction);
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
     return enip_tx_has_cip_attribute(tx, ctx);
 }
 
 unsafe extern "C" fn cip_attribute_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     // Just unbox...
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
-    SCDetectU32Free(ctx);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
+    SCDetectU32ArrayFree(ctx);
 }
 
 unsafe extern "C" fn cip_class_setup(

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -26,8 +26,8 @@ use std::os::raw::{c_int, c_void};
 use super::constant::{EnipCommand, EnipStatus};
 use super::enip::{EnipTransaction, ALPROTO_ENIP};
 use super::parser::{
-    CipData, CipDir, EnipCipRequestPayload, EnipCipResponsePayload, EnipItemPayload, EnipPayload,
-    CIP_MULTIPLE_SERVICE,
+    CipData, CipDir, EnipCipPathSegment, EnipCipRequestPayload, EnipCipResponsePayload,
+    EnipItemPayload, EnipPayload, CIP_MULTIPLE_SERVICE,
 };
 
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
@@ -294,18 +294,34 @@ fn enip_get_status(tx: &EnipTransaction, direction: Direction) -> Option<u32> {
     return None;
 }
 
+macro_rules! get_enip_segment_val {
+    ($segment_type:expr) => {
+        |seg: &EnipCipPathSegment| {
+            if seg.segment_type >> 2 == $segment_type {
+                Some(seg.value)
+            } else {
+                None
+            }
+        }
+    };
+}
+
 fn enip_cip_match_segment(
-    d: &CipData, ctx: &DetectUintData<u32>, segment_type: u8,
+    d: &CipData, ctx: &DetectUintArrayData<u32>, segment_type: u8, done: bool,
 ) -> std::os::raw::c_int {
     if let CipDir::Request(req) = &d.cipdir {
-        for seg in req.path.iter() {
-            if seg.segment_type >> 2 == segment_type && detect_match_uint(ctx, seg.value) {
-                return 1;
-            }
+        let r = detect_uint_match_at_index::<EnipCipPathSegment, u32>(
+            &req.path,
+            ctx,
+            get_enip_segment_val!(segment_type),
+            done,
+        );
+        if r == 1 {
+            return 1;
         }
         if let EnipCipRequestPayload::Multiple(m) = &req.payload {
             for p in m.packet_list.iter() {
-                if enip_cip_match_segment(p, ctx, segment_type) == 1 {
+                if enip_cip_match_segment(p, ctx, segment_type, done) == 1 {
                     return 1;
                 }
             }
@@ -315,13 +331,13 @@ fn enip_cip_match_segment(
 }
 
 fn enip_tx_has_cip_segment(
-    tx: &EnipTransaction, ctx: &DetectUintData<u32>, segment_type: u8,
+    tx: &EnipTransaction, ctx: &DetectUintArrayData<u32>, segment_type: u8,
 ) -> std::os::raw::c_int {
     if let Some(pdu) = &tx.request {
         if let EnipPayload::Cip(c) = &pdu.payload {
             for item in c.items.iter() {
                 if let EnipItemPayload::Data(d) = &item.payload {
-                    return enip_cip_match_segment(&d.cip, ctx, segment_type);
+                    return enip_cip_match_segment(&d.cip, ctx, segment_type, tx.done);
                 }
             }
         }
@@ -329,7 +345,9 @@ fn enip_tx_has_cip_segment(
     return 0;
 }
 
-fn enip_cip_match_attribute(d: &CipData, ctx: &DetectUintArrayData<u32>, done: bool) -> std::os::raw::c_int {
+fn enip_cip_match_attribute(
+    d: &CipData, ctx: &DetectUintArrayData<u32>, done: bool,
+) -> std::os::raw::c_int {
     if let CipDir::Request(req) = &d.cipdir {
         let mut vals = Vec::new();
         for seg in req.path.iter() {
@@ -609,7 +627,7 @@ unsafe extern "C" fn cip_class_setup(
     if SCDetectSignatureSetAppProto(s, ALPROTO_ENIP) != 0 {
         return -1;
     }
-    let ctx = SCDetectU32Parse(raw) as *mut c_void;
+    let ctx = SCDetectU32ArrayParse(raw) as *mut c_void;
     if ctx.is_null() {
         return -1;
     }
@@ -633,14 +651,14 @@ unsafe extern "C" fn cip_class_match(
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
     let tx = cast_pointer!(tx, EnipTransaction);
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
     return enip_tx_has_cip_segment(tx, ctx, 8);
 }
 
 unsafe extern "C" fn cip_class_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     // Just unbox...
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
-    SCDetectU32Free(ctx);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
+    SCDetectU32ArrayFree(ctx);
 }
 
 unsafe extern "C" fn vendor_id_setup(
@@ -1222,7 +1240,7 @@ unsafe extern "C" fn cip_instance_setup(
     if SCDetectSignatureSetAppProto(s, ALPROTO_ENIP) != 0 {
         return -1;
     }
-    let ctx = SCDetectU32Parse(raw) as *mut c_void;
+    let ctx = SCDetectU32ArrayParse(raw) as *mut c_void;
     if ctx.is_null() {
         return -1;
     }
@@ -1246,14 +1264,14 @@ unsafe extern "C" fn cip_instance_match(
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
     let tx = cast_pointer!(tx, EnipTransaction);
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
     return enip_tx_has_cip_segment(tx, ctx, 9);
 }
 
 unsafe extern "C" fn cip_instance_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
     // Just unbox...
-    let ctx = cast_pointer!(ctx, DetectUintData<u32>);
-    SCDetectU32Free(ctx);
+    let ctx = cast_pointer!(ctx, DetectUintArrayData<u32>);
+    SCDetectU32ArrayFree(ctx);
 }
 
 unsafe extern "C" fn cip_extendedstatus_setup(

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -29,7 +29,7 @@ use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Match,
 };
-use crate::detect::{SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_MULTI_UINT, SIGMATCH_INFO_UINT32};
+use crate::detect::{SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT32};
 use kerberos_parser::krb5::EncryptionType;
 
 use nom8::branch::alt;
@@ -437,7 +437,7 @@ pub unsafe extern "C" fn SCDetectKrb5MsgTypeRegister() {
         AppLayerTxMatch: Some(krb5_msg_type_match),
         Setup: Some(krb5_msg_type_setup),
         Free: Some(krb5_msg_type_free),
-        flags: SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT | SIGMATCH_INFO_UINT32,
+        flags: SIGMATCH_INFO_ENUM_UINT | SIGMATCH_INFO_UINT32,
     };
     G_KRB5_MSG_TYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_KRB5_MSG_TYPE_BUFFER_ID = SCDetectHelperBufferProgressRegister(

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -1073,7 +1073,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         AppLayerTxMatch: Some(mqtt_flags_match),
         Setup: Some(mqtt_flags_setup),
         Free: Some(mqtt_flags_free),
-        flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_BITFLAGS_UINT,
+        flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_BITFLAGS_UINT,
     };
     G_MQTT_FLAGS_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_MQTT_FLAGS_BUFFER_ID = SCDetectHelperBufferProgressRegister(
@@ -1089,7 +1089,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         AppLayerTxMatch: Some(mqtt_conn_flags_match),
         Setup: Some(mqtt_conn_flags_setup),
         Free: Some(mqtt_conn_flags_free),
-        flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_BITFLAGS_UINT,
+        flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_BITFLAGS_UINT,
     };
     G_MQTT_CONN_FLAGS_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_MQTT_CONN_FLAGS_BUFFER_ID = SCDetectHelperBufferProgressRegister(

--- a/rust/src/nfs/detect.rs
+++ b/rust/src/nfs/detect.rs
@@ -30,7 +30,7 @@ use crate::core::STREAM_TOSERVER;
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, detect_parse_uint_inclusive, DetectUintData,
 };
-use crate::detect::{SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_MULTI_UINT, SIGMATCH_INFO_UINT32};
+use crate::detect::{SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT32};
 
 use std::ffi::{c_int, CStr};
 use std::os::raw::c_void;
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn SCDetectNfsProcedureRegister() {
         AppLayerTxMatch: Some(nfs_procedure_match),
         Setup: Some(nfs_procedure_setup),
         Free: Some(nfs_procedure_free),
-        flags: SIGMATCH_INFO_UINT32 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT,
+        flags: SIGMATCH_INFO_UINT32 | SIGMATCH_INFO_ENUM_UINT,
     };
     G_NFS_PROCEDURE_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_NFS_PROCEDURE_BUFFER_ID = SCDetectHelperBufferProgressRegister(

--- a/scripts/check-uint-keywords.py
+++ b/scripts/check-uint-keywords.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Check that each Suricata keyword with "multi .*uint" features can be used
+in a rule with the syntax:  keyword: >1, all;
+
+Usage:
+    python3 scripts/check-multi-uint-keywords.py [--suricata-bin PATH] [--suricata-yaml PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+
+MULTI_UINT_RE = re.compile(r"multi .*uint\d+")
+
+
+def resolve_suricata_bin(repo_root: Path, configured: Optional[str]) -> Path:
+    if configured:
+        return Path(configured)
+
+    in_path = shutil.which("suricata")
+    if in_path:
+        return Path(in_path)
+
+    candidates = [repo_root / "src" / "suricata", repo_root / "suricata"]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    raise SystemExit(
+        "Unable to find Suricata binary. Use --suricata-bin to provide it."
+    )
+
+
+def list_multi_uint_keywords(suricata_bin: Path) -> list[str]:
+    """Return keyword names whose features column matches 'multi .*uint<N>'."""
+    proc = subprocess.run(
+        [str(suricata_bin), "--list-keywords=csv"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = proc.stdout or proc.stderr
+    reader = csv.reader(io.StringIO(output), delimiter=";")
+    keywords = []
+    for i, row in enumerate(reader):
+        if i == 0:
+            # header row
+            continue
+        if len(row) < 4:
+            continue
+        name = row[0].strip()
+        features = row[3].strip()
+        if MULTI_UINT_RE.search(features):
+            keywords.append(name)
+    return keywords
+
+
+SID_RE = re.compile(r"sid:(?P<sid>\d+)")
+
+
+def check_keywords(
+    keywords: list[str],
+    suricata_bin: Path,
+    suricata_yaml: Path,
+) -> dict[str, list[str]]:
+    """Write all rules to one file, run suricata -T once, return keyword->errors map."""
+    sid_to_keyword: dict[int, str] = {}
+    rules = []
+    for sid, keyword in enumerate(keywords, start=1):
+        sid_to_keyword[sid] = keyword
+        rules.append(
+            f'alert ip any any -> any any '
+            f'(msg:"check {keyword} multi uint"; {keyword}: >1,all; sid:{sid};)\n'
+        )
+
+    with tempfile.TemporaryDirectory(prefix="multi-uint-check-") as tmpdir:
+        rule_file = Path(tmpdir) / "test.rules"
+        rule_file.write_text("".join(rules))
+        cmd = [
+            str(suricata_bin),
+            "-T",
+            "-c", str(suricata_yaml),
+            "-S", str(rule_file),
+            "-l", tmpdir,
+        ]
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        # Attribute each error line to the keyword via the sid embedded in the message.
+        keyword_errors: dict[str, list[str]] = {}
+        current_sid: Optional[int] = None
+        for line in proc.stderr.splitlines():
+            m = SID_RE.search(line)
+            if m:
+                current_sid = int(m.group("sid"))
+            if current_sid is not None and current_sid in sid_to_keyword:
+                kw = sid_to_keyword[current_sid]
+                keyword_errors.setdefault(kw, []).append(line)
+        return keyword_errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check multi-uint keywords can be used with '>1, all' syntax."
+    )
+    parser.add_argument(
+        "--suricata-bin",
+        default=None,
+        help="Path to Suricata binary (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--suricata-yaml",
+        default=None,
+        help="Path to suricata.yaml (default: <repo>/scripts/docrules/docrules.yaml)",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    suricata_bin = resolve_suricata_bin(repo_root, args.suricata_bin)
+    suricata_yaml = (
+        Path(args.suricata_yaml)
+        if args.suricata_yaml
+        else (repo_root / "scripts" / "docrules" / "docrules.yaml")
+    )
+    if not suricata_yaml.exists():
+        raise SystemExit(
+            f"suricata.yaml not found: {suricata_yaml}. Use --suricata-yaml."
+        )
+
+    keywords = list_multi_uint_keywords(suricata_bin)
+    if not keywords:
+        print("No multi-uint keywords found.")
+        return 0
+
+    print(f"Testing {len(keywords)} multi-uint keyword(s): {', '.join(keywords)}\n")
+
+    keyword_errors = check_keywords(keywords, suricata_bin, suricata_yaml)
+
+    for keyword in keywords:
+        status = "FAIL" if keyword in keyword_errors else "OK"
+        print(f"  [{status}] {keyword}")
+
+    if keyword_errors:
+        print(f"\n{len(keyword_errors)} keyword(s) failed:\n")
+        for keyword in keywords:
+            if keyword not in keyword_errors:
+                continue
+            errors = "\n".join(keyword_errors[keyword])
+            print(f"  keyword: {keyword}")
+            print(f"  suricata output:\n    " + errors.replace("\n", "\n    "))
+            print()
+        return 1
+
+    print("\nAll keywords passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-uint-keywords.py
+++ b/scripts/check-uint-keywords.py
@@ -22,6 +22,14 @@ from typing import Optional
 
 MULTI_UINT_RE = re.compile(r"multi .*uint\d+")
 
+# Per-integer-width checks: feature word -> rule option to test
+UINT_CHECKS: dict[str, tuple[re.Pattern[str], str]] = {
+    "uint8":  (re.compile(r"\buint8\b"),  ">1"),
+    "uint16": (re.compile(r"\buint16\b"), ">0x101"),
+    "uint32": (re.compile(r"\buint32\b"), ">0x10001"),
+    "uint64": (re.compile(r"\buint64\b"), ">0x100000001"),
+}
+
 
 def resolve_suricata_bin(repo_root: Path, configured: Optional[str]) -> Path:
     if configured:
@@ -41,8 +49,8 @@ def resolve_suricata_bin(repo_root: Path, configured: Optional[str]) -> Path:
     )
 
 
-def list_multi_uint_keywords(suricata_bin: Path) -> list[str]:
-    """Return keyword names whose features column matches 'multi .*uint<N>'."""
+def list_keywords(suricata_bin: Path) -> list[tuple[str, str]]:
+    """Return (name, features) pairs for all keywords from --list-keywords=csv."""
     proc = subprocess.run(
         [str(suricata_bin), "--list-keywords=csv"],
         check=False,
@@ -51,39 +59,43 @@ def list_multi_uint_keywords(suricata_bin: Path) -> list[str]:
     )
     output = proc.stdout or proc.stderr
     reader = csv.reader(io.StringIO(output), delimiter=";")
-    keywords = []
+    result = []
     for i, row in enumerate(reader):
         if i == 0:
-            # header row
             continue
         if len(row) < 4:
             continue
-        name = row[0].strip()
-        features = row[3].strip()
-        if MULTI_UINT_RE.search(features):
-            keywords.append(name)
-    return keywords
+        result.append((row[0].strip(), row[3].strip()))
+    return result
 
 
 SID_RE = re.compile(r"sid:(?P<sid>\d+)")
 
 
 def check_keywords(
-    keywords: list[str],
+    entries: list[tuple[str, str]],
     suricata_bin: Path,
     suricata_yaml: Path,
-) -> dict[str, list[str]]:
-    """Write all rules to one file, run suricata -T once, return keyword->errors map."""
-    sid_to_keyword: dict[int, str] = {}
-    rules = []
-    for sid, keyword in enumerate(keywords, start=1):
-        sid_to_keyword[sid] = keyword
-        rules.append(
-            f'alert ip any any -> any any '
-            f'(msg:"check {keyword} multi uint"; {keyword}: >1,all; sid:{sid};)\n'
-        )
+) -> dict[int, list[str]]:
+    """Write one rule per (keyword, option) entry, run suricata -T once.
 
-    with tempfile.TemporaryDirectory(prefix="multi-uint-check-") as tmpdir:
+    Returns a mapping of entry index (0-based) -> error lines for failed rules.
+    """
+    rules = []
+    for sid, (keyword, option) in enumerate(entries, start=1):
+        if keyword == "bsize":
+            # bsize is a special case: it requires a sticky buffer first.
+            rules.append(
+                f'alert ip any any -> any any '
+                f'(msg:"check {keyword} {option}"; http.uri; {keyword}: {option}; sid:{sid};)\n'
+            )
+        else:
+            rules.append(
+                f'alert ip any any -> any any '
+                f'(msg:"check {keyword} {option}"; {keyword}: {option}; sid:{sid};)\n'
+            )
+
+    with tempfile.TemporaryDirectory(prefix="uint-check-") as tmpdir:
         rule_file = Path(tmpdir) / "test.rules"
         rule_file.write_text("".join(rules))
         cmd = [
@@ -100,17 +112,16 @@ def check_keywords(
             text=True,
         )
 
-        # Attribute each error line to the keyword via the sid embedded in the message.
-        keyword_errors: dict[str, list[str]] = {}
-        current_sid: Optional[int] = None
+        # Attribute each error line to its entry via the sid embedded in the message.
+        errors_by_idx: dict[int, list[str]] = {}
+        current_idx: Optional[int] = None
         for line in proc.stderr.splitlines():
             m = SID_RE.search(line)
             if m:
-                current_sid = int(m.group("sid"))
-            if current_sid is not None and current_sid in sid_to_keyword:
-                kw = sid_to_keyword[current_sid]
-                keyword_errors.setdefault(kw, []).append(line)
-        return keyword_errors
+                current_idx = int(m.group("sid")) - 1  # convert to 0-based
+            if current_idx is not None and 0 <= current_idx < len(entries):
+                errors_by_idx.setdefault(current_idx, []).append(line)
+        return errors_by_idx
 
 
 def main() -> int:
@@ -141,31 +152,61 @@ def main() -> int:
             f"suricata.yaml not found: {suricata_yaml}. Use --suricata-yaml."
         )
 
-    keywords = list_multi_uint_keywords(suricata_bin)
-    if not keywords:
-        print("No multi-uint keywords found.")
+    all_kw = list_keywords(suricata_bin)
+
+    # Build the flat list of (keyword, option) entries for a single suricata run,
+    # alongside metadata needed for reporting.
+    # Each entry: (group_label, keyword, option)
+    groups: list[tuple[str, str, str]] = []
+
+    for name, features in all_kw:
+        if MULTI_UINT_RE.search(features):
+            groups.append(("multi-uint", name, ">1,all"))
+
+    for type_name, (pattern, option) in UINT_CHECKS.items():
+        for name, features in all_kw:
+            if pattern.search(features):
+                groups.append((type_name, name, option))
+
+    if not groups:
+        print("No matching keywords found.")
         return 0
 
-    print(f"Testing {len(keywords)} multi-uint keyword(s): {', '.join(keywords)}\n")
+    entries = [(kw, opt) for _, kw, opt in groups]
+    print(f"Running {len(entries)} check(s) across {len(set(kw for _, kw, _ in groups))} keyword(s)...\n")
 
-    keyword_errors = check_keywords(keywords, suricata_bin, suricata_yaml)
+    errors_by_idx = check_keywords(entries, suricata_bin, suricata_yaml)
 
-    for keyword in keywords:
-        status = "FAIL" if keyword in keyword_errors else "OK"
-        print(f"  [{status}] {keyword}")
+    # Report grouped by label
+    seen_labels: list[str] = []
+    for label in [g[0] for g in groups]:
+        if label not in seen_labels:
+            seen_labels.append(label)
 
-    if keyword_errors:
-        print(f"\n{len(keyword_errors)} keyword(s) failed:\n")
-        for keyword in keywords:
-            if keyword not in keyword_errors:
-                continue
-            errors = "\n".join(keyword_errors[keyword])
-            print(f"  keyword: {keyword}")
-            print(f"  suricata output:\n    " + errors.replace("\n", "\n    "))
+    any_failure = False
+    failures: list[tuple[str, str, str, str]] = []  # (label, keyword, option, output)
+
+    for label in seen_labels:
+        label_entries = [(i, kw, opt) for i, (lbl, kw, opt) in enumerate(groups) if lbl == label]
+        print(f"--- {label} ---")
+        for idx, keyword, option in label_entries:
+            failed = idx in errors_by_idx
+            status = "FAIL" if failed else "OK"
+            print(f"  [{status}] {keyword}: {option}")
+            if failed:
+                any_failure = True
+                failures.append((label, keyword, option, "\n".join(errors_by_idx[idx])))
+        print()
+
+    if any_failure:
+        print(f"{len(failures)} check(s) failed:\n")
+        for label, keyword, option, output in failures:
+            print(f"  [{label}] {keyword}: {option}")
+            print(f"  suricata output:\n    " + output.replace("\n", "\n    "))
             print()
         return 1
 
-    print("\nAll keywords passed.")
+    print("All checks passed.")
     return 0
 
 

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -66,8 +66,7 @@ void DetectFilesizeRegister(void)
     sigmatch_table[DETECT_FILESIZE].FileMatch = DetectFilesizeMatch;
     sigmatch_table[DETECT_FILESIZE].Setup = DetectFilesizeSetup;
     sigmatch_table[DETECT_FILESIZE].Free = DetectFilesizeFree;
-    sigmatch_table[DETECT_FILESIZE].flags =
-            SIGMATCH_SUPPORT_DIR | SIGMATCH_INFO_UINT64 | SIGMATCH_INFO_MULTI_UINT;
+    sigmatch_table[DETECT_FILESIZE].flags = SIGMATCH_SUPPORT_DIR | SIGMATCH_INFO_UINT64;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_FILESIZE].RegisterTests = DetectFilesizeRegisterTests;
 #endif

--- a/src/detect-sctp-chunk-type.c
+++ b/src/detect-sctp-chunk-type.c
@@ -53,8 +53,7 @@ void DetectSCTPChunkTypeRegister(void)
     sigmatch_table[DETECT_SCTP_CHUNK_TYPE].Match = DetectSCTPChunkTypeMatch;
     sigmatch_table[DETECT_SCTP_CHUNK_TYPE].Setup = DetectSCTPChunkTypeSetup;
     sigmatch_table[DETECT_SCTP_CHUNK_TYPE].Free = DetectSCTPChunkTypeFree;
-    sigmatch_table[DETECT_SCTP_CHUNK_TYPE].flags =
-            SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT;
+    sigmatch_table[DETECT_SCTP_CHUNK_TYPE].flags = SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_ENUM_UINT;
     sigmatch_table[DETECT_SCTP_CHUNK_TYPE].SupportsPrefilter =
             PrefilterSCTPChunkTypeIsPrefilterable;
     sigmatch_table[DETECT_SCTP_CHUNK_TYPE].SetupPrefilter = PrefilterSetupSCTPChunkType;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7929

Describe changes:
- remove wrongly flagged SIGMATCH_INFO_MULTI_UINT for krb5_msg_type
- make enip keywords support multi-integer options
- remove flags SIGMATCH_INFO_MULTI_UINT where we do not implement it (yet ?)

https://github.com/OISF/suricata/pull/15703 with CI checks

@glongo what do you think about SCTP ?
Did you mean to add support for multi-integer ? Then you should use `detect_parse_array_uint_enum` instead of `detect_parse_uint_enum` and so on... (DetectUintArrayData instead of DetectUintData...)
