### PR TITLE
bug/FM: no flow timeout when hash-size < 10 v1

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -800,7 +800,9 @@ static void GetWorkUnitSizing(const uint32_t rows, const uint32_t mp, const bool
     }
     /* minimum busy score is 10 */
     const uint32_t emp = MAX(mp, 10);
-    const uint32_t rows_per_sec = (uint32_t)((float)rows * (float)((float)emp / (float)100));
+    /* ensure minimum rows_per_sec is at least 1 */
+    const uint32_t rows_per_sec =
+            MAX(1, (uint32_t)((float)rows * (float)((float)emp / (float)100)));
     /* calc how much time we estimate the work will take, in ms. We assume
      * each row takes an average of 1usec. Maxing out at 1sec. */
     const uint32_t work_per_unit = MIN(rows_per_sec / 1000, 1000);


### PR DESCRIPTION
This Pull Request fixes an issue where flows were not being timed out by Flow Manager because the variable `rows_per_sec` was set to `0` after a calculation that includes casting a float to a uint32_t. 

This incorrect rounding happened in a case where `flow.hash-size < 10`.

The fix ensures that the minimum value for `rows_per_sec` is `1`.


Link to ticket: https://redmine.openinfosecfoundation.org/issues/8710
