### PR TITLE
rust: clippy fixups for 1.97

### DIFF
--- a/rust/src/detect/requires.rs
+++ b/rust/src/detect/requires.rs
@@ -410,7 +410,7 @@ pub unsafe extern "C" fn SCDetectRequiresStatusLog(
                 "rule was"
             },
             suricata_version,
-            &min_version
+            min_version
         );
         parts.push(msg);
     }
@@ -447,7 +447,7 @@ pub unsafe extern "C" fn SCDetectRequiresStatusLog(
                 "rule was"
             },
             if status.feature_count > 1 { "s" } else { "" },
-            &features
+            features
         );
         parts.push(msg);
     }

--- a/rust/src/http2/logger.rs
+++ b/rust/src/http2/logger.rs
@@ -128,7 +128,7 @@ fn log_http2_frames(frames: &[HTTP2Frame], js: &mut JsonBuilder) -> Result<bool,
                 js.start_object()?;
                 js.set_string(
                     "settings_id",
-                    &format!("SETTINGS{}", &e.id.to_string().to_uppercase()),
+                    &format!("SETTINGS{}", e.id.to_string().to_uppercase()),
                 )?;
                 js.set_uint("settings_value", e.value as u64)?;
                 js.close()?;

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -172,7 +172,7 @@ impl JsonBuilder {
     // Reset the builder to its initial state, without losing
     // the current capacity.
     pub fn reset(&mut self) {
-        self.buf.truncate(0);
+        self.buf.clear();
         self.state.clear();
         match self.init_type {
             Type::Array => {
@@ -1618,6 +1618,4 @@ static ESCAPED: [u8; 256] = [
     __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
 ];
 
-pub static HEX: [u8; 16] = [
-    b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b', b'c', b'd', b'e', b'f',
-];
+pub static HEX: [u8; 16] = *b"0123456789abcdef";

--- a/rust/src/mime/mime.rs
+++ b/rust/src/mime/mime.rs
@@ -117,13 +117,11 @@ pub fn mime_find_header_token<'a>(
                     // check for initial section of a parameter
                     current_section_slice.extend_from_slice(token);
                     current_section_slice.extend_from_slice(b"*0");
-                    match t.tokens.get(&current_section_slice[..]) {
-                        Some(value) => {
-                            sections_values.extend_from_slice(value);
-                            let l = current_section_slice.len();
-                            current_section_slice[l - 1] = b'1';
-                        }
-                        None => return None,
+                    {
+                        let value = t.tokens.get(&current_section_slice[..])?;
+                        sections_values.extend_from_slice(value);
+                        let l = current_section_slice.len();
+                        current_section_slice[l - 1] = b'1';
                     }
                 }
             }

--- a/rust/src/sdp/parser.rs
+++ b/rust/src/sdp/parser.rs
@@ -264,9 +264,9 @@ fn parse_connection_data(i: &[u8]) -> IResult<&[u8], String> {
 
     let mut connection_data = format!(
         "{} {} {}",
-        &nettype,
-        &addrtype,
-        &connection_address.to_string()
+        nettype,
+        addrtype,
+        connection_address
     );
     if let Some(ttl) = ttl {
         connection_data = format!("{}/{}", connection_data, ttl);
@@ -477,7 +477,7 @@ fn parse_media_description(i: &[u8]) -> IResult<&[u8], MediaDescription> {
     } else {
         format!("{}", port)
     };
-    let mut media_str = format!("{} {} {}", &media, &port, &proto);
+    let mut media_str = format!("{} {} {}", media, port, proto);
     if !fmt.is_empty() {
         let fmt: Vec<String> = fmt.into_iter().map(String::from).collect();
         media_str = format!("{} {}", media_str, fmt.join(" "));

--- a/rust/src/ssh/parser.rs
+++ b/rust/src/ssh/parser.rs
@@ -162,7 +162,7 @@ pub struct SshPacketKeyExchange<'a> {
     pub reserved: u32,
 }
 
-const SSH_HASSH_STRING_DELIMITER_SLICE: [u8; 1] = [b';'];
+const SSH_HASSH_STRING_DELIMITER_SLICE: [u8; 1] = *b";";
 
 impl SshPacketKeyExchange<'_> {
     pub fn generate_hassh(

--- a/rust/suricatasc/src/unix/client.rs
+++ b/rust/suricatasc/src/unix/client.rs
@@ -62,7 +62,7 @@ impl Client {
     {
         let mut encoded = serde_json::to_string(&msg)?;
         if self.verbose {
-            println!("SND: {}", &encoded);
+            println!("SND: {}", encoded);
         }
         encoded.push('\n');
         self.socket.write_all(encoded.as_bytes())?;

--- a/rust/suricatasc/src/unix/main.rs
+++ b/rust/suricatasc/src/unix/main.rs
@@ -39,13 +39,13 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let verbose = args.verbose;
     if verbose {
-        println!("Using Suricata command socket: {}", &socket_filename);
+        println!("Using Suricata command socket: {}", socket_filename);
     }
 
     let client = match Client::connect(&socket_filename, verbose) {
         Ok(client) => client,
         Err(err) => {
-            eprintln!("Unable to connect socket to {}: {}", &socket_filename, err);
+            eprintln!("Unable to connect socket to {}: {}", socket_filename, err);
             std::process::exit(1);
         }
     };
@@ -95,7 +95,7 @@ fn run_interactive(mut client: Client) -> Result<(), Box<dyn std::error::Error>>
                             break;
                         }
                         if let Err(err) = client.reconnect() {
-                            println!("Error: {}", &err);
+                            println!("Error: {}", err);
                             break;
                         } else {
                             retry = true;


### PR DESCRIPTION
Mostly provided by clippy --fix, and one `.to_string()` removal where
not needed.
