### PR TITLE
detect/byte: reject negative nbytes var in byte_test and byte_jump

### DIFF
--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -97,7 +97,7 @@ void DetectBytejumpRegister (void)
  */
 static inline bool DetectBytejumpValidateNbytesOnly(const DetectBytejumpData *data, int32_t nbytes)
 {
-    return (data->flags & DETECT_BYTEJUMP_STRING && nbytes <= 23) || (nbytes <= 8);
+    return nbytes >= 0 && ((data->flags & DETECT_BYTEJUMP_STRING && nbytes <= 23) || (nbytes <= 8));
 }
 
 static bool DetectBytejumpValidateNbytes(const DetectBytejumpData *data, int32_t nbytes)
@@ -1302,6 +1302,34 @@ static int DetectByteJumpTestPacket08 (void)
 }
 
 /**
+ * \test A byte_jump nbytes taken from a byte_extract variable is packet
+ *       controlled and can be negative once cast to int32_t. Such a value must
+ *       be rejected before extraction; otherwise the (uint16_t) truncation in
+ *       DetectBytejumpDoMatch turns it back into a small positive count and
+ *       reads past the buffer.
+ */
+static int DetectByteJumpTestNbytesVarNegative(void)
+{
+    DetectBytejumpData data;
+    memset(&data, 0, sizeof(data));
+    data.flags = DETECT_BYTEJUMP_NBYTES_VAR;
+
+    /* Two byte buffer so an eight byte read runs past the end. */
+    uint8_t *buf = SCMalloc(2);
+    FAIL_IF_NULL(buf);
+    buf[0] = 0x00;
+    buf[1] = 0x00;
+
+    /* 0x80000008 is negative as int32_t but truncates to 8 as uint16_t. */
+    const int32_t nbytes = (int32_t)0x80000008;
+    bool r = DetectBytejumpDoMatch(NULL, NULL, (const SigMatchCtx *)&data, buf, 2, 0, nbytes, 0);
+    FAIL_IF(r);
+
+    SCFree(buf);
+    PASS;
+}
+
+/**
  * \brief this function registers unit tests for DetectBytejump
  */
 static void DetectBytejumpRegisterTests(void)
@@ -1334,5 +1362,6 @@ static void DetectBytejumpRegisterTests(void)
     UtRegisterTest("DetectByteJumpTestPacket06", DetectByteJumpTestPacket06);
     UtRegisterTest("DetectByteJumpTestPacket07", DetectByteJumpTestPacket07);
     UtRegisterTest("DetectByteJumpTestPacket08", DetectByteJumpTestPacket08);
+    UtRegisterTest("DetectByteJumpTestNbytesVarNegative", DetectByteJumpTestNbytesVarNegative);
 }
 #endif /* UNITTESTS */

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -99,7 +99,8 @@ void DetectBytetestRegister (void)
  */
 static inline bool DetectBytetestValidateNbytesOnly(const DetectBytetestData *data, int32_t nbytes)
 {
-    return ((data->flags & DETECT_BYTETEST_STRING) && nbytes <= 23) || (nbytes <= 8);
+    return nbytes >= 0 &&
+           (((data->flags & DETECT_BYTETEST_STRING) && nbytes <= 23) || (nbytes <= 8));
 }
 
 static bool DetectBytetestValidateNbytes(
@@ -1314,6 +1315,35 @@ static int DetectBytetestTestParse24(void)
 }
 
 /**
+ * \test A byte_test nbytes taken from a byte_extract variable is packet
+ *       controlled and can be negative once cast to int32_t. Such a value must
+ *       be rejected before extraction; otherwise the (uint16_t) truncation in
+ *       DetectBytetestDoMatch turns it back into a small positive count and
+ *       reads past the buffer.
+ */
+static int DetectBytetestTestNbytesVarNegative(void)
+{
+    DetectBytetestData data;
+    memset(&data, 0, sizeof(data));
+    data.op = DETECT_BYTETEST_OP_EQ;
+    data.flags = DETECT_BYTETEST_NBYTES_VAR;
+
+    /* Two byte buffer so an eight byte read runs past the end. */
+    uint8_t *buf = SCMalloc(2);
+    FAIL_IF_NULL(buf);
+    buf[0] = 0x00;
+    buf[1] = 0x00;
+
+    /* 0x80000008 is negative as int32_t but truncates to 8 as uint16_t. */
+    const int32_t nbytes = (int32_t)0x80000008;
+    int r = DetectBytetestDoMatch(NULL, NULL, (const SigMatchCtx *)&data, buf, 2, 0, 0, nbytes, 0);
+    FAIL_IF(r != 0);
+
+    SCFree(buf);
+    PASS;
+}
+
+/**
  * \brief this function registers unit tests for DetectBytetest
  */
 static void DetectBytetestRegisterTests(void)
@@ -1345,5 +1375,6 @@ static void DetectBytetestRegisterTests(void)
     UtRegisterTest("DetectBytetestTestParse22", DetectBytetestTestParse22);
     UtRegisterTest("DetectBytetestTestParse23", DetectBytetestTestParse23);
     UtRegisterTest("DetectBytetestTestParse24", DetectBytetestTestParse24);
+    UtRegisterTest("DetectBytetestTestNbytesVarNegative", DetectBytetestTestNbytesVarNegative);
 }
 #endif /* UNITTESTS */


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in doc/userguide/) to reflect the changes made
- [ ] I have updated the JSON schema (in etc/schema.json) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- byte_test and byte_jump can take nbytes from a byte_extract variable, so the count is packet controlled. It reaches DetectBytetestDoMatch/DetectBytejumpDoMatch as an int32_t and can be negative; the match-time validators only bound the upper side, and the in-buffer check is a signed `nbytes > len`, so a negative value passes both. ByteExtractUint64 is then called with `(uint16_t)nbytes`, which turns something like 0x80000008 back into 8 and reads that many bytes past the end of the inspected buffer.
- Before: a negative extracted nbytes reads up to 8 bytes off the end (ASan reports a heap-buffer-overflow in ByteExtractUint64 at util-byte.c:86). After: the shared validators reject nbytes < 0, so both keywords no-match before extraction is reached. Zero stays valid: `byte_jump:0,0,...,post_offset N` is an established idiom (bug-4623 and detect-bytejump-05 in suricata-verify depend on it) and a variable can legitimately resolve to 0, which extracts nothing and is harmless.
- Added a regression unit test for each keyword that drives the match function with a negative variable nbytes against a two byte buffer; both fail on the current tree under ASan and pass with the fix.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
