### PR TITLE
dhcp/rdp: mark single-direction transactions to fix tx leak

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -114,7 +114,7 @@ pub struct AppLayerTxData {
     pub updated_tc: bool,
     pub updated_ts: bool,
 
-    flags: u8,
+    pub flags: u8,
 
     /// logger flags for tx logging api
     logged: LoggerFlags,

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2021 Open Information Security Foundation
+/* Copyright (C) 2018-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -23,6 +23,7 @@ use suricata_sys::sys::{
 use crate::applayer::{self, *};
 use crate::core::{ALPROTO_UNKNOWN, IPPROTO_UDP};
 use crate::dhcp::parser::*;
+use crate::direction::Direction;
 use crate::flow::Flow;
 use std;
 use std::ffi::CString;
@@ -88,11 +89,11 @@ pub struct DHCPTransaction {
 }
 
 impl DHCPTransaction {
-    pub fn new(id: u64, message: DHCPMessage) -> DHCPTransaction {
+    pub fn new(id: u64, message: DHCPMessage, direction: Direction) -> DHCPTransaction {
         DHCPTransaction {
             tx_id: id,
             message,
-            tx_data: applayer::AppLayerTxData::new(),
+            tx_data: applayer::AppLayerTxData::for_direction(direction),
         }
     }
 }
@@ -131,13 +132,13 @@ impl DHCPState {
         Default::default()
     }
 
-    pub fn parse(&mut self, input: &[u8]) -> bool {
+    pub fn parse(&mut self, input: &[u8], direction: Direction) -> bool {
         match parse_dhcp(input) {
             Ok((_, message)) => {
                 let malformed_options = message.malformed_options;
                 let truncated_options = message.truncated_options;
                 self.tx_id += 1;
-                let transaction = DHCPTransaction::new(self.tx_id, message);
+                let transaction = DHCPTransaction::new(self.tx_id, message, direction);
                 self.transactions.push(transaction);
                 if malformed_options {
                     self.set_event(DHCPEvent::MalformedOptions);
@@ -226,12 +227,23 @@ unsafe extern "C" fn dhcp_state_get_tx_count(state: *mut std::os::raw::c_void) -
     return state.tx_id;
 }
 
-unsafe extern "C" fn dhcp_parse(
+unsafe extern "C" fn dhcp_parse_request(
     _flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut AppLayerParserState,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, DHCPState);
-    if state.parse(stream_slice.as_slice()) {
+    if state.parse(stream_slice.as_slice(), Direction::ToServer) {
+        return AppLayerResult::ok();
+    }
+    return AppLayerResult::err();
+}
+
+unsafe extern "C" fn dhcp_parse_response(
+    _flow: *mut Flow, state: *mut std::os::raw::c_void, _pstate: *mut AppLayerParserState,
+    stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
+) -> AppLayerResult {
+    let state = cast_pointer!(state, DHCPState);
+    if state.parse(stream_slice.as_slice(), Direction::ToClient) {
         return AppLayerResult::ok();
     }
     return AppLayerResult::err();
@@ -274,8 +286,8 @@ pub unsafe extern "C" fn SCRegisterDhcpParser() {
         state_new: dhcp_state_new,
         state_free: dhcp_state_free,
         tx_free: dhcp_state_tx_free,
-        parse_ts: dhcp_parse,
-        parse_tc: dhcp_parse,
+        parse_ts: dhcp_parse_request,
+        parse_tc: dhcp_parse_response,
         get_tx_count: dhcp_state_get_tx_count,
         get_tx: dhcp_state_get_tx,
         tx_comp_st_ts: 1,
@@ -307,5 +319,34 @@ pub unsafe extern "C" fn SCRegisterDhcpParser() {
         }
     } else {
         SCLogDebug!("Protocol detector and parser disabled for DHCP.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tx_skip_inspect_direction() {
+        let pcap = include_bytes!("discover.pcap");
+        let payload = &pcap[24 + 16 + 42..];
+
+        // a to-server tx should be marked to skip the to-client inspection it
+        // will never be observed in, and a to-client tx the reverse
+        let (_rem, message) = parse_dhcp(payload).unwrap();
+        let ts_tx = DHCPTransaction::new(1, message, Direction::ToServer);
+        assert_eq!(
+            APP_LAYER_TX_SKIP_INSPECT_TC,
+            ts_tx.tx_data.flags & APP_LAYER_TX_SKIP_INSPECT_TC
+        );
+        assert_eq!(0, ts_tx.tx_data.flags & APP_LAYER_TX_SKIP_INSPECT_TS);
+
+        let (_rem, message) = parse_dhcp(payload).unwrap();
+        let tc_tx = DHCPTransaction::new(2, message, Direction::ToClient);
+        assert_eq!(
+            APP_LAYER_TX_SKIP_INSPECT_TS,
+            tc_tx.tx_data.flags & APP_LAYER_TX_SKIP_INSPECT_TS
+        );
+        assert_eq!(0, tc_tx.tx_data.flags & APP_LAYER_TX_SKIP_INSPECT_TC);
     }
 }

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019-2022 Open Information Security Foundation
+/* Copyright (C) 2019-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -70,11 +70,11 @@ impl Transaction for RdpTransaction {
 }
 
 impl RdpTransaction {
-    fn new(id: u64, item: RdpTransactionItem) -> Self {
+    fn new(id: u64, item: RdpTransactionItem, direction: Direction) -> Self {
         Self {
             id,
             item,
-            tx_data: AppLayerTxData::new(),
+            tx_data: AppLayerTxData::for_direction(direction),
         }
     }
 }
@@ -161,9 +161,9 @@ impl RdpState {
         self.transactions.iter().find(|&tx| tx.id == tx_id)
     }
 
-    fn new_tx(&mut self, item: RdpTransactionItem) -> RdpTransaction {
+    fn new_tx(&mut self, item: RdpTransactionItem, direction: Direction) -> RdpTransaction {
         self.next_id += 1;
-        let tx = RdpTransaction::new(self.next_id, item);
+        let tx = RdpTransaction::new(self.next_id, item, direction);
         return tx;
     }
 
@@ -209,8 +209,10 @@ impl RdpState {
                         match t123.child {
                             // X.224 connection request
                             T123TpktChild::X224ConnectionRequest(x224) => {
-                                let tx =
-                                    self.new_tx(RdpTransactionItem::X224ConnectionRequest(x224));
+                                let tx = self.new_tx(
+                                    RdpTransactionItem::X224ConnectionRequest(x224),
+                                    Direction::ToServer,
+                                );
                                 self.transactions.push_back(tx);
                                 if !flow.is_null() {
                                     sc_app_layer_parser_trigger_raw_stream_inspection(
@@ -225,8 +227,10 @@ impl RdpState {
                                 #[allow(clippy::single_match)]
                                 match x223.child {
                                     X223DataChild::McsConnectRequest(mcs) => {
-                                        let tx =
-                                            self.new_tx(RdpTransactionItem::McsConnectRequest(mcs));
+                                        let tx = self.new_tx(
+                                            RdpTransactionItem::McsConnectRequest(mcs),
+                                            Direction::ToServer,
+                                        );
                                         self.transactions.push_back(tx);
                                         if !flow.is_null() {
                                             sc_app_layer_parser_trigger_raw_stream_inspection(
@@ -302,8 +306,10 @@ impl RdpState {
                                             data: cert.data.to_vec(),
                                         });
                                     }
-                                    let tx =
-                                        self.new_tx(RdpTransactionItem::TlsCertificateChain(chain));
+                                    let tx = self.new_tx(
+                                        RdpTransactionItem::TlsCertificateChain(chain),
+                                        Direction::ToClient,
+                                    );
                                     self.transactions.push_back(tx);
                                     if !flow.is_null() {
                                         sc_app_layer_parser_trigger_raw_stream_inspection(
@@ -341,8 +347,10 @@ impl RdpState {
                         match t123.child {
                             // X.224 connection confirm
                             T123TpktChild::X224ConnectionConfirm(x224) => {
-                                let tx =
-                                    self.new_tx(RdpTransactionItem::X224ConnectionConfirm(x224));
+                                let tx = self.new_tx(
+                                    RdpTransactionItem::X224ConnectionConfirm(x224),
+                                    Direction::ToClient,
+                                );
                                 self.transactions.push_back(tx);
                                 if !flow.is_null() {
                                     sc_app_layer_parser_trigger_raw_stream_inspection(
@@ -357,8 +365,10 @@ impl RdpState {
                                 #[allow(clippy::single_match)]
                                 match x223.child {
                                     X223DataChild::McsConnectResponse(mcs) => {
-                                        let tx = self
-                                            .new_tx(RdpTransactionItem::McsConnectResponse(mcs));
+                                        let tx = self.new_tx(
+                                            RdpTransactionItem::McsConnectResponse(mcs),
+                                            Direction::ToClient,
+                                        );
                                         self.transactions.push_back(tx);
                                         if !flow.is_null() {
                                             sc_app_layer_parser_trigger_raw_stream_inspection(
@@ -649,8 +659,8 @@ mod tests {
         let item1 = RdpTransactionItem::McsConnectRequest(McsConnectRequest {
             children: Vec::new(),
         });
-        let tx0 = state.new_tx(item0);
-        let tx1 = state.new_tx(item1);
+        let tx0 = state.new_tx(item0, Direction::ToServer);
+        let tx1 = state.new_tx(item1, Direction::ToServer);
         assert_eq!(2, state.next_id);
         state.transactions.push_back(tx0);
         state.transactions.push_back(tx1);
@@ -659,6 +669,32 @@ mod tests {
         assert_eq!(2, state.transactions[1].id);
         assert!(!state.tls_parsing);
         assert!(!state.bypass_parsing);
+    }
+
+    #[test]
+    fn test_tx_skip_inspect_direction() {
+        // a to-server tx should be marked to skip the to-client inspection it
+        // will never be observed in, and a to-client tx the reverse
+        let ts_item = RdpTransactionItem::McsConnectRequest(McsConnectRequest {
+            children: Vec::new(),
+        });
+        let ts_tx = RdpTransaction::new(1, ts_item, Direction::ToServer);
+        assert_eq!(
+            APP_LAYER_TX_SKIP_INSPECT_TC,
+            ts_tx.tx_data.flags & APP_LAYER_TX_SKIP_INSPECT_TC
+        );
+        assert_eq!(0, ts_tx.tx_data.flags & APP_LAYER_TX_SKIP_INSPECT_TS);
+
+        let tc_tx = RdpTransaction::new(
+            2,
+            RdpTransactionItem::McsConnectResponse(McsConnectResponse {}),
+            Direction::ToClient,
+        );
+        assert_eq!(
+            APP_LAYER_TX_SKIP_INSPECT_TS,
+            tc_tx.tx_data.flags & APP_LAYER_TX_SKIP_INSPECT_TS
+        );
+        assert_eq!(0, tc_tx.tx_data.flags & APP_LAYER_TX_SKIP_INSPECT_TC);
     }
 
     #[test]
@@ -673,9 +709,9 @@ mod tests {
         let item2 = RdpTransactionItem::McsConnectRequest(McsConnectRequest {
             children: Vec::new(),
         });
-        let tx0 = state.new_tx(item0);
-        let tx1 = state.new_tx(item1);
-        let tx2 = state.new_tx(item2);
+        let tx0 = state.new_tx(item0, Direction::ToServer);
+        let tx1 = state.new_tx(item1, Direction::ToServer);
+        let tx2 = state.new_tx(item2, Direction::ToServer);
         state.transactions.push_back(tx0);
         state.transactions.push_back(tx1);
         state.transactions.push_back(tx2);
@@ -694,9 +730,9 @@ mod tests {
         let item2 = RdpTransactionItem::McsConnectRequest(McsConnectRequest {
             children: Vec::new(),
         });
-        let tx0 = state.new_tx(item0);
-        let tx1 = state.new_tx(item1);
-        let tx2 = state.new_tx(item2);
+        let tx0 = state.new_tx(item0, Direction::ToServer);
+        let tx1 = state.new_tx(item1, Direction::ToServer);
+        let tx2 = state.new_tx(item2, Direction::ToServer);
         state.transactions.push_back(tx0);
         state.transactions.push_back(tx1);
         state.transactions.push_back(tx2);


### PR DESCRIPTION
Cherry-pick of 8621 fix

Include direction when creating dhcp/rdp transaction so the opposite direction is marked with SKIP_INSPECT. 

Link to tickets: 
- https://redmine.openinfosecfoundation.org/issues/8622

Describe changes:
- Include direction when creating DHCP/RDP transactions
- dhcp: replace directionless parse with parse_request/parse_response. 
- Rust unit tests for DHCP/RDP changes.

