### PR TITLE
websocket: implement over HTTP2

### DIFF
--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -32,6 +32,7 @@ use crate::flow::Flow;
 use crate::frames::Frame;
 
 use crate::dns::dns::{dns_parse_request, dns_parse_response, DNSTransaction};
+use crate::websocket::websocket::{WebSocketState, WebSocketTransaction, ALPROTO_WEBSOCKET};
 
 use nom7::Err;
 use std;
@@ -180,6 +181,8 @@ pub struct HTTP2Transaction {
     pub resp_line: Vec<u8>,
 
     pub doh: Option<DohHttp2Tx>,
+    pub is_websocket: Option<WebSocketState>,
+    pub websocket_tx: Option<WebSocketTransaction>,
 }
 
 impl Transaction for HTTP2Transaction {
@@ -213,6 +216,8 @@ impl HTTP2Transaction {
             req_line: Vec::new(),
             resp_line: Vec::new(),
             doh: None,
+            is_websocket: None,
+            websocket_tx: None,
         }
     }
 
@@ -247,9 +252,19 @@ impl HTTP2Transaction {
         let mut path = None;
         let mut doh = false;
         let mut host = None;
+        let mut is_connect = false;
         for block in blocks {
             if block.name.as_ref() == b"content-encoding" {
                 self.decoder.http2_encoding_fromvec(&block.value, dir);
+            } else if block.name.as_ref() == b":method" && block.value.as_ref() == b"CONNECT" {
+                is_connect = true;
+            } else if block.name.as_ref() == b":protocol"
+                && block.value.as_ref() == b"websocket"
+                && is_connect
+                && self.is_websocket.is_none()
+                && unsafe { ALPROTO_WEBSOCKET } != ALPROTO_UNKNOWN
+            {
+                self.is_websocket = Some(WebSocketState::new());
             } else if block.name.as_ref() == b"accept" {
                 //TODO? faster pattern matching
                 if block.value.as_ref() == b"application/dns-message" {
@@ -391,6 +406,14 @@ impl HTTP2Transaction {
                     }
                 }
             }
+        }
+        if let Some(ref mut wss) = &mut self.is_websocket {
+            wss.parse(
+                StreamSlice::default(),
+                dir,
+                std::ptr::null_mut(),
+                decompressed,
+            );
         }
         return Ok(());
     }
@@ -759,6 +782,18 @@ impl HTTP2State {
         // a global tx (stream id 0) does not hold files cf RFC 9113 section 5.1.1
         self.transactions.push_back(tx);
         return self.transactions.back_mut().unwrap();
+    }
+
+    fn create_websocket_tx(t: WebSocketTransaction, dir: Direction) -> HTTP2Transaction {
+        //special transaction with only one frame
+        //as it affects the global connection, there is no end to it
+        let mut tx = HTTP2Transaction::new();
+        tx.tx_data = AppLayerTxData::for_direction(dir);
+        tx.progress_tc = HTTP2TxProgress::HTTP2ProgGlobal;
+        tx.progress_ts = HTTP2TxProgress::HTTP2ProgGlobal;
+        tx.websocket_tx = Some(t);
+        // a global tx (stream id 0) does not hold files cf RFC 9113 section 5.1.1
+        return tx;
     }
 
     pub fn find_or_create_tx(
@@ -1311,15 +1346,24 @@ impl HTTP2State {
                             )
                         };
                         let (il, ol) = (il + comp_len, ol + decomp_len);
