### PR TITLE
defrag: fix defrag.memuse counter reporting memcap

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -957,7 +957,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         if (other_last_sec == 0 || other_last_sec < (uint32_t)SCTIME_SECS(ts)) {
             if (ftd->instance == 0) {
                 StatsCounterSetI64(
-                        &th_v->stats, ftd->counter_defrag_memuse, DefragTrackerGetMemcap());
+                        &th_v->stats, ftd->counter_defrag_memuse, DefragTrackerGetMemuse());
                 uint32_t defrag_cnt = DefragTimeoutHash(ts);
                 if (defrag_cnt) {
                     StatsCounterAddI64(


### PR DESCRIPTION
Populate defrag.memuse from DefragTrackerGetMemuse() rather than DefragTrackerGetMemcap(), so it reports actual usage, not the cap.

Issue: 8752


Link to ticket: https://redmine.openinfosecfoundation.org/issues/8752

Describe changes:
- Use memuse getter when registering stat

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
