### PR TITLE
doc: add missing "value" to entropy examples

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -800,7 +800,7 @@ This results in the calculated entropy value being compared with
 
 Example::
 
-  entropy: 7.01
+  entropy: value 7.01
 
 A match occurs when the calculated entropy and specified entropy values agree.
 This is determined by calculating the entropy value and comparing it with the
@@ -808,7 +808,7 @@ value from the rule using the specified operator.
 
 Example::
 
-  entropy: <7.01
+  entropy: value <7.01
 
 Options have default values:
 - bytes is equal to the current content length


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none, just some doc fixup

@jlucovsky should we have a ticket ? backport ?

Describe changes:
- doc: add missing "value" to entropy examples

https://github.com/OISF/suricata/pull/15507 owning the commit with a proper git id and crediting Hydraze