### PR TITLE
output/anomaly: report unknown ethertype in decode events

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -176,6 +176,13 @@ Anomalies are reported by and configured by type:
 - Stream
 - Application layer
 
+The ``decoder.ethernet.unknown_ethertype`` decode anomaly event includes the
+ethertype value that could not be decoded in the ``anomaly.ether_type`` field.
+With nested headers, e.g., VLAN, this is the innermost ethertype that could
+not be decoded rather than the ethertype of the outer header. This event is
+also raised (alongside ``decoder.vlan.unknown_type`` and the E-Tag/VN-Tag
+equivalents) when the unrecognized ethertype follows a tag.
+
 Metadata::
 
     - anomaly:

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -57,6 +57,10 @@ Logging Changes
   E.g., previously, ``ether_type`` values were logged in host order;  an ethertype value of ``0xfbb7``
   (network order) was logged as `47099`` (``0xb7fb``). This ethertype value will be logged as ``64439``.
 
+- The ``decoder.ethernet.unknown_ethertype`` anomaly event now includes the
+  ethertype value that could not be decoded in the ``anomaly.ether_type``
+  field.
+
 - Alert verdict key is changed from to ``reject-target`` to ``reject_target``
 
 - App-layer stats protocols names replace dash by underscore, meaning

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -169,6 +169,10 @@
                 "code": {
                     "type": "integer"
                 },
+                "ether_type": {
+                    "type": "integer",
+                    "description": "The unknown ethertype that triggered the event"
+                },
                 "event": {
                     "type": "string"
                 },

--- a/src/decode.h
+++ b/src/decode.h
@@ -428,6 +428,10 @@ enum PacketL2Types {
 
 struct PacketL2 {
     enum PacketL2Types type;
+    /** innermost ethertype that could not be decoded; set on the
+     *  unknown-ethertype decode path and reported by the
+     *  decoder.ethernet.unknown_ethertype anomaly event */
+    uint16_t unknown_ethertype;
     union L2Hdrs {
         EthernetHdr *ethh;
     } hdrs;
@@ -1552,6 +1556,7 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
             SCLogDebug("unknown ether type: %" PRIx16 "", proto);
             StatsCounterIncr(&tv->stats, dtv->counter_ethertype_unknown);
             ENGINE_SET_EVENT(p, ETHERNET_UNKNOWN_ETHERTYPE);
+            p->l2.unknown_ethertype = proto;
             return false;
     }
     return true;

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -131,6 +131,9 @@ static int AnomalyDecodeEventJson(ThreadVars *tv, JsonAnomalyLogThread *aft,
                 JB_SET_STRING(js, "type", "stream");
             }
             SCJbSetString(js, "event", event);
+            if (event_code == ETHERNET_UNKNOWN_ETHERTYPE) {
+                SCJbSetUint(js, "ether_type", p->l2.unknown_ethertype);
+            }
         } else {
             JB_SET_STRING(js, "type", "unknown");
             SCJbSetUint(js, "code", event_code);


### PR DESCRIPTION
Continuation of #15795 

Report unknown ethertype values in anomaly events to identify the value that triggered the event.
Also, update the vlan/vntag/etag handling so the inner ethertype value is included.

Link to ticket:
* https://redmine.openinfosecfoundation.org/issues/7849
* https://redmine.openinfosecfoundation.org/issues/8142

Describe changes:
- Include ethertype values with anomaly events, including those from vlang/etag/vntag frames
- Add an option to display ethertype values as hex strings when ethernet values are being logged
- Document the config option, and the inclusion of ethertype info the ethernet/vlan/etag/vntag anomaly events.

Updates:
- Rebase
- Single type for ethernet value (int)
- Updated log path to check ETHERNET_UNKNOWN_ETHERTYPE for all unrecognized "type" values.
- The `unknown_ethertype` value in the `L2` header is maintained to store the decode-time value and make it available for logging; because of holes in the structure, adding the 16 bit value doesn't increase the struct size.
- New s-v branch within decode-unknown test case diretory.

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3230
