### PR TITLE
ebpf: raise RLIMIT_MEMLOCK only on kernel >= 5.11

### DIFF
--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -44,6 +44,7 @@
 #include "util-affinity.h"
 #include "util-cpu.h"
 #include "util-device-private.h"
+#include "util-host-info.h"
 
 #include "device-storage.h"
 #include "flow-storage.h"
@@ -321,12 +322,15 @@ int EBPFLoadFile(const char *iface, const char *path, const char * section,
         return -1;
     }
 
-    /* Sending the eBPF code to the kernel requires a large amount of
-     * locked memory so we set it to unlimited to avoid a ENOPERM error */
-    struct rlimit r = {RLIM_INFINITY, RLIM_INFINITY};
-    if (setrlimit(RLIMIT_MEMLOCK, &r) != 0) {
-        SCLogError("Unable to lock memory: %s (%d)", strerror(errno), errno);
-        return -1;
+    /* Since kernel 5.11 BPF map memory is memcg-accounted and no longer
+     * charged against RLIMIT_MEMLOCK (https://lwn.net/Articles/829307/), so
+     * raising the limit is only needed on older kernels. Raising it requires CAP_SYS_RESOURCE */
+    if (!SCKernelVersionIsAtLeast(5, 11)) {
+        struct rlimit r = { RLIM_INFINITY, RLIM_INFINITY };
+        if (setrlimit(RLIMIT_MEMLOCK, &r) != 0) {
+            SCLogError("Unable to lock memory: %s (%d)", strerror(errno), errno);
+            return -1;
+        }
     }
 
     /* Open the eBPF file and parse it */


### PR DESCRIPTION
EBPFLoadFile() unconditionally raised RLIMIT_MEMLOCK to infinity and aborted the eBPF/XDP load if the call failed.

Since Linux 5.11 BPF map memory is memcg-accounted and is no longer charged against RLIMIT_MEMLOCK (https://lwn.net/Articles/829307/), so raising the limit is unnecessary on those kernels. 

Ticket: 8719

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/issues/8719
      
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8719

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
