### PR TITLE
smtp: firewall, quit - v6

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -95,6 +95,7 @@
 /* All other commands are represented by this var */
 #define SMTP_COMMAND_OTHER_CMD 5
 #define SMTP_COMMAND_RSET      6
+#define SMTP_COMMAND_QUIT      7
 
 #define SMTP_DEFAULT_MAX_TX 256
 
@@ -1088,6 +1089,11 @@ static int SMTPProcessReply(
                 !(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
             SMTPTransactionComplete(reply_tx);
         }
+    } else if (IsReplyToCommand(state, SMTP_COMMAND_QUIT)) {
+        if (reply_code == SMTP_REPLY_221 && reply_tx &&
+                !(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
+            SMTPTransactionComplete(reply_tx);
+        }
     } else {
         /* we don't care for any other command for now */
     }
@@ -1284,8 +1290,9 @@ static int SMTPProcessRequest(
     if (line->len == 0 && line->delim_len == 0) {
         return 0;
     }
-    if (state->curr_tx == NULL ||
-            (SMTPTransactionRequestIsComplete(state->curr_tx) && !NoNewTx(state, line))) {
+    const bool no_new_tx = NoNewTx(state, line);
+    if ((state->curr_tx == NULL && (state->tx_cnt == 0 || !no_new_tx)) ||
+            (SMTPTransactionRequestIsComplete(state->curr_tx) && !no_new_tx)) {
         tx = SMTPTransactionCreate(state);
         if (tx == NULL)
             return -1;
@@ -1301,7 +1308,9 @@ static int SMTPProcessRequest(
     if (frame != NULL && state->curr_tx) {
         AppLayerFrameSetTxId(frame, state->curr_tx->tx_id);
     }
-    tx->tx_data.updated_ts = true;
+    if (tx != NULL) {
+        tx->tx_data.updated_ts = true;
+    }
 
     state->toserver_data_count += (line->len + line->delim_len);
 
@@ -1385,6 +1394,8 @@ static int SMTPProcessRequest(
             // Resets chunk index in case of connection reuse
             state->bdat_chunk_idx = 0;
             state->current_command = SMTP_COMMAND_RSET;
+        } else if (line->len >= 4 && SCMemcmpLowercase("quit", line->buf, 4) == 0) {
+            state->current_command = SMTP_COMMAND_QUIT;
         } else {
             state->current_command = SMTP_COMMAND_OTHER_CMD;
         }
@@ -2870,7 +2881,7 @@ static int SMTPParserTest02(void)
         goto end;
     }
     if (smtp_state->cmds_cnt != 1 || smtp_state->cmds_idx != 0 ||
-            smtp_state->cmds[0] != SMTP_COMMAND_OTHER_CMD ||
+            smtp_state->cmds[0] != SMTP_COMMAND_QUIT ||
             smtp_state->parser_state != SMTP_PARSER_STATE_FIRST_REPLY_SEEN) {
         printf("smtp parser in inconsistent state\n");
         goto end;
@@ -3352,7 +3363,7 @@ static int SMTPParserTest05(void)
         goto end;
     }
     if (smtp_state->cmds_cnt != 1 || smtp_state->cmds_idx != 0 ||
-            smtp_state->cmds[0] != SMTP_COMMAND_OTHER_CMD ||
+            smtp_state->cmds[0] != SMTP_COMMAND_QUIT ||
             smtp_state->parser_state !=
                     (SMTP_PARSER_STATE_FIRST_REPLY_SEEN | SMTP_PARSER_STATE_PIPELINING_SERVER)) {
         printf("smtp parser in inconsistent state\n");
@@ -4370,7 +4381,7 @@ static int SMTPParserTest14(void)
         goto end;
     }
     if (smtp_state->cmds_cnt != 1 || smtp_state->cmds_idx != 0 ||
-            smtp_state->cmds[0] != SMTP_COMMAND_OTHER_CMD ||
+            smtp_state->cmds[0] != SMTP_COMMAND_QUIT ||
             smtp_state->parser_state != SMTP_PARSER_STATE_FIRST_REPLY_SEEN) {
         printf("smtp parser in inconsistent state l.%d\n", __LINE__);
         goto end;

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -98,6 +98,9 @@
 
 #define SMTP_DEFAULT_MAX_TX 256
 
+/* command buffer tx id for commands with no owning transaction */
+#define SMTP_NO_TX_ID UINT64_MAX
+
 typedef struct SMTPInput_ {
     /* current input that is being parsed */
     const uint8_t *buf;
@@ -229,13 +232,13 @@ static inline void SMTPSetProgressTC(SMTPTransaction *tx, uint8_t progress)
 {
     if (tx != NULL && tx->progress_tc < progress) {
         tx->progress_tc = progress;
+        tx->tx_data.updated_tc = true;
     }
 }
 
-static bool SMTPTransactionIsComplete(const SMTPTransaction *tx)
+static bool SMTPTransactionRequestIsComplete(const SMTPTransaction *tx)
 {
-    return tx && tx->progress_ts == SMTP_REQUEST_COMPLETE &&
-           tx->progress_tc == SMTP_RESPONSE_COMPLETE;
+    return tx && tx->progress_ts == SMTP_REQUEST_COMPLETE;
 }
 
 typedef struct SMTPThreadCtx_ {
@@ -673,7 +676,8 @@ static AppLayerResult SMTPGetLine(Flow *f, StreamSlice *slice, SMTPState *state,
     }
 }
 
-static int SMTPInsertCommandIntoCommandBuffer(uint8_t command, SMTPState *state)
+static int SMTPInsertCommandIntoCommandBuffer(
+        SMTPState *state, uint8_t command, const SMTPTransaction *tx)
 {
     SCEnter();
     void *ptmp;
@@ -688,11 +692,25 @@ static int SMTPInsertCommandIntoCommandBuffer(uint8_t command, SMTPState *state)
                          sizeof(uint8_t) * (state->cmds_buffer_len + increment));
         if (ptmp == NULL) {
             SCFree(state->cmds);
+            SCFree(state->cmds_tx_ids);
             state->cmds = NULL;
+            state->cmds_tx_ids = NULL;
             SCLogDebug("SCRealloc failure");
             return -1;
         }
         state->cmds = ptmp;
+
+        ptmp = SCRealloc(
+                state->cmds_tx_ids, sizeof(uint64_t) * (state->cmds_buffer_len + increment));
+        if (ptmp == NULL) {
+            SCFree(state->cmds);
+            SCFree(state->cmds_tx_ids);
+            state->cmds = NULL;
+            state->cmds_tx_ids = NULL;
+            SCLogDebug("SCRealloc failure");
+            return -1;
+        }
+        state->cmds_tx_ids = ptmp;
 
         state->cmds_buffer_len += increment;
     }
@@ -712,6 +730,7 @@ static int SMTPInsertCommandIntoCommandBuffer(uint8_t command, SMTPState *state)
     }
 
     state->cmds[state->cmds_cnt] = command;
+    state->cmds_tx_ids[state->cmds_cnt] = tx != NULL ? tx->tx_id : SMTP_NO_TX_ID;
     state->cmds_cnt++;
 
     return 0;
@@ -766,29 +785,29 @@ static void SetMimeEvents(SMTPState *state, uint32_t events)
     }
 }
 
-static inline void SMTPTransactionComplete(SMTPState *state)
+static inline void SMTPTransactionComplete(SMTPTransaction *tx)
 {
-    DEBUG_VALIDATE_BUG_ON(state->curr_tx == NULL);
-    if (state->curr_tx) {
-        SMTPSetProgressTS(state->curr_tx, SMTP_REQUEST_COMPLETE);
-        SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_COMPLETE);
+    DEBUG_VALIDATE_BUG_ON(tx == NULL);
+    if (tx) {
+        SMTPSetProgressTS(tx, SMTP_REQUEST_COMPLETE);
+        SMTPSetProgressTC(tx, SMTP_RESPONSE_COMPLETE);
     }
 }
 
-static inline void SMTPTransactionCompleteTS(SMTPState *state)
+static inline void SMTPTransactionCompleteTS(SMTPTransaction *tx)
 {
-    DEBUG_VALIDATE_BUG_ON(state->curr_tx == NULL);
-    if (state->curr_tx) {
-        SMTPSetProgressTS(state->curr_tx, SMTP_REQUEST_COMPLETE);
+    DEBUG_VALIDATE_BUG_ON(tx == NULL);
+    if (tx) {
+        SMTPSetProgressTS(tx, SMTP_REQUEST_COMPLETE);
         SCLogDebug("marked tx as ts complete");
     }
 }
 
-static inline void SMTPTransactionCompleteTC(SMTPState *state)
+static inline void SMTPTransactionCompleteTC(SMTPTransaction *tx)
 {
-    DEBUG_VALIDATE_BUG_ON(state->curr_tx == NULL);
-    if (state->curr_tx) {
-        SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_COMPLETE);
+    DEBUG_VALIDATE_BUG_ON(tx == NULL);
+    if (tx) {
+        SMTPSetProgressTC(tx, SMTP_RESPONSE_COMPLETE);
         SCLogDebug("marked tx as tc complete");
     }
 }
@@ -815,7 +834,7 @@ static int SMTPProcessCommandDATA(
          * acknowledged with a reply.  We insert a dummy command to
          * the command buffer to be used by the reply handler to match
          * the reply received */
-        SMTPInsertCommandIntoCommandBuffer(SMTP_COMMAND_DATA_MODE, state);
+        SMTPInsertCommandIntoCommandBuffer(state, SMTP_COMMAND_DATA_MODE, tx);
         if (smtp_config.raw_extraction) {
             /* we use this as the signal that message data is complete. */
             FileCloseFile(&tx->files_ts, &smtp_config.sbcfg, NULL, 0, 0);
@@ -827,7 +846,7 @@ static int SMTPProcessCommandDATA(
                         FileFlowToFlags(f, STREAM_TOSERVER));
             }
         }
-        SMTPTransactionCompleteTS(state);
+        SMTPTransactionCompleteTS(tx);
     } else if (smtp_config.raw_extraction) {
         // message not over, store the line. This is a substitution of
         // ProcessDataChunk
@@ -924,8 +943,35 @@ static int SMTPProcessCommandDATA(
 
 static inline bool IsReplyToCommand(const SMTPState *state, const uint8_t cmd)
 {
-    return (state->cmds_idx < state->cmds_buffer_len &&
-            state->cmds[state->cmds_idx] == cmd);
+    return (state->cmds_idx < state->cmds_cnt && state->cmds[state->cmds_idx] == cmd);
+}
+
+static SMTPTransaction *SMTPStateGetTxById(SMTPState *state, uint64_t tx_id)
+{
+    SMTPTransaction *tx = NULL;
+    TAILQ_FOREACH (tx, &state->tx_list, next) {
+        if (tx->tx_id == tx_id) {
+            return tx;
+        }
+        if (tx->tx_id > tx_id) {
+            break;
+        }
+    }
+    return NULL;
+}
+
+static SMTPTransaction *SMTPGetReplyTx(SMTPState *state)
+{
+    if (state->cmds_idx >= state->cmds_cnt) {
+        return state->curr_tx;
+    }
+
+    /* a command with no owning tx, or whose tx is gone, must not resolve
+     * to another tx */
+    if (state->cmds_tx_ids[state->cmds_idx] == SMTP_NO_TX_ID) {
+        return NULL;
+    }
+    return SMTPStateGetTxById(state, state->cmds_tx_ids[state->cmds_idx]);
 }
 
 static int SMTPProcessReply(
@@ -938,8 +984,9 @@ static int SMTPProcessReply(
         return 0; // to continue processing further
     }
 
-    if (state->curr_tx) {
-        state->curr_tx->tx_data.updated_tc = true;
+    SMTPTransaction *reply_tx = SMTPGetReplyTx(state);
+    if (reply_tx != NULL) {
+        reply_tx->tx_data.updated_tc = true;
     }
     /* the reply code has to contain at least 3 bytes, to hold the 3 digit
      * reply code */
@@ -1010,8 +1057,8 @@ static int SMTPProcessReply(
             if (!SCAppLayerRequestProtocolTLSUpgrade(f)) {
                 SMTPSetEvent(state, SMTP_DECODER_EVENT_FAILED_PROTOCOL_CHANGE);
             }
-            if (state->curr_tx) {
-                SMTPTransactionComplete(state);
+            if (reply_tx) {
+                SMTPTransactionComplete(reply_tx);
             }
         } else {
             /* decoder event */
@@ -1019,7 +1066,7 @@ static int SMTPProcessReply(
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_DATA)) {
         if (reply_code == SMTP_REPLY_354) {
-            SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_DATA);
+            SMTPSetProgressTC(reply_tx, SMTP_RESPONSE_DATA);
             /* Next comes the mail for the DATA command in toserver direction */
             state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
         } else {
@@ -1031,15 +1078,15 @@ static int SMTPProcessReply(
             SMTPSetEvent(state, SMTP_DECODER_EVENT_DATA_COMMAND_REJECTED);
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_BDAT)) {
-        SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_DATA);
+        SMTPSetProgressTC(reply_tx, SMTP_RESPONSE_DATA);
     } else if (IsReplyToCommand(state, SMTP_COMMAND_DATA_MODE)) {
         if (!(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
-            SMTPTransactionCompleteTC(state);
+            SMTPTransactionCompleteTC(reply_tx);
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_RSET)) {
-        if (reply_code == SMTP_REPLY_250 && state->curr_tx &&
+        if (reply_code == SMTP_REPLY_250 && reply_tx &&
                 !(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
-            SMTPTransactionComplete(state);
+            SMTPTransactionComplete(reply_tx);
         }
     } else {
         /* we don't care for any other command for now */
@@ -1238,7 +1285,7 @@ static int SMTPProcessRequest(
         return 0;
     }
     if (state->curr_tx == NULL ||
-            (SMTPTransactionIsComplete(state->curr_tx) && !NoNewTx(state, line))) {
+            (SMTPTransactionRequestIsComplete(state->curr_tx) && !NoNewTx(state, line))) {
         tx = SMTPTransactionCreate(state);
         if (tx == NULL)
             return -1;
@@ -1344,7 +1391,7 @@ static int SMTPProcessRequest(
 
         /* Every command is inserted into a command buffer, to be matched
          * against reply(ies) sent by the server */
-        if (SMTPInsertCommandIntoCommandBuffer(state->current_command, state) == -1) {
+        if (SMTPInsertCommandIntoCommandBuffer(state, state->current_command, tx) == -1) {
             SCReturnInt(-1);
         }
 
@@ -1594,6 +1641,12 @@ void *SMTPStateAlloc(void *orig_state, AppProto proto_orig)
         SCFree(smtp_state);
         return NULL;
     }
+    smtp_state->cmds_tx_ids = SCMalloc(sizeof(uint64_t) * SMTP_COMMAND_BUFFER_STEPS);
+    if (smtp_state->cmds_tx_ids == NULL) {
+        SCFree(smtp_state->cmds);
+        SCFree(smtp_state);
+        return NULL;
+    }
     smtp_state->cmds_buffer_len = SMTP_COMMAND_BUFFER_STEPS;
 
     TAILQ_INIT(&smtp_state->tx_list);
@@ -1690,6 +1743,9 @@ static void SMTPStateFree(void *p)
 
     if (smtp_state->cmds != NULL) {
         SCFree(smtp_state->cmds);
+    }
+    if (smtp_state->cmds_tx_ids != NULL) {
+        SCFree(smtp_state->cmds_tx_ids);
     }
 
     if (smtp_state->helo) {
@@ -4341,6 +4397,7 @@ end:
     StreamTcpFreeConfig(true);
     return result;
 }
+
 #endif /* UNITTESTS */
 
 void SMTPParserRegisterTests(void)

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -186,6 +186,52 @@ static const char *SMTPGetFrameNameById(const uint8_t frame_id)
     return name;
 }
 
+static SCEnumCharMap smtp_state_client_table[] = {
+    { "request_started", SMTP_REQUEST_STARTED },
+    { "request_data", SMTP_REQUEST_DATA },
+    { "request_complete", SMTP_REQUEST_COMPLETE },
+    { NULL, -1 },
+};
+
+static SCEnumCharMap smtp_state_server_table[] = {
+    { "response_started", SMTP_RESPONSE_STARTED },
+    { "response_data", SMTP_RESPONSE_DATA },
+    { "response_complete", SMTP_RESPONSE_COMPLETE },
+    { NULL, -1 },
+};
+
+static int SMTPStateGetStateIdByName(const char *name, const uint8_t direction)
+{
+    SCEnumCharMap *map =
+            direction == STREAM_TOSERVER ? smtp_state_client_table : smtp_state_server_table;
+    int id = SCMapEnumNameToValue(name, map);
+    if (id < 0) {
+        return -1;
+    }
+    return id;
+}
+
+static const char *SMTPStateGetStateNameById(const int id, const uint8_t direction)
+{
+    SCEnumCharMap *map =
+            direction == STREAM_TOSERVER ? smtp_state_client_table : smtp_state_server_table;
+    return SCMapEnumValueToName(id, map);
+}
+
+static inline void SMTPSetProgressTS(SMTPTransaction *tx, uint8_t progress)
+{
+    if (tx != NULL && tx->progress_ts < progress) {
+        tx->progress_ts = progress;
+    }
+}
+
+static inline void SMTPSetProgressTC(SMTPTransaction *tx, uint8_t progress)
+{
+    if (tx != NULL && tx->progress_tc < progress) {
+        tx->progress_tc = progress;
+    }
+}
+
 typedef struct SMTPThreadCtx_ {
     MpmThreadCtx *smtp_mpm_thread_ctx;
     PrefilterRuleStore *pmq;
@@ -948,6 +994,7 @@ static int SMTPProcessReply(
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_DATA)) {
         if (reply_code == SMTP_REPLY_354) {
+            SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_DATA);
             /* Next comes the mail for the DATA command in toserver direction */
             state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
         } else {
@@ -958,6 +1005,8 @@ static int SMTPProcessReply(
             }
             SMTPSetEvent(state, SMTP_DECODER_EVENT_DATA_COMMAND_REJECTED);
         }
+    } else if (IsReplyToCommand(state, SMTP_COMMAND_BDAT)) {
+        SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_DATA);
     } else if (IsReplyToCommand(state, SMTP_COMMAND_RSET)) {
         if (reply_code == SMTP_REPLY_250 && state->curr_tx &&
                 !(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
@@ -1193,6 +1242,7 @@ static int SMTPProcessRequest(
             state->current_command = SMTP_COMMAND_STARTTLS;
         } else if (line->len >= 4 && SCMemcmpLowercase("data", line->buf, 4) == 0) {
             state->current_command = SMTP_COMMAND_DATA;
+            SMTPSetProgressTS(tx, SMTP_REQUEST_DATA);
             if (state->curr_tx->is_data) {
                 // We did not receive a confirmation from server
                 // And now client sends a next DATA
@@ -1233,6 +1283,7 @@ static int SMTPProcessRequest(
                 SCReturnInt(-1);
             }
             state->current_command = SMTP_COMMAND_BDAT;
+            SMTPSetProgressTS(tx, SMTP_REQUEST_DATA);
             state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
         } else if (line->len >= 4 && ((SCMemcmpLowercase("helo", line->buf, 4) == 0) ||
                                              SCMemcmpLowercase("ehlo", line->buf, 4) == 0)) {
@@ -1809,7 +1860,10 @@ static void *SMTPStateGetTx(void *state, uint64_t id)
 static int SMTPStateGetAlstateProgress(void *vtx, uint8_t direction)
 {
     SMTPTransaction *tx = vtx;
-    return tx->done;
+    if (direction & STREAM_TOSERVER) {
+        return tx->done ? SMTP_REQUEST_COMPLETE : tx->progress_ts;
+    }
+    return tx->done ? SMTP_RESPONSE_COMPLETE : tx->progress_tc;
 }
 
 static AppLayerGetFileState SMTPGetTxFiles(void *txv, uint8_t direction)
@@ -1912,9 +1966,12 @@ void RegisterSMTPParsers(void)
         AppLayerParserRegisterGetTxIterator(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetTxIterator);
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetTxData);
         AppLayerParserRegisterStateDataFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetStateData);
-        AppLayerParserRegisterStateProgressCompletionStatus(ALPROTO_SMTP, 1, 1);
+        AppLayerParserRegisterStateProgressCompletionStatus(
+                ALPROTO_SMTP, SMTP_REQUEST_COMPLETE, SMTP_RESPONSE_COMPLETE);
         AppLayerParserRegisterGetFrameFuncs(
                 IPPROTO_TCP, ALPROTO_SMTP, SMTPGetFrameIdByName, SMTPGetFrameNameById);
+        AppLayerParserRegisterGetStateFuncs(
+                IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetStateIdByName, SMTPStateGetStateNameById);
     } else {
         SCLogInfo("Parser disabled for %s protocol. Protocol detection still on.", proto_name);
     }

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -232,6 +232,12 @@ static inline void SMTPSetProgressTC(SMTPTransaction *tx, uint8_t progress)
     }
 }
 
+static bool SMTPTransactionIsComplete(const SMTPTransaction *tx)
+{
+    return tx && tx->progress_ts == SMTP_REQUEST_COMPLETE &&
+           tx->progress_tc == SMTP_RESPONSE_COMPLETE;
+}
+
 typedef struct SMTPThreadCtx_ {
     MpmThreadCtx *smtp_mpm_thread_ctx;
     PrefilterRuleStore *pmq;
@@ -763,8 +769,28 @@ static void SetMimeEvents(SMTPState *state, uint32_t events)
 static inline void SMTPTransactionComplete(SMTPState *state)
 {
     DEBUG_VALIDATE_BUG_ON(state->curr_tx == NULL);
-    if (state->curr_tx)
-        state->curr_tx->done = true;
+    if (state->curr_tx) {
+        SMTPSetProgressTS(state->curr_tx, SMTP_REQUEST_COMPLETE);
+        SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_COMPLETE);
+    }
+}
+
+static inline void SMTPTransactionCompleteTS(SMTPState *state)
+{
+    DEBUG_VALIDATE_BUG_ON(state->curr_tx == NULL);
+    if (state->curr_tx) {
+        SMTPSetProgressTS(state->curr_tx, SMTP_REQUEST_COMPLETE);
+        SCLogDebug("marked tx as ts complete");
+    }
+}
+
+static inline void SMTPTransactionCompleteTC(SMTPState *state)
+{
+    DEBUG_VALIDATE_BUG_ON(state->curr_tx == NULL);
+    if (state->curr_tx) {
+        SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_COMPLETE);
+        SCLogDebug("marked tx as tc complete");
+    }
 }
 
 /**
@@ -801,8 +827,7 @@ static int SMTPProcessCommandDATA(
                         FileFlowToFlags(f, STREAM_TOSERVER));
             }
         }
-        SMTPTransactionComplete(state);
-        SCLogDebug("marked tx as done");
+        SMTPTransactionCompleteTS(state);
     } else if (smtp_config.raw_extraction) {
         // message not over, store the line. This is a substitution of
         // ProcessDataChunk
@@ -1007,6 +1032,10 @@ static int SMTPProcessReply(
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_BDAT)) {
         SMTPSetProgressTC(state->curr_tx, SMTP_RESPONSE_DATA);
+    } else if (IsReplyToCommand(state, SMTP_COMMAND_DATA_MODE)) {
+        if (!(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
+            SMTPTransactionCompleteTC(state);
+        }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_RSET)) {
         if (reply_code == SMTP_REPLY_250 && state->curr_tx &&
                 !(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
@@ -1208,7 +1237,8 @@ static int SMTPProcessRequest(
     if (line->len == 0 && line->delim_len == 0) {
         return 0;
     }
-    if (state->curr_tx == NULL || (state->curr_tx->done && !NoNewTx(state, line))) {
+    if (state->curr_tx == NULL ||
+            (SMTPTransactionIsComplete(state->curr_tx) && !NoNewTx(state, line))) {
         tx = SMTPTransactionCreate(state);
         if (tx == NULL)
             return -1;
@@ -1861,9 +1891,9 @@ static int SMTPStateGetAlstateProgress(void *vtx, uint8_t direction)
 {
     SMTPTransaction *tx = vtx;
     if (direction & STREAM_TOSERVER) {
-        return tx->done ? SMTP_REQUEST_COMPLETE : tx->progress_ts;
+        return tx->progress_ts;
     }
-    return tx->done ? SMTP_RESPONSE_COMPLETE : tx->progress_tc;
+    return tx->progress_tc;
 }
 
 static AppLayerGetFileState SMTPGetTxFiles(void *txv, uint8_t direction)

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -153,6 +153,8 @@ typedef struct SMTPState_ {
      * stored command in the buffer to match the reply(ies) with the command */
     /** the command buffer */
     uint8_t *cmds;
+    /** tx id for each stored command */
+    uint64_t *cmds_tx_ids;
     /** the buffer length */
     uint16_t cmds_buffer_len;
     /** no of commands stored in the above buffer */

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -70,6 +70,18 @@ typedef struct SMTPString_ {
     TAILQ_ENTRY(SMTPString_) next;
 } SMTPString;
 
+enum SMTPRequestProgress {
+    SMTP_REQUEST_STARTED = 0,
+    SMTP_REQUEST_DATA = 1,
+    SMTP_REQUEST_COMPLETE = 2,
+};
+
+enum SMTPResponseProgress {
+    SMTP_RESPONSE_STARTED = 0,
+    SMTP_RESPONSE_DATA = 1,
+    SMTP_RESPONSE_COMPLETE = 2,
+};
+
 typedef struct SMTPTransaction_ {
     /** id of this tx, starting at 0 */
     uint64_t tx_id;
@@ -78,6 +90,10 @@ typedef struct SMTPTransaction_ {
 
     /** the tx is complete and can be logged and cleaned */
     bool done;
+    /** to-server firewall progress state. */
+    uint8_t progress_ts;
+    /** to-client firewall progress state. */
+    uint8_t progress_tc;
     /** the tx has seen a DATA command */
     // another DATA command within the same context
     // will trigger an app-layer event.

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -88,8 +88,6 @@ typedef struct SMTPTransaction_ {
 
     AppLayerTxData tx_data;
 
-    /** the tx is complete and can be logged and cleaned */
-    bool done;
     /** to-server firewall progress state. */
     uint8_t progress_ts;
     /** to-client firewall progress state. */

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -260,8 +260,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailFromSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_from_buffer_id = SCDetectHelperBufferMpmRegister(
-            "email.from", "MIME EMAIL FROM", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailFromData);
+    g_mime_email_from_buffer_id =
+            SCDetectHelperBufferProgressMpmRegister("email.from", "MIME EMAIL FROM", ALPROTO_SMTP,
+                    STREAM_TOSERVER, GetMimeEmailFromData, SMTP_REQUEST_DATA);
 
     kw.name = "email.subject";
     kw.desc = "'Subject' field from an email";
@@ -269,8 +270,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailSubjectSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_subject_buffer_id = SCDetectHelperBufferMpmRegister("email.subject",
-            "MIME EMAIL SUBJECT", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailSubjectData);
+    g_mime_email_subject_buffer_id =
+            SCDetectHelperBufferProgressMpmRegister("email.subject", "MIME EMAIL SUBJECT",
+                    ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailSubjectData, SMTP_REQUEST_DATA);
 
     kw.name = "email.to";
     kw.desc = "'To' field from an email";
@@ -278,8 +280,8 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailToSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_to_buffer_id = SCDetectHelperBufferMpmRegister(
-            "email.to", "MIME EMAIL TO", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailToData);
+    g_mime_email_to_buffer_id = SCDetectHelperBufferProgressMpmRegister("email.to", "MIME EMAIL TO",
+            ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailToData, SMTP_REQUEST_DATA);
 
     kw.name = "email.cc";
     kw.desc = "'Cc' field from an email";
@@ -287,8 +289,8 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailCcSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_cc_buffer_id = SCDetectHelperBufferMpmRegister(
-            "email.cc", "MIME EMAIL CC", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailCcData);
+    g_mime_email_cc_buffer_id = SCDetectHelperBufferProgressMpmRegister("email.cc", "MIME EMAIL CC",
+            ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailCcData, SMTP_REQUEST_DATA);
 
     kw.name = "email.date";
     kw.desc = "'Date' field from an email";
@@ -296,8 +298,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailDateSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_date_buffer_id = SCDetectHelperBufferMpmRegister(
-            "email.date", "MIME EMAIL DATE", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailDateData);
+    g_mime_email_date_buffer_id =
+            SCDetectHelperBufferProgressMpmRegister("email.date", "MIME EMAIL DATE", ALPROTO_SMTP,
+                    STREAM_TOSERVER, GetMimeEmailDateData, SMTP_REQUEST_DATA);
 
     kw.name = "email.message_id";
     kw.desc = "'Message-Id' field from an email";
@@ -305,8 +308,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailMessageIdSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_message_id_buffer_id = SCDetectHelperBufferMpmRegister("email.message_id",
-            "MIME EMAIL Message-Id", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailMessageIdData);
+    g_mime_email_message_id_buffer_id =
+            SCDetectHelperBufferProgressMpmRegister("email.message_id", "MIME EMAIL Message-Id",
+                    ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailMessageIdData, SMTP_REQUEST_DATA);
 
     kw.name = "email.x_mailer";
     kw.desc = "'X-Mailer' field from an email";
@@ -314,8 +318,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailXMailerSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_x_mailer_buffer_id = SCDetectHelperBufferMpmRegister("email.x_mailer",
-            "MIME EMAIL X-Mailer", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailXMailerData);
+    g_mime_email_x_mailer_buffer_id =
+            SCDetectHelperBufferProgressMpmRegister("email.x_mailer", "MIME EMAIL X-Mailer",
+                    ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailXMailerData, SMTP_REQUEST_DATA);
 
     kw.name = "email.url";
     kw.desc = "'Url' extracted from an email";
@@ -323,8 +328,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailUrlSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_url_buffer_id = SCDetectHelperMultiBufferMpmRegister(
-            "email.url", "MIME EMAIL URL", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailUrlData);
+    g_mime_email_url_buffer_id =
+            SCDetectHelperMultiBufferProgressMpmRegister("email.url", "MIME EMAIL URL",
+                    ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailUrlData, SMTP_REQUEST_DATA);
 
     kw.name = "email.received";
     kw.desc = "'Received' field from an email";
@@ -332,8 +338,9 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailReceivedSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_INFO_MULTI_BUFFER;
     SCDetectHelperKeywordRegister(&kw);
-    g_mime_email_received_buffer_id = SCDetectHelperMultiBufferMpmRegister("email.received",
-            "MIME EMAIL RECEIVED", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailReceivedData);
+    g_mime_email_received_buffer_id =
+            SCDetectHelperMultiBufferProgressMpmRegister("email.received", "MIME EMAIL RECEIVED",
+                    ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailReceivedData, SMTP_REQUEST_DATA);
 
     if (!MimeBodyMd5IsDisabled()) {
         // do not register the keyword if explicitly disabled
@@ -343,10 +350,9 @@ void DetectEmailRegister(void)
         kw.Setup = DetectMimeEmailBodyMd5Setup;
         kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
         DETECT_EMAIL_BODY_MD5 = SCDetectHelperKeywordRegister(&kw);
-        // We do not need a progress because SMTP tx has only progress 0 or 1
-        // even if we have a MimeSmtpMd5State enumeration
-        g_mime_email_body_md5_buffer_id = SCDetectHelperBufferMpmRegister("email.body_md5",
-                "MIME EMAIL BODY MD5", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailBodyMd5Data);
+        g_mime_email_body_md5_buffer_id =
+                SCDetectHelperBufferProgressMpmRegister("email.body_md5", "MIME EMAIL BODY MD5",
+                        ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailBodyMd5Data, SMTP_REQUEST_DATA);
         DetectBufferTypeRegisterValidateCallback("email.body_md5", DetectMd5ValidateCallback);
     }
 }

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -93,7 +93,8 @@ DetectFileHandlerProtocol al_protocols[ALPROTO_WITHFILES_MAX] = {
             .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT,
             .progress_tc = HTTP2ProgData,
             .progress_ts = HTTP2ProgData },
-    { .alproto = ALPROTO_SMTP, .direction = SIG_FLAG_TOSERVER }, { .alproto = ALPROTO_UNKNOWN }
+    { .alproto = ALPROTO_SMTP, .direction = SIG_FLAG_TOSERVER, .progress_ts = SMTP_REQUEST_DATA },
+    { .alproto = ALPROTO_UNKNOWN }
 };
 
 void DetectFileRegisterProto(


### PR DESCRIPTION
This PR is https://github.com/OISF/suricata/pull/15818, but with additional
commits:

- Don't create a transaction for a trailing quit.

Tickets:
- https://redmine.openinfosecfoundation.org/issues/8393
- https://redmine.openinfosecfoundation.org/issues/8728

PR #15818 has a condition where when rules are used the trailing QUIT did not
result in a TX, but when rules were left out it did. Not really a showstopped,
but this brings rule/non-rule runs into sync by fixing issue 8728.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3224
