### PR TITLE
detect/bsize: apply as content depth #

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -374,6 +374,13 @@ If one or more ``content`` keywords precedes ``bsize``, each occurrence of ``con
 will be inspected and an error will be raised if the content length and the bsize
 value prevent a match.
 
+A buffer may carry more than one ``bsize`` keyword, and the buffer must satisfy
+them all; the tightest (smallest) upper bound is the one applied to content
+inspection. A common use is a lower and an upper bound that together form a
+range, for example ``bsize:>359; bsize:<370``. If the keywords cannot be
+satisfied at once -- two different exact lengths, or a lower bound above an
+upper bound -- no buffer length can ever match and the rule is rejected at load.
+
 Format::
 
   bsize:<number>;

--- a/doc/userguide/rules/rule-types.rst
+++ b/doc/userguide/rules/rule-types.rst
@@ -274,6 +274,40 @@ There is a work-in-progress to add information about this to the ``engine-analys
 report (ticket `#7456 <https://redmine.openinfosecfoundation.org/issues/7456>`_).
 
 
+.. _engine-analysis-notes-warnings:
+
+Notes and Warnings
+------------------
+
+When the JSON rule analysis is enabled (``engine-analysis.rules: yes``), each
+rule in ``rules.json`` may carry two optional arrays of free-form strings:
+
+``warnings``
+    Conditions that are likely to make the rule behave in a surprising way, for
+    example a firewall ``packet:filter`` table with no ``accept`` rules, where
+    the default policy will be applied instead.
+
+``notes``
+    Informational hints. These cover both optimizations the engine applied to
+    the rule and suggestions for expressing the rule more efficiently.
+
+Each array is only present when the rule has at least one entry. The strings
+are meant to be self-explanatory; some examples of ``notes`` are:
+
+- ``'within' option for pattern w/o previous content was converted to 'depth'``
+- ``'bsize' on the buffer was applied as a 'depth' to this content`` -- the
+  engine derived a content ``depth`` from a ``bsize`` on the same buffer, so the
+  pattern search is bounded to the buffer length.
+- ``buffer '<name>' pins a single content to the whole buffer with
+  'startswith'/'endswith'; 'bsize:<len>' is an equivalent that also prefilters
+  on length`` -- a suggestion to replace the anchored form with a single
+  ``bsize`` keyword.
+- ``buffer '<name>' uses multiple 'bsize' keywords; a single bsize range
+  (bsize:lo<>hi) expresses a bounded length more clearly`` -- a suggestion to
+  collapse a lower and an upper ``bsize`` bound on one buffer into a single
+  range.
+
+
 Signatures per Type
 -------------------
 

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -43,55 +43,63 @@ static int DetectBsizeSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectBsizeFree (DetectEngineCtx *, void *);
 static int SigParseGetMaxBsize(const DetectU64Data *bsz, uint64_t *bsize);
 static bool SigBsizeBufferMaxBound(const SignatureInitDataBuffer *b, uint64_t *bound, bool *exact);
