### PR TITLE
rust/ffi: specify sys crate dependency version

### DIFF
--- a/rust/ffi/Cargo.toml.in
+++ b/rust/ffi/Cargo.toml.in
@@ -6,7 +6,7 @@ license = "GPL-2.0-only"
 description = "Nice wrappers around Suricata C interface"
 
 [dependencies]
-suricata-sys = { path = "../sys" }
+suricata-sys = { path = "../sys", version = "@PACKAGE_VERSION@" }
 
 [features]
 debug = []


### PR DESCRIPTION
No Cargo.lock update required.
