### PR TITLE
conf: disable flowbits.max-per-signature by default

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1895,8 +1895,8 @@ detect:
       include-rules: false      # very verbose
       include-mpm-stats: false
 
-  flowbits:
-    max-per-signature: 8    # maximum number of flowbits keyword usage per signature, minimum value allowed is 1
+  #flowbits:
+  #  max-per-signature: 8    # maximum number of flowbits keyword usage per signature, minimum value allowed is 1
 
 # Select the multi pattern algorithm you want to run for scan/search the
 # in the engine.


### PR DESCRIPTION
As pointed by Jason. ref: https://github.com/OISF/suricata/pull/15697#discussion_r3554978327

Previous PR: https://github.com/OISF/suricata/pull/15847

Changes since v1:
- fixed indentation in commented config to match the correct layout