### PR TITLE
eve: fix pcap_filename race with --pcap-file-recursive - v7

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -42,6 +42,7 @@
 #include "flow-timeout.h"
 #include "pkt-var.h"
 #include "host.h"
+#include "source-pcap-file-helper.h"
 
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
@@ -94,6 +95,8 @@ static inline Packet *FlowPseudoPacketSetup(
     memcpy(&p->vlan_id[0], &f->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = f->vlan_idx;
     p->livedev_id = f->livedev_id;
+    /* no extra ref: the flow's reference outlives this pseudo packet */
+    p->pcap_v.pfv = FlowGetPcapFileVars(f);
 
     if (f->flags & FLOW_NOPAYLOAD_INSPECTION) {
         DecodeSetNoPayloadInspectionFlag(p);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -38,6 +38,7 @@
 #include "util-macset.h"
 #include "util-flow-rate.h"
 #include "flow-storage.h"
+#include "source-pcap-file-helper.h"
 
 #include "detect.h"
 #include "detect-engine-state.h"
@@ -211,6 +212,10 @@ void FlowInit(ThreadVars *tv, Flow *f, const Packet *p)
         DEBUG_VALIDATE_BUG_ON(SCFlowGetStorageById(f, FlowRateGetStorageID()) != NULL);
         FlowRateStore *frs = FlowRateStoreInit();
         SCFlowSetStorageById(f, FlowRateGetStorageID(), frs);
+    }
+
+    if (FlowPcapFileVarsStorageEnabled() && p->pcap_v.pfv != NULL) {
+        FlowSetPcapFileVars(f, p->pcap_v.pfv);
     }
 
     SCFlowRunInitCallbacks(tv, f, p);

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1028,7 +1028,17 @@ void OutputJsonBuilderBuffer(
     }
 
     if (file_ctx->is_pcap_offline) {
-        SCJbSetString(js, "pcap_filename", PcapFileGetFilename());
+        /* prefer the packet's/flow's own file; the global is updated by the RX
+         * thread as it advances through files and would race for events logged
+         * from earlier packets */
+        const char *filename;
+        if (p != NULL && p->pcap_v.pfv != NULL) {
+            filename = p->pcap_v.pfv->filename;
+        } else {
+            PcapFileFileVars *pfv = (f != NULL) ? FlowGetPcapFileVars(f) : NULL;
+            filename = (pfv != NULL) ? pfv->filename : PcapFileGetFilename();
+        }
+        SCJbSetString(js, "pcap_filename", filename);
     }
 
     SCEveRunCallbacks(tv, p, f, js);

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -1121,6 +1121,51 @@ static int SourcePcapFileHelperTest16(void)
 }
 
 /**
+ * \test A packet's pfv->filename is independent of the global pcap_filename.
+ */
+static int SourcePcapFileHelperTest17(void)
+{
+    extern char pcap_filename[PATH_MAX];
+    strlcpy(pcap_filename, "file_B.pcap", sizeof(pcap_filename));
+
+    PcapFileFileVars *pfv = SCCalloc(1, sizeof(*pfv));
+    FAIL_IF_NULL(pfv);
+    pfv->filename = SCStrdup("file_A.pcap");
+    FAIL_IF_NULL(pfv->filename);
+    SC_ATOMIC_INIT(pfv->ref_cnt);
+    SC_ATOMIC_SET(pfv->ref_cnt, 0);
+    SC_ATOMIC_INIT(pfv->alerts_count);
+
+    Packet *p = PacketGetFromAlloc();
+    FAIL_IF_NULL(p);
+    p->pcap_v.pfv = pfv;
+
+    FAIL_IF_NOT(strcmp(p->pcap_v.pfv->filename, "file_A.pcap") == 0);
+    FAIL_IF_NOT(strcmp(PcapFileGetFilename(), "file_B.pcap") == 0);
+
+    PacketFreeOrRelease(p);
+    CleanupPcapFileFileVars(pfv);
+    strlcpy(pcap_filename, "unknown", sizeof(pcap_filename));
+    PASS;
+}
+
+/**
+ * \test With neither packet nor flow (stats events), the global is used.
+ */
+static int SourcePcapFileHelperTest18(void)
+{
+    extern char pcap_filename[PATH_MAX];
+    strlcpy(pcap_filename, "current_file.pcap", sizeof(pcap_filename));
+    FAIL_IF_NOT(strcmp(PcapFileGetFilename(), "current_file.pcap") == 0);
+
+    strlcpy(pcap_filename, "next_file.pcap", sizeof(pcap_filename));
+    FAIL_IF_NOT(strcmp(PcapFileGetFilename(), "next_file.pcap") == 0);
+
+    strlcpy(pcap_filename, "unknown", sizeof(pcap_filename));
+    PASS;
+}
+
+/**
  * \brief Register unit tests for pcap file helper
  */
 void SourcePcapFileHelperRegisterTests(void)
@@ -1141,5 +1186,7 @@ void SourcePcapFileHelperRegisterTests(void)
     UtRegisterTest("SourcePcapFileHelperTest14", SourcePcapFileHelperTest14);
     UtRegisterTest("SourcePcapFileHelperTest15", SourcePcapFileHelperTest15);
     UtRegisterTest("SourcePcapFileHelperTest16", SourcePcapFileHelperTest16);
+    UtRegisterTest("SourcePcapFileHelperTest17", SourcePcapFileHelperTest17);
+    UtRegisterTest("SourcePcapFileHelperTest18", SourcePcapFileHelperTest18);
 }
 #endif /* UNITTESTS */

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -25,6 +25,10 @@
 
 #include "source-pcap-file-helper.h"
 #include "suricata.h"
