### PR TITLE
detect-engine-mpm: Prevent out-of-bounds write for negative transforms->cnt

### DIFF
--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -207,7 +207,7 @@ static void BuildBasicPname(char *out, const size_t out_size, const char *name, 
 static void AppendTransformsToPname(
         char *out, const size_t out_size, const DetectEngineTransforms *transforms)
 {
-    if (transforms == NULL || transforms->cnt == 0)
+    if (transforms == NULL || transforms->cnt <= 0)
         return;
 
     ssize_t left = (ssize_t)out_size - (ssize_t)strlen(out) - (ssize_t)4;


### PR DESCRIPTION
Replaced transforms->cnt == 0 with transforms->cnt <= 0 to properly handle invalid negative values. If cnt is negative, the loop is skipped, leaving xforms empty. The subsequent xforms[strlen(xforms) - 1] = '\0' then writes to xforms[-1], causing an out-of-bounds write and undefined behavior.

Flagged by Svace static analyzer.

Ticket: 8690
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8690
