### PR TITLE
af-packet: respect vlan.use-for-tracking in eBPF bypass - v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2959,7 +2959,7 @@ jobs:
       - uses: ./.github/actions/install-cbindgen
       - run: tar xf prep/suricata-verify.tar.gz
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
+      - run: CFLAGS="${DEFAULT_CFLAGS} -DAFPACKET_TEST_REPLAY" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
       - run: make -j ${{ env.CPUS }}
       - run: make check
       - name: Running suricata-verify

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2895,6 +2895,79 @@ jobs:
       # DPDK configuration checks
       - run: ./qa/live/dpdk/dpdk-testsuite.sh
 
+  ubuntu-xdp:
+    name: Ubuntu (xdp)
+    runs-on: ubuntu-latest
+    needs: [prepare-deps]
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
+      - run: sudo apt update
+      - run: |
+          sudo apt -y install \
+              autoconf \
+              automake \
+              build-essential \
+              cmake \
+              curl \
+              git \
+              hwloc \
+              libhwloc-dev \
+              jq \
+              make \
+              libpcre3 \
+              libpcre3-dbg \
+              libpcre3-dev \
+              libpcre2-dev \
+              libtool \
+              libpcap-dev \
+              libnet1-dev \
+              libyaml-0-2 \
+              libyaml-dev \
+              libcap-ng-dev \
+              libcap-ng0 \
+              libjansson-dev \
+              libjansson4 \
+              libnuma-dev \
+              liblz4-dev \
+              libssl-dev \
+              pkg-config \
+              python3 \
+              python3-yaml \
+              tcpreplay \
+              zlib1g \
+              zlib1g-dev \
+              clang \
+              libxdp-dev
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: prep
+          path: prep
+      - name: Install Rust
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $(grep rust-version rust/Cargo.toml.in|sed 's/\"//g'|awk '{print $3}') -y
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: ./autogen.sh
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
+      - run: make -j ${{ env.CPUS }}
+      - run: make check
+      - name: Running suricata-verify
+        run: python3 ./suricata-verify/run.py -q --debug-failed
+      - run: ulimit -a
+      - name: Running suricata-verify live tests
+        run: sudo python3 ./suricata-verify/run.py --live --debug-failed
+
   debian-12:
     name: Debian 12 (xdp)
     runs-on: ubuntu-latest

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -594,7 +594,13 @@ static void *ParseAFPConfig(const char *iface)
         SCLogError("%s: XDP support is not built-in", iface);
 #endif
     }
-
+#ifdef AFPACKET_TEST_REPLAY
+    if ((SCConfGetChildValueIntWithDefault(if_root, if_default, "max-packets", &value)) == 1) {
+        aconf->max_packets = (uint32_t)value;
+    } else {
+        aconf->max_packets = 0;
+    }
+#endif
     if ((SCConfGetChildValueIntWithDefault(if_root, if_default, "buffer-size", &value)) == 1) {
         aconf->buffer_size = (int)value;
     } else {

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -355,7 +355,9 @@ typedef struct AFPThreadVars_
     int ebpf_filter_fd;
     struct ebpf_timeout_config ebpf_t_config;
 #endif
-
+#ifdef AFPACKET_TEST_REPLAY
+    uint32_t max_packets;
+#endif
 } AFPThreadVars;
 
 static TmEcode ReceiveAFPThreadInit(ThreadVars *, const void *, void **);
