### PR TITLE
app-layer: fix inverted tx inspected flag on passed flows

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -999,8 +999,7 @@ void AppLayerParserTransactionsCleanup(Flow *f, const uint8_t pkt_dir)
             goto next;
         }
 
-        // for passing flow, do not skip tx as we will not run detection on the other side
-        if (has_tx_detect_flags && (f->flags & (FLOW_ACTION_PASS)) == 0) {
+        if (has_tx_detect_flags) {
             if (!IS_DISRUPTED(ts_disrupt_flags) &&
                     (f->sgh_toserver != NULL || (f->flags & FLOW_SGH_TOSERVER) == 0)) {
                 if ((txd->flags & (APP_LAYER_TX_INSPECTED_TS | APP_LAYER_TX_SKIP_INSPECT_TS)) ==

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -812,7 +812,7 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
         if (tag_txs_as_inspected) {
             const uint8_t inspected_flag = (flags & STREAM_TOSERVER) ? APP_LAYER_TX_INSPECTED_TS
                                                                      : APP_LAYER_TX_INSPECTED_TC;
-            if (txd->flags & inspected_flag) {
+            if (!(txd->flags & inspected_flag)) {
                 txd->flags |= inspected_flag;
                 SCLogDebug("%p/%" PRIu64 " in-order tx is done for direction %s. Flags %02x", tx,
                         idx, flags & STREAM_TOSERVER ? "toserver" : "toclient", txd->flags);
@@ -851,7 +851,7 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
             AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx);
             const uint8_t inspected_flag = (flags & STREAM_TOSERVER) ? APP_LAYER_TX_INSPECTED_TS
                                                                      : APP_LAYER_TX_INSPECTED_TC;
-            if (txd->flags & inspected_flag) {
+            if (!(txd->flags & inspected_flag)) {
                 txd->flags |= inspected_flag;
                 SCLogDebug("%p/%" PRIu64 " out of order tx is done for direction %s. Flag %02x", tx,
                         idx, flags & STREAM_TOSERVER ? "toserver" : "toclient", txd->flags);


### PR DESCRIPTION
This fixes the tx-inspection regression tracked in #8628 and removes the targeted  issue 8619 workaround that the fix makes redundant.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8628

Describe changes:
- Fix inverted tx inspected flag check (regression from 834378ff88)
- Revert fix for issue 8619 (commit 2eede11195)

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
