### PR TITLE
smtp: add firewall progress states - v4


### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -230,6 +230,12 @@ static inline void SMTPSetProgressTC(SMTPTransaction *tx, uint8_t progress)
         tx->progress_tc = progress;
 }
 
+static bool SMTPTransactionIsComplete(const SMTPTransaction *tx)
+{
+    return tx && tx->progress_ts == SMTP_REQUEST_COMPLETE &&
+           tx->progress_tc == SMTP_RESPONSE_COMPLETE;
+}
+
 typedef struct SMTPThreadCtx_ {
     MpmThreadCtx *smtp_mpm_thread_ctx;
     PrefilterRuleStore *pmq;
@@ -761,8 +767,28 @@ static void SetMimeEvents(SMTPState *state, uint32_t events)
 static inline void SMTPTransactionComplete(SMTPState *state)
 {
     DEBUG_VALIDATE_BUG_ON(state->curr_tx == NULL);
-    if (state->curr_tx)
-        state->curr_tx->done = true;
+    if (state->curr_tx) {
+        SMTPSetProgressTS(state->curr_tx, SMTP_REQUEST_COMPLETE);
+        SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_COMPLETE);
+    }
+}
+
+static inline void SMTPTransactionCompleteTS(SMTPState *state)
+{
+    DEBUG_VALIDATE_BUG_ON(state->curr_tx == NULL);
+    if (state->curr_tx) {
+        SMTPSetProgressTS(state->curr_tx, SMTP_REQUEST_COMPLETE);
+        SCLogDebug("marked tx as ts complete");
+    }
+}
+
+static inline void SMTPTransactionCompleteTC(SMTPState *state)
+{
+    DEBUG_VALIDATE_BUG_ON(state->curr_tx == NULL);
+    if (state->curr_tx) {
+        SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_COMPLETE);
+        SCLogDebug("marked tx as tc complete");
+    }
 }
 
 /**
@@ -799,8 +825,7 @@ static int SMTPProcessCommandDATA(
                         FileFlowToFlags(f, STREAM_TOSERVER));
             }
         }
-        SMTPTransactionComplete(state);
-        SCLogDebug("marked tx as done");
+        SMTPTransactionCompleteTS(state);
     } else if (smtp_config.raw_extraction) {
         // message not over, store the line. This is a substitution of
         // ProcessDataChunk
@@ -1005,6 +1030,10 @@ static int SMTPProcessReply(
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_BDAT)) {
         SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_DATA);
+    } else if (IsReplyToCommand(state, SMTP_COMMAND_DATA_MODE)) {
+        if (!(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
+            SMTPTransactionCompleteTC(state);
+        }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_RSET)) {
         if (reply_code == SMTP_REPLY_250 && state->curr_tx &&
                 !(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
@@ -1206,7 +1235,8 @@ static int SMTPProcessRequest(
     if (line->len == 0 && line->delim_len == 0) {
         return 0;
     }
-    if (state->curr_tx == NULL || (state->curr_tx->done && !NoNewTx(state, line))) {
+    if (state->curr_tx == NULL ||
+            (SMTPTransactionIsComplete(state->curr_tx) && !NoNewTx(state, line))) {
         tx = SMTPTransactionCreate(state);
         if (tx == NULL)
             return -1;
@@ -1859,8 +1889,8 @@ static int SMTPStateGetAlstateProgress(void *vtx, uint8_t direction)
 {
     SMTPTransaction *tx = vtx;
     if (direction & STREAM_TOSERVER)
-        return tx->done ? SMTP_REQUEST_COMPLETE : tx->progress_ts;
-    return tx->done ? SMTP_RESPONSE_COMPLETE : tx->progress_tc;
+        return tx->progress_ts;
+    return tx->progress_tc;
 }
 
 static AppLayerGetFileState SMTPGetTxFiles(void *txv, uint8_t direction)
@@ -2604,6 +2634,13 @@ static int SMTPParserTest02(void)
         printf("smtp parser in inconsistent state\n");
         goto end;
     }
+    if (SMTPStateGetAlstateProgress(smtp_state->curr_tx, STREAM_TOSERVER) !=
+                    SMTP_REQUEST_COMPLETE ||
+            SMTPStateGetAlstateProgress(smtp_state->curr_tx, STREAM_TOCLIENT) !=
+                    SMTP_RESPONSE_DATA) {
+        printf("smtp progress in inconsistent state\n");
+        goto end;
+    }
 
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_SMTP,
                             STREAM_TOCLIENT, reply5, reply5_len);
@@ -2614,6 +2651,13 @@ static int SMTPParserTest02(void)
     if (smtp_state->cmds_cnt != 0 || smtp_state->cmds_idx != 0 ||
             smtp_state->parser_state != (SMTP_PARSER_STATE_FIRST_REPLY_SEEN)) {
         printf("smtp parser in inconsistent state\n");
+        goto end;
+    }
+    if (SMTPStateGetAlstateProgress(smtp_state->curr_tx, STREAM_TOSERVER) !=
+                    SMTP_REQUEST_COMPLETE ||
+            SMTPStateGetAlstateProgress(smtp_state->curr_tx, STREAM_TOCLIENT) !=
+                    SMTP_RESPONSE_COMPLETE) {
+        printf("smtp progress in inconsistent state\n");
         goto end;
     }
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -526,7 +526,20 @@ static void SMTPSetEvent(SMTPState *s, uint8_t e)
     SCLogDebug("couldn't set event %u", e);
 }
 
-static SMTPTransaction *SMTPTransactionCreate(SMTPState *state)
+static uint8_t *SMTPCopyParam(const uint8_t *src, uint16_t len)
+{
+    uint8_t *copy = SCMalloc(len + 1);
+    if (copy == NULL) {
+        return NULL;
+    }
+    if (len > 0) {
+        memcpy(copy, src, len);
+    }
+    copy[len] = '\0';
+    return copy;
+}
+
+static SMTPTransaction *SMTPTransactionCreate(SMTPState *state, bool inherit_helo)
 {
     if (state->tx_cnt > smtp_config.max_tx) {
         return NULL;
@@ -538,6 +551,14 @@ static SMTPTransaction *SMTPTransactionCreate(SMTPState *state)
 
     TAILQ_INIT(&tx->rcpt_to_list);
     tx->tx_data.file_tx = STREAM_TOSERVER; // can xfer files
+    if (inherit_helo && state->helo != NULL) {
+        tx->helo = SMTPCopyParam(state->helo, state->helo_len);
+        if (tx->helo == NULL) {
+            SCFree(tx);
+            return NULL;
+        }
+        tx->helo_len = state->helo_len;
+    }
     return tx;
 }
 
@@ -1140,11 +1161,24 @@ static int SMTPParseCommandWithParam(SMTPState *state, const SMTPLine *line, uin
 
 static int SMTPParseCommandHELO(SMTPState *state, const SMTPLine *line)
 {
-    if (state->helo) {
+    if (state->curr_tx->helo) {
         SMTPSetEvent(state, SMTP_DECODER_EVENT_DUPLICATE_FIELDS);
         return 0;
     }
-    return SMTPParseCommandWithParam(state, line, 4, &state->helo, &state->helo_len);
+    int r = SMTPParseCommandWithParam(
+            state, line, 4, &state->curr_tx->helo, &state->curr_tx->helo_len);
+    if (r == 0) {
+        uint8_t *helo = SMTPCopyParam(state->curr_tx->helo, state->curr_tx->helo_len);
+        if (helo == NULL) {
+            return -1;
+        }
+        if (state->helo) {
+            SCFree(state->helo);
+        }
+        state->helo = helo;
+        state->helo_len = state->curr_tx->helo_len;
+    }
+    return r;
 }
 
 static int SMTPParseCommandMAILFROM(SMTPState *state, const SMTPLine *line)
@@ -1176,6 +1210,12 @@ static int SMTPParseCommandRCPTTO(SMTPState *state, const SMTPLine *line)
         return -1;
     }
     return 0;
+}
+
+static bool SMTPLineIsHelo(const SMTPLine *line)
+{
+    return line->len >= 4 && (SCMemcmpLowercase("helo", line->buf, 4) == 0 ||
+                                     SCMemcmpLowercase("ehlo", line->buf, 4) == 0);
 }
 
 /* consider 'rset' and 'quit' to be part of the existing state */
