### PR TITLE
Snmp keywords 8485 v8

### DIFF
--- a/doc/userguide/rules/snmp-keywords.rst
+++ b/doc/userguide/rules/snmp-keywords.rst
@@ -138,3 +138,20 @@ Syntax::
 ``snmp.trap_oid`` is a 'sticky buffer'.
 
 ``snmp.trap_oid`` can be used as ``fast_pattern``.
+
+snmp.trap_address
+-----------------
+
+SNMP Trap Address is the IP address of the agent.
+
+Syntax::
+
+ snmp.trap_address; content:"192.168.1.2";
+
+.. container:: example-rule
+
+ alert snmp any any -> any any (msg:"SNMP trap address example"; snmp.trap_address; content:"192.168.1.2"; sid:4; rev:1;)
+
+``snmp.trap_address`` is a 'sticky buffer'.
+
+``snmp.trap_address`` can be used as ``fast_pattern``.

--- a/doc/userguide/rules/snmp-keywords.rst
+++ b/doc/userguide/rules/snmp-keywords.rst
@@ -121,3 +121,20 @@ Syntax::
 Signature example::
 
  alert snmp any any -> any 162 (msg:"SNMP trap cold start"; snmp.pdu_type:trap_v1; snmp.trap_type:coldstart; sid:3; rev:1;)
+
+snmp.trap_oid
+-------------
+
+SNMP Trap OID (Object Identifier) is used to uniquely identify the type of trap being sent.
+
+Syntax::
+
+ snmp.trap_oid; content:"1.3.6.1.4.1.4.1.2.21";
+
+.. container:: example-rule
+
+ alert snmp any any -> any any (msg:"SNMP trap OID example"; snmp.trap_oid; content:"1.3.6.1.4.1.4.1.2.21"; sid:4; rev:1;)
+
+``snmp.trap_oid`` is a 'sticky buffer'.
+
+``snmp.trap_oid`` can be used as ``fast_pattern``.

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6159,7 +6159,12 @@
                     "type": "string"
                 },
                 "trap_oid": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "snmp.trap_oid"
+                        ]
+                    }
                 },
                 "trap_type": {
                     "type": "string",

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6140,7 +6140,12 @@
             "additionalProperties": false,
             "properties": {
                 "community": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "snmp.community"
+                        ]
+                    }
                 },
                 "pdu_type": {
                     "type": "string",
@@ -6165,7 +6170,12 @@
                     }
                 },
                 "usm": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "snmp.usm"
+                        ]
+                    }
                 },
                 "vars": {
                     "type": "array",

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6156,7 +6156,12 @@
                     }
                 },
                 "trap_address": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "snmp.trap_address"
