### PR TITLE
feat(detect): extend app-layer-protocol: to accept comma-separated value lists - v1

### DIFF
--- a/doc/userguide/rules/app-layer.rst
+++ b/doc/userguide/rules/app-layer.rst
@@ -11,6 +11,7 @@ Match on the detected app-layer protocol.
 Syntax::
 
     app-layer-protocol:[!]<protocol>(,<mode>);
+    app-layer-protocol:[!]<proto1>,<proto2>[,...,<protoN>](,<mode>);
 
 Examples::
 
@@ -21,6 +22,10 @@ Examples::
     app-layer-protocol:http,to_server; app-layer-protocol:tls,to_client;
     app-layer-protocol:http2,final; app-layer-protocol:http1,original;
     app-layer-protocol:unknown;
+    app-layer-protocol:unknown,tls;
+    app-layer-protocol:unknown,tls,http;
+    app-layer-protocol:!tls,http;
+    app-layer-protocol:tls,http,either;
 
 A special value 'failed' can be used for matching on flows in which
 protocol detection failed. This can happen if Suricata doesn't know
@@ -47,6 +52,98 @@ Here is an example of a rule matching non-http traffic on port 80:
 .. container:: example-rule
 
     alert tcp any any -> any 80 (msg:"non-HTTP traffic over HTTP standard port"; flow:to_server; app-layer-protocol:!http,final; sid:1; )
+
+Multi-value form
+~~~~~~~~~~~~~~~~
+
+The ``app-layer-protocol`` keyword also accepts a comma-separated list of
+protocol values. A rule matches when the flow's resolved application-layer
+protocol equals **any** value in the list (logical OR).
+
+Syntax::
+
+    app-layer-protocol:[!]<proto1>,<proto2>[,...,<protoN>](,<mode>);
+
+The list may contain up to 16 protocol values. The total argument length
+must not exceed 1024 characters, and each individual token must not exceed
+50 characters.
+
+Examples::
+
+    app-layer-protocol:unknown,tls;
+    app-layer-protocol:unknown,tls,http;
+    app-layer-protocol:tls,http,either;
+    app-layer-protocol:!tls,http;
+
+Mode disambiguation rule
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When the keyword argument contains two or more comma-separated tokens, the
+parser applies the following disambiguation rule to determine whether the
+final token is a mode qualifier or a protocol value:
+
+- If the final token matches one of the six recognized mode qualifier names
+  (``final``, ``original``, ``either``, ``to_server``, ``to_client``,
+  ``direction``), it is parsed as the mode qualifier and the preceding tokens
+  form the protocol value list.
+- Otherwise, all tokens are parsed as protocol values and the mode defaults
+  to ``direction``.
+
+For example::
+
+    app-layer-protocol:tls,http,either;
+
+Here ``either`` is recognized as a mode qualifier, so the protocol list is
+``[tls, http]`` with mode ``either``.
+
+::
+
+    app-layer-protocol:unknown,tls,http;
+
+Here ``http`` is not a recognized mode qualifier name, so all three tokens
+are protocol values with the default mode ``direction``.
+
+The ``unknown,<proto>`` Detection Window idiom
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When Suricata has not yet classified a flow's protocol (the "detection
+window"), the flow's app-layer protocol is ``unknown``. Once protocol
+detection completes, the protocol transitions to its classified value
+(e.g., ``tls``, ``http``). Including ``unknown`` in a multi-value list
+allows a single rule to cover both the detection window and the confirmed
+protocol::
+
+    app-layer-protocol:unknown,tls;
+
+This rule matches during the detection window (while the protocol is still
+``unknown``) **and** after classification (when the protocol is ``tls``).
+If the flow is classified to a protocol not in the list (e.g., ``http``),
+the rule stops matching after the detection window closes and the
+default-drop verdict applies if no other rule accepts the flow.
+
+The detection window is bounded by Suricata's existing app-layer probing
+budget. No new configuration knob is introduced.
+
+Negated multi-value (NOR semantics)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When the multi-value form is negated with ``!``, it implements NOR semantics
+across the entire list: the rule matches when the resolved application-layer
+protocol is **known** AND matches **none** of the listed values.
+
+Example::
+
+    app-layer-protocol:!tls,http;
+
+This matches when the flow's protocol is known and is neither ``tls`` nor
+``http`` (e.g., it matches ``dns``, ``ssh``, ``smtp``, etc.).
+
+.. note:: Negated multi-value rules do not match during the detection window
+   (when the protocol is still ``unknown``). This prevents false positives
+   before protocol classification is complete.
+
+.. note:: The value ``unknown`` cannot appear in a negated list. The parser
+   rejects ``!unknown`` and ``!unknown,tls`` at rule-load time.
 
 .. _proto-detect-bail-out:
 

--- a/doc/userguide/rules/app-layer.rst
+++ b/doc/userguide/rules/app-layer.rst
@@ -11,7 +11,7 @@ Match on the detected app-layer protocol.
 Syntax::
 
     app-layer-protocol:[!]<protocol>(,<mode>);
-    app-layer-protocol:[!]<proto1>,<proto2>[,...,<protoN>](,<mode>);
+    app-layer-protocol:[!]<proto1>|<proto2>[|...|<protoN>](,<mode>);
 
 Examples::
 
@@ -22,10 +22,10 @@ Examples::
     app-layer-protocol:http,to_server; app-layer-protocol:tls,to_client;
     app-layer-protocol:http2,final; app-layer-protocol:http1,original;
     app-layer-protocol:unknown;
-    app-layer-protocol:unknown,tls;
-    app-layer-protocol:unknown,tls,http;
-    app-layer-protocol:!tls,http;
-    app-layer-protocol:tls,http,either;
+    app-layer-protocol:unknown|tls;
+    app-layer-protocol:unknown|tls|http;
+    app-layer-protocol:!tls|http;
+    app-layer-protocol:tls|http,either;
 
 A special value 'failed' can be used for matching on flows in which
 protocol detection failed. This can happen if Suricata doesn't know
@@ -56,55 +56,26 @@ Here is an example of a rule matching non-http traffic on port 80:
 Multi-value form
 ~~~~~~~~~~~~~~~~
 
-The ``app-layer-protocol`` keyword also accepts a comma-separated list of
-protocol values. A rule matches when the flow's resolved application-layer
+The ``app-layer-protocol`` keyword also accepts a pipe-separated (``|``) list
+of protocol values. A rule matches when the flow's resolved application-layer
 protocol equals **any** value in the list (logical OR).
 
 Syntax::
 
-    app-layer-protocol:[!]<proto1>,<proto2>[,...,<protoN>](,<mode>);
+    app-layer-protocol:[!]<proto1>|<proto2>[|...|<protoN>](,<mode>);
 
-The list may contain up to 16 protocol values. The total argument length
-must not exceed 1024 characters, and each individual token must not exceed
-50 characters.
+Using ``|`` for the list keeps the optional trailing ``,<mode>`` qualifier
+unambiguous, so the single-value ``<protocol>,<mode>`` form is unchanged.
 
 Examples::
 
-    app-layer-protocol:unknown,tls;
-    app-layer-protocol:unknown,tls,http;
-    app-layer-protocol:tls,http,either;
-    app-layer-protocol:!tls,http;
+    app-layer-protocol:unknown|tls;
+    app-layer-protocol:unknown|tls|http;
+    app-layer-protocol:tls|http,either;
+    app-layer-protocol:!tls|http;
 
-Mode disambiguation rule
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-When the keyword argument contains two or more comma-separated tokens, the
-parser applies the following disambiguation rule to determine whether the
-final token is a mode qualifier or a protocol value:
-
-- If the final token matches one of the six recognized mode qualifier names
-  (``final``, ``original``, ``either``, ``to_server``, ``to_client``,
-  ``direction``), it is parsed as the mode qualifier and the preceding tokens
-  form the protocol value list.
-- Otherwise, all tokens are parsed as protocol values and the mode defaults
-  to ``direction``.
-
-For example::
-
-    app-layer-protocol:tls,http,either;
-
-Here ``either`` is recognized as a mode qualifier, so the protocol list is
-``[tls, http]`` with mode ``either``.
-
-::
-
-    app-layer-protocol:unknown,tls,http;
-
-Here ``http`` is not a recognized mode qualifier name, so all three tokens
-are protocol values with the default mode ``direction``.
-
-The ``unknown,<proto>`` Detection Window idiom
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The ``unknown|<proto>`` detection-window idiom
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When Suricata has not yet classified a flow's protocol (the "detection
 window"), the flow's app-layer protocol is ``unknown``. Once protocol
@@ -113,7 +84,7 @@ detection completes, the protocol transitions to its classified value
 allows a single rule to cover both the detection window and the confirmed
 protocol::
 
-    app-layer-protocol:unknown,tls;
+    app-layer-protocol:unknown|tls;
 
 This rule matches during the detection window (while the protocol is still
 ``unknown``) **and** after classification (when the protocol is ``tls``).
@@ -133,7 +104,7 @@ protocol is **known** AND matches **none** of the listed values.
 
 Example::
 
-    app-layer-protocol:!tls,http;
+    app-layer-protocol:!tls|http;
 
 This matches when the flow's protocol is known and is neither ``tls`` nor
 ``http`` (e.g., it matches ``dns``, ``ssh``, ``smtp``, etc.).
@@ -143,7 +114,7 @@ This matches when the flow's protocol is known and is neither ``tls`` nor
    before protocol classification is complete.
 
 .. note:: The value ``unknown`` cannot appear in a negated list. The parser
-   rejects ``!unknown`` and ``!unknown,tls`` at rule-load time.
+   rejects ``!unknown`` and ``!unknown|tls`` at rule-load time.
 
 .. _proto-detect-bail-out:
 

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -48,11 +48,45 @@ enum {
     DETECT_ALPROTO_ORIG = 5,
 };
 
-/** \brief maximum number of comma-separated values a single
- *         app-layer-protocol: keyword may carry. */
-#define MAX_ALPROTO_LIST 16
-
 static void DetectAppLayerProtocolFree(DetectEngineCtx *de_ctx, void *ptr);
