### PR TITLE
detect: allow bypass keyword for fw rules in firewall mode (only) - v1

### DIFF
--- a/doc/userguide/rules/bypass-keyword.rst
+++ b/doc/userguide/rules/bypass-keyword.rst
@@ -13,8 +13,10 @@ The ``bypass`` keyword is considered a post-match keyword.
 
 .. note::
 
-   ``bypass`` cannot be used in firewall mode, not even with Threat Detection
-   rules, as this could lead to bypassing the firewall altogether.
+   In firewall mode, ``bypass`` can only be used in firewall rules. If a threat
+   detection rule uses the ``bypass`` keyword and you want to run Suricata in
+   firewall mode, the engine will error out. This is to prevent a threat detection
+   rule, from bypassing the firewall altogether.
 
 bypass
 ------

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -24,6 +24,7 @@ pub const SIGMATCH_INFO_ENUM_UINT: u32 = 524288;
 pub const SIGMATCH_INFO_BITFLAGS_UINT: u32 = 1048576;
 pub const SIGMATCH_BAN_FIREWALL_RULE: u32 = 2097152;
 pub const SIGMATCH_BAN_FIREWALL_MODE: u32 = 4194304;
+pub const SIGMATCH_BAN_TD_FIREWALL_MODE: u32 = 8388608;
 pub type __intmax_t = ::std::os::raw::c_long;
 pub type intmax_t = __intmax_t;
 #[repr(u32)]

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -64,7 +64,7 @@ void DetectBypassRegister(void)
     sigmatch_table[DETECT_BYPASS].Match = DetectBypassMatch;
     sigmatch_table[DETECT_BYPASS].Setup = DetectBypassSetup;
     sigmatch_table[DETECT_BYPASS].Free  = NULL;
-    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_BAN_FIREWALL_MODE;
+    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_BAN_TD_FIREWALL_MODE;
 }
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -344,6 +344,12 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
         printf("banned from firewall mode");
         prev = 1;
     }
+    if (flags & SIGMATCH_BAN_TD_FIREWALL_MODE) {
+        if (prev == 1)
+            printf("%c", sep);
+        printf("banned from threat detection rules in firewall mode");
+        prev = 1;
+    }
     if (e->Transform) {
         if (prev == 1)
             printf("%c", sep);

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -354,6 +354,8 @@ extern int DETECT_TBLSIZE_IDX;
 #define SIGMATCH_BAN_FIREWALL_RULE (1UL << (21))
 /** keyword cannot be used in firewall mode */
 #define SIGMATCH_BAN_FIREWALL_MODE (1UL << (22))
+/** keyword cannot be used in td rules with firewall mode */
+#define SIGMATCH_BAN_TD_FIREWALL_MODE (1UL << (23))
 
 int SigTableList(const char *keyword);
 void SigTableCleanup(void);

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -978,6 +978,12 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
         goto error;
     }
 
+    if (EngineModeIsFirewall() && !s->init_data->firewall_rule &&
+            (st->flags & SIGMATCH_BAN_TD_FIREWALL_MODE) != 0) {
+        SCLogError("keyword \'%s\' is not allowed in threat detection rules with firewall mode",
+                optname);
+        goto error;
+    }
     int setup_ret = 0;
 
     /* Validate double quoting, trimming trailing white space along the way. */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/8459

Describe changes:
- allow `bypass` keyword in firewall mode, for firewall rules, only (banned from TD rules)
- update the keyword doc accordingly

In draft, as there are cases like single packet flow, `accept: packet` and such where we likely need more tests and logic to ensure proper behavior.
We may need to add clarification around this being local bypass only?

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3237