+#include "flow.h"
+#include "flow-util.h"
+#include "flow-storage.h"
+#include "util-storage.h"
 #include "util-datalink.h"
 #include "util-checksum.h"
 #include "util-profiling.h"
@@ -409,6 +413,60 @@ void PcapFileAddAlertCount(PcapFileFileVars *pfv, uint16_t alert_count)
     if (pfv != NULL && alert_count > 0) {
         SC_ATOMIC_ADD(pfv->alerts_count, alert_count);
     }
+}
+
+void PcapFileRef(PcapFileFileVars *pfv)
+{
+    if (pfv != NULL) {
+        SC_ATOMIC_ADD(pfv->ref_cnt, 1);
+    }
+}
+
+void PcapFileUnref(PcapFileFileVars *pfv)
+{
+    if (pfv != NULL) {
+        uint32_t prev = SC_ATOMIC_SUB(pfv->ref_cnt, 1);
+        if (prev == 1 && pfv->cleanup_requested) {
+            CleanupPcapFileFileVars(pfv);
+        }
+    }
+}
+
+/* Per-flow storage remembering which pcap file a flow's packets came from, so
+ * events emitted after the RX thread has moved to the next file still report
+ * the correct filename. Registered for offline run modes only. */
+static SCFlowStorageId g_flow_pcap_file_vars_id = { .id = -1 };
+
+static void FlowPcapFileVarsFree(void *ptr)
+{
+    PcapFileUnref((PcapFileFileVars *)ptr);
+}
+
+void RegisterFlowPcapFileVars(void)
+{
+    g_flow_pcap_file_vars_id = SCFlowStorageRegister("pcap_file_vars", FlowPcapFileVarsFree);
+}
+
+bool FlowPcapFileVarsStorageEnabled(void)
+{
+    return g_flow_pcap_file_vars_id.id >= 0;
+}
+
+void FlowSetPcapFileVars(Flow *f, PcapFileFileVars *pfv)
+{
+    if (pfv == NULL || g_flow_pcap_file_vars_id.id < 0) {
+        return;
+    }
+    PcapFileRef(pfv);
+    SCFlowSetStorageById(f, g_flow_pcap_file_vars_id, pfv);
+}
+
+PcapFileFileVars *FlowGetPcapFileVars(const Flow *f)
+{
+    if (g_flow_pcap_file_vars_id.id < 0) {
+        return NULL;
+    }
+    return SCFlowGetStorageById(f, g_flow_pcap_file_vars_id);
 }
 
 static void PcapCaptureOnPacketWithAlerts(const Packet *p)
