### PR TITLE
app-layer/smtp: check return value of FileAppendData in raw extraction mode

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -760,7 +760,12 @@ static int SMTPProcessCommandDATA(
     } else if (smtp_config.raw_extraction) {
         // message not over, store the line. This is a substitution of
         // ProcessDataChunk
-        FileAppendData(&tx->files_ts, &smtp_config.sbcfg, line->buf, line->len + line->delim_len);
+        int r = FileAppendData(&tx->files_ts, &smtp_config.sbcfg, line->buf, line->len + line->delim_len);
+        if (r == -2) {
+            SCLogDebug("FileAppendData() - file no longer being extracted");
+        } else if (r < 0) {
+            SCLogDebug("FileAppendData() failed: %d", r);
+        }
     }
 
     /* If DATA, then parse out a MIME message */


### PR DESCRIPTION
Ticket: [8679](https://redmine.openinfosecfoundation.org/issues/8679) https://redmine.openinfosecfoundation.org/issues/8679

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8679

Describe changes:
In SMTPProcessCommandDATA() (src/app-layer-smtp.c), the return value of
FileAppendData() was ignored in the raw_extraction branch. On failure, the
file silently transitions to FILE_STATE_ERROR without any diagnostic message,
leading to incomplete file inspection and potential missed detections.

Check the return value and log a debug message, consistent with 6 of 7 other
FileAppendData call sites in the codebase.

Flagged by Svace static analyzer (UNCHECKED_FUNC_RES.STAT).

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=