### PR TITLE
af-packet: invert ebpf g_flowv4_ok log flag v1

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2594,9 +2594,9 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, const void *initdata, void **data)
     if (ptv->flags & (AFP_BYPASS|AFP_XDPBYPASS)) {
         ptv->v4_map_fd = EBPFGetMapFDByName(ptv->iface, "flow_table_v4");
         if (ptv->v4_map_fd == -1) {
-            if (!g_flowv4_ok) {
+            if (g_flowv4_ok) {
                 SCLogError("Can't find eBPF map fd for '%s'", "flow_table_v4");
-                g_flowv4_ok = true;
+                g_flowv4_ok = false;
             }
         }
         ptv->v6_map_fd = EBPFGetMapFDByName(ptv->iface, "flow_table_v6");


### PR DESCRIPTION
This PR fixes how error messages are printed in case `EBPFGetMapFDByName()` for `flow_table_v4` returns value `-1` in the ebpf flow table code. 

The log flag `g_flowv4_ok` is set initially to `true`, and due to how the condition `if (!g_flowv4_ok)`  is structured,  the code block following the condition was never executed, and the error messages were never printed.

The fix follows the code's handling of the `g_flowv6_ok` flag.


Link to ticket: https://redmine.openinfosecfoundation.org/issues/8704
