### PR TITLE
Lua http2 6409 v1

### DIFF
--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -90,17 +90,22 @@ static int LuaHttpGetRequestUriRaw(lua_State *luastate)
         lua_pushnil(luastate);
         return 1;
     }
-    if (tx->alproto != ALPROTO_HTTP1) {
-        lua_pushnil(luastate);
-        return 1;
-    }
-    const struct bstr *uri = htp_tx_request_uri(tx->tx);
-    if (uri == NULL) {
-        lua_pushnil(luastate);
-        return 1;
-    }
+    if (tx->alproto == ALPROTO_HTTP1) {
+        const struct bstr *uri = htp_tx_request_uri(tx->tx);
+        if (uri == NULL) {
+            lua_pushnil(luastate);
+            return 1;
+        }
+        return LuaPushStringBuffer(luastate, bstr_ptr(uri), bstr_len(uri));
+    } // else ALPROTO_HTTP2
+    uint32_t b_len = 0;
+    const uint8_t *b = NULL;
 
-    return LuaPushStringBuffer(luastate, bstr_ptr(uri), bstr_len(uri));
+    if (SCHttp2TxGetUri(tx->tx, &b, &b_len) != 1) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+    return LuaPushStringBuffer(luastate, b, b_len);
 }
 
 static int LuaHttpGetRequestUriNormalized(lua_State *luastate)

--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -31,16 +31,21 @@
 static const char htp_tx[] = "suricata:http:tx";
 
 struct LuaTx {
-    htp_tx_t *tx;
+    void *tx;
+    AppProto alproto;
 };
 
 static int LuaHttpGetTx(lua_State *luastate)
 {
-    if (!LuaStateNeedProto(luastate, ALPROTO_HTTP1)) {
+    Flow *flow = LuaStateGetFlow(luastate);
+    if (flow == NULL)
+        return LuaCallbackError(luastate, "internal error: no flow");
+
+    if (flow->alproto != ALPROTO_HTTP1 && flow->alproto != ALPROTO_HTTP2) {
         return LuaCallbackError(luastate, "error: protocol not http");
     }
 
-    htp_tx_t *tx = LuaStateGetTX(luastate);
+    void *tx = LuaStateGetTX(luastate);
     if (tx == NULL) {
         return LuaCallbackError(luastate, "error: no tx available");
     }
@@ -50,6 +55,7 @@ static int LuaHttpGetTx(lua_State *luastate)
     }
 
     ltx->tx = tx;
+    ltx->alproto = flow->alproto;
 
     luaL_getmetatable(luastate, htp_tx);
     lua_setmetatable(luastate, -2);
@@ -61,6 +67,10 @@ static int LuaHttpGetRequestHost(lua_State *luastate)
 {
     struct LuaTx *tx = luaL_testudata(luastate, 1, htp_tx);
     if (tx == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+    if (tx->alproto != ALPROTO_HTTP1) {
         lua_pushnil(luastate);
         return 1;
     }
@@ -80,6 +90,10 @@ static int LuaHttpGetRequestUriRaw(lua_State *luastate)
         lua_pushnil(luastate);
         return 1;
     }
+    if (tx->alproto != ALPROTO_HTTP1) {
+        lua_pushnil(luastate);
+        return 1;
+    }
     const struct bstr *uri = htp_tx_request_uri(tx->tx);
     if (uri == NULL) {
         lua_pushnil(luastate);
@@ -93,6 +107,10 @@ static int LuaHttpGetRequestUriNormalized(lua_State *luastate)
 {
     struct LuaTx *tx = luaL_testudata(luastate, 1, htp_tx);
     if (tx == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+    if (tx->alproto != ALPROTO_HTTP1) {
         lua_pushnil(luastate);
         return 1;
     }
@@ -113,6 +131,10 @@ static int LuaHttpGetRequestLine(lua_State *luastate)
         lua_pushnil(luastate);
         return 1;
     }
+    if (tx->alproto != ALPROTO_HTTP1) {
+        lua_pushnil(luastate);
+        return 1;
+    }
 
     const struct bstr *line = htp_tx_request_line(tx->tx);
     if (line == NULL) {
@@ -130,6 +152,10 @@ static int LuaHttpGetResponseLine(lua_State *luastate)
         lua_pushnil(luastate);
         return 1;
     }
+    if (tx->alproto != ALPROTO_HTTP1) {
+        lua_pushnil(luastate);
+        return 1;
+    }
 
     const struct bstr *line = htp_tx_response_line(tx->tx);
     if (line == NULL) {
@@ -144,6 +170,10 @@ static int LuaHttpGetHeader(lua_State *luastate, int dir)
 {
     struct LuaTx *tx = luaL_testudata(luastate, 1, htp_tx);
     if (tx == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+    if (tx->alproto != ALPROTO_HTTP1) {
         lua_pushnil(luastate);
         return 1;
     }
@@ -185,6 +215,10 @@ static int LuaHttpGetRawHeaders(lua_State *luastate, int dir)
         lua_pushnil(luastate);
         return 1;
     }
+    if (tx->alproto != ALPROTO_HTTP1) {
+        lua_pushnil(luastate);
+        return 1;
+    }
     HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx->tx);
 
     uint8_t *raw = htud->request_headers_raw;
@@ -214,6 +248,10 @@ static int LuaHttpGetHeaders(lua_State *luastate, int dir)
 {
     struct LuaTx *tx = luaL_testudata(luastate, 1, htp_tx);
     if (tx == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+    if (tx->alproto != ALPROTO_HTTP1) {
         lua_pushnil(luastate);
         return 1;
     }
@@ -255,6 +293,10 @@ static int LuaHttpGetBody(lua_State *luastate, int dir)
 {
     struct LuaTx *tx = luaL_testudata(luastate, 1, htp_tx);
     if (tx == NULL) {
+        lua_pushnil(luastate);
+        return 1;
+    }
+    if (tx->alproto != ALPROTO_HTTP1) {
         lua_pushnil(luastate);
         return 1;
     }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/6409

Describe changes:
- lua : begin support for HTTP2

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3232


DRAFT : 
First question is 
Do we want to present the rule writer an unique http library for both http1 and http2 ? I think we do like `local http = require("suricata.http")`

Second question would then be how do we trigger a lua script for both http versions ?
See SV PR https://github.com/OISF/suricata-verify/pull/3232/changes#r3573799610

Now I have both
```
alert http2:stream:request_headers
alert http1:request_line
```

that works for either http2 or http1, but I do not have a way to express that I want to run my lua script for whatever http version