+                        ]
+                    }
                 },
                 "trap_oid": {
                     "type": "string",

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -504,6 +504,7 @@ pub unsafe extern "C" fn SCDetectDcerpcRegister() {
         ALPROTO_DCERPC,
         STREAM_TOSERVER | STREAM_TOCLIENT,
         Some(dcerpc_tx_get_stub_data),
+        0,
     );
     G_DCERPC_STUB_BUFFER_ID = SCDetectHelperBufferMpmRegister(
         b"dce_stub_data\0".as_ptr() as *const libc::c_char,

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -36,7 +36,7 @@ pub mod uint;
 pub mod uri;
 pub mod vlan;
 
-use std::ffi::CString;
+use std::ffi::{c_void, CString};
 
 /// EnumString trait that will be implemented on enums that
 /// derive StringEnum.
@@ -90,6 +90,22 @@ pub use suricata_sys::sys::{
     SIGMATCH_INFO_UINT32, SIGMATCH_INFO_UINT64, SIGMATCH_INFO_UINT8, SIGMATCH_NOOPT,
     SIGMATCH_OPTIONAL_OPT, SIGMATCH_QUOTES_MANDATORY, SIGMATCH_SUPPORT_FIREWALL,
 };
+
+#[derive(Default)]
+pub(crate) struct DetectThreadBuf {
+    pub data: Vec<u8>,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectThreadBufDataInit(_cfg: *mut c_void) -> *mut c_void {
+    let boxed = Box::new(DetectThreadBuf::default());
+    return Box::into_raw(boxed) as *mut c_void;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectThreadBufDataFree(ctx: *mut c_void) {
+    std::mem::drop(Box::from_raw(ctx as *mut DetectThreadBuf));
+}
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -23,7 +23,7 @@ use crate::detect::uint::{
     detect_match_uint, detect_parse_array_uint_enum, detect_uint_match_at_index,
     DetectUintArrayData, DetectUintData, DetectUintIndex, DetectUintMode,
 };
-use crate::detect::EnumString;
+use crate::detect::{DetectThreadBuf, EnumString};
 use crate::direction::Direction;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use std::ffi::CStr;
@@ -572,7 +572,7 @@ pub unsafe extern "C" fn SCHttp2TxGetMethod(
 pub unsafe extern "C" fn SCHttp2TxGetHost(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32, tbuf: *mut c_void,
 ) -> u8 {
-    let tbuf = cast_pointer!(tbuf, Http2ThreadBuf);
+    let tbuf = cast_pointer!(tbuf, DetectThreadBuf);
     if let Some(value) = http2_frames_get_header_value(tx, Direction::ToServer, ":authority") {
         match value {
             Http2Header::Single(v) => {
@@ -644,7 +644,7 @@ fn http2_normalize_host(ve: Http2Header) -> Http2Header {
 pub unsafe extern "C" fn SCHttp2TxGetHostNorm(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32, tbuf: *mut c_void,
 ) -> u8 {
-    let tbuf = cast_pointer!(tbuf, Http2ThreadBuf);
+    let tbuf = cast_pointer!(tbuf, DetectThreadBuf);
     if let Some(value) = http2_frames_get_header_value(tx, Direction::ToServer, ":authority") {
         match http2_normalize_host(value) {
             Http2Header::Single(v) => {
@@ -666,7 +666,7 @@ pub unsafe extern "C" fn SCHttp2TxGetHostNorm(
 pub unsafe extern "C" fn SCHttp2TxGetUserAgent(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32, tbuf: *mut c_void,
 ) -> u8 {
-    let tbuf = cast_pointer!(tbuf, Http2ThreadBuf);
+    let tbuf = cast_pointer!(tbuf, DetectThreadBuf);
     if let Some(value) = http2_frames_get_header_value(tx, Direction::ToServer, "user-agent") {
         match value {
             Http2Header::Single(v) => {
@@ -701,7 +701,7 @@ pub unsafe extern "C" fn SCHttp2TxGetCookie(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
     tbuf: *mut c_void,
 ) -> u8 {
-    let tbuf = cast_pointer!(tbuf, Http2ThreadBuf);
+    let tbuf = cast_pointer!(tbuf, DetectThreadBuf);
     if direction == u8::from(Direction::ToServer) {
         if let Some(value) = http2_frames_get_header_value(tx, Direction::ToServer, "cookie") {
             match value {
@@ -740,7 +740,7 @@ pub unsafe extern "C" fn SCHttp2TxGetHeaderValue(
     tx: &mut HTTP2Transaction, direction: u8, strname: *const std::os::raw::c_char,
     buffer: *mut *const u8, buffer_len: *mut u32, tbuf: *mut c_void,
 ) -> u8 {
-    let tbuf = cast_pointer!(tbuf, Http2ThreadBuf);
+    let tbuf = cast_pointer!(tbuf, DetectThreadBuf);
     let hname: &CStr = CStr::from_ptr(strname); //unsafe
     if let Ok(s) = hname.to_str() {
         if let Some(value) = http2_frames_get_header_value(tx, direction.into(), &s.to_lowercase())
@@ -772,28 +772,12 @@ fn http2_escape_header(blocks: &[parser::HTTP2FrameHeaderBlock], i: u32) -> Vec<
     return vec;
 }
 
-#[derive(Default)]
-struct Http2ThreadBuf {
-    data: Vec<u8>,
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn SCHttp2ThreadBufDataInit(_cfg: *mut c_void) -> *mut c_void {
-    let boxed = Box::new(Http2ThreadBuf::default());
-    return Box::into_raw(boxed) as *mut c_void;
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn SCHttp2ThreadBufDataFree(ctx: *mut c_void) {
-    std::mem::drop(Box::from_raw(ctx as *mut Http2ThreadBuf));
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn SCHttp2TxGetHeaderNames(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
     tbuf: *mut c_void,
 ) -> u8 {
-    let tbuf = cast_pointer!(tbuf, Http2ThreadBuf);
+    let tbuf = cast_pointer!(tbuf, DetectThreadBuf);
     tbuf.data.clear();
     tbuf.data.extend_from_slice(b"\r\n");
     let frames = if direction & Direction::ToServer as u8 != 0 {
@@ -857,7 +841,7 @@ pub unsafe extern "C" fn SCHttp2TxGetHeaders(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
     tbuf: *mut c_void,
 ) -> u8 {
-    let tbuf = cast_pointer!(tbuf, Http2ThreadBuf);
+    let tbuf = cast_pointer!(tbuf, DetectThreadBuf);
     tbuf.data.clear();
     let frames = if direction & Direction::ToServer as u8 != 0 {
         &tx.frames_ts
@@ -891,7 +875,7 @@ pub unsafe extern "C" fn SCHttp2TxGetHeadersRaw(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
     tbuf: *mut c_void,
 ) -> u8 {
-    let tbuf = cast_pointer!(tbuf, Http2ThreadBuf);
+    let tbuf = cast_pointer!(tbuf, DetectThreadBuf);
     tbuf.data.clear();
     let frames = if direction & Direction::ToServer as u8 != 0 {
         &tx.frames_ts

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -28,6 +28,7 @@ use crate::detect::{
     SCDetectThreadBufDataInit, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
     SIGMATCH_INFO_UINT32, SIGMATCH_INFO_UINT8, SIGMATCH_SUPPORT_FIREWALL,
 };
+use snmp_parser::NetworkAddress;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
@@ -46,6 +47,8 @@ static mut G_SNMP_USM_BUFFER_ID: c_int = 0;
 static mut G_SNMP_COMMUNITY_BUFFER_ID: c_int = 0;
 static mut G_SNMP_TRAPOID_BUFFER_ID: c_int = 0;
 static mut G_SNMP_TRAPOID_THREAD_ID: c_int = 0;
+static mut G_SNMP_TRAPADDRESS_BUFFER_ID: c_int = 0;
+static mut G_SNMP_TRAPADDRESS_THREAD_ID: c_int = 0;
 static mut G_SNMP_TRAPTYPE_KW_ID: u16 = 0;
 static mut G_SNMP_GENERIC_BUFFER_ID: c_int = 0;
 
@@ -304,6 +307,48 @@ unsafe extern "C" fn snmp_detect_trapoid_get_data(
     return buffer;
 }
 
+unsafe extern "C" fn snmp_detect_trapaddress_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_SNMP) != 0 {
+        return -1;
+    }
+    if SCDetectBufferSetActiveList(de, s, G_SNMP_TRAPADDRESS_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn snmp_detect_trapaddress_get_data(
+    det_ctx: *mut DetectEngineThreadCtx, transforms: *const DetectEngineTransforms,
+    _flow: *mut Flow, _dir: u8, tx: *mut c_void, list_id: c_int,
+) -> *mut InspectionBuffer {
+    let tx = cast_pointer!(tx, SNMPTransaction);
+    let buffer = SCInspectionBufferGet(det_ctx, list_id);
+    if !(*buffer).initialized {
+        if let Some(info) = &tx.info {
+            if let Some((_trap_type, _oid, address)) = &info.trap_type {
+                let NetworkAddress::IPv4(ip) = &address;
+                let tbuf = SCDetectThreadCtxGetGlobalKeywordThreadCtx(
+                    det_ctx,
+                    G_SNMP_TRAPADDRESS_THREAD_ID,
+                );
+                let tbuf = cast_pointer!(tbuf, DetectThreadBuf);
+                tbuf.data.clear();
+                tbuf.data.extend_from_slice(ip.to_string().as_bytes());
+                let data = tbuf.data.as_ptr();
+                let data_len = tbuf.data.len() as u32;
+                SCInspectionBufferSetupAndApplyTransforms(
+                    det_ctx, list_id, buffer, data, data_len, transforms,
+                );
+                return buffer;
+            }
+        }
+        return std::ptr::null_mut();
+    }
+    return buffer;
+}
+
 pub(super) unsafe extern "C" fn detect_snmp_register() {
     G_SNMP_GENERIC_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"snmp.generic\0".as_ptr() as *const libc::c_char,
@@ -393,6 +438,28 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
     );
     G_SNMP_TRAPOID_THREAD_ID = SCDetectRegisterThreadCtxGlobalFuncs(
         b"snmp.trap_oid\0".as_ptr() as *const libc::c_char,
+        Some(SCDetectThreadBufDataInit),
+        std::ptr::null_mut(),
+        Some(SCDetectThreadBufDataFree),
+    );
+
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("snmp.trap_address"),
+        desc: String::from("SNMP trap address sticky buffer"),
+        url: String::from("/rules/snmp-keywords.html#snmp-trap-address"),
+        setup: snmp_detect_trapaddress_setup,
+    };
+    let _g_snmp_trapaddress_kw_id = helper_keyword_register_sticky_buffer(&kw);
+    G_SNMP_TRAPADDRESS_BUFFER_ID = SCDetectRegisterMpmGeneric(
+        b"snmp.trap_address\0".as_ptr() as *const libc::c_char,
+        b"SNMP Trap Address\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SNMP,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        Some(snmp_detect_trapaddress_get_data),
+        1,
+    );
+    G_SNMP_TRAPADDRESS_THREAD_ID = SCDetectRegisterThreadCtxGlobalFuncs(
+        b"snmp.trap_address\0".as_ptr() as *const libc::c_char,
         Some(SCDetectThreadBufDataInit),
         std::ptr::null_mut(),
         Some(SCDetectThreadBufDataFree),

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -24,22 +24,28 @@ use crate::detect::uint::{
     SCDetectU8Free, SCDetectU8Match,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
+    helper_keyword_register_sticky_buffer, DetectThreadBuf, SCDetectThreadBufDataFree,
+    SCDetectThreadBufDataInit, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
     SIGMATCH_INFO_UINT32, SIGMATCH_INFO_UINT8, SIGMATCH_SUPPORT_FIREWALL,
 };
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
-    DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
-    SCDetectHelperBufferProgressMpmRegister, SCDetectHelperBufferProgressRegister,
-    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
-    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+    DetectEngineCtx, DetectEngineThreadCtx, DetectEngineTransforms, Flow, InspectionBuffer,
+    SCDetectBufferSetActiveList, SCDetectHelperBufferProgressMpmRegister,
+    SCDetectHelperBufferProgressRegister, SCDetectHelperKeywordRegister,
+    SCDetectRegisterMpmGeneric, SCDetectRegisterThreadCtxGlobalFuncs, SCDetectSignatureSetAppProto,
+    SCDetectThreadCtxGetGlobalKeywordThreadCtx, SCInspectionBufferGet,
+    SCInspectionBufferSetupAndApplyTransforms, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt,
+    SigMatchCtx, Signature,
 };
 
 static mut G_SNMP_VERSION_KW_ID: u16 = 0;
 static mut G_SNMP_PDUTYPE_KW_ID: u16 = 0;
 static mut G_SNMP_USM_BUFFER_ID: c_int = 0;
 static mut G_SNMP_COMMUNITY_BUFFER_ID: c_int = 0;
+static mut G_SNMP_TRAPOID_BUFFER_ID: c_int = 0;
+static mut G_SNMP_TRAPOID_THREAD_ID: c_int = 0;
 static mut G_SNMP_TRAPTYPE_KW_ID: u16 = 0;
 static mut G_SNMP_GENERIC_BUFFER_ID: c_int = 0;
 
@@ -259,6 +265,45 @@ unsafe extern "C" fn snmp_detect_community_get_data(
     return false;
 }
 
+unsafe extern "C" fn snmp_detect_trapoid_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_SNMP) != 0 {
+        return -1;
+    }
+    if SCDetectBufferSetActiveList(de, s, G_SNMP_TRAPOID_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn snmp_detect_trapoid_get_data(
+    det_ctx: *mut DetectEngineThreadCtx, transforms: *const DetectEngineTransforms,
+    _flow: *mut Flow, _dir: u8, tx: *mut c_void, list_id: c_int,
+) -> *mut InspectionBuffer {
+    let tx = cast_pointer!(tx, SNMPTransaction);
+    let buffer = SCInspectionBufferGet(det_ctx, list_id);
+    if !(*buffer).initialized {
+        if let Some(ref info) = tx.info {
+            if let Some((_trap_type, ref oid, _address)) = info.trap_type {
+                let tbuf =
+                    SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, G_SNMP_TRAPOID_THREAD_ID);
+                let tbuf = cast_pointer!(tbuf, DetectThreadBuf);
+                tbuf.data.clear();
+                tbuf.data.extend_from_slice(oid.to_string().as_bytes());
+                let data = tbuf.data.as_ptr();
+                let data_len = tbuf.data.len() as u32;
+                SCInspectionBufferSetupAndApplyTransforms(
+                    det_ctx, list_id, buffer, data, data_len, transforms,
+                );
+                return buffer;
+            }
+        }
+        return std::ptr::null_mut();
+    }
+    return buffer;
+}
+
 pub(super) unsafe extern "C" fn detect_snmp_register() {
     G_SNMP_GENERIC_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"snmp.generic\0".as_ptr() as *const libc::c_char,
@@ -330,4 +375,26 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_ENUM_UINT | SIGMATCH_SUPPORT_FIREWALL,
     };
     G_SNMP_TRAPTYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("snmp.trap_oid"),
+        desc: String::from("SNMP trap_oid sticky buffer"),
+        url: String::from("/rules/snmp-keywords.html#snmp-trap-oid"),
+        setup: snmp_detect_trapoid_setup,
+    };
+    let _g_snmp_trapoid_kw_id = helper_keyword_register_sticky_buffer(&kw);
+    G_SNMP_TRAPOID_BUFFER_ID = SCDetectRegisterMpmGeneric(
+        b"snmp.trap_oid\0".as_ptr() as *const libc::c_char,
+        b"SNMP Trap OID\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SNMP,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        Some(snmp_detect_trapoid_get_data),
+        1,
+    );
+    G_SNMP_TRAPOID_THREAD_ID = SCDetectRegisterThreadCtxGlobalFuncs(
+        b"snmp.trap_oid\0".as_ptr() as *const libc::c_char,
+        Some(SCDetectThreadBufDataInit),
+        std::ptr::null_mut(),
+        Some(SCDetectThreadBufDataFree),
+    );
 }

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -897,7 +897,7 @@ extern "C" {
 extern "C" {
     pub fn SCDetectRegisterMpmGeneric(
         name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
-        alproto: AppProto, direction: u8, GetData: InspectionBufferGetDataPtr,
+        alproto: AppProto, direction: u8, GetData: InspectionBufferGetDataPtr, progress: u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -648,6 +648,12 @@ pub struct DetectEngineCtx_ {
 pub type DetectEngineCtx = DetectEngineCtx_;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct DetectEngineThreadCtx_ {
+    _unused: [u8; 0],
+}
+pub type DetectEngineThreadCtx = DetectEngineThreadCtx_;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct Signature_ {
     _unused: [u8; 0],
 }
@@ -667,6 +673,21 @@ extern "C" {
     pub fn SCDetectSignatureAddTransform(
         s: *mut Signature, transform: ::std::os::raw::c_int, options: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SCDetectRegisterThreadCtxGlobalFuncs(
+        name: *const ::std::os::raw::c_char,
+        InitFunc: ::std::option::Option<
+            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> *mut ::std::os::raw::c_void,
+        >,
+        data: *mut ::std::os::raw::c_void,
+        FreeFunc: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SCDetectThreadCtxGetGlobalKeywordThreadCtx(
+        det_ctx: *mut DetectEngineThreadCtx, id: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_void;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -697,12 +718,6 @@ impl Default for InspectionBuffer {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DetectEngineThreadCtx_ {
-    _unused: [u8; 0],
-}
-pub type DetectEngineThreadCtx = DetectEngineThreadCtx_;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct DetectEngineTransforms {

--- a/src/detect-engine-buffer.h
+++ b/src/detect-engine-buffer.h
@@ -27,6 +27,7 @@
 // types from detect.h with only forward declarations for bindgen
 // could be #ifndef SURICATA_BINDGEN_H #include "detect.h" #endif
 typedef struct DetectEngineCtx_ DetectEngineCtx;
+typedef struct DetectEngineThreadCtx_ DetectEngineThreadCtx;
 typedef struct Signature_ Signature;
 typedef struct SigMatch_ SigMatch;
 
@@ -35,5 +36,11 @@ int DetectBufferGetActiveList(DetectEngineCtx *de_ctx, Signature *s);
 SigMatch *DetectBufferGetFirstSigMatch(const Signature *s, const uint32_t buf_id);
 SigMatch *DetectBufferGetLastSigMatch(const Signature *s, const uint32_t buf_id);
 int SCDetectSignatureAddTransform(Signature *s, int transform, void *options);
+
+// Declared here for bindgen
+// But defined in detect-engine.c to access g_master_de_ctx
+int SCDetectRegisterThreadCtxGlobalFuncs(
+        const char *name, void *(*InitFunc)(void *), void *data, void (*FreeFunc)(void *));
+void *SCDetectThreadCtxGetGlobalKeywordThreadCtx(DetectEngineThreadCtx *det_ctx, int id);
 
 #endif /* SURICATA_DETECT_ENGINE_BUFFER_H */

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -65,19 +65,19 @@ int SCDetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto
 }
 
 int SCDetectRegisterMpmGeneric(const char *name, const char *desc, AppProto alproto,
-        uint8_t direction, InspectionBufferGetDataPtr GetData)
+        uint8_t direction, InspectionBufferGetDataPtr GetData, uint8_t progress)
 {
     if (direction & STREAM_TOSERVER) {
-        DetectAppLayerInspectEngineRegister(
-                name, alproto, SIG_FLAG_TOSERVER, 0, DetectEngineInspectBufferGeneric, GetData);
-        DetectAppLayerMpmRegister(
-                name, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister, GetData, alproto, 0);
+        DetectAppLayerInspectEngineRegister(name, alproto, SIG_FLAG_TOSERVER, progress,
+                DetectEngineInspectBufferGeneric, GetData);
+        DetectAppLayerMpmRegister(name, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister, GetData,
+                alproto, progress);
     }
     if (direction & STREAM_TOCLIENT) {
-        DetectAppLayerInspectEngineRegister(
-                name, alproto, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectBufferGeneric, GetData);
-        DetectAppLayerMpmRegister(
-                name, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister, GetData, alproto, 0);
+        DetectAppLayerInspectEngineRegister(name, alproto, SIG_FLAG_TOCLIENT, progress,
+                DetectEngineInspectBufferGeneric, GetData);
+        DetectAppLayerMpmRegister(name, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister, GetData,
+                alproto, progress);
     }
     DetectBufferTypeSetDescriptionByName(name, desc);
     return DetectBufferTypeGetByName(name);

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -86,7 +86,7 @@ int SCDetectHelperBufferProgressRegister(
 int SCDetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionSingleBufferGetDataPtr GetData);
 int SCDetectRegisterMpmGeneric(const char *name, const char *desc, AppProto alproto,
-        uint8_t direction, InspectionBufferGetDataPtr GetData);
+        uint8_t direction, InspectionBufferGetDataPtr GetData, uint8_t progress);
 int SCDetectHelperBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionSingleBufferGetDataPtr GetData, uint8_t progress);
 int SCDetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -40,6 +40,7 @@
 #include "detect-engine-sigorder.h"
 
 #include "detect-engine-build.h"
+#include "detect-engine-buffer.h"
 #include "detect-engine-siggroup.h"
 #include "detect-engine-address.h"
 #include "detect-engine-port.h"
@@ -3895,8 +3896,8 @@ void *DetectThreadCtxGetKeywordThreadCtx(DetectEngineThreadCtx *det_ctx, int id)
  *  \retval id for retrieval of ctx at runtime
  *  \retval -1 on error
  */
-int DetectRegisterThreadCtxGlobalFuncs(const char *name,
-        void *(*InitFunc)(void *), void *data, void (*FreeFunc)(void *))
+int SCDetectRegisterThreadCtxGlobalFuncs(
+        const char *name, void *(*InitFunc)(void *), void *data, void (*FreeFunc)(void *))
 {
     int id;
     BUG_ON(InitFunc == NULL || FreeFunc == NULL);
@@ -3939,7 +3940,7 @@ int DetectRegisterThreadCtxGlobalFuncs(const char *name,
  *
  *  \retval ctx or NULL on error
  */
-void *DetectThreadCtxGetGlobalKeywordThreadCtx(DetectEngineThreadCtx *det_ctx, int id)
+void *SCDetectThreadCtxGetGlobalKeywordThreadCtx(DetectEngineThreadCtx *det_ctx, int id)
 {
     if (id < 0 || id > det_ctx->global_keyword_ctxs_size ||
         det_ctx->global_keyword_ctxs_array == NULL) {

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -80,10 +80,6 @@ DetectEngineCtx *DetectEngineCtxInitStubForMT(void);
 void DetectEngineCtxFree(DetectEngineCtx *);
 int DetectEngineThreadCtxGetJsonContext(DetectEngineThreadCtx *det_ctx);
 
-int DetectRegisterThreadCtxGlobalFuncs(const char *name,
-        void *(*InitFunc)(void *), void *data, void (*FreeFunc)(void *));
-void *DetectThreadCtxGetGlobalKeywordThreadCtx(DetectEngineThreadCtx *det_ctx, int id);
-
 TmEcode DetectEngineThreadCtxInit(ThreadVars *, void *, void **);
 TmEcode DetectEngineThreadCtxDeinit(ThreadVars *, void *);
 bool DetectEngineMpmCachingEnabled(void);

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -133,7 +133,7 @@ void DetectHttpCookieRegister(void)
             "http cookie header");
 
     g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
-            "http_cookie", SCHttp2ThreadBufDataInit, NULL, SCHttp2ThreadBufDataFree);
+            "http_cookie", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_http_cookie_buffer_id = DetectBufferTypeGetByName("http_cookie");
 }

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -132,7 +132,7 @@ void DetectHttpCookieRegister(void)
     DetectBufferTypeSetDescriptionByName("http_cookie",
             "http cookie header");
 
-    g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
+    g_http2_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
             "http_cookie", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_http_cookie_buffer_id = DetectBufferTypeGetByName("http_cookie");
@@ -238,7 +238,7 @@ static InspectionBuffer *GetRequestData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        void *thread_buf = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
+        void *thread_buf = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
         if (thread_buf == NULL)
             return NULL;
         if (SCHttp2TxGetCookie(txv, STREAM_TOSERVER, &b, &b_len, thread_buf) != 1)
@@ -261,7 +261,7 @@ static InspectionBuffer *GetResponseData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        void *thread_buf = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
+        void *thread_buf = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
         if (thread_buf == NULL)
             return NULL;
         if (SCHttp2TxGetCookie(txv, STREAM_TOCLIENT, &b, &b_len, thread_buf) != 1)

--- a/src/detect-http-header-common.c
+++ b/src/detect-http-header-common.c
@@ -28,6 +28,7 @@
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-engine.h"
+#include "detect-engine-buffer.h"
 #include "detect-engine-mpm.h"
 #include "detect-engine-state.h"
 #include "detect-engine-prefilter.h"
@@ -101,8 +102,7 @@ HttpHeaderBuffer *HttpHeaderGetBufferSpace(DetectEngineThreadCtx *det_ctx, uint8
 {
     *ret_hdr_td = NULL;
 
-    HttpHeaderThreadData *hdr_td =
-        DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, keyword_id);
+    HttpHeaderThreadData *hdr_td = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, keyword_id);
     if (hdr_td == NULL)
         return NULL;
     *ret_hdr_td = hdr_td;

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -170,7 +170,7 @@ static InspectionBuffer *GetBuffer2ForTX(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        void *thread_buf = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
+        void *thread_buf = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
         if (thread_buf == NULL)
             return NULL;
 
@@ -249,10 +249,10 @@ void DetectHttpHeaderNamesRegister(void)
 
     g_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 
-    g_keyword_thread_id = DetectRegisterThreadCtxGlobalFuncs(KEYWORD_NAME,
-            HttpHeaderThreadDataInit, &g_td_config, HttpHeaderThreadDataFree);
+    g_keyword_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
+            KEYWORD_NAME, HttpHeaderThreadDataInit, &g_td_config, HttpHeaderThreadDataFree);
 
-    g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
+    g_http2_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
             "http2.header_names", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     SCLogDebug("keyword %s registered. Thread id %d. "

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -253,7 +253,7 @@ void DetectHttpHeaderNamesRegister(void)
             HttpHeaderThreadDataInit, &g_td_config, HttpHeaderThreadDataFree);
 
     g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
-            "http2.header_names", SCHttp2ThreadBufDataInit, NULL, SCHttp2ThreadBufDataFree);
+            "http2.header_names", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     SCLogDebug("keyword %s registered. Thread id %d. "
             "Buffer %s registered. Buffer id %d",

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -416,7 +416,7 @@ void DetectHttpHeaderRegister(void)
     g_keyword_thread_id = DetectRegisterThreadCtxGlobalFuncs("http_header",
             HttpHeaderThreadDataInit, &g_td_config, HttpHeaderThreadDataFree);
     g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
-            "http2.header", SCHttp2ThreadBufDataInit, NULL, SCHttp2ThreadBufDataFree);
+            "http2.header", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 }
 
 static int g_http_request_header_buffer_id = 0;

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -152,7 +152,7 @@ static InspectionBuffer *GetBuffer2ForTX(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        void *thread_buf = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
+        void *thread_buf = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
         if (thread_buf == NULL)
             return NULL;
         if (SCHttp2TxGetHeaders(txv, flow_flags, &b, &b_len, thread_buf) != 1)
@@ -413,9 +413,9 @@ void DetectHttpHeaderRegister(void)
 
     g_http_header_buffer_id = DetectBufferTypeGetByName("http_header");
 
-    g_keyword_thread_id = DetectRegisterThreadCtxGlobalFuncs("http_header",
-            HttpHeaderThreadDataInit, &g_td_config, HttpHeaderThreadDataFree);
-    g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
+    g_keyword_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
+            "http_header", HttpHeaderThreadDataInit, &g_td_config, HttpHeaderThreadDataFree);
+    g_http2_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
             "http2.header", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 }
 
@@ -472,7 +472,7 @@ static bool GetHttp2HeaderData(DetectEngineThreadCtx *det_ctx, const void *txv, 
     } else {
         kw_thread_id = g_h2_response_header_thread_id;
     }
-    void *hdr_td = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, kw_thread_id);
+    void *hdr_td = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, kw_thread_id);
     if (unlikely(hdr_td == NULL)) {
         return false;
     }
@@ -491,7 +491,7 @@ static bool GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx, const void *txv, 
         kw_thread_id = g_response_header_thread_id;
     }
     HttpMultiBufHeaderThreadData *hdr_td =
-            DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, kw_thread_id);
+            SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, kw_thread_id);
     if (unlikely(hdr_td == NULL)) {
         return false;
     }
@@ -582,9 +582,9 @@ void DetectHttpRequestHeaderRegister(void)
     DetectBufferTypeSetDescriptionByName("http_request_header", "HTTP header name and value");
     g_http_request_header_buffer_id = DetectBufferTypeGetByName("http_request_header");
     DetectBufferTypeSupportsMultiInstance("http_request_header");
-    g_request_header_thread_id = DetectRegisterThreadCtxGlobalFuncs("http_request_header",
+    g_request_header_thread_id = SCDetectRegisterThreadCtxGlobalFuncs("http_request_header",
             HttpMultiBufHeaderThreadDataInit, NULL, HttpMultiBufHeaderThreadDataFree);
-    g_h2_request_header_thread_id = DetectRegisterThreadCtxGlobalFuncs("http2_request_header",
+    g_h2_request_header_thread_id = SCDetectRegisterThreadCtxGlobalFuncs("http2_request_header",
             SCHttp2ThreadMultiBufDataInit, NULL, SCHttp2ThreadMultiBufDataFree);
 }
 
@@ -618,9 +618,9 @@ void DetectHttpResponseHeaderRegister(void)
     DetectBufferTypeSetDescriptionByName("http_response_header", "HTTP header name and value");
     g_http_response_header_buffer_id = DetectBufferTypeGetByName("http_response_header");
     DetectBufferTypeSupportsMultiInstance("http_response_header");
-    g_response_header_thread_id = DetectRegisterThreadCtxGlobalFuncs("http_response_header",
+    g_response_header_thread_id = SCDetectRegisterThreadCtxGlobalFuncs("http_response_header",
             HttpMultiBufHeaderThreadDataInit, NULL, HttpMultiBufHeaderThreadDataFree);
-    g_h2_response_header_thread_id = DetectRegisterThreadCtxGlobalFuncs("http2_response_header",
+    g_h2_response_header_thread_id = SCDetectRegisterThreadCtxGlobalFuncs("http2_response_header",
             SCHttp2ThreadMultiBufDataInit, NULL, SCHttp2ThreadMultiBufDataFree);
 }
 

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -222,7 +222,7 @@ static void DetectHttpHeadersRegisterStub(void)
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 
     g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
-            BUFFER_NAME, SCHttp2ThreadBufDataInit, NULL, SCHttp2ThreadBufDataFree);
+            BUFFER_NAME, SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 }

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -86,7 +86,7 @@ static InspectionBuffer *GetRequestData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        void *thread_buf = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
+        void *thread_buf = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
         if (thread_buf == NULL)
             return NULL;
         if (SCHttp2TxGetHeaderValue(txv, STREAM_TOSERVER, HEADER_NAME, &b, &b_len, thread_buf) != 1)
@@ -143,7 +143,7 @@ static InspectionBuffer *GetResponseData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        void *thread_buf = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
+        void *thread_buf = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
         if (thread_buf == NULL)
             return NULL;
         if (SCHttp2TxGetHeaderValue(txv, STREAM_TOCLIENT, HEADER_NAME, &b, &b_len, thread_buf) != 1)
@@ -221,7 +221,7 @@ static void DetectHttpHeadersRegisterStub(void)
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 
-    g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
+    g_http2_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
             BUFFER_NAME, SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -128,7 +128,7 @@ void DetectHttpHHRegister(void)
             "http host");
 
     g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
-            "http_host", SCHttp2ThreadBufDataInit, NULL, SCHttp2ThreadBufDataFree);
+            "http_host", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_http_host_buffer_id = DetectBufferTypeGetByName("http_host");
 
@@ -164,7 +164,7 @@ void DetectHttpHHRegister(void)
             "http raw host header");
 
     g_http2_raw_thread_id = DetectRegisterThreadCtxGlobalFuncs(
-            "http_raw_host", SCHttp2ThreadBufDataInit, NULL, SCHttp2ThreadBufDataFree);
+            "http_raw_host", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_http_raw_host_buffer_id = DetectBufferTypeGetByName("http_raw_host");
 }

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -127,7 +127,7 @@ void DetectHttpHHRegister(void)
     DetectBufferTypeSetDescriptionByName("http_host",
             "http host");
 
-    g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
+    g_http2_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
             "http_host", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_http_host_buffer_id = DetectBufferTypeGetByName("http_host");
@@ -163,7 +163,7 @@ void DetectHttpHHRegister(void)
     DetectBufferTypeSetDescriptionByName("http_raw_host",
             "http raw host header");
 
-    g_http2_raw_thread_id = DetectRegisterThreadCtxGlobalFuncs(
+    g_http2_raw_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
             "http_raw_host", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_http_raw_host_buffer_id = DetectBufferTypeGetByName("http_raw_host");
@@ -275,7 +275,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
-        void *thread_buf = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
+        void *thread_buf = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
         if (thread_buf == NULL)
             return NULL;
         if (SCHttp2TxGetHostNorm(txv, &b, &b_len, thread_buf) != 1)
@@ -297,7 +297,8 @@ static InspectionBuffer *GetRawData2(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
-        void *thread_buf = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_raw_thread_id);
+        void *thread_buf =
+                SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_raw_thread_id);
         if (thread_buf == NULL)
             return NULL;
 

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -129,7 +129,7 @@ void DetectHttpRawHeaderRegister(void)
     DetectBufferTypeRegisterValidateCallback("http_raw_header",
             DetectHttpRawHeaderValidateCallback);
     g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
-            "http2.raw_header", SCHttp2ThreadBufDataInit, NULL, SCHttp2ThreadBufDataFree);
+            "http2.raw_header", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_http_raw_header_buffer_id = DetectBufferTypeGetByName("http_raw_header");
 }

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -128,7 +128,7 @@ void DetectHttpRawHeaderRegister(void)
 
     DetectBufferTypeRegisterValidateCallback("http_raw_header",
             DetectHttpRawHeaderValidateCallback);
-    g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
+    g_http2_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
             "http2.raw_header", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_http_raw_header_buffer_id = DetectBufferTypeGetByName("http_raw_header");
@@ -220,7 +220,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        void *thread_buf = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
+        void *thread_buf = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
         if (thread_buf == NULL)
             return NULL;
         if (SCHttp2TxGetHeadersRaw(txv, flow_flags, &b, &b_len, thread_buf) != 1)

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -203,8 +203,8 @@ void DetectHttpStartRegister(void)
 
     g_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 
-    g_keyword_thread_id = DetectRegisterThreadCtxGlobalFuncs(KEYWORD_NAME,
-            HttpHeaderThreadDataInit, &g_td_config, HttpHeaderThreadDataFree);
+    g_keyword_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
+            KEYWORD_NAME, HttpHeaderThreadDataInit, &g_td_config, HttpHeaderThreadDataFree);
 
     SCLogDebug("keyword %s registered. Thread id %d. "
             "Buffer %s registered. Buffer id %d",

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -117,7 +117,7 @@ void DetectHttpUARegister(void)
             "http user agent");
 
     g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
-            "http_user_agent", SCHttp2ThreadBufDataInit, NULL, SCHttp2ThreadBufDataFree);
+            "http_user_agent", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_http_ua_buffer_id = DetectBufferTypeGetByName("http_user_agent");
 }

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -116,7 +116,7 @@ void DetectHttpUARegister(void)
     DetectBufferTypeSetDescriptionByName("http_user_agent",
             "http user agent");
 
-    g_http2_thread_id = DetectRegisterThreadCtxGlobalFuncs(
+    g_http2_thread_id = SCDetectRegisterThreadCtxGlobalFuncs(
             "http_user_agent", SCDetectThreadBufDataInit, NULL, SCDetectThreadBufDataFree);
 
     g_http_ua_buffer_id = DetectBufferTypeGetByName("http_user_agent");
@@ -196,7 +196,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
-        void *thread_buf = DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
+        void *thread_buf = SCDetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, g_http2_thread_id);
         if (thread_buf == NULL)
             return NULL;
         if (SCHttp2TxGetUserAgent(txv, &b, &b_len, thread_buf) != 1)


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8485
https://redmine.openinfosecfoundation.org/issues/8486

Describe changes:
- snmp : adds keywords `snmp.trap_oid` and `snmp.trap_address`

To do so
- reuses `Http2ThreadBuf` by renaming it to more generic `DetectThreadBuf`
- bindgen the  ThreadCtx keyword functions to rust
- add progress argument to SCDetectRegisterMpmGeneric

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3138

#15815 with warning fix