+static bool SigBsizeBufferFeasible(const SignatureInitDataBuffer *b);
 #ifdef UNITTESTS
 static void DetectBsizeRegisterTests (void);
 #endif
 
 bool DetectBsizeValidateContentCallback(const Signature *s, const SignatureInitDataBuffer *b)
 {
-    uint64_t bsize;
-    int retval = -1;
-    const DetectU64Data *bsz;
-    for (const SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
-        if (sm->type == DETECT_BSIZE) {
-            bsz = (const DetectU64Data *)sm->ctx;
-            retval = SigParseGetMaxBsize(bsz, &bsize);
-            break;
-        }
+    /* A buffer may carry more than one bsize; the buffer must satisfy them all.
+     * Reject the signature at load if those bounds have no common length -- e.g.
+     * bsize:15 and bsize:27, or bsize:>20; bsize:<10 -- since no buffer can ever
+     * match. A single lower+upper pair (bsize:>N; bsize:<M) remains valid. */
+    if (!SigBsizeBufferFeasible(b)) {
+        SCLogError("signature can't match: the buffer's 'bsize' keywords are "
+                   "mutually exclusive, no buffer length satisfies them all");
+        return false;
     }
 
-    if (retval == -1) {
+    uint64_t bsize;
+    if (!SigBsizeBufferMaxBound(b, &bsize, NULL)) {
         return true;
     }
 
-    uint64_t needed;
-    if (retval == 0) {
-        int len, offset;
-        SigParseRequiredContentSize(s, bsize, b->head, &len, &offset);
-        SCLogDebug("bsize: %" PRIu64 "; len: %d; offset: %d [%s]", bsize, len, offset, s->sig_str);
-        needed = len;
-        if ((uint64_t)len > bsize) {
-            goto value_error;
-        }
-        if ((uint64_t)(len + offset) > bsize) {
-            needed += offset;
-            goto value_error;
-        }
+    int len, offset;
+    SigParseRequiredContentSize(s, bsize, b->head, &len, &offset);
+    SCLogDebug("bsize: %" PRIu64 "; len: %d; offset: %d [%s]", bsize, len, offset, s->sig_str);
+    uint64_t needed = len;
+    if ((uint64_t)len > bsize) {
+        goto value_error;
+    }
+    if ((uint64_t)(len + offset) > bsize) {
+        needed += offset;
+        goto value_error;
     }
 
     return true;
-value_error:
-    if (bsz->mode == DETECT_UINT_RA) {
+value_error: {
+    /* find the bsize that set the tightest bound, to describe it in the error */
+    const DetectU64Data *bsz = NULL;
+    for (const SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
+        uint64_t cur;
+        if (sm->type == DETECT_BSIZE &&
+                SigParseGetMaxBsize((const DetectU64Data *)sm->ctx, &cur) == 0 && cur == bsize) {
+            bsz = (const DetectU64Data *)sm->ctx;
+            break;
+        }
+    }
+    if (bsz != NULL && bsz->mode == DETECT_UINT_RA) {
         SCLogError("signature can't match as required content length %" PRIu64
                    " exceeds bsize range: %" PRIu64 "-%" PRIu64,
                 needed, bsz->arg1, bsz->arg2);
     } else {
         SCLogError("signature can't match as required content length %" PRIu64
-                   " exceeds bsize value: "
-                   "%" PRIu64,
-                needed, bsz->arg1);
+                   " exceeds bsize value: %" PRIu64,
+                needed, bsz != NULL ? bsz->arg1 : bsize);
     }
     return false;
+}
 }
 
 /**
@@ -218,6 +226,73 @@ static bool SigBsizeBufferMaxBound(const SignatureInitDataBuffer *b, uint64_t *b
     *bound = b_min;
     if (exact != NULL)
         *exact = is_exact;
+    return true;
+}
+
+/**
+ * \brief report whether a buffer's bsize keywords can be jointly satisfied
+ *
+ * Each bsize keyword constrains the buffer length to an inclusive interval; the
+ * buffer must satisfy every keyword, so the feasible set is their intersection.
+ * A lower bound (bsize:>N) and an upper bound (bsize:<M) form a valid range as
+ * long as they overlap. This returns false when the intersection is empty --
+ * two differing exact bsizes, or a lower bound above an upper bound -- meaning
+ * no buffer length can ever match.
+ *
+ * \param b buffer to scan
+ * \retval true the bsize keywords share at least one satisfiable length
+ * \retval false the bsize keywords are mutually exclusive
+ */
+static bool SigBsizeBufferFeasible(const SignatureInitDataBuffer *b)
+{
+    uint64_t lo = 0;
+    uint64_t hi = UINT64_MAX;
+    for (const SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
+        if (sm->type != DETECT_BSIZE)
+            continue;
+
+        const DetectU64Data *bsz = (const DetectU64Data *)sm->ctx;
+        uint64_t clo = 0;
+        uint64_t chi = UINT64_MAX;
+        switch (bsz->mode) {
+            case DETECT_UINT_EQ:
+                clo = chi = bsz->arg1;
+                break;
+            case DETECT_UINT_LT:
+                if (bsz->arg1 == 0)
+                    return false; /* length < 0 is impossible */
+                chi = bsz->arg1 - 1;
+                break;
+            case DETECT_UINT_LTE:
+                chi = bsz->arg1;
+                break;
+            case DETECT_UINT_GT:
+                if (bsz->arg1 == UINT64_MAX)
+                    return false;
+                clo = bsz->arg1 + 1;
+                break;
+            case DETECT_UINT_GTE:
+                clo = bsz->arg1;
+                break;
+            case DETECT_UINT_RA:
+                /* exclusive range: arg1 < length < arg2 */
+                if (bsz->arg2 == 0 || bsz->arg1 + 1 > bsz->arg2 - 1)
+                    return false;
+                clo = bsz->arg1 + 1;
+                chi = bsz->arg2 - 1;
+                break;
+            default:
+                continue;
+        }
+
+        if (clo > lo)
+            lo = clo;
+        if (chi < hi)
+            hi = chi;
+        if (lo > hi)
+            return false;
+    }
+
     return true;
 }
 

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2022 Open Information Security Foundation
+/* Copyright (C) 2017-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -42,6 +42,7 @@
 static int DetectBsizeSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectBsizeFree (DetectEngineCtx *, void *);
 static int SigParseGetMaxBsize(const DetectU64Data *bsz, uint64_t *bsize);
+static bool SigBsizeBufferMaxBound(const SignatureInitDataBuffer *b, uint64_t *bound, bool *exact);
 #ifdef UNITTESTS
 static void DetectBsizeRegisterTests (void);
 #endif
@@ -175,6 +176,117 @@ static int SigParseGetMaxBsize(const DetectU64Data *bsz, uint64_t *bsize)
             SCReturnInt(-2);
     }
     SCReturnInt(-1);
+}
+
+/**
+ * \brief find the tightest usable bsize upper bound for a buffer
+ *
+ * A buffer may carry more than one bsize; the buffer must satisfy them all, so
+ * the tightest (smallest) usable upper bound applies. bsize:>N yields no upper
+ * bound and is ignored.
+ *
+ * \param b buffer to scan
+ * \param bound set to the smallest usable upper bound on success
+ * \param exact if non-NULL, set to true when that bound comes from an exact
+ *              bsize (bsize:N)
+ * \retval true a usable upper bound was found
+ * \retval false no bsize with a usable upper bound (e.g. only bsize:>N)
+ */
+static bool SigBsizeBufferMaxBound(const SignatureInitDataBuffer *b, uint64_t *bound, bool *exact)
+{
+    uint64_t b_min = UINT64_MAX;
+    bool found = false;
+    bool is_exact = false;
+    for (const SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
+        if (sm->type != DETECT_BSIZE)
+            continue;
+
+        const DetectU64Data *bsz = (const DetectU64Data *)sm->ctx;
+        uint64_t cur;
+        if (SigParseGetMaxBsize(bsz, &cur) != 0)
+            continue;
+        if (cur < b_min) {
+            b_min = cur;
+            is_exact = (bsz->mode == DETECT_UINT_EQ);
+        }
+        found = true;
+    }
+
+    if (!found)
+        return false;
+
+    *bound = b_min;
+    if (exact != NULL)
+        *exact = is_exact;
+    return true;
+}
+
+/**
+ * \brief apply each buffer's bsize upper bound to its content matches
+ *
+ * When a buffer carries a bsize keyword that yields a usable upper bound
+ * (bsize:N, bsize:<N or bsize:N<>M), every content in that buffer can be
+ * constrained to that depth: the content can't match beyond the end of the
+ * buffer, and the buffer is at most \c bsize bytes long. This lets the mpm and
+ * content inspection bound their search instead of scanning the whole buffer,
+ * mirroring the dsize and urilen optimizations.
+ *
+ * As a stronger case, when an exact bsize (bsize:N) equals the length of a lone
+ * content in the buffer, that content must span the whole buffer: it both
+ * starts and ends it. Mark it startswith/endswith so the mpm anchoring and the
+ * endswith inspection short-circuit apply, as Victor described in #4226.
+ *
+ * \param s signature whose buffers are processed
+ */
+void DetectBsizeApplyToContent(const Signature *s)
+{
+    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
+        const SignatureInitDataBuffer *b = &s->init_data->buffers[x];
+
+        uint64_t bsize;
+        bool exact;
+        if (!SigBsizeBufferMaxBound(b, &bsize, &exact))
+            continue;
+
+        /* depth is a uint16_t; a larger bound can't be expressed as a depth */
+        if (bsize > UINT16_MAX)
+            continue;
+
+        uint32_t content_cnt = 0;
+        DetectContentData *single = NULL;
+        for (SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
+            if (sm->type != DETECT_CONTENT)
+                continue;
+
+            DetectContentData *cd = (DetectContentData *)sm->ctx;
+            if (cd == NULL)
+                continue;
+
+            content_cnt++;
+            single = cd;
+
+            if (cd->depth == 0 || cd->depth > (uint16_t)bsize) {
+                cd->depth = (uint16_t)bsize;
+                cd->flags |= DETECT_CONTENT_DEPTH;
+                cd->flags |= DETECT_CONTENT_BSIZE2DEPTH;
+                SCLogDebug("updated %u, content %u to have depth %u because of bsize.", s->id,
+                        cd->id, cd->depth);
+            }
+        }
+
+        /* exact bsize matching a lone content's length: the content fills the
+         * buffer, so it starts and ends it. Skip if the content is anchored
+         * elsewhere or negated, where that doesn't hold. */
+        if (content_cnt == 1 && exact && single->content_len == (uint16_t)bsize &&
+                (single->flags & (DETECT_CONTENT_OFFSET | DETECT_CONTENT_DISTANCE |
+                                         DETECT_CONTENT_WITHIN | DETECT_CONTENT_NEGATED)) == 0) {
+            single->depth = single->content_len;
+            single->flags |=
+                    DETECT_CONTENT_DEPTH | DETECT_CONTENT_STARTS_WITH | DETECT_CONTENT_ENDS_WITH;
+            SCLogDebug("updated %u, content %u to startswith/endswith because of exact bsize %u.",
+                    s->id, single->id, (uint16_t)bsize);
+        }
+    }
 }
 
 /**

--- a/src/detect-bsize.h
+++ b/src/detect-bsize.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2023 Open Information Security Foundation
+/* Copyright (C) 2017-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -27,5 +27,6 @@
 void DetectBsizeRegister(void);
 int DetectBsizeMatch(const SigMatchCtx *ctx, const uint64_t buffer_size, bool eof);
 bool DetectBsizeValidateContentCallback(const Signature *s, const SignatureInitDataBuffer *);
+void DetectBsizeApplyToContent(const Signature *s);
 
 #endif /* SURICATA_DETECT_BSIZE_H */

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -61,6 +61,7 @@
 #define DETECT_CONTENT_MPM              BIT_U32(20)
 #define DETECT_CONTENT_WITHIN2DEPTH     BIT_U32(21)
 #define DETECT_CONTENT_DISTANCE2OFFSET  BIT_U32(22)
+#define DETECT_CONTENT_BSIZE2DEPTH      BIT_U32(23)
 
 /** a relative match to this content is next, used in matching phase */
 #define DETECT_CONTENT_RELATIVE_NEXT    (DETECT_CONTENT_WITHIN_NEXT|DETECT_CONTENT_DISTANCE_NEXT)

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2025 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -767,6 +767,10 @@ static void DumpMatches(RuleAnalyzer *ctx, SCJsonBuilder *js, const SigMatchData
                 if (cd->flags & DETECT_CONTENT_DISTANCE2OFFSET) {
                     AnalyzerNote(ctx, (char *)"'distance' option for pattern w/o previous content "
                                               "was converted to 'offset'");
+                }
+                if (cd->flags & DETECT_CONTENT_BSIZE2DEPTH) {
+                    AnalyzerNote(ctx, (char *)"'bsize' on the buffer was applied as a 'depth' to "
+                                              "this content");
                 }
                 SCJbClose(js);
                 break;

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1112,6 +1112,81 @@ static void DumpMatches(RuleAnalyzer *ctx, SCJsonBuilder *js, const SigMatchData
     SCJbClose(js);
 }
 
+/**
+ * \brief suggest 'bsize' where a buffer is already pinned to an exact length
+ *
+ * A single content marked both 'startswith' and 'endswith' must span the whole
+ * buffer, so its length is fixed at the content length. ('endswith' also covers
+ * the 'isdataat:!1,relative' form, which the parser folds into the same flag.)
+ * 'bsize:<len>' expresses that in one keyword and lets the engine prefilter on
+ * buffer length. This is a high-signal hint: it only fires when the rule has
+ * already encoded a fixed length the long way.
+ */
+static void AnalyzerSuggestBsize(RuleAnalyzer *ctx, const char *buffer, const SigMatchData *smd)
+{
+    if (smd == NULL)
+        return;
+
+    uint32_t content_cnt = 0;
+    uint32_t bsize_cnt = 0;
+    bool has_lower = false;
+    bool has_upper = false;
+    const DetectContentData *cd = NULL;
+    for (const SigMatchData *smv = smd;; smv++) {
+        if (smv->type == DETECT_CONTENT) {
+            content_cnt++;
+            cd = (const DetectContentData *)smv->ctx;
+        } else if (smv->type == DETECT_BSIZE) {
+            bsize_cnt++;
+            const DetectU64Data *bsz = (const DetectU64Data *)smv->ctx;
+            /* a range keyword already bounds both ends; a bare >/>= is a lower
+             * bound and </<= an upper. An exact bsize is a single length, not a
+             * side of a range, so it doesn't count toward a two-sided bound. */
+            switch (bsz->mode) {
+                case DETECT_UINT_GT:
+                case DETECT_UINT_GTE:
+                    has_lower = true;
+                    break;
+                case DETECT_UINT_LT:
+                case DETECT_UINT_LTE:
+                    has_upper = true;
+                    break;
+                case DETECT_UINT_RA:
+                    has_lower = true;
+                    has_upper = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+        if (smv->is_last)
+            break;
+    }
+
+    /* Only suggest folding into a range when the keywords actually form a
+     * two-sided bound (a lower and an upper). Same-direction or exact bsizes
+     * aren't a range, and mutually exclusive ones are rejected at load. */
+    if (bsize_cnt > 1 && has_lower && has_upper) {
+        AnalyzerNote(ctx,
+                (char *)"buffer '%s' uses multiple 'bsize' keywords; a single bsize range "
+                        "(bsize:lo<>hi) expresses a bounded length more clearly",
+                buffer);
+    }
+
+    if (content_cnt != 1 || bsize_cnt != 0 || cd == NULL)
+        return;
+
+    const uint32_t anchored = DETECT_CONTENT_STARTS_WITH | DETECT_CONTENT_ENDS_WITH;
+    if ((cd->flags & anchored) != anchored)
+        return;
+
+    AnalyzerNote(ctx,
+            (char *)"buffer '%s' pins a single content to the whole buffer with "
+                    "'startswith'/'endswith'; 'bsize:%u' is an equivalent that also prefilters on "
+                    "length",
+            buffer, cd->content_len);
+}
+
 SCMutex g_rules_analyzer_write_m = SCMUTEX_INITIALIZER;
 void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
 {
@@ -1461,6 +1536,8 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
             }
             DumpMatches(&ctx, ctx.js, app->smd);
             SCJbClose(ctx.js);
+            if (app->sm_list != DETECT_SM_LIST_PMATCH && app->v2.transforms == NULL)
+                AnalyzerSuggestBsize(&ctx, name, app->smd);
             if (app->mpm) {
                 app_mpm = app;
             }

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2025 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -33,6 +33,7 @@
 #include "detect-engine-threshold.h"
 
 #include "detect-dsize.h"
+#include "detect-bsize.h"
 #include "detect-tcp-flags.h"
 #include "detect-flow.h"
 #include "detect-config.h"
@@ -1858,6 +1859,7 @@ int SigPrepareStage1(DetectEngineCtx *de_ctx)
         SignatureCreateMask(s);
         DetectContentPropagateLimits(s);
         SigParseApplyDsizeToContent(s);
+        DetectBsizeApplyToContent(s);
 
         RuleSetScore(s);
 


### PR DESCRIPTION
Continuation of #15806

Optimize content checks by using `bsize` as an upper bound, similar to what
`dsize` and `urilen` do. This improves performance on large buffers; small buffers see less, if any, boost.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/4226

Describe changes:
- Use `bsize` as an upper bound and apply it as a `depth` so content inspection is bounded to the buffer instead of scanning the whole buffer.
- When an exact `bsize` equals a lone content's length, mark the content
 `startswith`/`endswith` so the mpm is anchored and the engine prefilters on length.
- When a buffer carries more than one `bsize`, apply the tightest (smallest) upper bound, and reject at load a buffer whose `bsize` keywords can never be satisfied together (two differing exact values, or a lower bound above an upper bound). A legitimate lower+upper pair forming a range stays valid.
- Have engine-analysis suggest `bsize` where a content is pinned to the whole buffer the long way (`startswith`/`endswith`), and suggest folding a genuine lower+upper `bsize` pair into a single `bsize:lo<>hi` range.
- Extend documentation: the `bsize` keyword reference and the engine analysis notes/warnings section.

Changes since #15806
- Rebase s-v and suri PRs

Changes since #15674:
 - Dropped the earlier `--strict-rule-keywords` idea for multiple `bsize`.
    Instead of rejecting multiple `bsize`, a real lower+upper range is accepted
    (e.g. `bsize:<370; bsize:>359`) and only infeasible combinations are rejected at load.
- Made the "fold into a range" analyzer note shape-aware: it fires only for a
    genuine lower+upper pair, not for same-direction or exact bounds.
- Added suricata-verify tests bug-4226-08 (infeasible bounds rejected) and
    bug-4226-09 (shape-aware suggestion).

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3155

## Benchmark: `bsize` applied as content `depth`

Measured with a standalone profiling harness (paired rules: each scenario has a `bsize`-form rule and the hand-written equivalent), run over three captures. Reproduction kit (script + synthetic pcap) attached separately.

  
[smallFlows.pcap.gz](https://github.com/user-attachments/files/29707613/smallFlows.pcap.gz)
[smallFlows.pcap.gz](https://github.com/user-attachments/files/29707613/smallFlows.pcap.gz)
[bsize-bench.pcap.gz](https://github.com/user-attachments/files/29707616/bsize-bench.pcap.gz)
[bsize-bench.pcap.gz](https://github.com/user-attachments/files/29707616/bsize-bench.pcap.gz)
[bsize-bench.rules.gz](https://github.com/user-attachments/files/29707617/bsize-bench.rules.gz)
[bsize-bench.rules.gz](https://github.com/user-attachments/files/29707617/bsize-bench.rules.gz)
**Definitions**

  - **base** — Suricata `master` (no `bsize`-as-depth optimization).
  - **opt** — this branch (`bsize` upper bound applied as content `depth`; for an
    exact `bsize` equal to a lone content's length, the content is also marked
    `startswith`+`endswith`).
  - **anchored** — the hand-written equivalent that pins the content to the buffer
    with `startswith; endswith`.
  - **plain** — the same content with no length constraint at all (a floating match).
  - **cost ratio** — the profiled cost of the `bsize`-form rule ÷ the cost of its
    hand-written equivalent, computed *within the same run*. `~1.0` means parity;
    `>1.0` means it is still paying extra. The within-run ratio cancels run-to-run
    and cross-binary tick noise.
  - **check counts** — how often each `bsize` rule is evaluated. A drop from base
    to opt means the depth bound made the MPM prefilter more selective.

  ### 1. Synthetic capture (uniform bodies — isolates the anchoring path)

  | scenario (cost ratio, ~1.0 == parity) | base | opt |
  |---|--:|--:|
  | A  file.data (large)   bsize/depth | 1.44 | 1.51 |
  | B  user_agent (small)  bsize/depth | 1.40 | 1.45 |
  | C  http.method (exact) bsize/anchored | 2.00 | 2.45 |
  | D  http.uri (exact)    bsize/anchored | 2.42 | 1.35 |
  | D  http.uri (exact)    bsize/plain | 1.77 | 0.90 |

  | bsize-rule check counts (rule evaluations) | base | opt |
  |---|--:|--:|
  | A  file.data (large)   bsize | 100 | 100 |
  | B  user_agent (small)  bsize | 200 | 200 |
  | C  http.method (exact) bsize | 100 | 100 |
  | D  http.uri (exact)    bsize | 300 | 300 |

  ### 2. `smallFlows.pcap` (real mixed traffic, ~9 MB)

  | scenario (cost ratio, ~1.0 == parity) | base | opt |
  |---|--:|--:|
  | A  file.data (large)   bsize/depth | 2.27 | 0.93 |
  | B  user_agent (small)  bsize/depth | 1.54 | 1.55 |
  | C  http.method (exact) bsize/anchored | 1.78 | 2.00 |
  | D  http.uri (exact)    bsize/anchored | 2.04 | 1.15 |
  | D  http.uri (exact)    bsize/plain | 1.56 | 0.81 |

  | bsize-rule check counts (rule evaluations) | base | opt |
  |---|--:|--:|
  | A  file.data (large)   bsize | 699 | 396 |
  | B  user_agent (small)  bsize | 525 | 525 |
  | C  http.method (exact) bsize | 533 | 533 |
  | D  http.uri (exact)    bsize | 544 | 544 |

  ### 3. `bigFlows.pcap` (real mixed traffic, ~368 MB)

  | scenario (cost ratio, ~1.0 == parity) | base | opt |
  |---|--:|--:|
  | A  file.data (large)   bsize/depth | 2.56 | 1.17 |
  | B  user_agent (small)  bsize/depth | 1.62 | 1.66 |
  | C  http.method (exact) bsize/anchored | 1.90 | 2.05 |
  | D  http.uri (exact)    bsize/anchored | 2.15 | 1.16 |
  | D  http.uri (exact)    bsize/plain | 1.54 | 0.79 |

  | bsize-rule check counts (rule evaluations) | base | opt |
  |---|--:|--:|
  | A  file.data (large)   bsize | 7006 | 3759 |
  | B  user_agent (small)  bsize | 6403 | 6403 |
  | C  http.method (exact) bsize | 6414 | 6414 |
  | D  http.uri (exact)    bsize | 6603 | 6603 |

  ### Reading the results

  The **anchoring win (D)** reproduces on every capture: the `bsize`-form rule
  drops from ~2x the cost of the manually-anchored equivalent to ~1.15x, and to
  *cheaper than* an unconstrained content (0.79–0.90x of plain).

  The **`file.data` depth win (A)** is prefilter-driven and only shows on
  realistic traffic. On the synthetic capture the bodies are uniform, so the
  fast-pattern can't become more selective and A is flat (100/100). On real
  traffic the depth bound roughly halves how often the rule is evaluated —
  smallFlows 699→396 (ratio 2.27→0.93), bigFlows 7006→3759 (ratio 2.56→1.17).

  **B** (small `user_agent`) and **C** (fixed-length `http.method`) are flat by
  design: the buffer is tiny or always equals the pinned length, so neither the
  depth bound nor the `endswith` short-circuit has room to help.