@@ -1235,9 +1275,15 @@ static int SMTPProcessRequest(
     if (line->len == 0 && line->delim_len == 0) {
         return 0;
     }
-    if (state->curr_tx == NULL ||
+    const bool command_mode = !(state->parser_state & SMTP_PARSER_STATE_COMMAND_DATA_MODE);
+    const bool helo_cmd = command_mode && SMTPLineIsHelo(line);
+    const bool subsequent_helo = helo_cmd && state->seen_helo;
+    if (subsequent_helo && state->curr_tx != NULL && !SMTPTransactionIsComplete(state->curr_tx)) {
+        SMTPTransactionComplete(state);
+    }
+    if (state->curr_tx == NULL || subsequent_helo ||
             (SMTPTransactionIsComplete(state->curr_tx) && !NoNewTx(state, line))) {
-        tx = SMTPTransactionCreate(state);
+        tx = SMTPTransactionCreate(state, !subsequent_helo);
         if (tx == NULL)
             return -1;
         state->curr_tx = tx;
@@ -1313,12 +1359,12 @@ static int SMTPProcessRequest(
             state->current_command = SMTP_COMMAND_BDAT;
             SMTPSetProgressTS(tx, SMTP_REQUEST_DATA);
             state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
-        } else if (line->len >= 4 && ((SCMemcmpLowercase("helo", line->buf, 4) == 0) ||
-                                             SCMemcmpLowercase("ehlo", line->buf, 4) == 0)) {
+        } else if (helo_cmd) {
             r = SMTPParseCommandHELO(state, line);
             if (r == -1) {
                 SCReturnInt(-1);
             }
+            state->seen_helo = true;
             state->current_command = SMTP_COMMAND_OTHER_CMD;
         } else if (line->len >= 9 && SCMemcmpLowercase("mail from", line->buf, 9) == 0) {
             r = SMTPParseCommandMAILFROM(state, line);
@@ -1664,6 +1710,10 @@ static void SMTPTransactionFree(SMTPTransaction *tx, SMTPState *state)
     }
 
     SCAppLayerTxDataCleanup(&tx->tx_data);
+
+    if (tx->helo) {
+        SCFree(tx->helo);
+    }
 
     if (tx->mail_from)
         SCFree(tx->mail_from);
@@ -4121,8 +4171,10 @@ static int SMTPParserTest14(void)
         goto end;
     }
 
-    if ((smtp_state->helo_len != 7) || strncmp("boo.com", (char *)smtp_state->helo, 7)) {
-        printf("incorrect parsing of HELO field '%s' (%d)\n", smtp_state->helo, smtp_state->helo_len);
+    if ((smtp_state->curr_tx->helo_len != 7) ||
+            strncmp("boo.com", (char *)smtp_state->curr_tx->helo, 7)) {
+        printf("incorrect parsing of HELO field '%s' (%d)\n", smtp_state->curr_tx->helo,
+                smtp_state->curr_tx->helo_len);
         goto end;
     }
 
@@ -4352,6 +4404,7 @@ end:
     StreamTcpFreeConfig(true);
     return result;
 }
+
 #endif /* UNITTESTS */
 
 void SMTPParserRegisterTests(void)

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -186,6 +186,50 @@ static const char *SMTPGetFrameNameById(const uint8_t frame_id)
     return name;
 }
 
+static SCEnumCharMap smtp_state_client_table[] = {
+    { "request_started", SMTP_REQUEST_STARTED },
+    { "request_data", SMTP_REQUEST_DATA },
+    { "request_complete", SMTP_REQUEST_COMPLETE },
+    { NULL, -1 },
+};
+
+static SCEnumCharMap smtp_state_server_table[] = {
+    { "response_started", SMTP_RESPONSE_STARTED },
+    { "response_data", SMTP_RESPONSE_DATA },
+    { "response_complete", SMTP_RESPONSE_COMPLETE },
+    { NULL, -1 },
+};
+
+static int SMTPStateGetStateIdByName(const char *name, const uint8_t direction)
+{
+    SCEnumCharMap *map =
+            direction == STREAM_TOSERVER ? smtp_state_client_table : smtp_state_server_table;
+    int id = SCMapEnumNameToValue(name, map);
+    if (id < 0) {
+        return -1;
+    }
+    return id;
+}
+
+static const char *SMTPStateGetStateNameById(const int id, const uint8_t direction)
+{
+    SCEnumCharMap *map =
+            direction == STREAM_TOSERVER ? smtp_state_client_table : smtp_state_server_table;
+    return SCMapEnumValueToName(id, map);
+}
+
+static inline void SMTPSetProgressTS(SMTPTransaction *tx, uint8_t progress)
+{
+    if (tx != NULL && tx->progress_ts < progress)
+        tx->progress_ts = progress;
+}
+
+static inline void SMTPSetProgressTC(SMTPTransaction *tx, uint8_t progress)
+{
+    if (tx != NULL && tx->progress_tc < progress)
+        tx->progress_tc = progress;
+}
+
 typedef struct SMTPThreadCtx_ {
     MpmThreadCtx *smtp_mpm_thread_ctx;
     PrefilterRuleStore *pmq;
@@ -948,6 +992,7 @@ static int SMTPProcessReply(
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_DATA)) {
         if (reply_code == SMTP_REPLY_354) {
+            SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_DATA);
             /* Next comes the mail for the DATA command in toserver direction */
             state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
         } else {
@@ -958,6 +1003,8 @@ static int SMTPProcessReply(
             }
             SMTPSetEvent(state, SMTP_DECODER_EVENT_DATA_COMMAND_REJECTED);
         }
+    } else if (IsReplyToCommand(state, SMTP_COMMAND_BDAT)) {
+        SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_DATA);
     } else if (IsReplyToCommand(state, SMTP_COMMAND_RSET)) {
         if (reply_code == SMTP_REPLY_250 && state->curr_tx &&
                 !(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
@@ -1193,6 +1240,7 @@ static int SMTPProcessRequest(
             state->current_command = SMTP_COMMAND_STARTTLS;
         } else if (line->len >= 4 && SCMemcmpLowercase("data", line->buf, 4) == 0) {
             state->current_command = SMTP_COMMAND_DATA;
+            SMTPSetProgressTS(tx, SMTP_REQUEST_DATA);
             if (state->curr_tx->is_data) {
                 // We did not receive a confirmation from server
                 // And now client sends a next DATA
@@ -1233,6 +1281,7 @@ static int SMTPProcessRequest(
                 SCReturnInt(-1);
             }
             state->current_command = SMTP_COMMAND_BDAT;
+            SMTPSetProgressTS(tx, SMTP_REQUEST_DATA);
             state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
         } else if (line->len >= 4 && ((SCMemcmpLowercase("helo", line->buf, 4) == 0) ||
                                              SCMemcmpLowercase("ehlo", line->buf, 4) == 0)) {
@@ -1809,7 +1858,9 @@ static void *SMTPStateGetTx(void *state, uint64_t id)
 static int SMTPStateGetAlstateProgress(void *vtx, uint8_t direction)
 {
     SMTPTransaction *tx = vtx;
-    return tx->done;
+    if (direction & STREAM_TOSERVER)
+        return tx->done ? SMTP_REQUEST_COMPLETE : tx->progress_ts;
+    return tx->done ? SMTP_RESPONSE_COMPLETE : tx->progress_tc;
 }
 
 static AppLayerGetFileState SMTPGetTxFiles(void *txv, uint8_t direction)
@@ -1912,9 +1963,12 @@ void RegisterSMTPParsers(void)
         AppLayerParserRegisterGetTxIterator(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetTxIterator);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetTxData);
         AppLayerParserRegisterStateDataFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetStateData);
-        AppLayerParserRegisterStateProgressCompletionStatus(ALPROTO_SMTP, 1, 1);
+        AppLayerParserRegisterStateProgressCompletionStatus(
+                ALPROTO_SMTP, SMTP_REQUEST_COMPLETE, SMTP_RESPONSE_COMPLETE);
         AppLayerParserRegisterGetFrameFuncs(
                 IPPROTO_TCP, ALPROTO_SMTP, SMTPGetFrameIdByName, SMTPGetFrameNameById);
+        AppLayerParserRegisterGetStateFuncs(
+                IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetStateIdByName, SMTPStateGetStateNameById);
     } else {
         SCLogInfo("Parser disabled for %s protocol. Protocol detection still on.", proto_name);
     }

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -70,6 +70,18 @@ typedef struct SMTPString_ {
     TAILQ_ENTRY(SMTPString_) next;
 } SMTPString;
 
+enum SMTPRequestProgress {
+    SMTP_REQUEST_STARTED = 0,
+    SMTP_REQUEST_DATA = 1,
+    SMTP_REQUEST_COMPLETE = 2,
+};
+
+enum SMTPResponseProgress {
+    SMTP_RESPONSE_STARTED = 0,
+    SMTP_RESPONSE_DATA = 1,
+    SMTP_RESPONSE_COMPLETE = 2,
+};
+
 typedef struct SMTPTransaction_ {
     /** id of this tx, starting at 0 */
     uint64_t tx_id;
@@ -78,6 +90,10 @@ typedef struct SMTPTransaction_ {
 
     /** the tx is complete and can be logged and cleaned */
     bool done;
+    /** to-server firewall progress state. */
+    uint8_t progress_ts;
+    /** to-client firewall progress state. */
+    uint8_t progress_tc;
     /** the tx has seen a DATA command */
     // another DATA command within the same context
     // will trigger an app-layer event.

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -88,8 +88,6 @@ typedef struct SMTPTransaction_ {
 
     AppLayerTxData tx_data;
 
-    /** the tx is complete and can be logged and cleaned */
-    bool done;
     /** to-server firewall progress state. */
     uint8_t progress_ts;
     /** to-client firewall progress state. */

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -99,6 +99,10 @@ typedef struct SMTPTransaction_ {
     /** the mime decoding parser state */
     MimeStateSMTP *mime_state;
 
+    /* HELO/EHLO parameter */
+    uint8_t *helo;
+    uint16_t helo_len;
+
     /* MAIL FROM parameters */
     uint8_t *mail_from;
     uint16_t mail_from_len;
@@ -161,9 +165,11 @@ typedef struct SMTPState_ {
      *  handler */
     uint16_t cmds_idx;
 
-    /* HELO of HELO message content */
-    uint16_t helo_len;
+    /* Last HELO/EHLO parameter seen on the flow */
     uint8_t *helo;
+    uint16_t helo_len;
+    /* flow has seen at least one HELO/EHLO command */
+    bool seen_helo;
 
     /* SMTP Mime decoding and file extraction */
     /** the list of files sent to the server */

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -260,8 +260,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailFromSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_from_buffer_id = SCDetectHelperBufferMpmRegister(
-            "email.from", "MIME EMAIL FROM", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailFromData);
+    g_mime_email_from_buffer_id =
+            SCDetectHelperBufferProgressMpmRegister("email.from", "MIME EMAIL FROM", ALPROTO_SMTP,
+                    STREAM_TOSERVER, GetMimeEmailFromData, SMTP_REQUEST_DATA);
 
     kw.name = "email.subject";
     kw.desc = "'Subject' field from an email";
@@ -269,8 +270,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailSubjectSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_subject_buffer_id = SCDetectHelperBufferMpmRegister("email.subject",
-            "MIME EMAIL SUBJECT", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailSubjectData);
+    g_mime_email_subject_buffer_id =
+            SCDetectHelperBufferProgressMpmRegister("email.subject", "MIME EMAIL SUBJECT",
+                    ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailSubjectData, SMTP_REQUEST_DATA);
 
     kw.name = "email.to";
     kw.desc = "'To' field from an email";
@@ -278,8 +280,8 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailToSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_to_buffer_id = SCDetectHelperBufferMpmRegister(
-            "email.to", "MIME EMAIL TO", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailToData);
+    g_mime_email_to_buffer_id = SCDetectHelperBufferProgressMpmRegister("email.to", "MIME EMAIL TO",
+            ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailToData, SMTP_REQUEST_DATA);
 
     kw.name = "email.cc";
     kw.desc = "'Cc' field from an email";
@@ -287,8 +289,8 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailCcSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_cc_buffer_id = SCDetectHelperBufferMpmRegister(
-            "email.cc", "MIME EMAIL CC", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailCcData);
+    g_mime_email_cc_buffer_id = SCDetectHelperBufferProgressMpmRegister("email.cc", "MIME EMAIL CC",
+            ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailCcData, SMTP_REQUEST_DATA);
 
     kw.name = "email.date";
     kw.desc = "'Date' field from an email";
@@ -296,8 +298,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailDateSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_date_buffer_id = SCDetectHelperBufferMpmRegister(
-            "email.date", "MIME EMAIL DATE", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailDateData);
+    g_mime_email_date_buffer_id =
+            SCDetectHelperBufferProgressMpmRegister("email.date", "MIME EMAIL DATE", ALPROTO_SMTP,
+                    STREAM_TOSERVER, GetMimeEmailDateData, SMTP_REQUEST_DATA);
 
     kw.name = "email.message_id";
     kw.desc = "'Message-Id' field from an email";
@@ -305,8 +308,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailMessageIdSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_message_id_buffer_id = SCDetectHelperBufferMpmRegister("email.message_id",
-            "MIME EMAIL Message-Id", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailMessageIdData);
+    g_mime_email_message_id_buffer_id =
+            SCDetectHelperBufferProgressMpmRegister("email.message_id", "MIME EMAIL Message-Id",
+                    ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailMessageIdData, SMTP_REQUEST_DATA);
 
     kw.name = "email.x_mailer";
     kw.desc = "'X-Mailer' field from an email";
@@ -314,8 +318,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailXMailerSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_x_mailer_buffer_id = SCDetectHelperBufferMpmRegister("email.x_mailer",
-            "MIME EMAIL X-Mailer", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailXMailerData);
+    g_mime_email_x_mailer_buffer_id =
+            SCDetectHelperBufferProgressMpmRegister("email.x_mailer", "MIME EMAIL X-Mailer",
+                    ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailXMailerData, SMTP_REQUEST_DATA);
 
     kw.name = "email.url";
     kw.desc = "'Url' extracted from an email";
@@ -323,8 +328,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailUrlSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_url_buffer_id = SCDetectHelperMultiBufferMpmRegister(
-            "email.url", "MIME EMAIL URL", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailUrlData);
+    g_mime_email_url_buffer_id =
+            SCDetectHelperMultiBufferProgressMpmRegister("email.url", "MIME EMAIL URL",
+                    ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailUrlData, SMTP_REQUEST_DATA);
 
     kw.name = "email.received";
     kw.desc = "'Received' field from an email";
@@ -332,8 +338,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailReceivedSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_received_buffer_id = SCDetectHelperMultiBufferMpmRegister("email.received",
-            "MIME EMAIL RECEIVED", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailReceivedData);
+    g_mime_email_received_buffer_id =
+            SCDetectHelperMultiBufferProgressMpmRegister("email.received", "MIME EMAIL RECEIVED",
+                    ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailReceivedData, SMTP_REQUEST_DATA);
 
     if (!MimeBodyMd5IsDisabled()) {
         // do not register the keyword if explicitly disabled
@@ -343,10 +350,9 @@ void DetectEmailRegister(void)
         kw.Setup = DetectMimeEmailBodyMd5Setup;
         kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
         DETECT_EMAIL_BODY_MD5 = SCDetectHelperKeywordRegister(&kw);
-        // We do not need a progress because SMTP tx has only progress 0 or 1
-        // even if we have a MimeSmtpMd5State enumeration
-        g_mime_email_body_md5_buffer_id = SCDetectHelperBufferMpmRegister("email.body_md5",
-                "MIME EMAIL BODY MD5", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailBodyMd5Data);
+        g_mime_email_body_md5_buffer_id =
+                SCDetectHelperBufferProgressMpmRegister("email.body_md5", "MIME EMAIL BODY MD5",
+                        ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailBodyMd5Data, SMTP_REQUEST_DATA);
         DetectBufferTypeRegisterValidateCallback("email.body_md5", DetectMd5ValidateCallback);
     }
 }

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -93,7 +93,8 @@ DetectFileHandlerProtocol al_protocols[ALPROTO_WITHFILES_MAX] = {
             .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT,
             .progress_tc = HTTP2ProgData,
             .progress_ts = HTTP2ProgData },
-    { .alproto = ALPROTO_SMTP, .direction = SIG_FLAG_TOSERVER }, { .alproto = ALPROTO_UNKNOWN }
+    { .alproto = ALPROTO_SMTP, .direction = SIG_FLAG_TOSERVER, .progress_ts = SMTP_REQUEST_DATA },
+    { .alproto = ALPROTO_UNKNOWN }
 };
 
 void DetectFileRegisterProto(

--- a/src/detect-smtp.c
+++ b/src/detect-smtp.c
@@ -55,13 +55,12 @@ static InspectionBuffer *GetSmtpHeloData(DetectEngineThreadCtx *det_ctx,
 {
     InspectionBuffer *buffer = SCInspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        SMTPState *smtp_state = (SMTPState *)FlowGetAppState(f);
-        if (smtp_state) {
-            if (smtp_state->helo == NULL || smtp_state->helo_len == 0)
-                return NULL;
-            InspectionBufferSetup(det_ctx, list_id, buffer, smtp_state->helo, smtp_state->helo_len);
-            InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        SMTPTransaction *tx = txv;
+        if (tx == NULL || tx->helo == NULL || tx->helo_len == 0) {
+            return NULL;
         }
+        InspectionBufferSetup(det_ctx, list_id, buffer, tx->helo, tx->helo_len);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -51,16 +51,16 @@
 #include "output-json-smtp.h"
 #include "output-json-email-common.h"
 
-static void EveSmtpDataLogger(void *state, void *vtx, SCJsonBuilder *js)
+static void EveSmtpDataLogger(void *vtx, SCJsonBuilder *js)
 {
-    if (state == NULL || vtx == NULL) {
+    if (vtx == NULL) {
         return;
     }
 
     SMTPTransaction *tx = vtx;
     SMTPString *rcptto_str;
-    if (((SMTPState *)state)->helo) {
-        SCJbSetString(js, "helo", (const char *)((SMTPState *)state)->helo);
+    if (tx->helo) {
+        SCJbSetString(js, "helo", (const char *)tx->helo);
     }
     if (tx->mail_from) {
         SCJbSetString(js, "mail_from", (const char *)tx->mail_from);
@@ -85,7 +85,7 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
         return TM_ECODE_OK;
 
     SCJbOpenObject(jb, "smtp");
-    EveSmtpDataLogger(state, tx, jb);
+    EveSmtpDataLogger(tx, jb);
     SCJbClose(jb);
 
     EveEmailLogJson(jhl, jb, p, f, state, tx, tx_id);
@@ -103,7 +103,7 @@ bool EveSMTPAddMetadata(const Flow *f, uint64_t tx_id, SCJsonBuilder *js)
     if (smtp_state) {
         SMTPTransaction *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_SMTP, smtp_state, tx_id);
         if (tx) {
-            EveSmtpDataLogger(smtp_state, tx, js);
+            EveSmtpDataLogger(tx, js);
             return true;
         }
     }


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8393
Ticket: https://redmine.openinfosecfoundation.org/issues/8715

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3202

Changes from previous PR:
- add direction to completion state, requires many sv test updates as they
  complete after server response instead of client end of data
- reset/start new transaction on subsequent helo's
