### PR TITLE
Http uri plus 8130 v2

### DIFF
--- a/rust/src/detect/transforms/urldecode.rs
+++ b/rust/src/detect/transforms/urldecode.rs
@@ -33,7 +33,7 @@ unsafe extern "C" fn url_decode_setup(
     return SCDetectSignatureAddTransform(s, G_TRANSFORM_URL_DECODE_ID, ptr::null_mut());
 }
 
-fn hex_value(i: u8) -> Option<u8> {
+pub(crate) fn hex_value(i: u8) -> Option<u8> {
     match i {
         0x30..=0x39 => Some(i - 0x30),
         0x41..=0x46 => Some(i - 0x41 + 10),

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -548,6 +548,20 @@ pub unsafe extern "C" fn SCHttp2TxGetResponseLine(
 pub unsafe extern "C" fn SCHttp2TxGetUri(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
+    if !tx.normalized_uri.is_empty()
+        || http2_frames_get_header_firstvalue(tx, Direction::ToServer, ":path").is_ok()
+    {
+        *buffer = tx.normalized_uri.as_ptr(); //unsafe
+        *buffer_len = tx.normalized_uri.len() as u32;
+        return 1;
+    }
+    return 0;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCHttp2TxGetRawUri(
+    tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> u8 {
     if let Ok(value) = http2_frames_get_header_firstvalue(tx, Direction::ToServer, ":path") {
         *buffer = value.as_ptr(); //unsafe
         *buffer_len = value.len() as u32;
@@ -1029,6 +1043,8 @@ pub unsafe extern "C" fn SCHttp2TxSetUri(
     state: &mut HTTP2State, buffer: *const u8, buffer_len: u32,
 ) {
     let slice = build_slice!(buffer, buffer_len as usize);
+    let tx = state.transactions.back_mut().unwrap();
+    tx.normalized_uri = slice.to_vec();
     http2_tx_set_header(state, ":path".as_bytes(), slice)
 }
 

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -24,6 +24,7 @@ use super::range::{SCHTPFileCloseHandleRange, SCHttpRangeFreeBlock};
 use crate::applayer::{self, *};
 use crate::conf::{conf_get, get_memval};
 use crate::core::*;
+use crate::detect::transforms::urldecode::hex_value;
 use crate::direction::Direction;
 use crate::dns::dns::DnsVariant;
 use crate::filecontainer::FileContainerWrapper;
@@ -165,6 +166,7 @@ pub struct HTTP2Transaction {
     pub progress_ts: HTTP2TxProgress,
     to_drop: bool,
     child_stream_id: u32,
+    pub normalized_uri: Vec<u8>,
 
     pub frames_tc: Vec<HTTP2Frame>,
     pub frames_ts: Vec<HTTP2Frame>,
@@ -180,6 +182,70 @@ pub struct HTTP2Transaction {
     pub resp_line: Vec<u8>,
 
     pub doh: Option<DohHttp2Tx>,
+}
+
+enum NormalizeUriState {
+    Path,
+    Percent,
+    Percent2,
+}
+
+fn http2_normalize_uri(uri: &[u8]) -> Vec<u8> {
+    let mut state = NormalizeUriState::Path;
+    let mut query = false;
+    let mut percent = 0u8;
+    let mut prevc = 0u8;
+    let mut r = Vec::with_capacity(uri.len());
+    for c in uri {
+        match state {
+            NormalizeUriState::Path => match c {
+                b'%' => state = NormalizeUriState::Percent,
+                b'+' if query => {
+                    r.push(b' ');
+                }
+                b'?' => {
+                    query = true;
+                    r.push(*c);
+                }
+                _ => {
+                    r.push(*c);
+                }
+            },
+            NormalizeUriState::Percent => {
+                if let Some(v) = hex_value(*c) {
+                    percent = v << 4;
+                    prevc = *c;
+                    state = NormalizeUriState::Percent2;
+                } else {
+                    r.push(b'%');
+                    r.push(*c);
+                    state = NormalizeUriState::Path;
+                }
+            }
+            NormalizeUriState::Percent2 => {
+                if let Some(v) = hex_value(*c) {
+                    percent |= v;
+                    r.push(percent);
+                } else {
+                    r.push(b'%');
+                    r.push(prevc);
+                    r.push(*c);
+                }
+                state = NormalizeUriState::Path;
+            }
+        }
+    }
+    match state {
+        NormalizeUriState::Percent => {
+            r.push(b'%');
+        }
+        NormalizeUriState::Percent2 => {
+            r.push(b'%');
+            r.push(prevc);
+        }
+        _ => {}
+    }
+    return r;
 }
 
 impl Transaction for HTTP2Transaction {
@@ -200,6 +266,7 @@ impl HTTP2Transaction {
             tx_id: 0,
             stream_id: 0,
             child_stream_id: 0,
+            normalized_uri: Vec::new(),
             progress_tc: HTTP2TxProgress::HTTP2ProgStart,
             progress_ts: HTTP2TxProgress::HTTP2ProgStart,
             to_drop: false,
@@ -265,7 +332,10 @@ impl HTTP2Transaction {
                         self.doh = Some(doh);
                     }
                 }
-            } else if block.name.as_ref() == b":path" {
+            } else if block.name.as_ref() == b":path" && dir == Direction::ToServer {
+                if self.normalized_uri.is_empty() {
+                    self.normalized_uri = http2_normalize_uri(&block.value);
+                }
                 path = Some(&block.value);
             } else if block.name.eq_ignore_ascii_case(b":authority") {
                 authority = Some(&block.value);
@@ -597,7 +667,7 @@ pub struct HTTP2State {
     response_frame_size: u32,
     dynamic_headers_ts: HTTP2DynTable,
     dynamic_headers_tc: HTTP2DynTable,
-    transactions: VecDeque<HTTP2Transaction>,
+    pub transactions: VecDeque<HTTP2Transaction>,
     progress: HTTP2ConnectionState,
 
     comp_len: u64,

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1946,8 +1946,6 @@ static void HTPConfigSetDefaultsPhase1(HTPCfgRec *cfg_prec)
     htp_config_set_parse_request_cookies(cfg_prec->cfg, 0);
     htp_config_set_allow_space_uri(cfg_prec->cfg, 1);
 
-    /* don't convert + to space by default */
-    htp_config_set_plusspace_decode(cfg_prec->cfg, 0);
     // enables request decompression
     htp_config_set_request_decompression(cfg_prec->cfg, 1);
     htp_config_set_lzma_layers(cfg_prec->cfg, HTP_CONFIG_DEFAULT_LZMA_LAYERS);
@@ -4472,6 +4470,7 @@ libhtp:\n\
     personality: IDS\n\
     double-decode-path: yes\n\
     double-decode-query: yes\n\
+    query-plusspace-decode: no\n\
 ";
 
     SCConfCreateContextBackup();

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -82,6 +82,28 @@ static int DetectHttpRawUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, co
 static int g_http_raw_uri_buffer_id = 0;
 static int g_http_uri_buffer_id = 0;
 
+static InspectionBuffer *GetRawData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    SCEnter();
+
+    InspectionBuffer *buffer = SCInspectionBufferGet(det_ctx, list_id);
+    if (!buffer->initialized) {
+        uint32_t b_len = 0;
+        const uint8_t *b = NULL;
+
+        if (SCHttp2TxGetRawUri(txv, &b, &b_len) != 1)
+            return NULL;
+        if (b == NULL || b_len == 0)
+            return NULL;
+
+        SCInspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
+    }
+
+    return buffer;
+}
+
 /**
  * \brief Registration function for keywords: http_uri and http.uri
  */
@@ -152,10 +174,10 @@ void DetectHttpUriRegister (void)
 
     // no difference between raw and decoded uri for HTTP2
     DetectAppLayerInspectEngineRegister("http_raw_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2ProgHeaders, DetectEngineInspectBufferGeneric, GetRawData2);
 
     DetectAppLayerMpmRegister("http_raw_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
+            GetRawData2, ALPROTO_HTTP2, HTTP2ProgHeaders);
 
     DetectBufferTypeSetDescriptionByName("http_raw_uri",
             "raw http uri");


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8130

Describe changes:
- http2: normalize uri
- http1: normalize uri by default for '+' to space

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3217

Next version of https://github.com/OISF/suricata/pull/15519

Draft: is this the version we want ? (Have the good default for normalization, not needing a transform of such)
See the differences between SV PRs versions

TODO: doc 