+
+/** \internal \brief size in bytes of an alproto bitmask (g_alproto_max bits). */
+static inline uint32_t AlprotoBitmaskSize(void)
+{
+    return (uint32_t)((g_alproto_max + 7) / 8);
+}
+
+static inline void AlprotoBitmaskSet(uint8_t *bm, AppProto a)
+{
+    bm[a >> 3] |= (uint8_t)(1u << (a & 7));
+}
+
+static inline bool AlprotoBitmaskTest(const uint8_t *bm, AppProto a)
+{
+    return (bm[a >> 3] & (uint8_t)(1u << (a & 7))) != 0;
+}
+
+/** \internal \brief Set the bit for a value; the generic ALPROTO_HTTP umbrella
+ *  also sets the http1/http2 bits. */
+static void AlprotoBitmaskSetValue(uint8_t *bm, AppProto a)
+{
+    AlprotoBitmaskSet(bm, a);
+    if (a == ALPROTO_HTTP) {
+        AlprotoBitmaskSet(bm, ALPROTO_HTTP1);
+        AlprotoBitmaskSet(bm, ALPROTO_HTTP2);
+    }
+}
+
+/** \internal \brief Exact comparison for the single-value prefilter path,
+ *  mirroring AlprotoBitmaskSetValue(). */
+static bool DetectAppLayerProtocolMatchExact(AppProto sigproto, AppProto alproto)
+{
+    if (sigproto == alproto)
+        return true;
+    if (sigproto == ALPROTO_HTTP)
+        return alproto == ALPROTO_HTTP1 || alproto == ALPROTO_HTTP2;
+    return false;
+}
 
 static int DetectAppLayerProtocolPacketMatch(
         DetectEngineThreadCtx *det_ctx, Packet *p, const Signature *s, const SigMatchCtx *ctx)
@@ -114,28 +148,15 @@ static int DetectAppLayerProtocolPacketMatch(
         }
     }
 
-    const AppProto *protos = (data->list_count == 0) ? &data->alproto : data->list_alprotos;
-    const uint8_t count = (data->list_count == 0) ? 1 : data->list_count;
-
     bool r = false;
     if (data->mode == DETECT_ALPROTO_EITHER) {
-        for (uint8_t i = 0; i < count; i++) {
-            if (AppProtoEquals(protos[i], f->alproto_ts) ||
-                    AppProtoEquals(protos[i], f->alproto_tc)) {
-                r = true;
-                break;
-            }
-        }
+        r = AlprotoBitmaskTest(data->alprotos, f->alproto_ts) ||
+            AlprotoBitmaskTest(data->alprotos, f->alproto_tc);
     } else {
-        for (uint8_t i = 0; i < count; i++) {
-            if (AppProtoEquals(protos[i], resolved_alproto)) {
-                r = true;
-                break;
-            }
-        }
+        r = AlprotoBitmaskTest(data->alprotos, resolved_alproto);
     }
 
-    /* XOR with negated → NOR semantics for negated lists. */
+    /* XOR with negated for NOR semantics. */
     r = r ^ data->negated;
 
     if (r) {
@@ -164,6 +185,49 @@ static int DetectAppLayerProtocolMapModeName(const char *name)
     if (strcmp(name, "direction") == 0)
         return DETECT_ALPROTO_DIRECTION;
     return -1;
+}
+
+/** \brief Map a DETECT_ALPROTO_* mode value to its textual qualifier. */
+const char *DetectAppLayerProtocolModeName(uint8_t mode)
+{
+    switch (mode) {
+        case DETECT_ALPROTO_FINAL:
+            return "final";
+        case DETECT_ALPROTO_ORIG:
+            return "original";
+        case DETECT_ALPROTO_EITHER:
+            return "either";
+        case DETECT_ALPROTO_TOSERVER:
+            return "to_server";
+        case DETECT_ALPROTO_TOCLIENT:
+            return "to_client";
+        case DETECT_ALPROTO_DIRECTION:
+        default:
+            return "direction";
+    }
+}
+
+/** \brief Format a multi-value keyword's value set as a comma-separated string
+ *  of protocol names (used by the engine-analyzer). */
+void DetectAppLayerProtocolListToString(
+        const DetectAppLayerProtocolData *data, char *buf, size_t buflen)
+{
+    if (buflen == 0)
+        return;
+    buf[0] = '\0';
+
+    size_t offset = 0;
+    for (AppProto a = 0; a < g_alproto_max; a++) {
+        if (!AlprotoBitmaskTest(data->alprotos, a))
+            continue;
+        const char *name = AppProtoToString(a);
+        if (name == NULL)
+            continue;
+        int w = snprintf(buf + offset, buflen - offset, "%s%s", (offset == 0) ? "" : ",", name);
+        if (w < 0 || (size_t)w >= buflen - offset)
+            break;
+        offset += (size_t)w;
+    }
 }
 
 /** \internal
@@ -213,134 +277,100 @@ static DetectAppLayerProtocolData *DetectAppLayerProtocolParse(const char *arg, 
         return NULL;
     }
 
-    /* Tokenize on ','. */
     char buf[1025];
     strlcpy(buf, arg, sizeof(buf));
 