@@ -1023,6 +1081,46 @@ static int SourcePcapFileHelperTest15(void)
 }
 
 /**
+ * \test A flow stores its source pfv (taking a reference) and releases it when
+ *       the flow is cleared.
+ */
+static int SourcePcapFileHelperTest16(void)
+{
+    SCStorageCleanup();
+    SCStorageInit();
+    RegisterFlowPcapFileVars();
+    FAIL_IF_NOT(FlowPcapFileVarsStorageEnabled());
+    FAIL_IF(SCStorageFinalize() < 0);
+
+    FlowInitConfig(FLOW_QUIET);
+
+    PcapFileFileVars *pfv = SCCalloc(1, sizeof(*pfv));
+    FAIL_IF_NULL(pfv);
+    SC_ATOMIC_INIT(pfv->ref_cnt);
+    SC_ATOMIC_SET(pfv->ref_cnt, 1);
+    SC_ATOMIC_INIT(pfv->alerts_count);
+
+    Flow *f = FlowAlloc();
+    FAIL_IF_NULL(f);
+
+    FlowSetPcapFileVars(f, pfv);
+    FAIL_IF_NOT(FlowGetPcapFileVars(f) == pfv);
+    FAIL_IF_NOT(SC_ATOMIC_GET(pfv->ref_cnt) == 2);
+
+    FlowClearMemory(f, 0);
+    FAIL_IF_NOT(SC_ATOMIC_GET(pfv->ref_cnt) == 1);
+    FlowFree(f);
+
+    FlowShutdown();
+    g_flow_pcap_file_vars_id.id = -1;
+    SCStorageCleanup();
+
+    SC_ATOMIC_SET(pfv->ref_cnt, 0);
+    CleanupPcapFileFileVars(pfv);
+    PASS;
+}
+
+/**
  * \brief Register unit tests for pcap file helper
  */
 void SourcePcapFileHelperRegisterTests(void)
@@ -1042,5 +1140,6 @@ void SourcePcapFileHelperRegisterTests(void)
     UtRegisterTest("SourcePcapFileHelperTest13", SourcePcapFileHelperTest13);
     UtRegisterTest("SourcePcapFileHelperTest14", SourcePcapFileHelperTest14);
     UtRegisterTest("SourcePcapFileHelperTest15", SourcePcapFileHelperTest15);
+    UtRegisterTest("SourcePcapFileHelperTest16", SourcePcapFileHelperTest16);
 }
 #endif /* UNITTESTS */

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -151,6 +151,21 @@ PcapFileFileVars *PcapFileGetCurrentPfv(void);
 
 void PcapFileInstallCaptureHooks(void);
 
+void PcapFileRef(PcapFileFileVars *pfv);
+void PcapFileUnref(PcapFileFileVars *pfv);
+
+struct Flow_;
+
+/** Register the per-flow storage that remembers the source pcap file of a
+ *  flow's packets. Offline run modes only; a no-op id otherwise. */
+void RegisterFlowPcapFileVars(void);
+bool FlowPcapFileVarsStorageEnabled(void);
+
+/** Store the source pcap file vars on a flow and take a reference. */
+void FlowSetPcapFileVars(struct Flow_ *f, PcapFileFileVars *pfv);
+/** Return the source pcap file vars stored on a flow, or NULL. */
+PcapFileFileVars *FlowGetPcapFileVars(const struct Flow_ *f);
+
 #ifdef UNITTESTS
 void SourcePcapFileHelperRegisterTests(void);
 #endif

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -52,6 +52,7 @@
 
 #include "stream-tcp-private.h"
 #include "stream-tcp.h"
+#include "source-pcap-file-helper.h"
 #include "stream-tcp-cache.h"
 #include "stream-tcp-inline.h"
 #include "stream-tcp-reassemble.h"
