### PR TITLE
smtp: check transaction before to-client completion - v1

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1081,7 +1081,7 @@ static int SMTPProcessReply(
     } else if (IsReplyToCommand(state, SMTP_COMMAND_BDAT)) {
         SMTPSetProgressTC(reply_tx, SMTP_RESPONSE_DATA);
     } else if (IsReplyToCommand(state, SMTP_COMMAND_DATA_MODE)) {
-        if (!(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
+        if (reply_tx && !(state->parser_state & SMTP_PARSER_STATE_PARSING_MULTILINE_REPLY)) {
             SMTPTransactionCompleteTC(reply_tx);
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_RSET)) {


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8739

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3231

Make sure the transaction still exists before completing it in the
to-client direction. A pipelined RSET reply may already have completed and
freed it while a later end-of-DATA marker still refers to it.

Found by OSS-Fuzz testcase 5498180758994944.