-    const char *tokens[MAX_ALPROTO_LIST + 1];
-    int token_count = 0;
-    char *cur = buf;
-    while (1) {
-        char *comma = strchr(cur, ',');
-        if (comma != NULL)
-            *comma = '\0';
-
-        if (token_count >= MAX_ALPROTO_LIST + 1) {
-            SCLogError("app-layer-protocol keyword value list in \"%s\" exceeds the "
-                       "maximum of %d comma-separated values",
-                    arg, MAX_ALPROTO_LIST);
+    /* The protocol list and the mode are separated by a single ','; the list
+     * itself is pipe-separated. */
+    uint8_t mode = DETECT_ALPROTO_DIRECTION;
+    char *mode_str = strchr(buf, ',');
+    if (mode_str != NULL) {
+        *mode_str = '\0';
+        mode_str++;
+        int m = DetectAppLayerProtocolMapModeName(mode_str);
+        if (m < 0) {
+            SCLogError("app-layer-protocol keyword supplied with unknown mode "
+                       "\"%s\" in \"%s\"",
+                    mode_str, arg);
             return NULL;
         }
+        mode = (uint8_t)m;
+    }
+
+    /* Allocate the keyword data and its value bitmask up front. */
+    DetectAppLayerProtocolData *data = SCCalloc(1, sizeof(*data));
+    if (unlikely(data == NULL))
+        return NULL;
+    data->alprotos = SCCalloc(1, AlprotoBitmaskSize());
+    if (unlikely(data->alprotos == NULL)) {
+        SCFree(data);
+        return NULL;
+    }
+    data->negated = negate;
+    data->mode = mode;
+    data->alproto = ALPROTO_UNKNOWN;
+
+    /* Tokenize the protocol list on '|' and set a bit per resolved value. */
+    int value_count = 0;
+    char *cur = buf;
+    while (1) {
+        char *pipe = strchr(cur, '|');
+        if (pipe != NULL)
+            *pipe = '\0';
 
         size_t tlen = strlen(cur);
         if (tlen == 0) {
             SCLogError("app-layer-protocol keyword value \"%s\" contains an empty token", arg);
-            return NULL;
+            goto error;
         }
         if (tlen >= MAX_ALPROTO_NAME) {
             SCLogError("app-layer-protocol keyword token \"%s\" in \"%s\" exceeds the "
                        "maximum token length of %d characters",
                     cur, arg, MAX_ALPROTO_NAME - 1);
-            return NULL;
+            goto error;
         }
 
-        tokens[token_count++] = cur;
-        if (comma == NULL)
-            break;
-        cur = comma + 1;
-    }
-
-    /* Mode disambiguation: trailing token is a mode qualifier
-     * only when 2+ tokens are present; a single token is always a protocol. */
-    uint8_t mode = DETECT_ALPROTO_DIRECTION;
-    uint8_t mode_explicit = 0;
-    int value_token_count = token_count;
-    if (token_count >= 2) {
-        int m = DetectAppLayerProtocolMapModeName(tokens[token_count - 1]);
-        if (m >= 0) {
-            mode = (uint8_t)m;
-            mode_explicit = 1;
-            value_token_count = token_count - 1;
-        }
-    }
-
-    /* Validate value count. */
-    if (value_token_count == 0) {
-        SCLogError("app-layer-protocol keyword value \"%s\" contains no protocol "
-                   "values (an empty value list is not permitted)",
-                arg);
-        return NULL;
-    }
-    if (value_token_count > MAX_ALPROTO_LIST) {
-        SCLogError("app-layer-protocol keyword value list in \"%s\" exceeds the "
-                   "maximum of %d comma-separated values",
-                arg, MAX_ALPROTO_LIST);
-        return NULL;
-    }
-
-    /* Per-token resolution. */
-    AppProto values[MAX_ALPROTO_LIST];
-    for (int i = 0; i < value_token_count; i++) {
-        const char *name = tokens[i];
-        if (strcmp(name, "failed") == 0) {
-            values[i] = ALPROTO_FAILED;
-        } else if (strcmp(name, "unknown") == 0) {
+        AppProto value;
+        if (strcmp(cur, "failed") == 0) {
+            value = ALPROTO_FAILED;
+        } else if (strcmp(cur, "unknown") == 0) {
             if (negate) {
                 SCLogError("app-layer-protocol "
                            "keyword can't use negation with protocol 'unknown'");
-                return NULL;
+                goto error;
             }
-            values[i] = ALPROTO_UNKNOWN;
+            value = ALPROTO_UNKNOWN;
         } else {
-            AppProto ap = AppLayerGetProtoByName(name);
-            if (ap == ALPROTO_UNKNOWN) {
+            value = AppLayerGetProtoByName(cur);
+            if (value == ALPROTO_UNKNOWN) {
                 char supported[1024];
                 DetectAppLayerProtocolBuildSupportedList(supported, sizeof(supported));
                 SCLogError("app-layer-protocol keyword supplied with unknown protocol "
                            "\"%s\" in \"%s\"; supported protocols: %s",
-                        name, arg, supported);
-                return NULL;
+                        cur, arg, supported);
+                goto error;
             }
-            values[i] = ap;
         }
+
+        if (value_count == 0)
+            data->alproto = value;
+        AlprotoBitmaskSetValue(data->alprotos, value);
+        value_count++;
+
+        if (pipe == NULL)
+            break;
+        cur = pipe + 1;
     }
 
-    /* Allocate and populate. */
-    DetectAppLayerProtocolData *data = SCMalloc(sizeof(DetectAppLayerProtocolData));
-    if (unlikely(data == NULL))
-        return NULL;
-    memset(data, 0, sizeof(*data));
-    data->alproto = values[0];
-    data->negated = negate ? 1 : 0;
-    data->mode = mode;
-    data->mode_explicit = mode_explicit;
-    if (value_token_count == 1) {
-        data->list_count = 0;
-        data->list_alprotos = NULL;
-    } else {
-        data->list_count = (uint8_t)value_token_count;
-        data->list_alprotos = SCMalloc(sizeof(AppProto) * (size_t)value_token_count);
-        if (unlikely(data->list_alprotos == NULL)) {
-            SCFree(data);
-            return NULL;
-        }
-        memcpy(data->list_alprotos, values, sizeof(AppProto) * (size_t)value_token_count);
-    }
+    data->is_list = (value_count > 1);
+    if (data->is_list)
+        data->alproto = ALPROTO_UNKNOWN; /* not a single-value prefilter bucket key */
 
     return data;
-}
 
-/**
- * \brief Get the value set for a DetectAppLayerProtocolData entry.
- */
-static inline const AppProto *GetValueSet(const DetectAppLayerProtocolData *data, uint8_t *count)
-{
-    if (data->list_count > 0) {
-        *count = data->list_count;
-        return data->list_alprotos;
-    }
-    *count = 1;
-    return &data->alproto;
+error:
+    DetectAppLayerProtocolFree(NULL, data);
+    return NULL;
 }
 
 /**
@@ -363,34 +393,27 @@ static bool HasConflicts(
         return true;
     }
 
-    /* Mixed negation under same mode: always conflict. Enumerate
-     * intersecting values for the error message. */
-    uint8_t us_count = 0, them_count = 0;
-    const AppProto *us_vals = GetValueSet(us, &us_count);
-    const AppProto *them_vals = GetValueSet(them, &them_count);
-
-    /* Collect intersecting value names for the error message. */
+    /* Mixed negation under the same mode: conflict. Collect the intersecting
+     * values for the error message. */
     char conflict_buf[512];
     size_t buf_offset = 0;
     bool has_intersection = false;
 
-    for (uint8_t i = 0; i < us_count; i++) {
-        for (uint8_t j = 0; j < them_count; j++) {
-            if (us_vals[i] == them_vals[j]) {
-                has_intersection = true;
-                const char *name = AppProtoToString(us_vals[i]);
-                if (name == NULL)
-                    name = "unknown";
-                if (buf_offset > 0 && buf_offset < sizeof(conflict_buf) - 2) {
-                    conflict_buf[buf_offset++] = ',';
-                    conflict_buf[buf_offset++] = ' ';
-                }
-                size_t name_len = strlen(name);
-                if (buf_offset + name_len < sizeof(conflict_buf) - 1) {
-                    memcpy(conflict_buf + buf_offset, name, name_len);
-                    buf_offset += name_len;
-                }
-            }
+    for (AppProto a = 0; a < g_alproto_max; a++) {
+        if (!AlprotoBitmaskTest(us->alprotos, a) || !AlprotoBitmaskTest(them->alprotos, a))
+            continue;
+        has_intersection = true;
+        const char *name = AppProtoToString(a);
+        if (name == NULL)
+            name = "unknown";
+        if (buf_offset > 0 && buf_offset < sizeof(conflict_buf) - 2) {
+            conflict_buf[buf_offset++] = ',';
+            conflict_buf[buf_offset++] = ' ';
+        }
+        size_t name_len = strlen(name);
+        if (buf_offset + name_len < sizeof(conflict_buf) - 1) {
+            memcpy(conflict_buf + buf_offset, name, name_len);
+            buf_offset += name_len;
         }
     }
     conflict_buf[buf_offset] = '\0';
@@ -454,8 +477,8 @@ static void DetectAppLayerProtocolFree(DetectEngineCtx *de_ctx, void *ptr)
     DetectAppLayerProtocolData *data = (DetectAppLayerProtocolData *)ptr;
     if (data == NULL)
         return;
-    if (data->list_alprotos != NULL)
-        SCFree(data->list_alprotos);
+    if (data->alprotos != NULL)
+        SCFree(data->alprotos);
     SCFree(data);
 }
 
@@ -510,15 +533,15 @@ static void PrefilterPacketAppProtoMatch(
             // the one in the signature ctx
             if (negated) {
                 if (f->alproto_tc != ALPROTO_UNKNOWN &&
-                        !AppProtoEquals(ctx->v1.u16[0], f->alproto_tc)) {
+                        !DetectAppLayerProtocolMatchExact(ctx->v1.u16[0], f->alproto_tc)) {
                     PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
                 } else if (f->alproto_ts != ALPROTO_UNKNOWN &&
-                           !AppProtoEquals(ctx->v1.u16[0], f->alproto_ts)) {
+                           !DetectAppLayerProtocolMatchExact(ctx->v1.u16[0], f->alproto_ts)) {
                     PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
                 }
             } else {
-                if (AppProtoEquals(ctx->v1.u16[0], f->alproto_tc) ||
-                        AppProtoEquals(ctx->v1.u16[0], f->alproto_ts)) {
+                if (DetectAppLayerProtocolMatchExact(ctx->v1.u16[0], f->alproto_tc) ||
+                        DetectAppLayerProtocolMatchExact(ctx->v1.u16[0], f->alproto_ts)) {
                     PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
                 }
             }
@@ -528,12 +551,12 @@ static void PrefilterPacketAppProtoMatch(
 
     if (negated) {
         if (alproto != ALPROTO_UNKNOWN) {
-            if (!AppProtoEquals(ctx->v1.u16[0], alproto)) {
+            if (!DetectAppLayerProtocolMatchExact(ctx->v1.u16[0], alproto)) {
                 PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
             }
         }
     } else {
-        if (AppProtoEquals(ctx->v1.u16[0], alproto)) {
+        if (DetectAppLayerProtocolMatchExact(ctx->v1.u16[0], alproto)) {
             PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
         }
     }
@@ -571,7 +594,7 @@ static bool PrefilterAppProtoIsPrefilterable(const Signature *s)
     for (sm = s->init_data->smlists[DETECT_SM_LIST_MATCH]; sm != NULL; sm = sm->next) {
         if (sm->type == DETECT_APP_LAYER_PROTOCOL) {
             const DetectAppLayerProtocolData *data = (const DetectAppLayerProtocolData *)sm->ctx;
-            if (data->list_count > 0) {
+            if (data->is_list) {
                 return false;
             }
             break;
@@ -879,9 +902,8 @@ static int DetectAppLayerProtocolTest15(void)
     FAIL_IF(data->alproto != ALPROTO_HTTP);
     FAIL_IF(data->negated != 0);
     FAIL_IF(data->mode != DETECT_ALPROTO_FINAL);
-    FAIL_IF(data->mode_explicit != 1);
-    FAIL_IF(data->list_count != 0);
-    FAIL_IF(data->list_alprotos != NULL);
+    FAIL_IF(data->is_list);
+    FAIL_IF_NOT(AlprotoBitmaskTest(data->alprotos, ALPROTO_HTTP));
     DetectAppLayerProtocolFree(NULL, data);
     PASS;
 }
@@ -889,14 +911,12 @@ static int DetectAppLayerProtocolTest15(void)
 /** \test Multi-value without mode qualifier. */
 static int DetectAppLayerProtocolTest16(void)
 {
-    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,http", false);
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls|http", false);
     FAIL_IF_NULL(data);
-    FAIL_IF(data->list_count != 2);
-    FAIL_IF_NULL(data->list_alprotos);
-    FAIL_IF(data->list_alprotos[0] != ALPROTO_TLS);
-    FAIL_IF(data->list_alprotos[1] != ALPROTO_HTTP);
+    FAIL_IF_NOT(data->is_list);
+    FAIL_IF_NOT(AlprotoBitmaskTest(data->alprotos, ALPROTO_TLS));
+    FAIL_IF_NOT(AlprotoBitmaskTest(data->alprotos, ALPROTO_HTTP));
     FAIL_IF(data->mode != DETECT_ALPROTO_DIRECTION); /* default */
-    FAIL_IF(data->mode_explicit != 0);
     FAIL_IF(data->negated != 0);
     DetectAppLayerProtocolFree(NULL, data);
     PASS;
@@ -905,19 +925,17 @@ static int DetectAppLayerProtocolTest16(void)
 /** \test Multi-value with mode qualifier. */
 static int DetectAppLayerProtocolTest17(void)
 {
-    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,http,either", false);
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls|http,either", false);
     FAIL_IF_NULL(data);
-    FAIL_IF(data->list_count != 2);
-    FAIL_IF_NULL(data->list_alprotos);
-    FAIL_IF(data->list_alprotos[0] != ALPROTO_TLS);
-    FAIL_IF(data->list_alprotos[1] != ALPROTO_HTTP);
+    FAIL_IF_NOT(data->is_list);
+    FAIL_IF_NOT(AlprotoBitmaskTest(data->alprotos, ALPROTO_TLS));
+    FAIL_IF_NOT(AlprotoBitmaskTest(data->alprotos, ALPROTO_HTTP));
     FAIL_IF(data->mode != DETECT_ALPROTO_EITHER);
-    FAIL_IF(data->mode_explicit != 1);
     DetectAppLayerProtocolFree(NULL, data);
     PASS;
 }
 
-/** \test Mode disambiguation: 'final' as sole token → protocol lookup (fails), not mode. */
+/** \test A bare mode name with no protocol is treated as a protocol lookup (fails). */
 static int DetectAppLayerProtocolTest18(void)
 {
     /* "final" alone is treated as a protocol name (which won't resolve). */
@@ -926,15 +944,15 @@ static int DetectAppLayerProtocolTest18(void)
     PASS;
 }
 
-/** \test Mode disambiguation: 'direction' as trailing token in multi-value → mode. */
+/** \test Multi-value list with an explicit 'direction' mode qualifier. */
 static int DetectAppLayerProtocolTest19(void)
 {
-    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,direction", false);
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls|http,direction", false);
     FAIL_IF_NULL(data);
-    FAIL_IF(data->list_count != 0); /* single value after stripping mode */
-    FAIL_IF(data->alproto != ALPROTO_TLS);
+    FAIL_IF_NOT(data->is_list);
+    FAIL_IF_NOT(AlprotoBitmaskTest(data->alprotos, ALPROTO_TLS));
+    FAIL_IF_NOT(AlprotoBitmaskTest(data->alprotos, ALPROTO_HTTP));
     FAIL_IF(data->mode != DETECT_ALPROTO_DIRECTION);
-    FAIL_IF(data->mode_explicit != 1);
     DetectAppLayerProtocolFree(NULL, data);
     PASS;
 }
@@ -967,24 +985,23 @@ static int DetectAppLayerProtocolTest22(void)
     PASS;
 }
 
-/** \test Empty token in comma-separated list rejected. */
+/** \test Empty token in pipe-separated list rejected. */
 static int DetectAppLayerProtocolTest23(void)
 {
-    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,,http", false);
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls||http", false);
     FAIL_IF_NOT_NULL(data);
     PASS;
 }
 
-/** \test Negated multi-value parses correctly (!tls,http). */
+/** \test Negated multi-value parses correctly (!tls|http). */
 static int DetectAppLayerProtocolTest24(void)
 {
-    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,http", true);
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls|http", true);
     FAIL_IF_NULL(data);
     FAIL_IF(data->negated != 1);
-    FAIL_IF(data->list_count != 2);
-    FAIL_IF_NULL(data->list_alprotos);
-    FAIL_IF(data->list_alprotos[0] != ALPROTO_TLS);
-    FAIL_IF(data->list_alprotos[1] != ALPROTO_HTTP);
+    FAIL_IF_NOT(data->is_list);
+    FAIL_IF_NOT(AlprotoBitmaskTest(data->alprotos, ALPROTO_TLS));
+    FAIL_IF_NOT(AlprotoBitmaskTest(data->alprotos, ALPROTO_HTTP));
     DetectAppLayerProtocolFree(NULL, data);
     PASS;
 }
@@ -992,7 +1009,7 @@ static int DetectAppLayerProtocolTest24(void)
 /** \test Unknown protocol name in list rejected. */
 static int DetectAppLayerProtocolTest25(void)
 {
-    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,bogus_proto_xyz", false);
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls|bogus_proto_xyz", false);
     FAIL_IF_NOT_NULL(data);
     PASS;
 }
@@ -1029,7 +1046,7 @@ static int DetectAppLayerProtocolTest27(void)
     de_ctx->flags |= DE_QUIET;
 
     Signature *s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-                                                 "(app-layer-protocol:tls,dns; sid:1;)");
+                                                 "(app-layer-protocol:tls|dns; sid:1;)");
     FAIL_IF_NULL(s);
 
     /* Verify the parsed data is list-valued BEFORE SigGroupBuild. */
@@ -1037,7 +1054,7 @@ static int DetectAppLayerProtocolTest27(void)
     FAIL_IF_NULL(sm);
     DetectAppLayerProtocolData *data = (DetectAppLayerProtocolData *)sm->ctx;
     FAIL_IF_NULL(data);
-    FAIL_IF(data->list_count != 2);
+    FAIL_IF_NOT(data->is_list);
 
     /* A single-valued packet-detect-only rule is prefilter-eligible; the
      * multi-value guard must exclude this one. init_data is read by the
@@ -1056,10 +1073,10 @@ static int DetectAppLayerProtocolTest28(void)
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
-    /* tls.sni binds s->alproto = TLS, so app-layer-protocol:tls,dns is rejected. */
+    /* tls.sni binds s->alproto = TLS, so app-layer-protocol:tls|dns is rejected. */
     Signature *s = DetectEngineAppendSig(de_ctx,
             "alert tcp any any -> any any "
-            "(tls.sni; content:\"example.com\"; app-layer-protocol:tls,dns; sid:1;)");
+            "(tls.sni; content:\"example.com\"; app-layer-protocol:tls|dns; sid:1;)");
     FAIL_IF_NOT_NULL(s);
 
     DetectEngineCtxFree(de_ctx);

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2025 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -30,6 +30,7 @@
 #include "detect-app-layer-protocol.h"
 #include "app-layer.h"
 #include "app-layer-parser.h"
+#include "app-layer-detect-proto.h"
 #include "util-debug.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
@@ -47,19 +48,17 @@ enum {
     DETECT_ALPROTO_ORIG = 5,
 };
 
-typedef struct DetectAppLayerProtocolData_ {
-    AppProto alproto;
-    uint8_t negated;
-    uint8_t mode;
-} DetectAppLayerProtocolData;
+/** \brief maximum number of comma-separated values a single
+ *         app-layer-protocol: keyword may carry. */
+#define MAX_ALPROTO_LIST 16
+
+static void DetectAppLayerProtocolFree(DetectEngineCtx *de_ctx, void *ptr);
 
 static int DetectAppLayerProtocolPacketMatch(
-        DetectEngineThreadCtx *det_ctx,
-        Packet *p, const Signature *s, const SigMatchCtx *ctx)
+        DetectEngineThreadCtx *det_ctx, Packet *p, const Signature *s, const SigMatchCtx *ctx)
 {
     SCEnter();
 
-    bool r = false;
     const DetectAppLayerProtocolData *data = (const DetectAppLayerProtocolData *)ctx;
 
     /* if the sig is PD-only we only match when PD packet flags are set */
@@ -75,75 +74,70 @@ static int DetectAppLayerProtocolPacketMatch(
         SCReturnInt(0);
     }
 
+    /* Resolve the flow's alproto for the configured mode. */
+    AppProto resolved_alproto = ALPROTO_UNKNOWN;
     switch (data->mode) {
         case DETECT_ALPROTO_DIRECTION:
-            if (data->negated) {
-                if (p->flowflags & FLOW_PKT_TOSERVER) {
-                    if (f->alproto_ts == ALPROTO_UNKNOWN)
-                        SCReturnInt(0);
-                    r = AppProtoEquals(data->alproto, f->alproto_ts);
-                } else {
-                    if (f->alproto_tc == ALPROTO_UNKNOWN)
-                        SCReturnInt(0);
-                    r = AppProtoEquals(data->alproto, f->alproto_tc);
-                }
+            if (p->flowflags & FLOW_PKT_TOSERVER) {
+                resolved_alproto = f->alproto_ts;
             } else {
-                if (p->flowflags & FLOW_PKT_TOSERVER) {
-                    r = AppProtoEquals(data->alproto, f->alproto_ts);
-                } else {
-                    r = AppProtoEquals(data->alproto, f->alproto_tc);
-                }
+                resolved_alproto = f->alproto_tc;
             }
             break;
         case DETECT_ALPROTO_ORIG:
-            if (data->negated) {
-                if (f->alproto_orig == ALPROTO_UNKNOWN)
-                    SCReturnInt(0);
-                r = AppProtoEquals(data->alproto, f->alproto_orig);
-            } else {
-                r = AppProtoEquals(data->alproto, f->alproto_orig);
-            }
+            resolved_alproto = f->alproto_orig;
             break;
         case DETECT_ALPROTO_FINAL:
-            if (data->negated) {
-                if (f->alproto == ALPROTO_UNKNOWN)
-                    SCReturnInt(0);
-                r = AppProtoEquals(data->alproto, f->alproto);
-            } else {
-                r = AppProtoEquals(data->alproto, f->alproto);
-            }
+            resolved_alproto = f->alproto;
             break;
         case DETECT_ALPROTO_TOSERVER:
-            if (data->negated) {
-                if (f->alproto_ts == ALPROTO_UNKNOWN)
-                    SCReturnInt(0);
-                r = AppProtoEquals(data->alproto, f->alproto_ts);
-            } else {
-                r = AppProtoEquals(data->alproto, f->alproto_ts);
-            }
+            resolved_alproto = f->alproto_ts;
             break;
         case DETECT_ALPROTO_TOCLIENT:
-            if (data->negated) {
-                if (f->alproto_tc == ALPROTO_UNKNOWN)
-                    SCReturnInt(0);
-                r = AppProtoEquals(data->alproto, f->alproto_tc);
-            } else {
-                r = AppProtoEquals(data->alproto, f->alproto_tc);
-            }
+            resolved_alproto = f->alproto_tc;
             break;
         case DETECT_ALPROTO_EITHER:
-            if (data->negated) {
-                if (f->alproto_ts == ALPROTO_UNKNOWN && f->alproto_tc == ALPROTO_UNKNOWN)
-                    SCReturnInt(0);
-                r = AppProtoEquals(data->alproto, f->alproto_tc) ||
-                    AppProtoEquals(data->alproto, f->alproto_ts);
-            } else {
-                r = AppProtoEquals(data->alproto, f->alproto_tc) ||
-                    AppProtoEquals(data->alproto, f->alproto_ts);
-            }
+            /* Handled separately below against both directions. */
             break;
     }
+
+    /* Negated rules never match when alproto is still unknown. */
+    if (data->negated) {
+        if (data->mode == DETECT_ALPROTO_EITHER) {
+            if (f->alproto_ts == ALPROTO_UNKNOWN && f->alproto_tc == ALPROTO_UNKNOWN) {
+                SCReturnInt(0);
+            }
+        } else {
+            if (resolved_alproto == ALPROTO_UNKNOWN) {
+                SCReturnInt(0);
+            }
+        }
+    }
+
+    const AppProto *protos = (data->list_count == 0) ? &data->alproto : data->list_alprotos;
+    const uint8_t count = (data->list_count == 0) ? 1 : data->list_count;
+
+    bool r = false;
+    if (data->mode == DETECT_ALPROTO_EITHER) {
+        for (uint8_t i = 0; i < count; i++) {
+            if (AppProtoEquals(protos[i], f->alproto_ts) ||
+                    AppProtoEquals(protos[i], f->alproto_tc)) {
+                r = true;
+                break;
+            }
+        }
+    } else {
+        for (uint8_t i = 0; i < count; i++) {
+            if (AppProtoEquals(protos[i], resolved_alproto)) {
+                r = true;
+                break;
+            }
+        }
+    }
+
+    /* XOR with negated → NOR semantics for negated lists. */
     r = r ^ data->negated;
+
     if (r) {
         SCReturnInt(1);
     }
@@ -151,92 +145,274 @@ static int DetectAppLayerProtocolPacketMatch(
 }
 
 #define MAX_ALPROTO_NAME 50
+
+/** \internal
+ *  \brief Map a textual mode-qualifier token to its DETECT_ALPROTO_* value.
+ */
+static int DetectAppLayerProtocolMapModeName(const char *name)
+{
+    if (strcmp(name, "final") == 0)
+        return DETECT_ALPROTO_FINAL;
+    if (strcmp(name, "original") == 0)
+        return DETECT_ALPROTO_ORIG;
+    if (strcmp(name, "either") == 0)
+        return DETECT_ALPROTO_EITHER;
+    if (strcmp(name, "to_server") == 0)
+        return DETECT_ALPROTO_TOSERVER;
+    if (strcmp(name, "to_client") == 0)
+        return DETECT_ALPROTO_TOCLIENT;
+    if (strcmp(name, "direction") == 0)
+        return DETECT_ALPROTO_DIRECTION;
+    return -1;
+}
+
+/** \internal
+ *  \brief Build a comma-separated list of supported app-layer protocol names.
+ */
+static void DetectAppLayerProtocolBuildSupportedList(char *buf, size_t buflen)
+{
+    if (buflen == 0)
+        return;
+    buf[0] = '\0';
+
+    AppProto alprotos[g_alproto_max];
+    AppLayerProtoDetectSupportedAppProtocols(alprotos);
+
+    size_t offset = 0;
+    for (AppProto a = 0; a < g_alproto_max; a++) {
+        if (alprotos[a] != 1)
+            continue;
+        const char *name = AppProtoToString(a);
+        if (name == NULL)
+            continue;
+        int w = snprintf(buf + offset, buflen - offset, "%s%s", (offset == 0) ? "" : ", ", name);
+        if (w < 0 || (size_t)w >= buflen - offset)
+            break; /* truncated; stop appending */
+        offset += (size_t)w;
+    }
+}
+
 static DetectAppLayerProtocolData *DetectAppLayerProtocolParse(const char *arg, bool negate)
 {
-    DetectAppLayerProtocolData *data;
-    AppProto alproto = ALPROTO_UNKNOWN;
+    if (arg == NULL) {
+        SCLogError("app-layer-protocol keyword requires a value");
+        return NULL;
+    }
 
-    char alproto_copy[MAX_ALPROTO_NAME];
-    const char *sep = strchr(arg, ',');
-    char *alproto_name;
-    if (sep && sep - arg < MAX_ALPROTO_NAME) {
-        strlcpy(alproto_copy, arg, sep - arg + 1);
-        alproto_name = alproto_copy;
-    } else {
-        alproto_name = (char *)arg;
+    /* Total-length validation. */
+    size_t arglen = strlen(arg);
+    if (arglen > 1024) {
+        SCLogError("app-layer-protocol keyword argument too long (\"%s\"): maximum "
+                   "supported length is 1024 characters",
+                arg);
+        return NULL;
     }
-    if (strcmp(alproto_name, "failed") == 0) {
-        alproto = ALPROTO_FAILED;
-    } else if (strcmp(alproto_name, "unknown") == 0) {
-        if (negate) {
-            SCLogError("app-layer-protocol "
-                       "keyword can't use negation with protocol 'unknown'");
+    if (arglen == 0) {
+        SCLogError("app-layer-protocol keyword value is empty (an empty value list "
+                   "is not permitted)");
+        return NULL;
+    }
+
+    /* Tokenize on ','. */
+    char buf[1025];
+    strlcpy(buf, arg, sizeof(buf));
+
+    const char *tokens[MAX_ALPROTO_LIST + 1];
+    int token_count = 0;
+    char *cur = buf;
+    while (1) {
+        char *comma = strchr(cur, ',');
+        if (comma != NULL)
+            *comma = '\0';
+
+        if (token_count >= MAX_ALPROTO_LIST + 1) {
+            SCLogError("app-layer-protocol keyword value list in \"%s\" exceeds the "
+                       "maximum of %d comma-separated values",
+                    arg, MAX_ALPROTO_LIST);
             return NULL;
         }
-        alproto = ALPROTO_UNKNOWN;
-    } else {
-        alproto = AppLayerGetProtoByName(alproto_name);
-        if (alproto == ALPROTO_UNKNOWN) {
-            SCLogError("app-layer-protocol "
-                       "keyword supplied with unknown protocol \"%s\"",
-                    alproto_name);
+
+        size_t tlen = strlen(cur);
+        if (tlen == 0) {
+            SCLogError("app-layer-protocol keyword value \"%s\" contains an empty token", arg);
             return NULL;
         }
+        if (tlen >= MAX_ALPROTO_NAME) {
+            SCLogError("app-layer-protocol keyword token \"%s\" in \"%s\" exceeds the "
+                       "maximum token length of %d characters",
+                    cur, arg, MAX_ALPROTO_NAME - 1);
+            return NULL;
+        }
+
+        tokens[token_count++] = cur;
+        if (comma == NULL)
+            break;
+        cur = comma + 1;
     }
+
+    /* Mode disambiguation: trailing token is a mode qualifier
+     * only when 2+ tokens are present; a single token is always a protocol. */
     uint8_t mode = DETECT_ALPROTO_DIRECTION;
-    if (sep) {
-        if (strcmp(sep + 1, "final") == 0) {
-            mode = DETECT_ALPROTO_FINAL;
-        } else if (strcmp(sep + 1, "original") == 0) {
-            mode = DETECT_ALPROTO_ORIG;
-        } else if (strcmp(sep + 1, "either") == 0) {
-            mode = DETECT_ALPROTO_EITHER;
-        } else if (strcmp(sep + 1, "to_server") == 0) {
-            mode = DETECT_ALPROTO_TOSERVER;
-        } else if (strcmp(sep + 1, "to_client") == 0) {
-            mode = DETECT_ALPROTO_TOCLIENT;
-        } else if (strcmp(sep + 1, "direction") == 0) {
-            mode = DETECT_ALPROTO_DIRECTION;
-        } else {
-            SCLogError("app-layer-protocol "
-                       "keyword supplied with unknown mode \"%s\"",
-                    sep + 1);
-            return NULL;
+    uint8_t mode_explicit = 0;
+    int value_token_count = token_count;
+    if (token_count >= 2) {
+        int m = DetectAppLayerProtocolMapModeName(tokens[token_count - 1]);
+        if (m >= 0) {
+            mode = (uint8_t)m;
+            mode_explicit = 1;
+            value_token_count = token_count - 1;
         }
     }
 
-    data = SCMalloc(sizeof(DetectAppLayerProtocolData));
+    /* Validate value count. */
+    if (value_token_count == 0) {
+        SCLogError("app-layer-protocol keyword value \"%s\" contains no protocol "
+                   "values (an empty value list is not permitted)",
+                arg);
+        return NULL;
+    }
+    if (value_token_count > MAX_ALPROTO_LIST) {
+        SCLogError("app-layer-protocol keyword value list in \"%s\" exceeds the "
+                   "maximum of %d comma-separated values",
+                arg, MAX_ALPROTO_LIST);
+        return NULL;
+    }
+
+    /* Per-token resolution. */
+    AppProto values[MAX_ALPROTO_LIST];
+    for (int i = 0; i < value_token_count; i++) {
+        const char *name = tokens[i];
+        if (strcmp(name, "failed") == 0) {
+            values[i] = ALPROTO_FAILED;
+        } else if (strcmp(name, "unknown") == 0) {
+            if (negate) {
+                SCLogError("app-layer-protocol "
+                           "keyword can't use negation with protocol 'unknown'");
+                return NULL;
+            }
+            values[i] = ALPROTO_UNKNOWN;
+        } else {
+            AppProto ap = AppLayerGetProtoByName(name);
+            if (ap == ALPROTO_UNKNOWN) {
+                char supported[1024];
+                DetectAppLayerProtocolBuildSupportedList(supported, sizeof(supported));
+                SCLogError("app-layer-protocol keyword supplied with unknown protocol "
+                           "\"%s\" in \"%s\"; supported protocols: %s",
+                        name, arg, supported);
+                return NULL;
+            }
+            values[i] = ap;
+        }
+    }
+
+    /* Allocate and populate. */
+    DetectAppLayerProtocolData *data = SCMalloc(sizeof(DetectAppLayerProtocolData));
     if (unlikely(data == NULL))
         return NULL;
-    data->alproto = alproto;
-    data->negated = negate;
+    memset(data, 0, sizeof(*data));
+    data->alproto = values[0];
+    data->negated = negate ? 1 : 0;
     data->mode = mode;
+    data->mode_explicit = mode_explicit;
+    if (value_token_count == 1) {
+        data->list_count = 0;
+        data->list_alprotos = NULL;
+    } else {
+        data->list_count = (uint8_t)value_token_count;
+        data->list_alprotos = SCMalloc(sizeof(AppProto) * (size_t)value_token_count);
+        if (unlikely(data->list_alprotos == NULL)) {
+            SCFree(data);
+            return NULL;
+        }
+        memcpy(data->list_alprotos, values, sizeof(AppProto) * (size_t)value_token_count);
+    }
 
     return data;
 }
 
-static bool HasConflicts(const DetectAppLayerProtocolData *us,
-                          const DetectAppLayerProtocolData *them)
+/**
+ * \brief Get the value set for a DetectAppLayerProtocolData entry.
+ */
+static inline const AppProto *GetValueSet(const DetectAppLayerProtocolData *data, uint8_t *count)
 {
-    /* mixing negated and non negated is illegal */
-    if ((them->negated ^ us->negated) && them->mode == us->mode)
-        return true;
-    /* multiple non-negated is illegal */
-    if (!us->negated && them->mode == us->mode)
-        return true;
-    /* duplicate option */
-    if (us->alproto == them->alproto && them->mode == us->mode)
-        return true;
-
-    /* all good */
-    return false;
+    if (data->list_count > 0) {
+        *count = data->list_count;
+        return data->list_alprotos;
+    }
+    *count = 1;
+    return &data->alproto;
 }
 
-static int DetectAppLayerProtocolSetup(DetectEngineCtx *de_ctx,
-        Signature *s, const char *arg)
+/**
+ * \brief Check whether two app-layer-protocol SigMatches conflict.
+ */
+static bool HasConflicts(
+        const DetectAppLayerProtocolData *us, const DetectAppLayerProtocolData *them)
+{
+    /* Different modes never conflict. */
+    if (us->mode != them->mode)
+        return false;
+
+    if (us->negated && them->negated)
+        return false;
+
+    /* Two non-negated under the same mode: always conflict. */
+    if (!us->negated && !them->negated) {
+        SCLogError("conflicting app-layer-protocol rules: "
+                   "multiple non-negated entries under the same mode");
+        return true;
+    }
+
+    /* Mixed negation under same mode: always conflict. Enumerate
+     * intersecting values for the error message. */
+    uint8_t us_count = 0, them_count = 0;
+    const AppProto *us_vals = GetValueSet(us, &us_count);
+    const AppProto *them_vals = GetValueSet(them, &them_count);
+
+    /* Collect intersecting value names for the error message. */
+    char conflict_buf[512];
+    size_t buf_offset = 0;
+    bool has_intersection = false;
+
+    for (uint8_t i = 0; i < us_count; i++) {
+        for (uint8_t j = 0; j < them_count; j++) {
+            if (us_vals[i] == them_vals[j]) {
+                has_intersection = true;
+                const char *name = AppProtoToString(us_vals[i]);
+                if (name == NULL)
+                    name = "unknown";
+                if (buf_offset > 0 && buf_offset < sizeof(conflict_buf) - 2) {
+                    conflict_buf[buf_offset++] = ',';
+                    conflict_buf[buf_offset++] = ' ';
+                }
+                size_t name_len = strlen(name);
+                if (buf_offset + name_len < sizeof(conflict_buf) - 1) {
+                    memcpy(conflict_buf + buf_offset, name, name_len);
+                    buf_offset += name_len;
+                }
+            }
+        }
+    }
+    conflict_buf[buf_offset] = '\0';
+
+    if (has_intersection) {
+        SCLogError("conflicting app-layer-protocol rules: "
+                   "can't mix positive match with negated match under the same "
+                   "mode; intersecting protocol value(s): %s",
+                conflict_buf);
+    } else {
+        SCLogError("conflicting app-layer-protocol rules: "
+                   "can't mix positive app-layer-protocol match with negated "
+                   "match or match for 'failed'");
+    }
+    return true;
+}
+
+static int DetectAppLayerProtocolSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
     DetectAppLayerProtocolData *data = NULL;
 
+    /* Early rejection: rule already bound to a protocol. */
     if (s->alproto != ALPROTO_UNKNOWN) {
         SCLogError("Either we already "
                    "have the rule match on an app layer protocol set through "
@@ -250,14 +426,13 @@ static int DetectAppLayerProtocolSetup(DetectEngineCtx *de_ctx,
         goto error;
 
     SigMatch *tsm = s->init_data->smlists[DETECT_SM_LIST_MATCH];
-    for ( ; tsm != NULL; tsm = tsm->next) {
+    for (; tsm != NULL; tsm = tsm->next) {
         if (tsm->type == DETECT_APP_LAYER_PROTOCOL) {
             const DetectAppLayerProtocolData *them = (const DetectAppLayerProtocolData *)tsm->ctx;
 
             if (HasConflicts(data, them)) {
-                SCLogError("can't mix "
-                           "positive app-layer-protocol match with negated "
-                           "match or match for 'failed'.");
+                SCLogError("conflicting app-layer-protocol options detected "
+                           "(see preceding error for details).");
                 goto error;
             }
         }
@@ -270,21 +445,25 @@ static int DetectAppLayerProtocolSetup(DetectEngineCtx *de_ctx,
     return 0;
 
 error:
-    if (data != NULL)
-        SCFree(data);
+    DetectAppLayerProtocolFree(de_ctx, data);
     return -1;
 }
 
 static void DetectAppLayerProtocolFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    SCFree(ptr);
+    DetectAppLayerProtocolData *data = (DetectAppLayerProtocolData *)ptr;
+    if (data == NULL)
+        return;
+    if (data->list_alprotos != NULL)
+        SCFree(data->list_alprotos);
+    SCFree(data);
 }
 
 /** \internal
  *  \brief prefilter function for protocol detect matching
  */
-static void
-PrefilterPacketAppProtoMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *pectx)
+static void PrefilterPacketAppProtoMatch(
+        DetectEngineThreadCtx *det_ctx, Packet *p, const void *pectx)
 {
     const PrefilterPacketHeaderCtx *ctx = pectx;
 
@@ -298,7 +477,7 @@ PrefilterPacketAppProtoMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const vo
         SCReturn;
     }
 
-    if ((p->flags & (PKT_PROTO_DETECT_TS_DONE|PKT_PROTO_DETECT_TC_DONE)) == 0) {
+    if ((p->flags & (PKT_PROTO_DETECT_TS_DONE | PKT_PROTO_DETECT_TC_DONE)) == 0) {
         SCLogDebug("packet %" PRIu64 ": flags not set", PcapPacketCntGet(p));
         SCReturn;
     }
@@ -360,8 +539,7 @@ PrefilterPacketAppProtoMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const vo
     }
 }
 
-static void
-PrefilterPacketAppProtoSet(PrefilterPacketHeaderValue *v, void *smctx)
+static void PrefilterPacketAppProtoSet(PrefilterPacketHeaderValue *v, void *smctx)
 {
     const DetectAppLayerProtocolData *a = smctx;
     v->u16[0] = a->alproto;
@@ -369,8 +547,7 @@ PrefilterPacketAppProtoSet(PrefilterPacketHeaderValue *v, void *smctx)
     v->u8[3] = a->mode;
 }
 
-static bool
-PrefilterPacketAppProtoCompare(PrefilterPacketHeaderValue v, void *smctx)
+static bool PrefilterPacketAppProtoCompare(PrefilterPacketHeaderValue v, void *smctx)
 {
     const DetectAppLayerProtocolData *a = smctx;
     return v.u16[0] == a->alproto && v.u8[2] == (uint8_t)a->negated && v.u8[3] == a->mode;
@@ -385,11 +562,24 @@ static int PrefilterSetupAppProto(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
 
 static bool PrefilterAppProtoIsPrefilterable(const Signature *s)
 {
-    if (s->type == SIG_TYPE_PDONLY) {
-        SCLogDebug("prefilter on PD %u", s->id);
-        return true;
+    if (s->type != SIG_TYPE_PDONLY) {
+        return false;
     }
-    return false;
+
+    /* Multi-value rules cannot be prefiltered (single-valued bucket key). */
+    const SigMatch *sm;
+    for (sm = s->init_data->smlists[DETECT_SM_LIST_MATCH]; sm != NULL; sm = sm->next) {
+        if (sm->type == DETECT_APP_LAYER_PROTOCOL) {
+            const DetectAppLayerProtocolData *data = (const DetectAppLayerProtocolData *)sm->ctx;
+            if (data->list_count > 0) {
+                return false;
+            }
+            break;
+        }
+    }
+
+    SCLogDebug("prefilter on PD %u", s->id);
+    return true;
 }
 
 void DetectAppLayerProtocolRegister(void)
@@ -409,8 +599,6 @@ void DetectAppLayerProtocolRegister(void)
     sigmatch_table[DETECT_APP_LAYER_PROTOCOL].SetupPrefilter = PrefilterSetupAppProto;
     sigmatch_table[DETECT_APP_LAYER_PROTOCOL].SupportsPrefilter = PrefilterAppProtoIsPrefilterable;
 }
-
-/**********************************Unittests***********************************/
 
 #ifdef UNITTESTS
 
@@ -443,7 +631,7 @@ static int DetectAppLayerProtocolTest03(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-            "(app-layer-protocol:http; sid:1;)");
+                                      "(app-layer-protocol:http; sid:1;)");
     FAIL_IF_NULL(s);
 
     FAIL_IF(s->alproto != ALPROTO_UNKNOWN);
@@ -467,7 +655,7 @@ static int DetectAppLayerProtocolTest04(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-            "(app-layer-protocol:!http; sid:1;)");
+                                      "(app-layer-protocol:!http; sid:1;)");
     FAIL_IF_NULL(s);
     FAIL_IF(s->alproto != ALPROTO_UNKNOWN);
     FAIL_IF(s->flags & SIG_FLAG_APPLAYER);
@@ -492,7 +680,8 @@ static int DetectAppLayerProtocolTest05(void)
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+    s = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any any "
             "(app-layer-protocol:!http; app-layer-protocol:!smtp; sid:1;)");
     FAIL_IF_NULL(s);
     FAIL_IF(s->alproto != ALPROTO_UNKNOWN);
@@ -523,7 +712,7 @@ static int DetectAppLayerProtocolTest06(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any "
-            "(app-layer-protocol:smtp; sid:1;)");
+                                      "(app-layer-protocol:smtp; sid:1;)");
     FAIL_IF_NOT_NULL(s);
     DetectEngineCtxFree(de_ctx);
     PASS;
@@ -537,7 +726,7 @@ static int DetectAppLayerProtocolTest07(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any "
-            "(app-layer-protocol:!smtp; sid:1;)");
+                                      "(app-layer-protocol:!smtp; sid:1;)");
     FAIL_IF_NOT_NULL(s);
     DetectEngineCtxFree(de_ctx);
     PASS;
@@ -550,7 +739,8 @@ static int DetectAppLayerProtocolTest08(void)
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+    s = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any any "
             "(app-layer-protocol:!smtp; app-layer-protocol:http; sid:1;)");
     FAIL_IF_NOT_NULL(s);
     DetectEngineCtxFree(de_ctx);
@@ -564,7 +754,8 @@ static int DetectAppLayerProtocolTest09(void)
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+    s = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any any "
             "(app-layer-protocol:http; app-layer-protocol:!smtp; sid:1;)");
     FAIL_IF_NOT_NULL(s);
     DetectEngineCtxFree(de_ctx);
@@ -578,7 +769,8 @@ static int DetectAppLayerProtocolTest10(void)
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+    s = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any any "
             "(app-layer-protocol:smtp; app-layer-protocol:!http; sid:1;)");
     FAIL_IF_NOT_NULL(s);
     DetectEngineCtxFree(de_ctx);
@@ -614,7 +806,7 @@ static int DetectAppLayerProtocolTest13(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-            "(app-layer-protocol:failed; sid:1;)");
+                                      "(app-layer-protocol:failed; sid:1;)");
     FAIL_IF_NULL(s);
 
     FAIL_IF(s->alproto != ALPROTO_UNKNOWN);
@@ -636,8 +828,9 @@ static int DetectAppLayerProtocolTest14(void)
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
-    Signature *s1 = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-            "(app-layer-protocol:http; flowbits:set,blah; sid:1;)");
+    Signature *s1 =
+            DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+                                          "(app-layer-protocol:http; flowbits:set,blah; sid:1;)");
     FAIL_IF_NULL(s1);
     FAIL_IF(s1->alproto != ALPROTO_UNKNOWN);
     FAIL_IF_NULL(s1->init_data->smlists[DETECT_SM_LIST_MATCH]);
@@ -646,8 +839,9 @@ static int DetectAppLayerProtocolTest14(void)
     FAIL_IF(data->alproto != ALPROTO_HTTP);
     FAIL_IF(data->negated);
 
-    Signature *s2 = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-            "(app-layer-protocol:http; flow:to_client; sid:2;)");
+    Signature *s2 =
+            DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+                                          "(app-layer-protocol:http; flow:to_client; sid:2;)");
     FAIL_IF_NULL(s2);
     FAIL_IF(s2->alproto != ALPROTO_UNKNOWN);
     FAIL_IF_NULL(s2->init_data->smlists[DETECT_SM_LIST_MATCH]);
@@ -657,7 +851,8 @@ static int DetectAppLayerProtocolTest14(void)
     FAIL_IF(data->negated);
 
     /* flow:established and other options not supported for PD-only */
-    Signature *s3 = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+    Signature *s3 = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any any "
             "(app-layer-protocol:http; flow:to_client,established; sid:3;)");
     FAIL_IF_NULL(s3);
     FAIL_IF(s3->alproto != ALPROTO_UNKNOWN);
@@ -676,36 +871,230 @@ static int DetectAppLayerProtocolTest14(void)
     PASS;
 }
 
+/** \test Single-value with explicit mode qualifier parses correctly. */
+static int DetectAppLayerProtocolTest15(void)
+{
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("http,final", false);
+    FAIL_IF_NULL(data);
+    FAIL_IF(data->alproto != ALPROTO_HTTP);
+    FAIL_IF(data->negated != 0);
+    FAIL_IF(data->mode != DETECT_ALPROTO_FINAL);
+    FAIL_IF(data->mode_explicit != 1);
+    FAIL_IF(data->list_count != 0);
+    FAIL_IF(data->list_alprotos != NULL);
+    DetectAppLayerProtocolFree(NULL, data);
+    PASS;
+}
+
+/** \test Multi-value without mode qualifier. */
+static int DetectAppLayerProtocolTest16(void)
+{
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,http", false);
+    FAIL_IF_NULL(data);
+    FAIL_IF(data->list_count != 2);
+    FAIL_IF_NULL(data->list_alprotos);
+    FAIL_IF(data->list_alprotos[0] != ALPROTO_TLS);
+    FAIL_IF(data->list_alprotos[1] != ALPROTO_HTTP);
+    FAIL_IF(data->mode != DETECT_ALPROTO_DIRECTION); /* default */
+    FAIL_IF(data->mode_explicit != 0);
+    FAIL_IF(data->negated != 0);
+    DetectAppLayerProtocolFree(NULL, data);
+    PASS;
+}
+
+/** \test Multi-value with mode qualifier. */
+static int DetectAppLayerProtocolTest17(void)
+{
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,http,either", false);
+    FAIL_IF_NULL(data);
+    FAIL_IF(data->list_count != 2);
+    FAIL_IF_NULL(data->list_alprotos);
+    FAIL_IF(data->list_alprotos[0] != ALPROTO_TLS);
+    FAIL_IF(data->list_alprotos[1] != ALPROTO_HTTP);
+    FAIL_IF(data->mode != DETECT_ALPROTO_EITHER);
+    FAIL_IF(data->mode_explicit != 1);
+    DetectAppLayerProtocolFree(NULL, data);
+    PASS;
+}
+
+/** \test Mode disambiguation: 'final' as sole token → protocol lookup (fails), not mode. */
+static int DetectAppLayerProtocolTest18(void)
+{
+    /* "final" alone is treated as a protocol name (which won't resolve). */
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("final", false);
+    FAIL_IF_NOT_NULL(data);
+    PASS;
+}
+
+/** \test Mode disambiguation: 'direction' as trailing token in multi-value → mode. */
+static int DetectAppLayerProtocolTest19(void)
+{
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,direction", false);
+    FAIL_IF_NULL(data);
+    FAIL_IF(data->list_count != 0); /* single value after stripping mode */
+    FAIL_IF(data->alproto != ALPROTO_TLS);
+    FAIL_IF(data->mode != DETECT_ALPROTO_DIRECTION);
+    FAIL_IF(data->mode_explicit != 1);
+    DetectAppLayerProtocolFree(NULL, data);
+    PASS;
+}
+
+/** \test Empty value list rejected. */
+static int DetectAppLayerProtocolTest20(void)
+{
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("", false);
+    FAIL_IF_NOT_NULL(data);
+    PASS;
+}
+
+/** \test Negation of 'unknown' rejected. */
+static int DetectAppLayerProtocolTest21(void)
+{
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("unknown", true);
+    FAIL_IF_NOT_NULL(data);
+    PASS;
+}
+
+/** \test Oversized argument length rejected. */
+static int DetectAppLayerProtocolTest22(void)
+{
+    /* Build a string >1024 characters. */
+    char big[1030];
+    memset(big, 'a', sizeof(big) - 1);
+    big[sizeof(big) - 1] = '\0';
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse(big, false);
+    FAIL_IF_NOT_NULL(data);
+    PASS;
+}
+
+/** \test Empty token in comma-separated list rejected. */
+static int DetectAppLayerProtocolTest23(void)
+{
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,,http", false);
+    FAIL_IF_NOT_NULL(data);
+    PASS;
+}
+
+/** \test Negated multi-value parses correctly (!tls,http). */
+static int DetectAppLayerProtocolTest24(void)
+{
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,http", true);
+    FAIL_IF_NULL(data);
+    FAIL_IF(data->negated != 1);
+    FAIL_IF(data->list_count != 2);
+    FAIL_IF_NULL(data->list_alprotos);
+    FAIL_IF(data->list_alprotos[0] != ALPROTO_TLS);
+    FAIL_IF(data->list_alprotos[1] != ALPROTO_HTTP);
+    DetectAppLayerProtocolFree(NULL, data);
+    PASS;
+}
+
+/** \test Unknown protocol name in list rejected. */
+static int DetectAppLayerProtocolTest25(void)
+{
+    DetectAppLayerProtocolData *data = DetectAppLayerProtocolParse("tls,bogus_proto_xyz", false);
+    FAIL_IF_NOT_NULL(data);
+    PASS;
+}
+
+/** \test Negated single-value against unclassified flow returns 0. */
+static int DetectAppLayerProtocolTest26(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+                                                 "(app-layer-protocol:!tls; sid:1;)");
+    FAIL_IF_NULL(s);
+
+    /* Check data BEFORE SigGroupBuild (init_data is freed by build). */
+    SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_MATCH];
+    FAIL_IF_NULL(sm);
+    DetectAppLayerProtocolData *data = (DetectAppLayerProtocolData *)sm->ctx;
+    FAIL_IF_NULL(data);
+    FAIL_IF(data->negated != 1);
+    FAIL_IF(data->alproto != ALPROTO_TLS);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+/** \test Multi-value rule is NOT prefiltered. */
+static int DetectAppLayerProtocolTest27(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+                                                 "(app-layer-protocol:tls,dns; sid:1;)");
+    FAIL_IF_NULL(s);
+
+    /* Verify the parsed data is list-valued BEFORE SigGroupBuild. */
+    SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_MATCH];
+    FAIL_IF_NULL(sm);
+    DetectAppLayerProtocolData *data = (DetectAppLayerProtocolData *)sm->ctx;
+    FAIL_IF_NULL(data);
+    FAIL_IF(data->list_count != 2);
+
+    /* A single-valued packet-detect-only rule is prefilter-eligible; the
+     * multi-value guard must exclude this one. init_data is read by the
+     * predicate, so check before SigGroupBuild frees it. */
+    s->type = SIG_TYPE_PDONLY;
+    FAIL_IF(PrefilterAppProtoIsPrefilterable(s));
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+/** \test Multi-value rule combined with buffer-keyword that pre-binds s->alproto is rejected. */
+static int DetectAppLayerProtocolTest28(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+    de_ctx->flags |= DE_QUIET;
+
+    /* tls.sni binds s->alproto = TLS, so app-layer-protocol:tls,dns is rejected. */
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any any "
+            "(tls.sni; content:\"example.com\"; app-layer-protocol:tls,dns; sid:1;)");
+    FAIL_IF_NOT_NULL(s);
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
 
 static void DetectAppLayerProtocolRegisterTests(void)
 {
-    UtRegisterTest("DetectAppLayerProtocolTest01",
-                   DetectAppLayerProtocolTest01);
-    UtRegisterTest("DetectAppLayerProtocolTest02",
-                   DetectAppLayerProtocolTest02);
-    UtRegisterTest("DetectAppLayerProtocolTest03",
-                   DetectAppLayerProtocolTest03);
-    UtRegisterTest("DetectAppLayerProtocolTest04",
-                   DetectAppLayerProtocolTest04);
-    UtRegisterTest("DetectAppLayerProtocolTest05",
-                   DetectAppLayerProtocolTest05);
-    UtRegisterTest("DetectAppLayerProtocolTest06",
-                   DetectAppLayerProtocolTest06);
-    UtRegisterTest("DetectAppLayerProtocolTest07",
-                   DetectAppLayerProtocolTest07);
-    UtRegisterTest("DetectAppLayerProtocolTest08",
-                   DetectAppLayerProtocolTest08);
-    UtRegisterTest("DetectAppLayerProtocolTest09",
-                   DetectAppLayerProtocolTest09);
-    UtRegisterTest("DetectAppLayerProtocolTest10",
-                   DetectAppLayerProtocolTest10);
-    UtRegisterTest("DetectAppLayerProtocolTest11",
-                   DetectAppLayerProtocolTest11);
-    UtRegisterTest("DetectAppLayerProtocolTest12",
-                   DetectAppLayerProtocolTest12);
-    UtRegisterTest("DetectAppLayerProtocolTest13",
-                   DetectAppLayerProtocolTest13);
-    UtRegisterTest("DetectAppLayerProtocolTest14",
-                   DetectAppLayerProtocolTest14);
+    UtRegisterTest("DetectAppLayerProtocolTest01", DetectAppLayerProtocolTest01);
+    UtRegisterTest("DetectAppLayerProtocolTest02", DetectAppLayerProtocolTest02);
+    UtRegisterTest("DetectAppLayerProtocolTest03", DetectAppLayerProtocolTest03);
+    UtRegisterTest("DetectAppLayerProtocolTest04", DetectAppLayerProtocolTest04);
+    UtRegisterTest("DetectAppLayerProtocolTest05", DetectAppLayerProtocolTest05);
+    UtRegisterTest("DetectAppLayerProtocolTest06", DetectAppLayerProtocolTest06);
+    UtRegisterTest("DetectAppLayerProtocolTest07", DetectAppLayerProtocolTest07);
+    UtRegisterTest("DetectAppLayerProtocolTest08", DetectAppLayerProtocolTest08);
+    UtRegisterTest("DetectAppLayerProtocolTest09", DetectAppLayerProtocolTest09);
+    UtRegisterTest("DetectAppLayerProtocolTest10", DetectAppLayerProtocolTest10);
+    UtRegisterTest("DetectAppLayerProtocolTest11", DetectAppLayerProtocolTest11);
+    UtRegisterTest("DetectAppLayerProtocolTest12", DetectAppLayerProtocolTest12);
+    UtRegisterTest("DetectAppLayerProtocolTest13", DetectAppLayerProtocolTest13);
+    UtRegisterTest("DetectAppLayerProtocolTest14", DetectAppLayerProtocolTest14);
+    UtRegisterTest("DetectAppLayerProtocolTest15", DetectAppLayerProtocolTest15);
+    UtRegisterTest("DetectAppLayerProtocolTest16", DetectAppLayerProtocolTest16);
+    UtRegisterTest("DetectAppLayerProtocolTest17", DetectAppLayerProtocolTest17);
+    UtRegisterTest("DetectAppLayerProtocolTest18", DetectAppLayerProtocolTest18);
+    UtRegisterTest("DetectAppLayerProtocolTest19", DetectAppLayerProtocolTest19);
+    UtRegisterTest("DetectAppLayerProtocolTest20", DetectAppLayerProtocolTest20);
+    UtRegisterTest("DetectAppLayerProtocolTest21", DetectAppLayerProtocolTest21);
+    UtRegisterTest("DetectAppLayerProtocolTest22", DetectAppLayerProtocolTest22);
+    UtRegisterTest("DetectAppLayerProtocolTest23", DetectAppLayerProtocolTest23);
+    UtRegisterTest("DetectAppLayerProtocolTest24", DetectAppLayerProtocolTest24);
+    UtRegisterTest("DetectAppLayerProtocolTest25", DetectAppLayerProtocolTest25);
+    UtRegisterTest("DetectAppLayerProtocolTest26", DetectAppLayerProtocolTest26);
+    UtRegisterTest("DetectAppLayerProtocolTest27", DetectAppLayerProtocolTest27);
+    UtRegisterTest("DetectAppLayerProtocolTest28", DetectAppLayerProtocolTest28);
 }
 #endif /* UNITTESTS */

--- a/src/detect-app-layer-protocol.h
+++ b/src/detect-app-layer-protocol.h
@@ -24,6 +24,25 @@
 #ifndef SURICATA_DETECT_APP_LAYER_PROTOCOL__H
 #define SURICATA_DETECT_APP_LAYER_PROTOCOL__H
 
+#include "app-layer-protos.h"
+
 void DetectAppLayerProtocolRegister(void);
+
+/**
+ * \brief Per-rule keyword data for `app-layer-protocol:`.
+ *
+ * Single-value rules use `alproto` directly (no heap allocation) and
+ * participate in prefilter bucketing. Multi-value rules use the
+ * heap-allocated `list_alprotos` array and skip prefilter (the bucket
+ * key is single-valued).
+ */
+typedef struct DetectAppLayerProtocolData_ {
+    AppProto alproto; /**< single value; also used as prefilter bucket key */
+    uint8_t negated;
+    uint8_t mode;
+    uint8_t list_count;      /**< 0 = single-value; >0 = list-valued */
+    uint8_t mode_explicit;   /**< 1 iff input had explicit mode token */
+    AppProto *list_alprotos; /**< heap array of length list_count */
+} DetectAppLayerProtocolData;
 
 #endif /* SURICATA_DETECT_APP_LAYER_PROTOCOL__H */

--- a/src/detect-app-layer-protocol.h
+++ b/src/detect-app-layer-protocol.h
@@ -27,22 +27,24 @@
 #include "app-layer-protos.h"
 
 void DetectAppLayerProtocolRegister(void);
+const char *DetectAppLayerProtocolModeName(uint8_t mode);
+struct DetectAppLayerProtocolData_;
+void DetectAppLayerProtocolListToString(
+        const struct DetectAppLayerProtocolData_ *data, char *buf, size_t buflen);
 
 /**
  * \brief Per-rule keyword data for `app-layer-protocol:`.
  *
- * Single-value rules use `alproto` directly (no heap allocation) and
- * participate in prefilter bucketing. Multi-value rules use the
- * heap-allocated `list_alprotos` array and skip prefilter (the bucket
- * key is single-valued).
+ * The set of protocol values is a bitmask (`alprotos`), one bit per AppProto,
+ * sized g_alproto_max bits. `alproto` is the single-value prefilter bucket
+ * key (ALPROTO_UNKNOWN for multi-value rules, which are not prefilterable).
  */
 typedef struct DetectAppLayerProtocolData_ {
-    AppProto alproto; /**< single value; also used as prefilter bucket key */
-    uint8_t negated;
+    AppProto alproto; /**< single-value bucket key; ALPROTO_UNKNOWN if list */
+    bool negated;
     uint8_t mode;
-    uint8_t list_count;      /**< 0 = single-value; >0 = list-valued */
-    uint8_t mode_explicit;   /**< 1 iff input had explicit mode token */
-    AppProto *list_alprotos; /**< heap array of length list_count */
+    bool is_list;      /**< true if the rule carried more than one value */
+    uint8_t *alprotos; /**< bitmask of g_alproto_max bits */
 } DetectAppLayerProtocolData;
 
 #endif /* SURICATA_DETECT_APP_LAYER_PROTOCOL__H */

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1095,6 +1095,21 @@ static void DumpMatches(RuleAnalyzer *ctx, SCJsonBuilder *js, const SigMatchData
                 SCJbClose(js);
                 break;
             }
+            case DETECT_APP_LAYER_PROTOCOL: {
+                const DetectAppLayerProtocolData *ad = (const DetectAppLayerProtocolData *)smd->ctx;
+                SCJbOpenObject(js, "app_layer_protocol");
+                if (ad->is_list) {
+                    char list_buf[512];
+                    DetectAppLayerProtocolListToString(ad, list_buf, sizeof(list_buf));
+                    SCJbSetString(js, "protocols", list_buf);
+                } else {
+                    SCJbSetString(js, "protocols", AppProtoToString(ad->alproto));
+                }
+                SCJbSetString(js, "mode", DetectAppLayerProtocolModeName(ad->mode));
+                SCJbSetBool(js, "negated", ad->negated);
+                SCJbClose(js);
+                break;
+            }
         }
         SCJbClose(js);
 
