### PR TITLE
eve/mdns: add requests and responses config flags

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -324,6 +324,25 @@ YAML::
             # Default: all.
             #types: [a, aaaa, cname, mx, ns, ptr, txt]
 
+mDNS
+~~~~
+
+mDNS records are logged as one entry for the request, and one entry for
+the response.
+
+YAML::
+
+        - mdns:
+            # Enable/disable this logger. Default: enabled.
+            #enabled: yes
+
+            # Control logging of requests and responses:
+            # - requests: enable logging of mDNS queries
+            # - responses: enable logging of mDNS answers
+            # By default both requests and responses are logged.
+            #requests: no
+            #responses: no
+
 TLS
 ~~~
 

--- a/src/output-json-mdns.c
+++ b/src/output-json-mdns.c
@@ -28,6 +28,10 @@
 #include "output-json-mdns.h"
 #include "rust.h"
 
+#define MDNS_LOG_REQUESTS  BIT_U64(0)
+#define MDNS_LOG_RESPONSES BIT_U64(1)
+#define MDNS_LOG_DEFAULT   (MDNS_LOG_REQUESTS | MDNS_LOG_RESPONSES)
+
 typedef struct SCDnsLogFileCtx_ {
     uint64_t flags; /** Store mode */
     OutputJsonCtx *eve_ctx;
@@ -49,6 +53,17 @@ static int JsonMdnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
 {
     SCDnsLogThread *td = (SCDnsLogThread *)thread_data;
     SCDnsLogFileCtx *dnslog_ctx = td->dnslog_ctx;
+
+    /* Filter based on the configured requests/responses flags. */
+    if (SCDnsTxIsRequest(txptr)) {
+        if (unlikely(dnslog_ctx->flags & MDNS_LOG_REQUESTS) == 0) {
+            return TM_ECODE_OK;
+        }
+    } else if (SCDnsTxIsResponse(txptr)) {
+        if (unlikely(dnslog_ctx->flags & MDNS_LOG_RESPONSES) == 0) {
+            return TM_ECODE_OK;
+        }
+    }
 
     SCJsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "mdns", NULL, dnslog_ctx->eve_ctx);
     if (unlikely(jb == NULL)) {
@@ -130,11 +145,19 @@ static OutputInitResult DnsLogInitCtxSub(SCConfNode *conf, OutputCtx *parent_ctx
     dnslog_ctx->eve_ctx = ojc;
     dnslog_ctx->version = DNS_LOG_VERSION_3;
 
-    /* For mDNS, log everything.
-     *
-     * TODO: Maybe add flags for request and/or response only.
-     */
-    dnslog_ctx->flags = ~0ULL;
+    /* By default both requests and responses are logged. The "requests"
+     * and "responses" config keys allow disabling either independently. */
+    dnslog_ctx->flags = MDNS_LOG_DEFAULT;
+
+    const char *requests = SCConfNodeLookupChildValue(conf, "requests");
+    if (requests != NULL && !SCConfValIsTrue(requests)) {
+        dnslog_ctx->flags &= ~MDNS_LOG_REQUESTS;
+    }
+
+    const char *responses = SCConfNodeLookupChildValue(conf, "responses");
+    if (responses != NULL && !SCConfValIsTrue(responses)) {
+        dnslog_ctx->flags &= ~MDNS_LOG_RESPONSES;
+    }
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -289,6 +289,15 @@ outputs:
             # Default: all.
             #types: [a, aaaa, cname, mx, ns, ptr, txt]
         - mdns:
+            # Enable/disable this logger. Default: enabled.
+            #enabled: yes
+
+            # Control logging of requests and responses:
+            # - requests: enable logging of mDNS queries
+            # - responses: enable logging of mDNS answers
+            # By default both requests and responses are logged.
+            #requests: no
+            #responses: no
         - tls:
             extended: yes     # enable this for extended logging information
             # output TLS transaction where the session is resumed using a


### PR DESCRIPTION
## Summary

Add "requests" and "responses" config keys to eve-log.mdns, mirroring
the existing eve-log.dns logger. Both default to enabled, preserving
current behavior. Setting either to "no" skips the corresponding
transactions before allocating the JSON builder.

## Why this is useful

The mDNS EVE logger previously logged every transaction unconditionally.
A TODO in src/output-json-mdns.c noted that request/response-only flags
"maybe" should be added. This PR resolves that TODO.

mDNS is broadcast-based and very chatty on local networks (IoT,
Bonjour/Avahi, home automation). In asset-inventory use cases the
responses (announcements) are the useful data; the flood of queries is
mostly noise. Allowing requests to be filtered out substantially
reduces EVE log volume while retaining the answer data. This also
brings mDNS logging into parity with the regular DNS logger, which
already exposes "requests" and "responses" flags.

## Files changed

- src/output-json-mdns.c — flag definitions, config parsing, logger filter
- suricata.yaml.in — documented new options under eve-log.mdns
- doc/userguide/output/eve/eve-json-output.rst — added mDNS section

## Backward compatibility

Fully backward compatible. With no new config keys set, behavior is
identical to before — all mDNS requests and responses are logged.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have signed the OISF contribution agreement
- [x] I have updated the User Guide
- [x] JSON schema — N/A (only filters which transactions are logged;
      the per-transaction output format is unchanged)
- [ ] Ticket — pending reviewer confirmation on whether one is required