@@ -1430,6 +1432,11 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
         } else if (r > 0) {
             StatsCounterIncr(&ptv->tv->stats, ptv->capture_afp_poll_data);
             r = AFPReadFunc(ptv);
+#ifdef AFPACKET_TEST_REPLAY
+            if (ptv->max_packets > 0 && ptv->pkts >= ptv->max_packets) {
+                suricata_ctl_flags |= SURICATA_STOP;
+            }
+#endif
             switch (r) {
                 case AFP_READ_OK:
                     /* Trigger one dump of stats every second */
@@ -2568,6 +2575,9 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, const void *initdata, void **data)
     ptv->promisc = afpconfig->promisc;
     ptv->checksum_mode = afpconfig->checksum_mode;
     ptv->bpf_filter = NULL;
+#ifdef AFPACKET_TEST_REPLAY
+    ptv->max_packets = afpconfig->max_packets;
+#endif
 
     ptv->threads = 1;
 #ifdef HAVE_PACKET_FANOUT

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2248,8 +2248,8 @@ static int AFPSetFlowStorage(Packet *p, int map_fd, void *key0, void* key1,
 #define FlowKeyIpFill(k, p)                                                                        \
     {                                                                                              \
         (k)->ip_proto = ((p)->proto == IPPROTO_TCP) ? 1 : 0;                                       \
-        (k)->vlan0 = (p)->vlan_id[0];                                                              \
-        (k)->vlan1 = (p)->vlan_id[1];                                                              \
+        (k)->vlan0 = (p)->vlan_id[0] & g_vlan_mask;                                                \
+        (k)->vlan1 = (p)->vlan_id[1] & g_vlan_mask;                                                \
     }
 
 /**

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -356,6 +356,9 @@ typedef struct AFPThreadVars_
     struct ebpf_timeout_config ebpf_t_config;
 #endif
 #ifdef AFPACKET_TEST_REPLAY
+    /* Test-replay stop condition: ReceiveAFPLoop exits after this many
+     * packets. Set from AFPIfaceConfig::max_packets at thread init. A
+     * value of 0 disables the cap (loop runs until normal stop). */
     uint32_t max_packets;
 #endif
 } AFPThreadVars;
@@ -1433,7 +1436,12 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
             StatsCounterIncr(&ptv->tv->stats, ptv->capture_afp_poll_data);
             r = AFPReadFunc(ptv);
 #ifdef AFPACKET_TEST_REPLAY
-            if (ptv->max_packets > 0 && ptv->pkts >= ptv->max_packets) {
+            /* Test-replay stop condition: signal Suricata to stop after the
+             * configured number of packets so suricata-verify live tests
+             * driven by tcpreplay terminate deterministically. ptv->pkts is
+             * uint64_t; widen max_packets so the comparison is unsigned and
+             * same-width. */
+            if (ptv->max_packets > 0 && ptv->pkts >= (uint64_t)ptv->max_packets) {
                 suricata_ctl_flags |= SURICATA_STOP;
             }
 #endif

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -121,6 +121,9 @@ typedef struct AFPIfaceConfig_
 #ifdef HAVE_PACKET_EBPF
     struct ebpf_timeout_config ebpf_t_config;
 #endif
+#ifdef AFPACKET_TEST_REPLAY
+    uint32_t max_packets;
+#endif
     SC_ATOMIC_DECLARE(unsigned int, ref);
     void (*DerefFunc)(void *);
 } AFPIfaceConfig;

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -122,6 +122,10 @@ typedef struct AFPIfaceConfig_
     struct ebpf_timeout_config ebpf_t_config;
 #endif
 #ifdef AFPACKET_TEST_REPLAY
+    /* Stop the af-packet receive loop after this many packets. Used by
+     * suricata-verify live tests driven by tcpreplay so Suricata exits
+     * deterministically once the replay completes. A value of 0 means no
+     * cap (loop runs until the normal stop signal). */
     uint32_t max_packets;
 #endif
     SC_ATOMIC_DECLARE(unsigned int, ref);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -844,6 +844,9 @@ static void PrintBuildInfo(void)
 #ifdef HAVE_PACKET_EBPF
     strlcat(features, "EBPF ", sizeof(features));
 #endif
+#ifdef AFPACKET_TEST_REPLAY
+    strlcat(features, "AFPACKET_TEST_REPLAY ", sizeof(features));
+#endif
 #ifdef PROFILE_LOCKING
     strlcat(features, "PROFILE_LOCKING ", sizeof(features));
 #endif


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request. Thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8242

Supersedes #15469 (rebased onto current main to resolve conflicts, as requested by @catenacyber).

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3113

## Describe changes

`AFPBypassCallback` and `AFPXDPBypassCallback` in `src/source-af-packet.c` now AND `p->vlan_id[N]` with `g_vlan_mask` before writing it into the eBPF `flow_table_v4` / `flow_table_v6` map keys, so the bypass key reflects the active `vlan.use-for-tracking` configuration instead of always including the raw VLAN id. Without this, `vlan.use-for-tracking: no` is silently ignored on the bypass path: tracked flows write keys with the VLAN id present, but the matching ingress lookup writes with the VLAN id zeroed, so the bypass never matches and the flow is reprocessed each packet.

## Changes since v3 (#15469)

- Rebased onto current main. The key-setting code was factorized upstream into the `FlowKeyIpFill()` macro (ee9b48493), so the fix is now two lines inside that macro instead of sixteen assignment sites.
- Dropped `features: add EBPF as a feature` — an equivalent change was merged to main separately (2ee4ef0ec).

## CI / SV coverage

This PR includes two commits from #15415, picked with @catenacyber's agreement, so SV coverage actually runs (the same two commits are also carried by #15746; whichever merges first, the other rebases cleanly):

- `ci: add new xdp build with live tests` (catenacyber): adds the `ubuntu-xdp` job to `.github/workflows/builds.yml` that runs `suricata-verify/run.py --live --debug-failed` (no equivalent job exists on `main` today).
- `test: new afpacket max-packets feature` (catenacyber): adds the `AFPACKET_TEST_REPLAY` compile-time feature (all changes `#ifdef`-guarded; only the new `ubuntu-xdp` job sets `-DAFPACKET_TEST_REPLAY`, so other builds are byte-identical), used by the SV live test in suricata-verify#3113 to stop Suricata cleanly after the replay.

The matching SV PR suricata-verify#3113 replays three VLAN-tagged UDP packets on the same 5-tuple through a dummy interface and asserts the bypass path engages with `vlan.use-for-tracking: no`.
