### PR TITLE
output/anomaly: report unknown ethertype in decode events

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -176,6 +176,13 @@ Anomalies are reported by and configured by type:
 - Stream
 - Application layer
 
+Decode anomaly events for unrecognized ethertypes
+(``decoder.ethernet.unknown_ethertype``, ``decoder.vlan.unknown_type``,
+``decoder.etag.unknown_type`` and ``decoder.vntag.unknown_type``) include the
+ethertype value that could not be decoded in the ``anomaly.ether_type`` field.
+With nested headers, e.g., VLAN, this is the innermost ethertype that could
+not be decoded rather than the ethertype of the outer header.
+
 Metadata::
 
     - anomaly:

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -57,6 +57,12 @@ Logging Changes
   E.g., previously, ``ether_type`` values were logged in host order;  an ethertype value of ``0xfbb7``
   (network order) was logged as `47099`` (``0xb7fb``). This ethertype value will be logged as ``64439``.
 
+- Anomaly events for unrecognized ethertypes
+  (``decoder.ethernet.unknown_ethertype``, ``decoder.vlan.unknown_type``,
+  ``decoder.etag.unknown_type`` and ``decoder.vntag.unknown_type``) now include
+  the ethertype value that could not be decoded in the ``anomaly.ether_type``
+  field.
+
 - Alert verdict key is changed from to ``reject-target`` to ``reject_target``
 
 - App-layer stats protocols names replace dash by underscore, meaning

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -169,6 +169,10 @@
                 "code": {
                     "type": "integer"
                 },
+                "ether_type": {
+                    "type": "integer",
+                    "description": "The unknown ethertype that triggered the event"
+                },
                 "event": {
                     "type": "string"
                 },

--- a/src/decode.h
+++ b/src/decode.h
@@ -428,6 +428,10 @@ enum PacketL2Types {
 
 struct PacketL2 {
     enum PacketL2Types type;
+    /** ethertype that could not be decoded; set on the unknown-ethertype
+     *  decode path and reported by the ethernet, VLAN, E-Tag and VN-Tag
+     *  unknown-type anomaly events */
+    uint16_t unknown_ethertype;
     union L2Hdrs {
         EthernetHdr *ethh;
     } hdrs;
@@ -1552,6 +1556,7 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
             SCLogDebug("unknown ether type: %" PRIx16 "", proto);
             StatsCounterIncr(&tv->stats, dtv->counter_ethertype_unknown);
             ENGINE_SET_EVENT(p, ETHERNET_UNKNOWN_ETHERTYPE);
+            p->l2.unknown_ethertype = proto;
             return false;
     }
     return true;

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -100,6 +100,22 @@ static void OutputAnomalyLoggerDisable(void)
         anomaly_loggers--;
 }
 
+/** \brief Does this decode event report an ethertype that could not be
+ *         decoded? Such events store the offending value in
+ *         Packet::l2.unknown_ethertype. */
+static bool DecodeEventHasUnknownEthertype(uint8_t event_code)
+{
+    switch (event_code) {
+        case ETHERNET_UNKNOWN_ETHERTYPE:
+        case VLAN_UNKNOWN_TYPE:
+        case ETAG_UNKNOWN_TYPE:
+        case VNTAG_UNKNOWN_TYPE:
+            return true;
+        default:
+            return false;
+    }
+}
+
 static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
                                   const Packet *p)
 {
@@ -131,6 +147,9 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
                 JB_SET_STRING(js, "type", "stream");
             }
             SCJbSetString(js, "event", event);
+            if (DecodeEventHasUnknownEthertype(event_code)) {
+                SCJbSetUint(js, "ether_type", p->l2.unknown_ethertype);
+            }
         } else {
             JB_SET_STRING(js, "type", "unknown");
             SCJbSetUint(js, "code", event_code);


### PR DESCRIPTION
Continuation of #15569 

Report unknown ethertype values in anomaly events to identify the value that triggered the event.
Also, update the vlan/vntag/etag handling so the inner ethertype value is included.

The values in the anomaly events are printed as hex strings, e.g "0x8193". When `ethernet: yes` is set, ether_type values are printed as hex strings when `etherrtype-hex: yes` is set.

Link to ticket:
* https://redmine.openinfosecfoundation.org/issues/7849
* https://redmine.openinfosecfoundation.org/issues/8142

Describe changes:
- Include ethertype values with anomaly events, including those from vlang/etag/vntag frames
- Add an option to display ethertype values as hex strings when ethernet values are being logged
- Document the config option, and the inclusion of ethertype info the ethernet/vlan/etag/vntag anomaly events.

Updates:
- Rebase
- Single type for ethernet value (int)

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3148
