### PR TITLE
rust: Update widestring dep

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -50,7 +50,7 @@ memchr = "~2.7.4"
 num = "~0.2.1"
 num-derive = "~0.4.2"
 num-traits = "~0.2.19"
-widestring = "~0.4.3"
+widestring = "~0.5.0"
 flate2 = { version = "~1.0.35", features = ["zlib"] }
 brotli = "~8.0.1"
 hkdf = "~0.12.4"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -5,6 +5,7 @@ license = "GPL-2.0-only"
 description = "Suricata Rust components"
 edition = "2021"
 rust-version = "1.75.0"
+repository = "https://github.com/OISF/suricata"
 
 [workspace]
 members = [


### PR DESCRIPTION
I cannot sign the CLA (employer restrictions), but there is no way to file issues, so I'm going to open a PR that contains the kernel of the changes I'd like to request.

`widestring` 0.4.x has some UB, which was fixed in https://github.com/VoidStarKat/widestring-rs/commit/8aad0270769fb1acfdeab4e13b30b43c91af62c4. `widestring` 0.5 seems to be fine. It would be nice if `suricata` updated its `widestring` dep.

This is probably going to fail CI since I couldn't quickly figure out how to get the `.in` files to generate.