### PR TITLE
util/file: fix integer overflow in file inspection window comparison

### DIFF
--- a/src/util-file.c
+++ b/src/util-file.c
@@ -388,7 +388,7 @@ static int FilePruneFile(File *file, const StreamingBufferConfig *cfg)
             SCLogDebug("window %"PRIu32", file_size %"PRIu64", data_size %"PRIu64,
                     window, file_size, data_size);
 
-            if (data_size > (window * 3)) {
+            if (data_size > ((uint64_t)window * 3)) {
                 file->content_inspected = MAX(file->content_inspected, file->size - window);
                 SCLogDebug("file->content_inspected now %" PRIu64, file->content_inspected);
             }


### PR DESCRIPTION
Ticket: 8678

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8678

Describe changes:
In FilePruneFile() (src/util-file.c), the expression window * 3 is computed
in uint32_t arithmetic before being compared with the uint64_t value data_size.
When file->inspect_window is configured to a value greater than UINT32_MAX/3
(~1.4 GB), the multiplication wraps around, producing an incorrect result that
silently breaks the file inspection range-limiting logic.

The content-inspect-window configuration parameter accepts values up to
UINT32_MAX (~4.29 GB) via ParseSizeStringU32, making the overflow reachable
through a legitimate configuration.

Fix: cast window to uint64_t before multiplying.

Flagged by Svace static analyzer (NO_CAST.INTEGER_OVERFLOW).

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=