### PR TITLE
Keywords integer list enum 8675 v6

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -3068,6 +3068,7 @@ jobs:
           DISTCHECK_CONFIGURE_FLAGS: "--enable-unittests --enable-debug --enable-geoip --enable-profiling --enable-profiling-locks --enable-dpdk --enable-ebpf --enable-ebpf-build"
       - run: python3 scripts/check-dist-rules.py
       - run: python3 scripts/check-uint-keywords.py
+      - run: python3 scripts/check-enum-uint-keywords.py
       - run: test -e doc/userguide/suricata.1
       - run: test -e doc/userguide/userguide.pdf
       - name: Building Rust documentation

--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -263,7 +263,7 @@
 
    List all supported application layer protocols.
 
-.. option:: --list-keywords=[all|csv|<kword>]
+.. option:: --list-keywords=[json|csv|<kword>]
 
    List all supported rule keywords.
 

--- a/doc/userguide/rules/dnp3-keywords.rst
+++ b/doc/userguide/rules/dnp3-keywords.rst
@@ -64,6 +64,8 @@ Where value is one of:
   * unsolicited_response
   * authenticate_resp
 
+See ``suricata --list-keywords=json | jq .dnp3_func.enum_values``
+
 dnp3_ind
 --------
 

--- a/doc/userguide/rules/dns-keywords.rst
+++ b/doc/userguide/rules/dns-keywords.rst
@@ -51,6 +51,8 @@ This keyword matches on the **rcode** field found in the DNS header flags.
 dns.rcode uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
 It can also be specified by text from the enumeration.
 
+See ``suricata --list-keywords=json | jq '."dns.rcode".enum_values'``
+
 Currently, Suricata only supports rcode values in the range [0-15], while
 the current DNS version supports rcode values from [0-23] as specified in
 `RFC 6895 <https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6>`_.
@@ -85,6 +87,8 @@ This keyword matches on the **rrtype** (integer) found in the DNS message.
 dns.rrtype uses an :ref:`unsigned 16-bit integer <rules-integer-keywords>`.
 
 dns.rrtype is also a :ref:`multi-integer <multi-integers>`.
+
+See ``suricata --list-keywords=json | jq '."dns.rrtype".enum_values'``
 
 It can also be specified by text from the enumeration.
 

--- a/doc/userguide/rules/enip-keyword.rst
+++ b/doc/userguide/rules/enip-keyword.rst
@@ -6,6 +6,8 @@ enip_command
 
 For the ENIP command, we are matching against the command field found in the ENIP encapsulation.
 
+See ``suricata --list-keywords=json | jq '."enip_command".enum_values'``
+
 Examples::
 
   enip_command:99;
@@ -41,6 +43,8 @@ It uses a 32-bit unsigned integer as value.
 
 enip.status uses an :ref:`unsigned 32-bits integer <rules-integer-keywords>`.
 It can also be specified by text from the enumeration.
+
+See ``suricata --list-keywords=json | jq '."enip.status".enum_values'``
 
 Examples::
 

--- a/doc/userguide/rules/http2-keywords.rst
+++ b/doc/userguide/rules/http2-keywords.rst
@@ -26,6 +26,8 @@ http2.frametype is also a :ref:`multi-integer <multi-integers>`.
 
 http2.frametype does not have any corresponding log output.
 
+See ``suricata --list-keywords=json | jq '."http2.frametype".enum_values'``
+
 Examples::
 
   http2.frametype:GOAWAY;
@@ -39,6 +41,8 @@ Match on the error code in a GOWAY or RST_STREAM frame
 http2.errorcode uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
 http2.errorcode is also a :ref:`multi-integer <multi-integers>`.
+
+See ``suricata --list-keywords=json | jq '."http2.errorcode".enum_values'``
 
 Examples::
 

--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -73,6 +73,9 @@ have a string/meaning associated to it.
 Rules can be written using one of these strings to check for equality or inequality.
 This is meant to make rules more human-readable and equivalent for matching.
 
+Possible string values for a keyword can be found by running
+``suricata --list-keywords=json | jq '."keyword".enum_values'``
+
 Examples::
 
     websocket.opcode:text;

--- a/doc/userguide/rules/kerberos-keywords.rst
+++ b/doc/userguide/rules/kerberos-keywords.rst
@@ -9,6 +9,8 @@ It is possible to specify the following values defined in RFC4120:
 
 krb5_msg_type uses :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
+See ``suricata --list-keywords=json | jq '."krb5_msg_type".enum_values'``
+
 * 10 (AS-REQ)
 * 11 (AS-REP)
 * 12 (TGS-REQ)

--- a/doc/userguide/rules/ldap-keywords.rst
+++ b/doc/userguide/rules/ldap-keywords.rst
@@ -40,6 +40,8 @@ LDAP Request and Response operations
 The keywords ldap.request.operation and ldap.responses.operation
 accept both the operation code and the operation name as arguments.
 
+See ``suricata --list-keywords=json | jq '."ldap.request.operation".enum_values'``
+
 ldap.request.operation
 ----------------------
 
@@ -275,6 +277,8 @@ Syntax::
 ldap.responses.result_code uses :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
 ldap.responses.result_code is also a :ref:`multi-integer <multi-integers>`.
+
+See ``suricata --list-keywords=json | jq '."ldap.responses.result_code".enum_values'``
 
 This keyword maps to the following eve fields:
 

--- a/doc/userguide/rules/mqtt-keywords.rst
+++ b/doc/userguide/rules/mqtt-keywords.rst
@@ -44,6 +44,9 @@ Valid values are :
 * ``AUTH``
 * ``UNASSIGNED``
 
+See ``suricata --list-keywords=json | jq '."mqtt.type".enum_values'``
+
+
 where ``UNASSIGNED`` refers to message type code 0.
 
 mqtt.type uses an :ref:`unsigned 8-bits integer <rules-integer-keywords>`.

--- a/doc/userguide/rules/nfs-keywords.rst
+++ b/doc/userguide/rules/nfs-keywords.rst
@@ -29,6 +29,8 @@ It is also possible to specify the string values for NFSv3 or NFSv4 procedures.
 ``nfs_procedure: getattr`` will match like ``nfs_procedure: 1; nfs.version: <4;``
 or ``nfs_procedure: 9; nfs.version: >=4;``
 
+See ``suricata --list-keywords=json | jq '."nfs_procedure".enum_values'``
+
 Unlike the other keywords, the usage of range is inclusive.
 
 Syntax::

--- a/doc/userguide/rules/ntp-keywords.rst
+++ b/doc/userguide/rules/ntp-keywords.rst
@@ -11,6 +11,8 @@ names.
 
 ``ntp.mode`` uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
 
