### PR TITLE
sip: store frame lens as u32 to avoid body truncation

### DIFF
--- a/rust/src/sip/parser.rs
+++ b/rust/src/sip/parser.rs
@@ -40,10 +40,10 @@ pub struct Request {
     pub version: String,
     pub headers: HashMap<String, Vec<String>>,
 
-    pub request_line_len: u16,
-    pub headers_len: u16,
-    pub body_offset: u16,
-    pub body_len: u16,
+    pub request_line_len: u32,
+    pub headers_len: u32,
+    pub body_offset: u32,
+    pub body_len: u32,
     pub body: Option<SdpMessage>,
 }
 
@@ -53,10 +53,10 @@ pub struct Response {
     pub code: String,
     pub reason: String,
     pub headers: HashMap<String, Vec<String>>,
-    pub response_line_len: u16,
-    pub headers_len: u16,
-    pub body_offset: u16,
-    pub body_len: u16,
+    pub response_line_len: u32,
+    pub headers_len: u32,
+    pub body_offset: u32,
+    pub body_len: u32,
     pub body: Option<SdpMessage>,
 }
 
@@ -149,10 +149,10 @@ pub fn parse_request(oi: &[u8]) -> IResult<&[u8], Request> {
             version,
             headers,
 
-            request_line_len: request_line_len as u16,
-            headers_len: headers_len as u16,
-            body_offset: body_offset as u16,
-            body_len: bi.len() as u16,
+            request_line_len: request_line_len as u32,
+            headers_len: headers_len as u32,
+            body_offset: body_offset as u32,
+            body_len: bi.len() as u32,
             body,
         },
     ))
@@ -179,10 +179,10 @@ pub fn parse_response(oi: &[u8]) -> IResult<&[u8], Response> {
             reason: reason.into(),
             headers,
 
-            response_line_len: response_line_len as u16,
-            headers_len: headers_len as u16,
-            body_offset: body_offset as u16,
-            body_len: bi.len() as u16,
+            response_line_len: response_line_len as u32,
+            headers_len: headers_len as u32,
+            body_offset: body_offset as u32,
+            body_len: bi.len() as u32,
             body,
         },
     ))
@@ -414,5 +414,43 @@ mod tests {
             req.headers["Route"].get(1).unwrap(),
             "<sip:carol@chicago.com>"
         );
+    }
+
+    #[test]
+    fn test_parse_request_large_body() {
+        let body = vec![b'X'; 65536];
+        let mut buf: Vec<u8> = b"INVITE sip:bob@target.com SIP/2.0\r\n\
+                                 From: <sip:alice@attacker.com>;tag=abc123\r\n\
+                                 To: <sip:bob@target.com>\r\n\
+                                 Content-Type: application/sdp\r\n\
+                                 Content-Length: 65536\r\n\
+                                 \r\n"
+            .to_vec();
+        let body_offset = buf.len();
+        buf.extend_from_slice(&body);
+
+        let (rem, req) = parse_request(&buf).expect("parsing failed");
+        assert_eq!(req.method, "INVITE");
+        assert_eq!(req.body_offset as usize, body_offset);
+        assert_eq!(req.body_len, 65536);
+        assert_eq!(rem, &body[..]);
+    }
+
+    #[test]
+    fn test_parse_response_large_body() {
+        let body = vec![b'X'; 65536];
+        let mut buf: Vec<u8> = b"SIP/2.0 200 OK\r\n\
+                                 Content-Type: application/sdp\r\n\
+                                 Content-Length: 65536\r\n\
+                                 \r\n"
+            .to_vec();
+        let body_offset = buf.len();
+        buf.extend_from_slice(&body);
+
+        let (rem, resp) = parse_response(&buf).expect("parsing failed");
+        assert_eq!(resp.code, "200");
+        assert_eq!(resp.body_offset as usize, body_offset);
+        assert_eq!(resp.body_len, 65536);
+        assert_eq!(rem, &body[..]);
     }
 }


### PR DESCRIPTION
Body lengths were stored as u16, so a SIP body of 65536 bytes truncated body_len to 0 and the RequestBody/ResponseBody frame was never created, letting body content evade inspection. Widen the frame fields to u32.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8582

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3191
