### PR TITLE
ci: upgrade FreeBSD Python package to 3.12 v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -3413,7 +3413,7 @@ jobs:
               pcre2 \
               pkgconf \
               python3 \
-              py311-pyyaml \
+              py312-pyyaml \
               rust
           run: |
             tar xf prep/suricata-verify.tar.gz


### PR DESCRIPTION
FreeBSD upgraded the default Python package to 3.12. With that the pip packages also updated to the new version.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

Describe changes:
- Python package version upgrade based on the recent default adjustment