+See ``suricata --list-keywords=json | jq '."ntp.mode".enum_values'``
+
 Syntax::
 
   ntp.mode:[op]<number>

--- a/doc/userguide/rules/rfb-keywords.rst
+++ b/doc/userguide/rules/rfb-keywords.rst
@@ -27,6 +27,8 @@ Match on the value of the RFB security result, e.g. ``ok``, ``fail``, ``toomany`
 
 rfb.secresult uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
+See ``suricata --list-keywords=json | jq '."rfb.secresult".enum_values'``
+
 Examples::
 
   rfb.secresult: ok;

--- a/doc/userguide/rules/sctp-keywords.rst
+++ b/doc/userguide/rules/sctp-keywords.rst
@@ -104,6 +104,8 @@ shutdown_complete 14
 forward_tsn       192
 ================= =====
 
+See ``suricata --list-keywords=json | jq '."sctp.chunk_type".enum_values'``
+
 Named values are case-insensitive and can be negated with ``!``::
 
  sctp.chunk_type:init          # INIT chunk

--- a/doc/userguide/rules/snmp-keywords.rst
+++ b/doc/userguide/rules/snmp-keywords.rst
@@ -85,6 +85,8 @@ You can specify the value as an integer or a string:
  - 7: trap_v2
  - 8: report
 
+See ``suricata --list-keywords=json | jq '."snmp.pdu_type".enum_values'``
+
 This keyword will not match if the value is not accessible within (for ex, an encrypted
 SNMP v3 message).
 
@@ -113,6 +115,8 @@ You can specify the value as an integer or a string:
  - 4: authenticationfailure
  - 5: egpneighborloss
  - 6: enterprisespecific
+
+See ``suricata --list-keywords=json | jq '."snmp.trap_type".enum_values'``
 
 Syntax::
 

--- a/doc/userguide/rules/websocket-keywords.rst
+++ b/doc/userguide/rules/websocket-keywords.rst
@@ -56,6 +56,8 @@ It can also be specified by text from the enumeration
 
 websocket.opcode uses an :ref:`unsigned 8-bits integer <rules-integer-keywords>`
 
+See ``suricata --list-keywords=json | jq '."websocket.opcode".enum_values'``
+
 Examples::
 
   websocket.opcode:1;

--- a/rust/derive/src/stringenum.rs
+++ b/rust/derive/src/stringenum.rs
@@ -89,6 +89,7 @@ where
     let mut values = Vec::new();
     let mut names = Vec::new();
     let mut names_upper = Vec::new();
+    let mut names_lower = Vec::new();
     let mut fields = Vec::new();
 
     let mut enum_string_style = String::from("");
@@ -105,11 +106,13 @@ where
                     "UPPERCASE" => {
                         names.push(v.ident.to_string().to_ascii_uppercase());
                         names_upper.push(v.ident.to_string().to_ascii_uppercase());
+                        names_lower.push(v.ident.to_string().to_ascii_lowercase());
                     }
                     "LOG_UPPERCASE" => {
                         names.push(v.ident.to_string().to_ascii_uppercase());
                         let fname = transform_name(&v.ident.to_string());
                         let fnameu = fname.to_ascii_uppercase();
+                        names_lower.push(fnameu.to_ascii_lowercase());
                         names_upper.push(fnameu);
                     }
                     "" => {
@@ -117,6 +120,7 @@ where
                         let fname = transform_name(&v.ident.to_string());
                         let fnameu = fname.to_ascii_uppercase();
                         names.push(fname);
+                        names_lower.push(fnameu.to_ascii_lowercase());
                         names_upper.push(fnameu);
                     }
                     _ => {
@@ -179,6 +183,12 @@ where
                     #( #names_upper => Some(#name::#fields) ,)*
                     _ => None
                 }
+            }
+            fn list_values(jsb: &mut #crate_id::jsonbuilder::JsonBuilder) -> Result<(), #crate_id::jsonbuilder::JsonError> {
+                jsb.open_object("enum_values")?;
+                #( jsb.set_uint(#names_lower, #values as u64)?;)*
+                jsb.close()?;
+                Ok(())
             }
         }
     };

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -56,6 +56,13 @@ pub trait EnumString<T> {
     fn from_str(s: &str) -> Option<Self>
     where
         Self: Sized;
+
+    /// Get an enum variant from parsing a string.
+    fn list_values(
+        jsb: &mut crate::jsonbuilder::JsonBuilder,
+    ) -> Result<(), crate::jsonbuilder::JsonError>
+    where
+        Self: Sized;
 }
 
 pub use suricata_ffi::detect::{

--- a/rust/src/dnp3/detect.rs
+++ b/rust/src/dnp3/detect.rs
@@ -18,6 +18,9 @@
 use crate::detect::uint::{
     detect_parse_uint_bitflags, detect_parse_uint_enum, DetectBitflagModifier, DetectUintData,
 };
+use crate::detect::EnumString;
+use crate::jsonbuilder::JsonBuilder;
+use suricata_sys::sys::SCJsonBuilder;
 
 use std::ffi::CStr;
 
@@ -101,6 +104,12 @@ pub unsafe extern "C" fn SCDnp3DetectIndParse(
         }
     }
     return std::ptr::null_mut();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDnp3DetectFuncListValues(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = Dnp3Func::list_values(jsb);
 }
 
 #[no_mangle]

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -25,18 +25,20 @@ use crate::detect::uint::{
     SCDetectU8Free, SCDetectU8Parse,
 };
 use crate::detect::{
-    helper_keyword_register_multi_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
-    SIGMATCH_INFO_MULTI_UINT, SIGMATCH_INFO_UINT16, SIGMATCH_INFO_UINT8,
+    helper_keyword_register_multi_buffer, EnumString, SigTableElmtStickyBuffer,
+    SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_MULTI_UINT, SIGMATCH_INFO_UINT16, SIGMATCH_INFO_UINT8,
 };
 use crate::direction::Direction;
+use crate::jsonbuilder::JsonBuilder;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
     SCDetectHelperBufferProgressRegister, SCDetectHelperKeywordAliasRegister,
-    SCDetectHelperKeywordRegister, SCDetectHelperMultiBufferProgressMpmRegister,
-    SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx,
-    Signature, SIGMATCH_SUPPORT_FIREWALL,
+    SCDetectHelperKeywordJsonInfoRegister, SCDetectHelperKeywordRegister,
+    SCDetectHelperMultiBufferProgressMpmRegister, SCDetectSignatureSetAppProto, SCJsonBuilder,
+    SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+    SIGMATCH_SUPPORT_FIREWALL,
 };
 
 /// Perform the DNS opcode match.
@@ -355,6 +357,16 @@ unsafe extern "C" fn dns_detect_query_setup(
     return 0;
 }
 
+unsafe extern "C" fn dns_rcode_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = DNSRcode::list_values(jsb);
+}
+
+unsafe extern "C" fn dns_rrtype_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = DNSRecordType::list_values(jsb);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectDNSRegister() {
     let kw = SigTableElmtStickyBuffer {
@@ -417,6 +429,8 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         flags: SIGMATCH_INFO_UINT16 | SIGMATCH_INFO_ENUM_UINT,
     };
     G_DNS_RCODE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(G_DNS_RCODE_KW_ID, Some(dns_rcode_list_values));
+
     G_DNS_RCODE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"dns.rcode\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,
@@ -433,6 +447,7 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         flags: SIGMATCH_INFO_UINT16 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT,
     };
     G_DNS_RRTYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(G_DNS_RRTYPE_KW_ID, Some(dns_rrtype_list_values));
     G_DNS_RRTYPE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"dns.rrtype\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -38,14 +38,17 @@ use crate::detect::uint::{
     SCDetectU32Parse, SCDetectU8Free, SCDetectU8Match, SCDetectU8Parse,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
-    SIGMATCH_INFO_MULTI_UINT, SIGMATCH_INFO_UINT16, SIGMATCH_INFO_UINT32, SIGMATCH_INFO_UINT8,
+    helper_keyword_register_sticky_buffer, EnumString, SigTableElmtStickyBuffer,
+    SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_MULTI_UINT, SIGMATCH_INFO_UINT16, SIGMATCH_INFO_UINT32,
+    SIGMATCH_INFO_UINT8,
 };
+use crate::jsonbuilder::JsonBuilder;
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
     SCDetectHelperBufferMpmRegister, SCDetectHelperBufferProgressRegister,
-    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
-    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+    SCDetectHelperKeywordJsonInfoRegister, SCDetectHelperKeywordRegister,
+    SCDetectSignatureSetAppProto, SCJsonBuilder, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt,
+    SigMatchCtx, Signature,
 };
 
 use crate::direction::Direction;
@@ -1378,6 +1381,16 @@ unsafe extern "C" fn service_name_get_data(
     return false;
 }
 
+unsafe extern "C" fn enip_status_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = EnipStatus::list_values(jsb);
+}
+
+unsafe extern "C" fn enip_command_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = EnipCommand::list_values(jsb);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectEnipRegister() {
     let kw = SCSigTableAppLiteElmt {
@@ -1471,6 +1484,8 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: SIGMATCH_INFO_UINT32 | SIGMATCH_INFO_ENUM_UINT,
     };
     G_ENIP_STATUS_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(G_ENIP_STATUS_KW_ID, Some(enip_status_list_values));
+
     G_ENIP_STATUS_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"enip.status\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
@@ -1567,6 +1582,8 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: SIGMATCH_INFO_UINT16 | SIGMATCH_INFO_ENUM_UINT,
     };
     G_ENIP_COMMAND_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(G_ENIP_COMMAND_KW_ID, Some(enip_command_list_values));
+
     G_ENIP_COMMAND_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"enip.command\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -24,8 +24,8 @@ use crate::detect::uint::{
     DetectUintArrayData, DetectUintData, DetectUintIndex, DetectUintMode,
 };
 use crate::detect::{DetectThreadBuf, EnumString};
-use crate::jsonbuilder::JsonBuilder;
 use crate::direction::Direction;
+use crate::jsonbuilder::JsonBuilder;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use std::ffi::CStr;
 use std::os::raw::c_void;

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -24,12 +24,13 @@ use crate::detect::uint::{
     DetectUintArrayData, DetectUintData, DetectUintIndex, DetectUintMode,
 };
 use crate::detect::{DetectThreadBuf, EnumString};
+use crate::jsonbuilder::JsonBuilder;
 use crate::direction::Direction;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use std::ffi::CStr;
 use std::os::raw::c_void;
 use std::rc::Rc;
-use suricata_sys::sys::DetectEngineThreadCtx;
+use suricata_sys::sys::{DetectEngineThreadCtx, SCJsonBuilder};
 
 #[no_mangle]
 pub unsafe extern "C" fn SCHttp2TxHasFrametype(
@@ -1156,4 +1157,16 @@ mod tests {
             }
         }
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectHTTP2frameTypeListValues(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = parser::HTTP2FrameType::list_values(jsb);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectHTTP2errorcodeListValues(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = parser::HTTP2ErrorCode::list_values(jsb);
 }

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -22,9 +22,9 @@ use suricata_sys::sys::AppProtoEnum::ALPROTO_KRB5;
 use suricata_sys::sys::{
     AppProto, DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
     SCDetectHelperBufferProgressRegister, SCDetectHelperKeywordAliasRegister,
-    SCDetectHelperKeywordRegister, SCDetectHelperMultiBufferProgressMpmRegister,
-    SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx,
-    Signature,
+    SCDetectHelperKeywordJsonInfoRegister, SCDetectHelperKeywordRegister,
+    SCDetectHelperMultiBufferProgressMpmRegister, SCDetectSignatureSetAppProto, SCJsonBuilder,
+    SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx, Signature,
 };
 
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
@@ -32,9 +32,10 @@ use crate::detect::uint::{
     detect_parse_uint, detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Match,
 };
 use crate::detect::{
-    helper_keyword_register_multi_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
-    SIGMATCH_INFO_UINT32,
+    helper_keyword_register_multi_buffer, EnumString, SigTableElmtStickyBuffer,
+    SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT32,
 };
+use crate::jsonbuilder::JsonBuilder;
 use kerberos_parser::krb5::EncryptionType;
 
 use nom8::branch::alt;
@@ -528,6 +529,11 @@ unsafe extern "C" fn krb5_ticket_encryption_free(_de: *mut DetectEngineCtx, ctx:
     std::mem::drop(Box::from_raw(ctx));
 }
 
+unsafe extern "C" fn krb5_msg_type_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = Krb5MessageType::list_values(jsb);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectKrb5Register() {
     let kw = SCSigTableAppLiteElmt {
@@ -540,6 +546,8 @@ pub unsafe extern "C" fn SCDetectKrb5Register() {
         flags: SIGMATCH_INFO_ENUM_UINT | SIGMATCH_INFO_UINT32,
     };
     G_KRB5_MSG_TYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(G_KRB5_MSG_TYPE_KW_ID, Some(krb5_msg_type_list_values));
+
     G_KRB5_GENERIC_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"krb5_generic\0".as_ptr() as *const libc::c_char,
         ALPROTO_KRB5 as AppProto,

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -23,18 +23,19 @@ use crate::detect::uint::{
     SCDetectU32Parse, SCDetectU8Free,
 };
 use crate::detect::{
-    helper_keyword_register_multi_buffer, helper_keyword_register_sticky_buffer,
+    helper_keyword_register_multi_buffer, helper_keyword_register_sticky_buffer, EnumString,
     SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_MULTI_UINT,
     SIGMATCH_INFO_UINT32, SIGMATCH_INFO_UINT8,
 };
+use crate::jsonbuilder::JsonBuilder;
 use crate::ldap::types::*;
 use ldap_parser::ldap::{LdapMessage, ProtocolOp};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
     SCDetectHelperBufferMpmRegister, SCDetectHelperBufferProgressRegister,
-    SCDetectHelperKeywordRegister, SCDetectHelperMultiBufferMpmRegister,
-    SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx,
-    Signature,
+    SCDetectHelperKeywordJsonInfoRegister, SCDetectHelperKeywordRegister,
+    SCDetectHelperMultiBufferMpmRegister, SCDetectSignatureSetAppProto, SCJsonBuilder,
+    SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx, Signature,
 };
 
 use std::ffi::CStr;
@@ -512,6 +513,16 @@ unsafe extern "C" fn ldap_tx_get_resp_attribute_type(
     return false;
 }
 
+unsafe extern "C" fn ldap_operation_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = ProtocolOpCode::list_values(jsb);
+}
+
+unsafe extern "C" fn ldap_result_code_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = LdapResultCode::list_values(jsb);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectLdapRegister() {
     let kw = SCSigTableAppLiteElmt {
@@ -524,6 +535,11 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_ENUM_UINT,
     };
     G_LDAP_REQUEST_OPERATION_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(
+        G_LDAP_REQUEST_OPERATION_KW_ID,
+        Some(ldap_operation_list_values),
+    );
+
     G_LDAP_REQUEST_OPERATION_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"ldap.request.operation\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
@@ -541,6 +557,11 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT,
     };
     G_LDAP_RESPONSES_OPERATION_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(
+        G_LDAP_RESPONSES_OPERATION_KW_ID,
+        Some(ldap_operation_list_values),
+    );
+
     G_LDAP_RESPONSES_OPERATION_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"ldap.responses.operation\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
@@ -602,6 +623,11 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         flags: SIGMATCH_INFO_UINT32 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT,
     };
     G_LDAP_RESPONSES_RESULT_CODE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(
+        G_LDAP_RESPONSES_RESULT_CODE_KW_ID,
+        Some(ldap_result_code_list_values),
+    );
+
     G_LDAP_RESPONSES_RESULT_CODE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"ldap.responses.result_code\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -24,16 +24,17 @@ use crate::detect::uint::{
     DetectUintIndex, SCDetectU8ArrayFree, SCDetectU8ArrayParse, SCDetectU8Free, SCDetectU8Parse,
 };
 use crate::detect::{
-    helper_keyword_register_multi_buffer, helper_keyword_register_sticky_buffer,
+    helper_keyword_register_multi_buffer, helper_keyword_register_sticky_buffer, EnumString,
     SigTableElmtStickyBuffer, SIGMATCH_INFO_BITFLAGS_UINT, SIGMATCH_INFO_ENUM_UINT,
     SIGMATCH_INFO_MULTI_UINT, SIGMATCH_INFO_UINT8,
 };
+use crate::jsonbuilder::JsonBuilder;
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
     SCDetectHelperBufferMpmRegister, SCDetectHelperBufferProgressRegister,
-    SCDetectHelperKeywordRegister, SCDetectHelperMultiBufferMpmRegister,
-    SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx,
-    Signature,
+    SCDetectHelperKeywordJsonInfoRegister, SCDetectHelperKeywordRegister,
+    SCDetectHelperMultiBufferMpmRegister, SCDetectSignatureSetAppProto, SCJsonBuilder,
+    SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx, Signature,
 };
 
 use super::mqtt::{MQTTState, MQTTTransaction, ALPROTO_MQTT};
@@ -906,6 +907,11 @@ unsafe extern "C" fn mqtt_conn_clientid_setup(
     return 0;
 }
 
+unsafe extern "C" fn mqtt_type_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = MQTTTypeCode::list_values(jsb);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectMqttRegister() {
     let keyword_name = b"mqtt.unsubscribe.topic\0".as_ptr() as *const libc::c_char;
@@ -941,6 +947,8 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT,
     };
     G_MQTT_TYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(G_MQTT_TYPE_KW_ID, Some(mqtt_type_list_values));
+
     G_MQTT_TYPE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"mqtt.type\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,

--- a/rust/src/nfs/detect.rs
+++ b/rust/src/nfs/detect.rs
@@ -17,11 +17,13 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
+use crate::jsonbuilder::JsonBuilder;
 use suricata_sys::sys::AppProtoEnum::ALPROTO_NFS;
 use suricata_sys::sys::{
     AppProto, DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectHelperBufferProgressRegister,
-    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
-    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+    SCDetectHelperKeywordJsonInfoRegister, SCDetectHelperKeywordRegister,
+    SCDetectSignatureSetAppProto, SCJsonBuilder, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt,
+    SigMatchCtx, Signature,
 };
 
 use super::nfs::{NFSTransaction, NFSTransactionTypeData};
@@ -30,7 +32,7 @@ use crate::core::STREAM_TOSERVER;
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, detect_parse_uint_inclusive, DetectUintData,
 };
-use crate::detect::{SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT32};
+use crate::detect::{EnumString, SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT32};
 
 use std::ffi::{c_int, CStr};
 use std::os::raw::c_void;
@@ -159,6 +161,21 @@ unsafe extern "C" fn nfs_procedure_free(_de: *mut DetectEngineCtx, ctx: *mut c_v
     std::mem::drop(Box::from_raw(ctx));
 }
 
+unsafe extern "C" fn nfs_procedure_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = jsb.open_object("enum_values");
+    let _ = jsb.open_object("v2");
+    let _ = NfsProc2::list_values(jsb);
+    let _ = jsb.close();
+    let _ = jsb.open_object("v3");
+    let _ = NfsProc3::list_values(jsb);
+    let _ = jsb.close();
+    let _ = jsb.open_object("v4");
+    let _ = NfsProc4::list_values(jsb);
+    let _ = jsb.close();
+    let _ = jsb.close();
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectNfsProcedureRegister() {
     let kw = SCSigTableAppLiteElmt {
@@ -171,6 +188,7 @@ pub unsafe extern "C" fn SCDetectNfsProcedureRegister() {
         flags: SIGMATCH_INFO_UINT32 | SIGMATCH_INFO_ENUM_UINT,
     };
     G_NFS_PROCEDURE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(G_NFS_PROCEDURE_KW_ID, Some(nfs_procedure_list_values));
     G_NFS_PROCEDURE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"nfs_procedure\0".as_ptr() as *const libc::c_char,
         ALPROTO_NFS as AppProto,

--- a/rust/src/ntp/detect.rs
+++ b/rust/src/ntp/detect.rs
@@ -21,16 +21,18 @@ use crate::detect::uint::{
     detect_parse_uint_enum, DetectUintData, SCDetectU8Free, SCDetectU8Match, SCDetectU8Parse,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
-    SIGMATCH_INFO_UINT8, SIGMATCH_SUPPORT_FIREWALL,
+    helper_keyword_register_sticky_buffer, EnumString, SigTableElmtStickyBuffer,
+    SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT8, SIGMATCH_SUPPORT_FIREWALL,
 };
+use crate::jsonbuilder::JsonBuilder;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
     SCDetectHelperBufferProgressMpmRegister, SCDetectHelperBufferProgressRegister,
-    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
-    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+    SCDetectHelperKeywordJsonInfoRegister, SCDetectHelperKeywordRegister,
+    SCDetectSignatureSetAppProto, SCJsonBuilder, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt,
+    SigMatchCtx, Signature,
 };
 
 static mut G_NTP_VERSION_KW_ID: u16 = 0;
@@ -191,6 +193,11 @@ unsafe extern "C" fn ntp_detect_reference_id_get_data(
     true
 }
 
+unsafe extern "C" fn ntp_mode_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = NTPMode::list_values(jsb);
+}
+
 pub(super) unsafe extern "C" fn detect_ntp_register() {
     let kw = SCSigTableAppLiteElmt {
         name: b"ntp.version\0".as_ptr() as *const libc::c_char,
@@ -219,6 +226,7 @@ pub(super) unsafe extern "C" fn detect_ntp_register() {
         flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_ENUM_UINT | SIGMATCH_SUPPORT_FIREWALL,
     };
     G_NTP_MODE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(G_NTP_MODE_KW_ID, Some(ntp_mode_list_values));
 
     let kw = SCSigTableAppLiteElmt {
         name: b"ntp.stratum\0".as_ptr() as *const libc::c_char,

--- a/rust/src/rfb/detect.rs
+++ b/rust/src/rfb/detect.rs
@@ -24,17 +24,19 @@ use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Parse,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
-    SIGMATCH_INFO_UINT32,
+    helper_keyword_register_sticky_buffer, EnumString, SigTableElmtStickyBuffer,
+    SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT32,
 };
+use crate::jsonbuilder::JsonBuilder;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use std::ptr;
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
     SCDetectHelperBufferMpmRegister, SCDetectHelperBufferProgressRegister,
-    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
-    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+    SCDetectHelperKeywordJsonInfoRegister, SCDetectHelperKeywordRegister,
+    SCDetectSignatureSetAppProto, SCJsonBuilder, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt,
+    SigMatchCtx, Signature,
 };
 
 unsafe extern "C" fn rfb_name_get(
@@ -183,6 +185,11 @@ unsafe extern "C" fn rfb_sec_result_free(_de: *mut DetectEngineCtx, ctx: *mut c_
     SCDetectU32Free(ctx);
 }
 
+unsafe extern "C" fn rfb_sec_result_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = RFBSecurityResultStatus::list_values(jsb);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectRfbRegister() {
     let kw = SigTableElmtStickyBuffer {
@@ -225,6 +232,8 @@ pub unsafe extern "C" fn SCDetectRfbRegister() {
         flags: SIGMATCH_INFO_UINT32 | SIGMATCH_INFO_ENUM_UINT,
     };
     G_RFB_SEC_RESULT_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(G_RFB_SEC_RESULT_KW_ID, Some(rfb_sec_result_list_values));
+
     G_RFB_SEC_RESULT_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"rfb.secresult\0".as_ptr() as *const libc::c_char,
         ALPROTO_RFB,

--- a/rust/src/sctp/detect.rs
+++ b/rust/src/sctp/detect.rs
@@ -18,6 +18,9 @@
 // Author: Giuseppe Longo <glongo@oisf.net>
 
 use crate::detect::uint::{detect_parse_uint_enum, DetectUintData};
+use crate::detect::EnumString;
+use crate::jsonbuilder::JsonBuilder;
+use suricata_sys::sys::SCJsonBuilder;
 
 use std::ffi::CStr;
 
@@ -80,6 +83,12 @@ pub extern "C" fn SCSctpChunkTypeToString(val: u8) -> *const std::os::raw::c_cha
         _ => return std::ptr::null(),
     };
     s.as_ptr() as *const std::os::raw::c_char
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectSCTPChunkTypeListValues(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = SctpChunkType::list_values(jsb);
 }
 
 #[cfg(test)]

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -24,21 +24,23 @@ use crate::detect::uint::{
     SCDetectU8Free, SCDetectU8Match,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectThreadBuf, SCDetectThreadBufDataFree,
+    helper_keyword_register_sticky_buffer, DetectThreadBuf, EnumString, SCDetectThreadBufDataFree,
     SCDetectThreadBufDataInit, SigTableElmtStickyBuffer, SIGMATCH_INFO_ENUM_UINT,
     SIGMATCH_INFO_UINT32, SIGMATCH_INFO_UINT8, SIGMATCH_SUPPORT_FIREWALL,
 };
+use crate::jsonbuilder::JsonBuilder;
 use snmp_parser::NetworkAddress;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, DetectEngineTransforms, Flow, InspectionBuffer,
     SCDetectBufferSetActiveList, SCDetectHelperBufferProgressMpmRegister,
-    SCDetectHelperBufferProgressRegister, SCDetectHelperKeywordRegister,
-    SCDetectRegisterMpmGeneric, SCDetectRegisterThreadCtxGlobalFuncs, SCDetectSignatureSetAppProto,
+    SCDetectHelperBufferProgressRegister, SCDetectHelperKeywordJsonInfoRegister,
+    SCDetectHelperKeywordRegister, SCDetectRegisterMpmGeneric,
+    SCDetectRegisterThreadCtxGlobalFuncs, SCDetectSignatureSetAppProto,
     SCDetectThreadCtxGetGlobalKeywordThreadCtx, SCInspectionBufferGet,
-    SCInspectionBufferSetupAndApplyTransforms, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt,
-    SigMatchCtx, Signature,
+    SCInspectionBufferSetupAndApplyTransforms, SCJsonBuilder, SCSigMatchAppendSMToList,
+    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
 };
 
 static mut G_SNMP_VERSION_KW_ID: u16 = 0;
@@ -349,6 +351,16 @@ unsafe extern "C" fn snmp_detect_trapaddress_get_data(
     return buffer;
 }
 
+unsafe extern "C" fn snmp_detect_pdutype_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = SnmpPduType::list_values(jsb);
+}
+
+unsafe extern "C" fn snmp_detect_traptype_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = SnmpTrapType::list_values(jsb);
+}
+
 pub(super) unsafe extern "C" fn detect_snmp_register() {
     G_SNMP_GENERIC_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"snmp.generic\0".as_ptr() as *const libc::c_char,
@@ -377,6 +389,10 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         flags: SIGMATCH_INFO_UINT32 | SIGMATCH_INFO_ENUM_UINT | SIGMATCH_SUPPORT_FIREWALL,
     };
     G_SNMP_PDUTYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(
+        G_SNMP_PDUTYPE_KW_ID,
+        Some(snmp_detect_pdutype_list_values),
+    );
 
     let kw = SigTableElmtStickyBuffer {
         name: String::from("snmp.usm"),
@@ -420,6 +436,10 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_ENUM_UINT | SIGMATCH_SUPPORT_FIREWALL,
     };
     G_SNMP_TRAPTYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(
+        G_SNMP_TRAPTYPE_KW_ID,
+        Some(snmp_detect_traptype_list_values),
+    );
 
     let kw = SigTableElmtStickyBuffer {
         name: String::from("snmp.trap_oid"),

--- a/rust/src/websocket/detect.rs
+++ b/rust/src/websocket/detect.rs
@@ -22,15 +22,18 @@ use crate::detect::uint::{
     SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse, SCDetectU8Free, SCDetectU8Match,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_BITFLAGS_UINT,
-    SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT32, SIGMATCH_INFO_UINT8,
+    helper_keyword_register_sticky_buffer, EnumString, SigTableElmtStickyBuffer,
+    SIGMATCH_INFO_BITFLAGS_UINT, SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT32,
+    SIGMATCH_INFO_UINT8,
 };
+use crate::jsonbuilder::JsonBuilder;
 use crate::websocket::parser::WebSocketOpcode;
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
     SCDetectHelperBufferMpmRegister, SCDetectHelperBufferProgressRegister,
-    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
-    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+    SCDetectHelperKeywordJsonInfoRegister, SCDetectHelperKeywordRegister,
+    SCDetectSignatureSetAppProto, SCJsonBuilder, SCSigMatchAppendSMToList, SCSigTableAppLiteElmt,
+    SigMatchCtx, Signature,
 };
 
 use std::ffi::CStr;
@@ -223,6 +226,11 @@ pub unsafe extern "C" fn websocket_detect_payload_get_data(
     return true;
 }
 
+unsafe extern "C" fn websocket_opcode_list_values(jsb: *mut SCJsonBuilder) {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let _ = WebSocketOpcode::list_values(jsb);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectWebsocketRegister() {
     let kw = SCSigTableAppLiteElmt {
@@ -235,6 +243,10 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
         flags: SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_ENUM_UINT,
     };
     G_WEBSOCKET_OPCODE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordJsonInfoRegister(
+        G_WEBSOCKET_OPCODE_KW_ID,
+        Some(websocket_opcode_list_values),
+    );
     G_WEBSOCKET_OPCODE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"websocket.opcode\0".as_ptr() as *const libc::c_char,
         ALPROTO_WEBSOCKET,

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -884,6 +884,11 @@ extern "C" {
     pub fn SCDetectHelperKeywordAliasRegister(kwid: u16, alias: *const ::std::os::raw::c_char);
 }
 extern "C" {
+    pub fn SCDetectHelperKeywordJsonInfoRegister(
+        kwid: u16, cb: ::std::option::Option<unsafe extern "C" fn(arg1: *mut SCJsonBuilder)>,
+    );
+}
+extern "C" {
     pub fn SCDetectHelperBufferProgressRegister(
         name: *const ::std::os::raw::c_char, alproto: AppProto, direction: u8, progress: u8,
     ) -> ::std::os::raw::c_int;

--- a/scripts/check-enum-uint-keywords.py
+++ b/scripts/check-enum-uint-keywords.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Check that each Suricata keyword with the feature "enum uint" has an
+"enum_values" object in --list-keywords=json output.
+
+Usage:
+    python3 scripts/check-enum-uint-keywords.py [--suricata-bin PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Optional
+
+
+def resolve_suricata_bin(repo_root: Path, configured: Optional[str]) -> Path:
+    if configured:
+        return Path(configured)
+
+    in_path = shutil.which("suricata")
+    if in_path:
+        return Path(in_path)
+
+    candidates = [repo_root / "src" / "suricata", repo_root / "suricata"]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    raise SystemExit(
+        "Unable to find Suricata binary. Use --suricata-bin to provide it."
+    )
+
+
+def list_keywords_json(suricata_bin: Path) -> list[dict[str, Any]]:
+    """Return keyword objects from --list-keywords=json output."""
+    proc = subprocess.run(
+        [str(suricata_bin), "--list-keywords=json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = proc.stdout.strip()
+    if not payload:
+        payload = proc.stderr.strip()
+
+    if not payload:
+        raise SystemExit("No output from suricata --list-keywords=json")
+
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Failed to parse JSON output: {exc}") from exc
+
+    r = []
+    for keyword in data:
+        obj = data[keyword]
+        obj["name"] = keyword
+        r.append(obj)
+
+    return r
+
+
+def has_enum_uint_feature(keyword_obj: dict[str, Any]) -> bool:
+    feature_fields = []
+    if "features" in keyword_obj:
+        for feature in keyword_obj["features"]:
+            if feature == "enum uint":
+                return True
+
+    return False
+
+
+def keyword_name(keyword_obj: dict[str, Any]) -> str:
+    for key in ("name", "keyword"):
+        value = keyword_obj.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return "<unknown>"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check enum-uint keywords expose enum_values object in "
+            "--list-keywords=json output."
+        )
+    )
+    parser.add_argument(
+        "--suricata-bin",
+        default=None,
+        help="Path to Suricata binary (default: auto-detect)",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    suricata_bin = resolve_suricata_bin(repo_root, args.suricata_bin)
+    keyword_objects = list_keywords_json(suricata_bin)
+
+    candidates = [obj for obj in keyword_objects if has_enum_uint_feature(obj)]
+
+    if not candidates:
+        print('No keywords found with feature "enum uint".')
+        return 0
+
+    failures: list[str] = []
+    print(f"Checking {len(candidates)} keyword(s) with feature 'enum uint'...\n")
+
+    for obj in candidates:
+        name = keyword_name(obj)
+        enum_values = obj.get("enum_values")
+        ok = isinstance(enum_values, dict)
+        print(f"  [{'OK' if ok else 'FAIL'}] {name}")
+        if not ok:
+            failures.append(name)
+
+    if failures:
+        print(f"\n{len(failures)} keyword(s) missing enum_values object:\n")
+        for name in failures:
+            print(f"  - {name}")
+        return 1
+
+    print("\nAll checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -268,6 +268,11 @@ static int DetectDNP3IndMatch(DetectEngineThreadCtx *det_ctx,
     return DetectU16Match((uint16_t)((tx->iin.iin1 << 8) | tx->iin.iin2), detect);
 }
 
+static void DetectDNP3FuncListValues(SCJsonBuilder *jsb)
+{
+    SCDnp3DetectFuncListValues(jsb);
+}
+
 static void DetectDNP3FuncRegister(void)
 {
     SCEnter();
@@ -282,6 +287,7 @@ static void DetectDNP3FuncRegister(void)
     sigmatch_table[DETECT_DNP3FUNC].Setup = DetectDNP3FuncSetup;
     sigmatch_table[DETECT_DNP3FUNC].Free = DetectDNP3FuncFree;
     sigmatch_table[DETECT_DNP3FUNC].flags = SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_ENUM_UINT;
+    sigmatch_table[DETECT_DNP3FUNC].JsonAdditionalInfo = DetectDNP3FuncListValues;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_DNP3FUNC].RegisterTests = DetectDNP3FuncRegisterTests;
 #endif

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -166,6 +166,11 @@ void SCDetectHelperKeywordAliasRegister(uint16_t kwid, const char *alias)
     sigmatch_table[kwid].alias = alias;
 }
 
+void SCDetectHelperKeywordJsonInfoRegister(uint16_t kwid, void (*cb)(struct SCJsonBuilder *))
+{
+    sigmatch_table[kwid].JsonAdditionalInfo = cb;
+}
+
 int SCDetectHelperTransformRegister(const SCTransformTableElmt *kw)
 {
     int transform_id = SCDetectHelperNewKeywordId();

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -80,6 +80,8 @@ int SCDetectHelperNewKeywordId(void);
 
 uint16_t SCDetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw);
 void SCDetectHelperKeywordAliasRegister(uint16_t kwid, const char *alias);
+typedef struct SCJsonBuilder SCJsonBuilder;
+void SCDetectHelperKeywordJsonInfoRegister(uint16_t kwid, void (*cb)(struct SCJsonBuilder *));
 int SCDetectHelperBufferProgressRegister(
         const char *name, AppProto alproto, uint8_t direction, uint8_t progress);
 

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -461,6 +461,9 @@ static void SigJsonPrint(void)
         }
         SCJbClose(js);
 
+        if (sigmatch_table[i].JsonAdditionalInfo) {
+            sigmatch_table[i].JsonAdditionalInfo(js);
+        }
         SCJbClose(js); // SCJbOpenObject keyword name
     }
 

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -377,6 +377,98 @@ static void SigMultilinePrint(size_t i, const char *prefix)
     printf("\n");
 }
 
+static void SigJsonPrint(void)
+{
+    SCJsonBuilder *js = SCJbNewObject();
+    if (unlikely(js == NULL)) {
+        return;
+    }
+
+    for (size_t i = 0; i < (size_t)DETECT_TBLSIZE; i++) {
+        if (sigmatch_table[i].name == NULL)
+            continue;
+        // do not show __flowvar__postmatch__ and such
+        if (sigmatch_table[i].name[0] == '_')
+            continue;
+
+        SCJbOpenObject(js, sigmatch_table[i].name);
+        if (sigmatch_table[i].desc) {
+            SCJbSetString(js, "description", sigmatch_table[i].desc);
+        }
+        if (sigmatch_table[i].url) {
+            char urldoc[2048];
+            snprintf(urldoc, sizeof(urldoc), "%s%s", GetDocURL(), sigmatch_table[i].url);
+            SCJbSetString(js, "doc", urldoc);
+        }
+        if (sigmatch_table[i].alternative) {
+            SCJbSetString(js, "alternative", sigmatch_table[sigmatch_table[i].alternative].name);
+        }
+        if (sigmatch_table[i].alias) {
+            SCJbSetString(js, "alias", sigmatch_table[i].alias);
+        }
+        SCJbOpenArray(js, "features");
+
+        const uint32_t flags = sigmatch_table[i].flags;
+        if (flags & SIGMATCH_NOOPT) {
+            SCJbAppendString(js, "No option");
+        }
+        if (flags & SIGMATCH_IPONLY_COMPAT) {
+            SCJbAppendString(js, "compatible with IP only rule");
+        }
+        if (flags & SIGMATCH_DEONLY_COMPAT) {
+            SCJbAppendString(js, "compatible with decoder event only rule");
+        }
+        if (flags & SIGMATCH_INFO_CONTENT_MODIFIER) {
+            SCJbAppendString(js, "content modifier");
+        }
+        if (flags & SIGMATCH_INFO_STICKY_BUFFER) {
+            SCJbAppendString(js, "sticky buffer");
+        }
+        if (flags & SIGMATCH_SUPPORT_FIREWALL) {
+            SCJbAppendString(js, "supports firewall");
+        }
+        if (flags & SIGMATCH_INFO_MULTI_BUFFER) {
+            SCJbAppendString(js, "multi buffer");
+        }
+        if (flags & (SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_UINT16 | SIGMATCH_INFO_UINT32 |
+                            SIGMATCH_INFO_UINT64)) {
+            if (flags & SIGMATCH_INFO_MULTI_UINT)
+                SCJbAppendString(js, "multi uint");
+            if (flags & SIGMATCH_INFO_ENUM_UINT)
+                SCJbAppendString(js, "enum uint");
+            if (flags & SIGMATCH_INFO_BITFLAGS_UINT)
+                SCJbAppendString(js, "bitflags");
+            if (flags & SIGMATCH_INFO_UINT8)
+                SCJbAppendString(js, "uint8");
+            if (flags & SIGMATCH_INFO_UINT16)
+                SCJbAppendString(js, "uint16");
+            if (flags & SIGMATCH_INFO_UINT32)
+                SCJbAppendString(js, "uint32");
+            if (flags & SIGMATCH_INFO_UINT64)
+                SCJbAppendString(js, "uint64");
+        }
+        if (flags & SIGMATCH_BAN_FIREWALL_RULE) {
+            SCJbAppendString(js, "banned from firewall rules");
+        }
+        if (flags & SIGMATCH_BAN_FIREWALL_MODE) {
+            SCJbAppendString(js, "banned from firewall mode");
+        }
+        if (sigmatch_table[i].Transform) {
+            SCJbAppendString(js, "transform");
+        }
+        if (sigmatch_table[i].SupportsPrefilter) {
+            SCJbAppendString(js, "prefilter");
+        }
+        SCJbClose(js);
+
+        SCJbClose(js); // SCJbOpenObject keyword name
+    }
+
+    SCJbClose(js);
+    fwrite(SCJbPtr(js), SCJbLen(js), 1, stdout);
+    SCJbFree(js);
+}
+
 /** \brief Check if a keyword exists. */
 bool SCSigTableHasKeyword(const char *keyword)
 {
@@ -444,6 +536,9 @@ int SigTableList(const char *keyword)
                 SigMultilinePrint(i, "\t");
             }
         }
+    } else if (strcmp("json", keyword) == 0) {
+        SigJsonPrint();
+        return TM_ECODE_DONE;
     } else {
         for (i = 0; i < size; i++) {
             if ((sigmatch_table[i].name != NULL) &&

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -97,6 +97,16 @@ static int g_http2_match_buffer_id = 0;
 static int g_http2_complete_buffer_id = 0;
 static int g_http2_header_buffer_id = 0;
 
+static void DetectHTTP2frameTypeListValues(SCJsonBuilder *jsb)
+{
+    SCDetectHTTP2frameTypeListValues(jsb);
+}
+
+static void DetectHTTP2errorcodeListValues(SCJsonBuilder *jsb)
+{
+    SCDetectHTTP2errorcodeListValues(jsb);
+}
+
 /**
  * \brief Registration function for HTTP2 keywords
  */
@@ -112,6 +122,7 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_FRAMETYPE].Free = DetectHTTP2frametypeFree;
     sigmatch_table[DETECT_HTTP2_FRAMETYPE].flags =
             SIGMATCH_INFO_UINT8 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT;
+    sigmatch_table[DETECT_HTTP2_FRAMETYPE].JsonAdditionalInfo = DetectHTTP2frameTypeListValues;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_HTTP2_FRAMETYPE].RegisterTests = DetectHTTP2frameTypeRegisterTests;
 #endif
@@ -125,6 +136,7 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_ERRORCODE].Free = DetectHTTP2errorcodeFree;
     sigmatch_table[DETECT_HTTP2_ERRORCODE].flags =
             SIGMATCH_INFO_UINT32 | SIGMATCH_INFO_MULTI_UINT | SIGMATCH_INFO_ENUM_UINT;
+    sigmatch_table[DETECT_HTTP2_ERRORCODE].JsonAdditionalInfo = DetectHTTP2errorcodeListValues;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_HTTP2_ERRORCODE].RegisterTests = DetectHTTP2errorCodeRegisterTests;
 #endif

--- a/src/detect-sctp-chunk-type.c
+++ b/src/detect-sctp-chunk-type.c
@@ -45,6 +45,11 @@ void DetectSCTPChunkTypeFree(DetectEngineCtx *, void *);
 static int PrefilterSetupSCTPChunkType(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 static bool PrefilterSCTPChunkTypeIsPrefilterable(const Signature *s);
 
+static void DetectSCTPChunkTypeListValues(SCJsonBuilder *jsb)
+{
+    SCDetectSCTPChunkTypeListValues(jsb);
+}
+
 void DetectSCTPChunkTypeRegister(void)
 {
     sigmatch_table[DETECT_SCTP_CHUNK_TYPE].name = "sctp.chunk_type";
@@ -57,6 +62,7 @@ void DetectSCTPChunkTypeRegister(void)
     sigmatch_table[DETECT_SCTP_CHUNK_TYPE].SupportsPrefilter =
             PrefilterSCTPChunkTypeIsPrefilterable;
     sigmatch_table[DETECT_SCTP_CHUNK_TYPE].SetupPrefilter = PrefilterSetupSCTPChunkType;
+    sigmatch_table[DETECT_SCTP_CHUNK_TYPE].JsonAdditionalInfo = DetectSCTPChunkTypeListValues;
 }
 
 static int DetectSCTPChunkTypeMatch(

--- a/src/detect.h
+++ b/src/detect.h
@@ -1464,6 +1464,9 @@ typedef struct DetectEngineThreadCtx_ {
 #endif
 } DetectEngineThreadCtx;
 
+// forward declaration
+typedef struct SCJsonBuilder SCJsonBuilder;
+
 /** \brief element in sigmatch type table.
  */
 typedef struct SigTableElmt_ {
@@ -1513,6 +1516,9 @@ typedef struct SigTableElmt_ {
 
     // Cleanup function for freeing rust allocated name or such
     void (*Cleanup)(struct SigTableElmt_ *);
+
+    // Cleanup function for freeing rust allocated name or such
+    void (*JsonAdditionalInfo)(struct SCJsonBuilder *);
 } SigTableElmt;
 
 /* event code */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -738,7 +738,7 @@ static void PrintUsage(const char *progname)
 
     printf("\n  Info:\n");
     printf("\t-V                                   : display Suricata version\n");
-    printf("\t--list-keywords[=all|csv|<kword>]    : list keywords implemented by the engine\n");
+    printf("\t--list-keywords[=json|csv|<kword>]   : list keywords implemented by the engine\n");
     printf("\t--list-runmodes                      : list supported runmodes\n");
     printf("\t--list-app-layer-protos              : list supported app layer protocols\n");
     printf("\t--list-rule-protos                   : list supported rule protocols\n");


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8675

Describe changes:
- option for `--list-keywords` to output as json
- enum integer keywords print list of possible values

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3219

Example output for `suricata --list-keywords=json:snmp| jq '."snmp.pdu_type"'`
```json
{
  "snmp.pdu_type": {
    "description": "match SNMP PDU type",
    "doc": "https://docs.suricata.io/en/latest/rules/snmp-keywords.html#snmp-pdu-type",
    "features": [
      "supports firewall",
      "enum uint",
      "uint32"
    ],
    "enum_values": {
      "get_request": 0,
      "get_next_request": 1,
      "response": 2,
      "set_request": 3,
      "trap_v1": 4,
      "get_bulk_request": 5,
      "inform_request": 6,
      "trap_v2": 7,
      "report": 8
    }
  }
}
```

https://github.com/OISF/suricata/pull/15840 with AI review : now derive uses names_lower, especially for the `LOG_UPPERCASE` case 
So `./src/suricata --list-keywords=json | jq '."http2.errorcode"'` lists the cortect values that can be used in a signature (with an underscore, even if the values are logged without underscore)

As AI noted nfs_procedure has a slightly different output since it has a different construction. If we want another format, let's tell me

And I do not skip the `template` keyword as the `template.buffer` is not skipped (depends on your config/build...)

I also do not advertise anymore the `all` mode because we prefer json :-p