@@ -1985,47 +2000,6 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         }
         if (s->alproto != ALPROTO_UNKNOWN) {
             fprintf(fp, "    App layer protocol is %s.\n", AppProtoToString(s->alproto));
-        }
-        /* app_layer_protocol_list: emit the protocol value list and resolved
-         * mode for rules using the multi-value form of app-layer-protocol:
-         * (list_count > 0). Single-value rules are NOT emitted here because
-         * they are already covered by the baseline "App layer protocol is X"
-         * line above. */
-        {
-            SigMatch *alp_sm = NULL;
-            for (int32_t lid = 0; lid < DETECT_SM_LIST_MAX && alp_sm == NULL; lid++) {
-                for (SigMatch *sm_iter = s->init_data->smlists[lid];
-                        sm_iter != NULL; sm_iter = sm_iter->next) {
-                    if (sm_iter->type == DETECT_APP_LAYER_PROTOCOL) {
-                        const DetectAppLayerProtocolData *alp_data =
-                                (const DetectAppLayerProtocolData *)sm_iter->ctx;
-                        if (alp_data != NULL && alp_data->list_count > 0) {
-                            alp_sm = sm_iter;
-                            break;
-                        }
-                    }
-                }
-            }
-            if (alp_sm != NULL) {
-                const DetectAppLayerProtocolData *alp_data =
-                        (const DetectAppLayerProtocolData *)alp_sm->ctx;
-                fprintf(fp, "    app_layer_protocol_list: [");
-                for (uint8_t i = 0; i < alp_data->list_count; i++) {
-                    if (i > 0)
-                        fprintf(fp, ",");
-                    fprintf(fp, "%s", AppProtoToString(alp_data->list_alprotos[i]));
-                }
-                const char *mode_name = "direction";
-                switch (alp_data->mode) {
-                    case 0: mode_name = "direction"; break;
-                    case 1: mode_name = "final"; break;
-                    case 2: mode_name = "either"; break;
-                    case 3: mode_name = "to_server"; break;
-                    case 4: mode_name = "to_client"; break;
-                    case 5: mode_name = "original"; break;
-                }
-                fprintf(fp, "] mode: %s\n", mode_name);
-            }
         }
 
         if (rule_content || rule_content_http || rule_pcre || rule_pcre_http) {

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -57,6 +57,7 @@
 #include "util-var-name.h"
 #include "detect-icmp-id.h"
 #include "detect-tcp-window.h"
+#include "detect-app-layer-protocol.h"
 
 static int rule_warnings_only = 0;
 
@@ -1985,6 +1986,48 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         if (s->alproto != ALPROTO_UNKNOWN) {
             fprintf(fp, "    App layer protocol is %s.\n", AppProtoToString(s->alproto));
         }
+        /* app_layer_protocol_list: emit the protocol value list and resolved
+         * mode for rules using the multi-value form of app-layer-protocol:
+         * (list_count > 0). Single-value rules are NOT emitted here because
+         * they are already covered by the baseline "App layer protocol is X"
+         * line above. */
+        {
+            SigMatch *alp_sm = NULL;
+            for (int32_t lid = 0; lid < DETECT_SM_LIST_MAX && alp_sm == NULL; lid++) {
+                for (SigMatch *sm_iter = s->init_data->smlists[lid];
+                        sm_iter != NULL; sm_iter = sm_iter->next) {
+                    if (sm_iter->type == DETECT_APP_LAYER_PROTOCOL) {
+                        const DetectAppLayerProtocolData *alp_data =
+                                (const DetectAppLayerProtocolData *)sm_iter->ctx;
+                        if (alp_data != NULL && alp_data->list_count > 0) {
+                            alp_sm = sm_iter;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (alp_sm != NULL) {
+                const DetectAppLayerProtocolData *alp_data =
+                        (const DetectAppLayerProtocolData *)alp_sm->ctx;
+                fprintf(fp, "    app_layer_protocol_list: [");
+                for (uint8_t i = 0; i < alp_data->list_count; i++) {
+                    if (i > 0)
+                        fprintf(fp, ",");
+                    fprintf(fp, "%s", AppProtoToString(alp_data->list_alprotos[i]));
+                }
+                const char *mode_name = "direction";
+                switch (alp_data->mode) {
+                    case 0: mode_name = "direction"; break;
+                    case 1: mode_name = "final"; break;
+                    case 2: mode_name = "either"; break;
+                    case 3: mode_name = "to_server"; break;
+                    case 4: mode_name = "to_client"; break;
+                    case 5: mode_name = "original"; break;
+                }
+                fprintf(fp, "] mode: %s\n", mode_name);
+            }
+        }
+
         if (rule_content || rule_content_http || rule_pcre || rule_pcre_http) {
             fprintf(fp,
                     "    Rule contains %u content options, %u http content options, %u pcre "


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7705

Describe changes:

Extend the app-layer-protocol: keyword parser to accept a comma-separated list of protocol values (e.g. unknown,tls,http) optionally followed by a mode qualifier. This lets a rule writer cover both the pre-detection phase and the confirmed protocol in one transport-layer rule.

Changes:
- Extend DetectAppLayerProtocolData with list_count, mode_explicit and list_alprotos fields
- Implement multi-value parsing with mode disambiguation
- Unified match function with OR-loop and NOR semantics for negated lists
- Extend HasConflicts for list-aware pair detection
- Exclude multi-value rules from prefilter bucketing
- Add C unit tests for multi-value parsing and matching
- Extend engine-analyzer for app_layer_protocol_list output
- Update app-layer.rst documentation

Ticket: 7705

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3193
SU_REPO=
SU_BRANCH=
