### PR TITLE
base64: size decode output slice to decoded length

### DIFF
--- a/rust/src/ffi/base64.rs
+++ b/rust/src/ffi/base64.rs
@@ -95,7 +95,10 @@ pub unsafe extern "C" fn SCBase64Decode(
     }
 
     let in_vec = build_slice!(input, len);
-    let out_vec = std::slice::from_raw_parts_mut(output, len);
+    // Callers such as the string dataset loader and the from_base64 transform
+    // allocate only the decoded size, so the output slice must not exceed it.
+    let out_len = get_decoded_buffer_size(len as u32) as usize;
+    let out_vec = std::slice::from_raw_parts_mut(output, out_len);
     let mut num_decoded: u32 = 0;
     let mut decoder = Decoder::new();
     match mode {

--- a/rust/src/utils/base64.rs
+++ b/rust/src/utils/base64.rs
@@ -108,7 +108,10 @@ impl Default for Decoder {
 }
 
 pub fn get_decoded_buffer_size(encoded_len: u32) -> u32 {
-    return ((encoded_len * 3) + (encoded_len % 4)) / 4;
+    // Compute in u64 so encoded_len * 3 cannot overflow; the result is
+    // at most encoded_len so it always fits back in u32.
+    let encoded_len = u64::from(encoded_len);
+    return (((encoded_len * 3) + (encoded_len % 4)) / 4) as u32;
 }
 
 pub fn decode_rfc4648(


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in doc/userguide/) to reflect the changes made
- [ ] I have updated the JSON schema (in etc/schema.json) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- Before: SCBase64Decode builds its output slice with `from_raw_parts_mut(output, len)`, using the input length. The string dataset loader in datasets.c uses a stack VLA sized `get_decoded_buffer_size(strlen)`, and the from_base64 transform expands the inspection buffer to `get_decoded_buffer_size(input_len)`; both allocate only the decoded size, which is about three quarters of the input. For those callers the `&mut [u8]` reaches past the backing allocation, so the `unsafe` block constructs an out-of-range slice.
- Base64 never grows the data, so the decoders write only the decoded bytes and stay inside the real allocation. Nothing is corrupted today, but the slice itself is invalid, and callers that pass the decoded size are the ones with the tightest buffer.
- After: size the slice to the decoded length. It now matches what the dataset loader and transform allocate, and stays within the callers that over-allocate to the input length (the base64_decode keyword buffer and the Lua binding). The math mirrors `get_decoded_buffer_size` but runs in usize, so it also sidesteps that helper's `encoded_len * 3` u32 overflow on very large inputs.
- Tradeoff: the decode buffers passed in must be at least the decoded size rather than the full input size. Every in-tree caller already satisfies that, and the encode side already takes an explicit output length, so this brings the decode side in line.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