-                        if ol > decompression::DEFAULT_BOMB_RATIO * il {
-                            if ol > unsafe { HTTP2_COMPRESSION_BOMB_LIMIT } {
-                                tx.set_event(HTTP2Event::CompressionBomb);
-                                return AppLayerResult::err();
+                        if ol > decompression::DEFAULT_BOMB_RATIO * il
+                            && ol > unsafe { HTTP2_COMPRESSION_BOMB_LIMIT }
+                        {
+                            tx.set_event(HTTP2Event::CompressionBomb);
+                            return AppLayerResult::err();
+                        }
+                        if let Some(wss) = &mut tx.is_websocket {
+                            let websocket_txs = std::mem::take(&mut wss.transactions);
+                            for t in websocket_txs {
+                                let mut ht = Self::create_websocket_tx(t, dir);
+                                ht.tx_id = self.tx_id + 1;
+                                self.tx_id += 1;
+                                self.transactions.push_back(ht);
                             }
-                            if over {
-                                self.comp_len += il;
-                                self.decomp_len += ol;
-                            }
+                        }
+                        if ol > decompression::DEFAULT_BOMB_RATIO * il && over {
+                            self.comp_len += il;
+                            self.decomp_len += ol;
                         }
                     }
                     sc_app_layer_parser_trigger_raw_stream_inspection(flow, dir as i32);
@@ -1412,6 +1456,16 @@ impl HTTP2State {
 }
 
 // C exports.
+
+#[no_mangle]
+pub unsafe extern "C" fn SCHttp2GetWebsocketTx(
+    tx: &HTTP2Transaction, _flags: u8,
+) -> *mut std::os::raw::c_void {
+    if let Some(wtx) = &tx.websocket_tx {
+        return wtx as *const _ as *mut _;
+    }
+    std::ptr::null_mut()
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn SCDoH2GetDnsTx(

--- a/rust/src/http2/logger.rs
+++ b/rust/src/http2/logger.rs
@@ -19,6 +19,7 @@ use super::http2::{HTTP2Frame, HTTP2FrameTypeData, HTTP2Transaction};
 use super::parser;
 use crate::detect::EnumString;
 use crate::jsonbuilder::{JsonBuilder, JsonError};
+use crate::websocket::logger::log_websocket;
 use std;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -197,6 +198,12 @@ fn log_http2_frames(frames: &[HTTP2Frame], js: &mut JsonBuilder) -> Result<bool,
 }
 
 fn log_http2(tx: &HTTP2Transaction, js: &mut JsonBuilder) -> Result<bool, JsonError> {
+    if let Some(wt) = &tx.websocket_tx {
+        match log_websocket(wt, js, false, false) {
+            Ok(()) => return Ok(true),
+            Err(e) => return Err(e),
+        }
+    }
     js.open_object("http")?;
     js.set_string("version", "2")?;
 

--- a/rust/src/websocket/logger.rs
+++ b/rust/src/websocket/logger.rs
@@ -21,7 +21,7 @@ use crate::detect::EnumString;
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 use std;
 
-fn log_websocket(
+pub(crate) fn log_websocket(
     tx: &WebSocketTransaction, js: &mut JsonBuilder, pp: bool, pb64: bool,
 ) -> Result<(), JsonError> {
     js.open_object("websocket")?;

--- a/rust/src/websocket/websocket.rs
+++ b/rust/src/websocket/websocket.rs
@@ -40,7 +40,7 @@ use std::collections::VecDeque;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 
-pub(super) static mut ALPROTO_WEBSOCKET: AppProto = ALPROTO_UNKNOWN;
+pub(crate) static mut ALPROTO_WEBSOCKET: AppProto = ALPROTO_UNKNOWN;
 
 static mut WEBSOCKET_MAX_PAYLOAD_SIZE: u32 = 0xFFFF;
 
@@ -59,7 +59,7 @@ pub enum WebSocketEvent {
     ReassemblyLimitReached,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct WebSocketTransaction {
     tx_id: u64,
     pub pdu: parser::WebSocketPdu,
@@ -81,17 +81,17 @@ impl Transaction for WebSocketTransaction {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct WebSocketReassemblyBuffer {
     data: Vec<u8>,
     compress: bool,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct WebSocketState {
     state_data: AppLayerStateData,
     tx_id: u64,
-    transactions: VecDeque<WebSocketTransaction>,
+    pub transactions: VecDeque<WebSocketTransaction>,
 
     c2s_dec: Option<flate2::Decompress>,
     s2c_dec: Option<flate2::Decompress>,
@@ -147,15 +147,20 @@ impl WebSocketState {
         return tx;
     }
 
-    fn parse(
+    pub(crate) fn parse(
         &mut self, stream_slice: StreamSlice, direction: Direction, flow: *mut Flow,
+        slice_input: &[u8],
     ) -> AppLayerResult {
         let to_skip = if direction == Direction::ToClient {
             &mut self.to_skip_tc
         } else {
             &mut self.to_skip_ts
         };
-        let input = stream_slice.as_slice();
+        let input = if flow.is_null() {
+            slice_input
+        } else {
+            stream_slice.as_slice()
+        };
         let mut start = input;
         if *to_skip > 0 {
             if *to_skip >= input.len() as u64 {
@@ -172,30 +177,32 @@ impl WebSocketState {
             match parser::parse_message(start, max_pl_size) {
                 Ok((rem, pdu)) => {
                     let mut tx = self.new_tx(direction);
-                    let _pdu = Frame::new(
-                        flow,
-                        &stream_slice,
-                        start,
-                        (start.len() - rem.len() - pdu.payload.len()) as i64,
-                        WebSocketFrameType::Header as u8,
-                        Some(tx.tx_id),
-                    );
-                    let _pdu = Frame::new(
-                        flow,
-                        &stream_slice,
-                        start,
-                        (start.len() - rem.len()) as i64,
-                        WebSocketFrameType::Pdu as u8,
-                        Some(tx.tx_id),
-                    );
-                    let _pdu = Frame::new(
-                        flow,
-                        &stream_slice,
-                        &start[(start.len() - rem.len() - pdu.payload.len())..],
-                        pdu.payload.len() as i64,
-                        WebSocketFrameType::Data as u8,
-                        Some(tx.tx_id),
-                    );
+                    if !flow.is_null() {
+                        let _pdu = Frame::new(
+                            flow,
+                            &stream_slice,
+                            start,
+                            (start.len() - rem.len() - pdu.payload.len()) as i64,
+                            WebSocketFrameType::Header as u8,
+                            Some(tx.tx_id),
+                        );
+                        let _pdu = Frame::new(
+                            flow,
+                            &stream_slice,
+                            start,
+                            (start.len() - rem.len()) as i64,
+                            WebSocketFrameType::Pdu as u8,
+                            Some(tx.tx_id),
+                        );
+                        let _pdu = Frame::new(
+                            flow,
+                            &stream_slice,
+                            &start[(start.len() - rem.len() - pdu.payload.len())..],
+                            pdu.payload.len() as i64,
+                            WebSocketFrameType::Data as u8,
+                            Some(tx.tx_id),
+                        );
+                    }
                     start = rem;
                     if pdu.to_skip > 0 {
                         if direction == Direction::ToClient {
@@ -287,7 +294,7 @@ impl WebSocketState {
                             }
                         }
                     }
-                    if tx.pdu.fin {
+                    if tx.pdu.fin && !flow.is_null() {
                         sc_app_layer_parser_trigger_raw_stream_inspection(flow, direction as i32);
                     }
                     self.transactions.push_back(tx);
@@ -351,7 +358,7 @@ unsafe extern "C" fn websocket_parse_request(
     stream_slice: StreamSlice, _data: *mut c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, WebSocketState);
-    state.parse(stream_slice, Direction::ToServer, flow)
+    state.parse(stream_slice, Direction::ToServer, flow, &[])
 }
 
 unsafe extern "C" fn websocket_parse_response(
@@ -359,7 +366,7 @@ unsafe extern "C" fn websocket_parse_response(
     stream_slice: StreamSlice, _data: *mut c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, WebSocketState);
-    state.parse(stream_slice, Direction::ToClient, flow)
+    state.parse(stream_slice, Direction::ToClient, flow, &[])
 }
 
 unsafe extern "C" fn websocket_state_get_tx(state: *mut c_void, tx_id: u64) -> *mut c_void {

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -113,6 +113,8 @@ static inline bool AppProtoEquals(AppProto sigproto, AppProto alproto)
             return (alproto == ALPROTO_HTTP1) || (alproto == ALPROTO_HTTP2);
         case ALPROTO_DCERPC:
             return (alproto == ALPROTO_SMB);
+        case ALPROTO_WEBSOCKET:
+            return (alproto == ALPROTO_HTTP2);
     }
     return false;
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1256,6 +1256,8 @@ void *DetectGetInnerTx(void *tx_ptr, AppProto alproto, AppProto engine_alproto, 
             // incompatible engine->alproto with flow alproto
             tx_ptr = NULL;
         }
+    } else if (alproto == ALPROTO_HTTP2 && engine_alproto == ALPROTO_WEBSOCKET) {
+        tx_ptr = SCHttp2GetWebsocketTx(tx_ptr, flow_flags);
     } else if (engine_alproto != alproto && engine_alproto != ALPROTO_UNKNOWN) {
         // incompatible engine->alproto with flow alproto
         tx_ptr = NULL;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/6729

Describe changes:
- draft websocket over http2

TODOs:
- Agree on the design and output
- SV test
- doc update
- commit segmentation and messages

Tested so far with
`suricata -c suricata.yaml -k none -r wss_h2.pcap -S ../suricata-verify/tests/websocket/test.rules -l log`

https://github.com/OISF/suricata/pull/15675 with rebase, squash, and some review nits implemented