@@ -6931,6 +6932,8 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     memcpy(&np->vlan_id[0], &f->vlan_id[0], sizeof(np->vlan_id));
     np->vlan_idx = f->vlan_idx;
     np->livedev_id = f->livedev_id;
+    /* no extra ref: the flow's reference outlives this pseudo packet */
+    np->pcap_v.pfv = FlowGetPcapFileVars(f);
 
     if (parent->flags & PKT_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(np);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2870,6 +2870,10 @@ int PostConfLoadedSetup(SCInstance *suri)
     MacSetRegisterFlowStorage();
     FlowRateRegisterFlowStorage();
 
+    if (IsRunModeOffline(suri->run_mode)) {
+        RegisterFlowPcapFileVars();
+    }
+
     SigTableInit();
 
 #ifdef HAVE_PLUGINS


### PR DESCRIPTION
When processing multiple pcap files with --pcap-file-recursive, the pcap_filename field in EVE JSON events could show the wrong filename. The RX thread updates a global variable as it moves to the next file, but worker threads logging events from the previous file would read the already-updated global.

Use the per-packet PcapFileFileVars reference (p->pcap_v.pfv->filename) that is set at capture time, making the filename immutable for the packet's lifetime. For flow/netflow events where no packet is available (p == NULL), the global fallback is correct as these events are emitted synchronously on the RX thread.

BUGFIX: We also fix in the first commit a bug that we did not increase the ref count in all needed cases. This raised now that we have to have it in this scenario. The first commit handles it.

Previous PR: https://github.com/OISF/suricata/pull/15176

v2:
- Avoid extending the flow struct.

v3:
- Update schema.

v4:
- Name the union (capture) so direct access requires f->capture.livedev, preventing future code from accidentally misinterpreting the union value.
- Update flow-hash.c, flow-manager.c, and util-ebpf.c for the named union.
- Use FlowGetLiveDev() accessor in flow-manager.c (bypassed-flow stats).
- Clarify PcapFileGetFilename() fallback comment (stats events only).

v5:
- Split commit 1 into two: flow: introduce capture union (pure mechanical rename) and flow: fix ref_cnt leak and use-after-free (accessors, ref counting, tests)
- Replace raw (LiveDevice_*) cast with FlowGetLiveDev(f) on pseudo-packet creation in stream-tcp.c and flow-timeout.c
- Add comment in CmpFlowPacket() explaining the pointer-equality trick for pcap-file mode
- Drop invalid "optional" JSON Schema keyword from in_iface in schema.json; keep description only

v6:
- Squash "eve: guard in_iface field" into the ref_cnt commit so no intermediate state has the union misread bug (3 commits instead of 4)
- Add clarifying comment in stream-tcp.c that Packet keeps livedev and pcap_v as separate fields (not a union), so both assignments are needed
- Add comment in output-json.c that the PcapFileGetFilename() legacy path is only used for stats events

v7:
- Rebased onto current main. Upstream's "flow: store livedev by id" replaced the `livedev` pointer with a `uint16_t livedev_id`, so the previous design (the `capture` union reusing the livedev pointer slot, the FlowGetLiveDev()/FlowGetPcapFileVars() union accessors, the in_iface guards and the CmpFlowPacket() comment) no longer applies and has been dropped
- New approach: the flow remembers its source pcap file via per-flow storage (`pcap_file_vars`), registered for offline run modes only - so live capture is unaffected and the core Flow struct is not grown (addresses the earlier "avoid extending the flow struct" concern). The stored PcapFileFileVars is ref-counted (referenced in FlowInit, released by the storage free callback) so it outlives the source file in --pcap-file-recursive.
- Flow/netflow events (p == NULL, emitted from the flow-manager thread) now read the flow's stored file instead of the global, correcting the earlier assumption that the global was safe for those events.
- Flow-timeout and stream detect-log-flush pseudo packets carry the flow's pcap file (no extra ref: each holds a flow reference that outlives it), fixing both the filename and per-file alert attribution.
- output-json resolves the filename as packet -> flow -> global (the global is now used for stats events only).
- Addressed prior review: trimmed the verbose comments and reworked/renumbered the unit tests.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5255
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3013

