### PR TITLE
Xdp tunnel 7674 v19.2

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -3126,6 +3126,10 @@ This section is a list of tunnels with the following parameters:
       dst: 192.168.1.3
       session: 123 # erspan span id or vxlan vni
 
+It is also recommended to define ``decoder.tunnels-ifaces`` list of interfaces
+receiving tunneled traffic. The traffic received on these interfaces that do
+not belong to a defined tunnel will be skipped.
+
 Advanced Options
 ----------------
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -3106,6 +3106,26 @@ default.
 Using this default setting, flows will be associated only if the compared packet
 headers are encapsulated in the same number of headers.
 
+Tunnels
+~~~~~~~
+
+If your packets sources are multiple tunnels encapsulating the traffic,
+you can configure the ``decoder.tunnels`` section to assign a tunnel
+identifier to each of these tunnels.
+
+These tunnel identifiers are used in flow hashing to be able to distinguish
+the same-looking flow (same 5-tuple) from different tunnels, meaning it
+is in fact a different subnetwork (like a VLAN identifier).
+
+This section is a list of tunnels with the following parameters:
+::
+
+    - id: 1
+      type: erspan2 # or vxlan
+      src: 192.168.1.1
+      dst: 192.168.1.3
+      session: 123 # erspan span id or vxlan vni
+
 Advanced Options
 ----------------
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -9499,8 +9499,16 @@
                 },
                 "src_port": {
                     "type": "integer"
+                },
+                "tunnel_id": {
+                    "type": "integer",
+                    "description": "If any, the tunnel identifier defined in suricata.yaml decoder.tunnels section"
                 }
             }
+        },
+        "tunnel_id": {
+            "type": "integer",
+            "description": "if any, the tunnel identifier defined in suricata.yaml decoder.tunnels section"
         },
         "tx_guessed": {
             "type": "boolean",

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -29,6 +29,7 @@ use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::ptr;
 use std::str;
+use std::str::FromStr;
 use suricata_sys::sys::SCConfGetChildValue;
 use suricata_sys::sys::SCConfGetChildValueBool;
 use suricata_sys::sys::SCConfGetFirstNode;
@@ -57,13 +58,47 @@ pub use suricata_ffi::conf::{conf_get, conf_get_bool};
 
 /// Wrap a Suricata ConfNode and expose some of its methods with a
 /// Rust friendly interface.
+#[derive(Copy, Clone)]
 pub struct ConfNode {
     pub conf: *const SCConfNode,
+}
+
+pub(crate) struct ConfNodeIter {
+    node: ConfNode,
+    start: bool,
+}
+
+impl Iterator for ConfNodeIter {
+    type Item = ConfNode;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let r = if self.start {
+            self.start = false;
+            self.node.first()
+        } else {
+            self.node.next()
+        };
+        if let Some(n) = r {
+            self.node = n;
+            return Some(self.node);
+        }
+        r
+    }
 }
 
 impl ConfNode {
     pub fn wrap(conf: *const SCConfNode) -> Self {
         return Self { conf };
+    }
+
+    // Return the value of key as T like u16.
+    pub(crate) fn get_child_from<T: FromStr>(&self, key: &str) -> Option<T> {
+        if let Some(n) = self.get_child_node(key) {
+            if let Ok(r) = T::from_str(n.value()) {
+                return Some(r);
+            }
+        }
+        return None;
     }
 
     pub fn get_child_node(&self, key: &str) -> Option<ConfNode> {
@@ -75,6 +110,13 @@ impl ConfNode {
             None
         } else {
             Some(ConfNode::wrap(node))
+        }
+    }
+
+    pub(crate) fn iter(&self) -> ConfNodeIter {
+        ConfNodeIter {
+            node: *self,
+            start: true,
         }
     }
 

--- a/rust/src/decode.rs
+++ b/rust/src/decode.rs
@@ -1,0 +1,134 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! Decode module.
+
+use crate::conf::conf_get_node;
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use suricata_sys::sys::SCPacketTunnelProto;
+
+pub const PKT_TUNNEL_UNKNOWN: u16 = u16::MAX;
+
+fn decoder_tunnel_proto(s: Option<&str>) -> Option<SCPacketTunnelProto> {
+    return match s {
+        Some("erspan2") => Some(SCPacketTunnelProto::DECODE_TUNNEL_ERSPANII),
+        Some("vxlan") => Some(SCPacketTunnelProto::DECODE_TUNNEL_VXLAN),
+        _ => None,
+    };
+}
+
+fn decoder_ipv4(o: Option<&str>) -> Option<u32> {
+    if let Some(s) = o {
+        if let Ok(i) = s.parse::<Ipv4Addr>() {
+            return Some(u32::from_be_bytes(i.octets()));
+        }
+    }
+    return None;
+}
+
+#[repr(C)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct flowtunnel_keys {
+    src: u32,
+    dst: u32,
+    // would be nice to have this field u24, like C __u32 session : 24; __u8 tunnel : 8;
+    session: u32, // erspan spanid or vxlan vni
+    tunnel_proto: u8,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn DecodeTunnelsConfig() -> *mut HashMap<flowtunnel_keys, u16> {
+    let mut r = HashMap::new();
+    if let Some(n) = conf_get_node("decoder.tunnels") {
+        for nodeu in n.iter() {
+            // Get all the fields with their right types
+            let nid = nodeu.get_child_from::<u16>("id");
+            if nid.is_none() {
+                SCLogWarning!("missing id for decoder tunnel");
+                continue;
+            }
+            let nid = nid.unwrap();
+
+            let ntype = nodeu.get_child_value("type");
+            let tunnel_proto = decoder_tunnel_proto(ntype);
+            if tunnel_proto.is_none() {
+                SCLogWarning!("unknown type for decoder tunnel {:?}", ntype);
+                continue;
+            }
+            let tunnel_proto = tunnel_proto.unwrap() as u8;
+
+            let session = nodeu.get_child_from::<u32>("session");
+            if session.is_none() {
+                SCLogWarning!("missing session for decoder tunnel");
+                continue;
+            }
+            let session = session.unwrap();
+
+            let nsrc = nodeu.get_child_value("src");
+            let src = decoder_ipv4(nsrc);
+            if src.is_none() {
+                SCLogWarning!("invalid ipv4 src for decoder tunnel {:?}", nsrc);
+                continue;
+            }
+            let src = src.unwrap();
+
+            let ndst = nodeu.get_child_value("dst");
+            let dst = decoder_ipv4(ndst);
+            if dst.is_none() {
+                SCLogWarning!("invalid ipv4 src for decoder tunnel {:?}", ndst);
+                continue;
+            }
+            let dst = dst.unwrap();
+
+            // Finally insert the tunnel in the map
+            let k = flowtunnel_keys {
+                src,
+                dst,
+                session,
+                tunnel_proto,
+            };
+            r.insert(k, nid);
+        }
+    } else {
+        // no decoder.tunnels section in conf
+        return std::ptr::null_mut();
+    }
+    return Box::into_raw(Box::new(r));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn DecodeTunnelsFree(map: *mut HashMap<flowtunnel_keys, u16>) {
+    if !map.is_null() {
+        let _ = Box::from_raw(map); // Automatically dropped at end of scope
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn DecodeTunnelsId(
+    map: *mut HashMap<flowtunnel_keys, u16>, key: flowtunnel_keys,
+) -> u16 {
+    if map.is_null() {
+        return PKT_TUNNEL_UNKNOWN;
+    }
+
+    let map = &*map;
+    match map.get(&key) {
+        Some(value) => *value,
+        None => PKT_TUNNEL_UNKNOWN,
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -72,6 +72,8 @@ pub mod core;
 #[macro_use]
 pub mod debug;
 
+pub mod decode;
+
 pub mod common;
 pub mod conf;
 pub mod jsonbuilder;

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -1268,6 +1268,23 @@ extern "C" {
 extern "C" {
     pub fn SCBasicSearchNocaseIndex(arg1: *const u8, arg2: u32, arg3: *const u8, arg4: u16) -> u32;
 }
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum SCPacketTunnelProto {
+    DECODE_TUNNEL_ETHERNET = 0,
+    DECODE_TUNNEL_ERSPANII = 1,
+    DECODE_TUNNEL_ERSPANI = 2,
+    DECODE_TUNNEL_VXLAN = 3,
+    DECODE_TUNNEL_VLAN = 4,
+    DECODE_TUNNEL_IPV4 = 5,
+    DECODE_TUNNEL_IPV6 = 6,
+    #[doc = "< separate protocol for stricter error handling"]
+    DECODE_TUNNEL_IPV6_TEREDO = 7,
+    DECODE_TUNNEL_PPP = 8,
+    DECODE_TUNNEL_NSH = 9,
+    DECODE_TUNNEL_ARP = 10,
+    DECODE_TUNNEL_UNSET = 11,
+}
 pub type ProbingParserFPtr = ::std::option::Option<
     unsafe extern "C" fn(
         f: *const Flow,

--- a/src/bindgen.h
+++ b/src/bindgen.h
@@ -34,6 +34,7 @@
 
 #include "app-layer-protos.h"
 #include "suricata-plugin.h"
+
 // do not export struct fields only used for debug validation
 // do this after suricata-plugin.h which needs autoconf.h to define SC_PACKAGE_VERSION
 #undef DEBUG_VALIDATION
@@ -51,6 +52,8 @@
 #include "util-mpm.h"
 #include "util-var.h"
 #include "util-spm-bs.h"
+
+#include "decode.h"
 
 #include "app-layer-detect-proto.h"
 #include "app-layer-parser.h"

--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -107,7 +107,7 @@ int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
         p->vlan_id[p->vlan_idx] = vlan_id;
         p->vlan_idx++;
     }
-
+    PacketSetTunnelId(p, SCNtohs(ehdr->flags_spanid) & 0x03ff);
     return DecodeEthernet(tv, dtv, p, pkt + sizeof(ErspanHdr), len - sizeof(ErspanHdr));
 }
 

--- a/src/decode-vxlan.c
+++ b/src/decode-vxlan.c
@@ -135,6 +135,17 @@ void DecodeVXLANConfig(void)
     }
 }
 
+// Just get the tunnel id (for the flow hash)
+// Then pass on to ethernet decoder on next layer
+int DecodeVXLANtunnel(
+        ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
+{
+    const VXLANHeader *vxlanh = (const VXLANHeader *)pkt;
+    uint32_t vni = (vxlanh->vni[0] << 16) + (vxlanh->vni[1] << 8) + (vxlanh->vni[2]);
+    PacketSetTunnelId(p, vni);
+    return DecodeEthernet(tv, dtv, p, pkt + VXLAN_HEADER_LEN, len - VXLAN_HEADER_LEN);
+}
+
 /** \param pkt payload data directly above UDP header
  *  \param len length in bytes of pkt
  *
@@ -214,8 +225,9 @@ int DecodeVXLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
     /* Set-up and process inner packet if it is a supported ethertype */
     if (eth_ok) {
-        Packet *tp = PacketTunnelPktSetup(
-                tv, dtv, p, pkt + VXLAN_HEADER_LEN, len - VXLAN_HEADER_LEN, DECODE_TUNNEL_VXLAN);
+        // do not advance in packet, as we will need child packet to read vxlan header
+        // to compute its tunnel_id before computing its hash
+        Packet *tp = PacketTunnelPktSetup(tv, dtv, p, pkt, len, DECODE_TUNNEL_VXLAN);
         if (tp != NULL) {
             PKT_SET_SRC(tp, PKT_SRC_DECODER_VXLAN);
             PacketEnqueueNoLock(&tv->decode_pq, tp);

--- a/src/decode.c
+++ b/src/decode.c
@@ -397,7 +397,7 @@ inline int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
  *  \retval p the pseudo packet or NULL if out of memory
  */
 Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *parent,
-                             const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto)
+        const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto)
 {
     int ret;
 
@@ -435,6 +435,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     }
     /* tell new packet it's part of a tunnel */
     p->ttype = PacketTunnelChild;
+    p->tproto = (uint8_t)proto;
 
     ret = DecodeTunnel(tv, dtv, p, GET_PKT_DATA(p),
                        GET_PKT_LEN(p), proto);

--- a/src/decode.c
+++ b/src/decode.c
@@ -71,6 +71,7 @@
 #include "util-profiling.h"
 #include "util-validate.h"
 #include "util-debug.h"
+#include "util-device-private.h"
 #include "util-exception-policy.h"
 #include "action-globals.h"
 
@@ -225,6 +226,14 @@ void PacketFree(Packet *p)
     SCFree(p);
 }
 
+static bool PacketIsInTunnelIface(Packet *p)
+{
+    LiveDevice *dev = LiveDeviceGetById(p->livedev_id);
+    if (dev) {
+        return dev->skip_non_tunnel;
+    }
+    return false;
+}
 /**
  * \brief Finalize decoding of a packet
  *
@@ -236,6 +245,10 @@ void PacketDecodeFinalize(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
     if (p->flags & PKT_IS_INVALID) {
         StatsCounterIncr(&tv->stats, dtv->counter_invalid);
+    }
+    if (p->tunnel_id == 0 && PacketIsInTunnelIface(p)) {
+        // skips non-tunnel packets
+        p->flags |= PKT_SKIP_WORK;
     }
 }
 
@@ -390,8 +403,12 @@ static void *decode_tunnels_map;
 
 void PacketSetTunnelId(Packet *p, uint32_t session)
 {
+    bool packet_in_tunnel_iface = PacketIsInTunnelIface(p);
     if (decode_tunnels_map == NULL || p->root == NULL || !PacketIsIPv4(p->root)) {
         p->tunnel_id = PKT_TUNNEL_UNKNOWN;
+        if (packet_in_tunnel_iface) {
+            p->flags |= PKT_SKIP_WORK;
+        }
         return;
     }
     struct flowtunnel_keys k = {};
@@ -400,6 +417,9 @@ void PacketSetTunnelId(Packet *p, uint32_t session)
     k.session = session;
     k.tunnel_proto = (uint8_t)p->tproto;
     p->tunnel_id = DecodeTunnelsId(decode_tunnels_map, k);
+    if (packet_in_tunnel_iface && p->tunnel_id == PKT_TUNNEL_UNKNOWN) {
+        p->flags |= PKT_SKIP_WORK;
+    }
 }
 
 /**
@@ -1166,6 +1186,20 @@ void DecodeGlobalConfig(void)
     DecodeVXLANConfig();
     DecodeERSPANConfig();
     decode_tunnels_map = DecodeTunnelsConfig();
+    SCConfNode *tunnel_ifaces_node = SCConfGetNode("decoder.tunnel-ifaces");
+    if (tunnel_ifaces_node != NULL) {
+        SCConfNode *child = NULL;
+        TAILQ_FOREACH (child, &tunnel_ifaces_node->head, next) {
+            if (child->val != NULL) {
+                LiveDevice *ld = LiveGetDevice(child->val);
+                if (ld != NULL) {
+                    ld->skip_non_tunnel = true;
+                } else {
+                    SCLogWarning("%s is not a registered device", child->val);
+                }
+            }
+        }
+    }
     intmax_t value = 0;
     if (SCConfGetInt("decoder.max-layers", &value) == 1) {
         if (value < 0 || value > UINT8_MAX) {

--- a/src/decode.c
+++ b/src/decode.c
@@ -180,10 +180,10 @@ void PacketAlertFree(PacketAlert *pa_array)
 }
 
 static int DecodeTunnel(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t,
-        enum DecodeTunnelProto) WARN_UNUSED;
+        enum SCPacketTunnelProto) WARN_UNUSED;
 
 static int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt,
-        uint32_t len, enum DecodeTunnelProto proto)
+        uint32_t len, enum SCPacketTunnelProto proto)
 {
     switch (proto) {
         case DECODE_TUNNEL_PPP:
@@ -204,7 +204,7 @@ static int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const 
         case DECODE_TUNNEL_ERSPANI:
             return DecodeERSPANTypeI(tv, dtv, p, pkt, len);
         case DECODE_TUNNEL_VXLAN:
-            return DecodeEthernet(tv, dtv, p, pkt, len);
+            return DecodeVXLANtunnel(tv, dtv, p, pkt, len);
         case DECODE_TUNNEL_NSH:
             return DecodeNSH(tv, dtv, p, pkt, len);
         case DECODE_TUNNEL_ARP:
@@ -386,6 +386,22 @@ inline int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
     return PacketCopyDataOffset(p, 0, pktdata, pktlen);
 }
 
+static void *decode_tunnels_map;
+
+void PacketSetTunnelId(Packet *p, uint32_t session)
+{
+    if (decode_tunnels_map == NULL || p->root == NULL || !PacketIsIPv4(p->root)) {
+        p->tunnel_id = PKT_TUNNEL_UNKNOWN;
+        return;
+    }
+    struct flowtunnel_keys k = {};
+    k.src = htonl(GET_IPV4_SRC_ADDR_U32(p->root));
+    k.dst = htonl(GET_IPV4_DST_ADDR_U32(p->root));
+    k.session = session;
+    k.tunnel_proto = (uint8_t)p->tproto;
+    p->tunnel_id = DecodeTunnelsId(decode_tunnels_map, k);
+}
+
 /**
  *  \brief Setup a pseudo packet (tunnel)
  *
@@ -397,7 +413,7 @@ inline int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
  *  \retval p the pseudo packet or NULL if out of memory
  */
 Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *parent,
-        const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto)
+        const uint8_t *pkt, uint32_t len, enum SCPacketTunnelProto proto)
 {
     int ret;
 
@@ -614,6 +630,7 @@ void DecodeUnregisterCounters(void)
         g_counter_table = NULL;
     }
     SCMutexUnlock(&g_counter_table_mutex);
+    DecodeTunnelsFree(decode_tunnels_map);
 }
 
 static bool IsDefragMemcapExceptionPolicyStatsValid(enum ExceptionPolicy policy)
@@ -1148,6 +1165,7 @@ void DecodeGlobalConfig(void)
     DecodeGeneveConfig();
     DecodeVXLANConfig();
     DecodeERSPANConfig();
+    decode_tunnels_map = DecodeTunnelsConfig();
     intmax_t value = 0;
     if (SCConfGetInt("decoder.max-layers", &value) == 1) {
         if (value < 0 || value > UINT8_MAX) {

--- a/src/decode.h
+++ b/src/decode.h
@@ -24,6 +24,22 @@
 #ifndef SURICATA_DECODE_H
 #define SURICATA_DECODE_H
 
+enum SCPacketTunnelProto {
+    DECODE_TUNNEL_ETHERNET,
+    DECODE_TUNNEL_ERSPANII,
+    DECODE_TUNNEL_ERSPANI,
+    DECODE_TUNNEL_VXLAN,
+    DECODE_TUNNEL_VLAN,
+    DECODE_TUNNEL_IPV4,
+    DECODE_TUNNEL_IPV6,
+    DECODE_TUNNEL_IPV6_TEREDO, /**< separate protocol for stricter error handling */
+    DECODE_TUNNEL_PPP,
+    DECODE_TUNNEL_NSH,
+    DECODE_TUNNEL_ARP,
+    DECODE_TUNNEL_UNSET
+};
+
+#ifndef SURICATA_BINDGEN_H
 //#define DBG_THREADS
 #define COUNTERS
 
@@ -540,6 +556,11 @@ typedef struct Packet_
      * has the exact same tuple as the lower levels */
     uint8_t recursion_level;
 
+    /* tunnel id if any, PKT_TUNNEL_UNKNOWN if unknown, 0 if none
+     * tunnel ids are configured in suricata.yaml decoder.tunnels section
+     */
+    uint16_t tunnel_id;
+
     uint16_t vlan_id[VLAN_MAX_LAYERS];
     uint8_t vlan_idx;
 
@@ -559,7 +580,7 @@ typedef struct Packet_
     uint8_t ttype; // enum PacketTunnelType
 
     /* tunnel protocol */
-    uint8_t tproto; // enum DecodeTunnelProto
+    uint8_t tproto; // enum SCPacketTunnelProto
 
     /* Pkt Flags */
     uint32_t flags;
@@ -1143,23 +1164,9 @@ static inline void PacketTunnelSetVerdicted(Packet *p)
     p->tunnel_verdicted = true;
 }
 
-enum DecodeTunnelProto {
-    DECODE_TUNNEL_ETHERNET,
-    DECODE_TUNNEL_ERSPANII,
-    DECODE_TUNNEL_ERSPANI,
-    DECODE_TUNNEL_VXLAN,
-    DECODE_TUNNEL_VLAN,
-    DECODE_TUNNEL_IPV4,
-    DECODE_TUNNEL_IPV6,
-    DECODE_TUNNEL_IPV6_TEREDO, /**< separate protocol for stricter error handling */
-    DECODE_TUNNEL_PPP,
-    DECODE_TUNNEL_NSH,
-    DECODE_TUNNEL_ARP,
-    DECODE_TUNNEL_UNSET
-};
-
 Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *parent,
-                             const uint8_t *pkt, uint32_t len, enum DecodeTunnelProto proto);
+        const uint8_t *pkt, uint32_t len, enum SCPacketTunnelProto proto);
+void PacketSetTunnelId(Packet *p, uint32_t session);
 Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, uint8_t proto);
 void PacketDefragPktSetupParent(Packet *parent);
 void DecodeRegisterPerfCounters(DecodeThreadVars *, ThreadVars *);
@@ -1208,6 +1215,7 @@ int DecodeETag(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint
 int DecodeIEEE8021ah(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeGeneve(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeVXLAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
+int DecodeVXLANtunnel(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeMPLS(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeERSPAN(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeERSPANTypeI(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
@@ -1560,6 +1568,7 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
     }
     return true;
 }
+#endif // SURICATA_BINDGEN_H
 
 uint64_t PcapPacketCntGet(const Packet *p);
 void PcapPacketCntSet(Packet *p, uint64_t pcap_cnt);

--- a/src/decode.h
+++ b/src/decode.h
@@ -1317,7 +1317,8 @@ void DecodeUnregisterCounters(void);
 /** Packet is part of established stream */
 #define PKT_STREAM_EST BIT_U32(6)
 
-// vacancy
+/** Flag to indicate that worker to skip the packet */
+#define PKT_SKIP_WORK BIT_U32(7)
 
 #define PKT_HAS_FLOW   BIT_U32(8)
 /** Pseudo packet to end the stream */

--- a/src/decode.h
+++ b/src/decode.h
@@ -558,6 +558,9 @@ typedef struct Packet_
     /* tunnel type: none, root or child */
     uint8_t ttype; // enum PacketTunnelType
 
+    /* tunnel protocol */
+    uint8_t tproto; // enum DecodeTunnelProto
+
     /* Pkt Flags */
     uint32_t flags;
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -105,6 +105,7 @@ static DetectEngineMasterCtx g_master_de_ctx = { SCMUTEX_INITIALIZER,
 static uint32_t TenantIdHash(HashTable *h, void *data, uint16_t data_len);
 static char TenantIdCompare(void *d1, uint16_t d1_len, void *d2, uint16_t d2_len);
 static void TenantIdFree(void *d);
+static uint32_t DetectEngineTenantGetIdFromTunnel(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromPcap(const void *ctx, const Packet *p);
@@ -3496,6 +3497,10 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
             det_ctx->TenantGetId = DetectEngineTenantGetIdFromLivedev;
             SCLogDebug("TENANT_SELECTOR_LIVEDEV");
             break;
+        case TENANT_SELECTOR_TUNNEL:
+            det_ctx->TenantGetId = DetectEngineTenantGetIdFromTunnel;
+            SCLogDebug("TENANT_SELECTOR_TUNNEL");
+            break;
         case TENANT_SELECTOR_DIRECT:
             det_ctx->TenantGetId = DetectEngineTenantGetIdFromPcap;
             SCLogDebug("TENANT_SELECTOR_DIRECT");
@@ -4435,6 +4440,57 @@ int DetectEngineReloadTenantsBlocking(const int reload_cnt)
     return 0;
 }
 
+static int DetectEngineMultiTenantSetupLoadTunnelMappings(
+        const SCConfNode *mappings_root_node, bool failure_fatal)
+{
+    SCConfNode *mapping_node = NULL;
+
+    int mapping_cnt = 0;
+    if (mappings_root_node != NULL) {
+        TAILQ_FOREACH (mapping_node, &mappings_root_node->head, next) {
+            SCConfNode *tenant_id_node = SCConfNodeLookupChild(mapping_node, "tenant-id");
+            if (tenant_id_node == NULL)
+                goto bad_mapping;
+            SCConfNode *tunnel_id_node = SCConfNodeLookupChild(mapping_node, "tunnel-id");
+            if (tunnel_id_node == NULL)
+                goto bad_mapping;
+
+            uint32_t tenant_id = 0;
+            if (StringParseUint32(&tenant_id, 10, (uint16_t)strlen(tenant_id_node->val),
+                        tenant_id_node->val) < 0) {
+                SCLogError("tenant-id  "
+                           "of %s is invalid",
+                        tenant_id_node->val);
+                goto bad_mapping;
+            }
+
+            uint16_t tunnel_id = 0;
+            if (StringParseUint16(&tunnel_id, 10, (uint16_t)strlen(tunnel_id_node->val),
+                        tunnel_id_node->val) < 0) {
+                SCLogError("tunnel id  "
+                           "of %s is invalid",
+                        tunnel_id_node->val);
+                goto bad_mapping;
+            }
+
+            if (DetectEngineTenantRegisterTunnel(tenant_id, tunnel_id) != 0) {
+                goto error;
+            }
+            SCLogConfig("tunnel %u connected to tenant-id %u", tunnel_id, tenant_id);
+            mapping_cnt++;
+            continue;
+
+        bad_mapping:
+            if (failure_fatal)
+                goto error;
+        }
+    }
+    return mapping_cnt;
+
+error:
+    return 0;
+}
+
 static int DetectEngineMultiTenantSetupLoadLivedevMappings(
         const SCConfNode *mappings_root_node, bool failure_fatal)
 {
@@ -4593,6 +4649,8 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
 
             } else if (strcmp(handler, "direct") == 0) {
                 tenant_selector = master->tenant_selector = TENANT_SELECTOR_DIRECT;
+            } else if (strcmp(handler, "tunnel") == 0) {
+                tenant_selector = master->tenant_selector = TENANT_SELECTOR_TUNNEL;
             } else if (strcmp(handler, "device") == 0) {
                 tenant_selector = master->tenant_selector = TENANT_SELECTOR_LIVEDEV;
                 if (EngineModeIsIPS()) {
@@ -4633,6 +4691,17 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
                     } else {
                         SCLogWarning("no multi-detect mappings defined");
                     }
+                }
+            }
+        } else if (tenant_selector == TENANT_SELECTOR_TUNNEL) {
+            int mapping_cnt = DetectEngineMultiTenantSetupLoadTunnelMappings(
+                    mappings_root_node, failure_fatal);
+            if (mapping_cnt == 0) {
+                if (failure_fatal) {
+                    SCLogError("no multi-detect mappings defined");
+                    goto error;
+                } else {
+                    SCLogWarning("no multi-detect mappings defined");
                 }
             }
         } else if (tenant_selector == TENANT_SELECTOR_LIVEDEV) {
@@ -4764,6 +4833,26 @@ static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet
     return ld->tenant_id;
 }
 
+static uint32_t DetectEngineTenantGetIdFromTunnel(const void *ctx, const Packet *p)
+{
+    const DetectEngineThreadCtx *det_ctx = ctx;
+
+    if (p->tunnel_id == 0 || p->tunnel_id == PKT_TUNNEL_UNKNOWN)
+        return 0;
+
+    if (det_ctx == NULL || det_ctx->tenant_array == NULL || det_ctx->tenant_array_size == 0)
+        return 0;
+
+    /* not very efficient, but for now we're targeting only limited amounts.
+     * Can use hash/tree approach later. */
+    for (uint32_t x = 0; x < det_ctx->tenant_array_size; x++) {
+        if (det_ctx->tenant_array[x].traffic_id == p->tunnel_id)
+            return det_ctx->tenant_array[x].tenant_id;
+    }
+
+    return 0;
+}
+
 static int DetectEngineTenantRegisterSelector(
         enum DetectEngineTenantSelectors selector, uint32_t tenant_id, uint32_t traffic_id)
 {
@@ -4845,6 +4934,12 @@ int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id)
 {
     return DetectEngineTenantRegisterSelector(
             TENANT_SELECTOR_LIVEDEV, tenant_id, (uint32_t)device_id);
+}
+
+int DetectEngineTenantRegisterTunnel(uint32_t tenant_id, uint16_t tunnel_id)
+{
+    return DetectEngineTenantRegisterSelector(
+            TENANT_SELECTOR_TUNNEL, tenant_id, (uint32_t)tunnel_id);
 }
 
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id)

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -117,6 +117,7 @@ int DetectEngineReloadTenantBlocking(uint32_t tenant_id, const char *yaml, int r
 int DetectEngineReloadTenantsBlocking(const int reload_cnt);
 
 int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id);
+int DetectEngineTenantRegisterTunnel(uint32_t tenant_id, uint16_t tunnel_id);
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantRegisterPcapFile(uint32_t tenant_id);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1711,12 +1711,12 @@ typedef struct SigGroupHead_ {
 
 } SigGroupHead;
 
-enum DetectEngineTenantSelectors
-{
-    TENANT_SELECTOR_UNKNOWN = 0,    /**< not set */
-    TENANT_SELECTOR_DIRECT,         /**< method provides direct tenant id */
-    TENANT_SELECTOR_VLAN,           /**< map vlan to tenant id */
-    TENANT_SELECTOR_LIVEDEV,        /**< map livedev to tenant id */
+enum DetectEngineTenantSelectors {
+    TENANT_SELECTOR_UNKNOWN = 0, /**< not set */
+    TENANT_SELECTOR_DIRECT,      /**< method provides direct tenant id */
+    TENANT_SELECTOR_VLAN,        /**< map vlan to tenant id */
+    TENANT_SELECTOR_LIVEDEV,     /**< map livedev to tenant id */
+    TENANT_SELECTOR_TUNNEL,      /**< map tunnel id to tenant id */
 };
 
 typedef struct DetectEngineTenantMapping_ {

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -93,7 +93,7 @@ typedef struct FlowHashKey4_ {
             uint8_t recur;
             uint16_t livedev;
             uint16_t vlan_id[VLAN_MAX_LAYERS];
-            uint16_t pad[1];
+            uint16_t tunnel_id;
         };
         const uint32_t u32[6];
     };
@@ -108,7 +108,7 @@ typedef struct FlowHashKey6_ {
             uint8_t recur;
             uint16_t livedev;
             uint16_t vlan_id[VLAN_MAX_LAYERS];
-            uint16_t pad[1];
+            uint16_t tunnel_id;
         };
         const uint32_t u32[12];
     };
@@ -130,6 +130,7 @@ static inline void FlowHashIp4Fill(FlowHashKey4 *fhk, const Packet *p)
     fhk->vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
     fhk->vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
     fhk->vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+    fhk->tunnel_id = p->tunnel_id;
 }
 
 static inline void FlowHashIp6Fill(FlowHashKey6 *fhk, const Packet *p)
@@ -141,15 +142,14 @@ static inline void FlowHashIp6Fill(FlowHashKey6 *fhk, const Packet *p)
     fhk->vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
     fhk->vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
     fhk->vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
+    fhk->tunnel_id = p->tunnel_id;
 }
 
 uint32_t FlowGetIpPairProtoHash(const Packet *p)
 {
     uint32_t hash = 0;
     if (PacketIsIPv4(p)) {
-        FlowHashKey4 fhk = {
-            .pad[0] = 0,
-        };
+        FlowHashKey4 fhk = {};
 
         int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);
         fhk.addrs[1 - ai] = p->src.addr_data32[0];
@@ -162,9 +162,7 @@ uint32_t FlowGetIpPairProtoHash(const Packet *p)
 
         hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
     } else if (PacketIsIPv6(p)) {
-        FlowHashKey6 fhk = {
-            .pad[0] = 0,
-        };
+        FlowHashKey6 fhk = {};
         if (FlowHashRawAddressIPv6GtU32(p->src.addr_data32, p->dst.addr_data32)) {
             fhk.src[0] = p->src.addr_data32[0];
             fhk.src[1] = p->src.addr_data32[1];
@@ -214,7 +212,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
 
     if (PacketIsIPv4(p)) {
         if (PacketIsTCP(p) || PacketIsUDP(p)) {
-            FlowHashKey4 fhk = { .pad[0] = 0 };
+            FlowHashKey4 fhk = {};
 
             int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);
             fhk.addrs[1-ai] = p->src.addr_data32[0];
@@ -231,7 +229,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
         } else if (ICMPV4_DEST_UNREACH_IS_VALID(p)) {
             uint32_t psrc = IPV4_GET_RAW_IPSRC_U32(PacketGetICMPv4EmbIPv4(p));
             uint32_t pdst = IPV4_GET_RAW_IPDST_U32(PacketGetICMPv4EmbIPv4(p));
-            FlowHashKey4 fhk = { .pad[0] = 0 };
+            FlowHashKey4 fhk = {};
 
             const int ai = (psrc > pdst);
             fhk.addrs[1-ai] = psrc;
@@ -247,7 +245,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
             hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
 
         } else {
-            FlowHashKey4 fhk = { .pad[0] = 0 };
+            FlowHashKey4 fhk = {};
             const int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);
             fhk.addrs[1-ai] = p->src.addr_data32[0];
             fhk.addrs[ai] = p->dst.addr_data32[0];
@@ -258,7 +256,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
             hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
         }
     } else if (PacketIsIPv6(p)) {
-        FlowHashKey6 fhk = { .pad[0] = 0 };
+        FlowHashKey6 fhk = {};
         if (FlowHashRawAddressIPv6GtU32(p->src.addr_data32, p->dst.addr_data32)) {
             fhk.src[0] = p->src.addr_data32[0];
             fhk.src[1] = p->src.addr_data32[1];
@@ -303,9 +301,7 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
     uint32_t hash = 0;
 
     if (fk->src.family == AF_INET) {
-        FlowHashKey4 fhk = {
-            .pad[0] = 0,
-        };
+        FlowHashKey4 fhk = {};
         int ai = (fk->src.address.address_un_data32[0] > fk->dst.address.address_un_data32[0]);
         fhk.addrs[1-ai] = fk->src.address.address_un_data32[0];
         fhk.addrs[ai] = fk->dst.address.address_un_data32[0];
@@ -320,12 +316,11 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
         fhk.vlan_id[0] = fk->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = fk->vlan_id[1] & g_vlan_mask;
         fhk.vlan_id[2] = fk->vlan_id[2] & g_vlan_mask;
+        fhk.tunnel_id = fk->tunnel_id;
 
         hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
     } else {
-        FlowHashKey6 fhk = {
-            .pad[0] = 0,
-        };
+        FlowHashKey6 fhk = {};
         if (FlowHashRawAddressIPv6GtU32(fk->src.address.address_un_data32,
                     fk->dst.address.address_un_data32)) {
             fhk.src[0] = fk->src.address.address_un_data32[0];
@@ -356,6 +351,7 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
         fhk.vlan_id[0] = fk->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = fk->vlan_id[1] & g_vlan_mask;
         fhk.vlan_id[2] = fk->vlan_id[2] & g_vlan_mask;
+        fhk.tunnel_id = fk->tunnel_id;
 
         hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
     }
@@ -398,7 +394,8 @@ static inline bool CmpLiveDevIds(const uint16_t id1, const uint16_t id2)
 #define CmpFlowMisc(x, y)                                                                          \
     (((x)->proto == (y)->proto) &&                                                                 \
             ((x)->recursion_level == (y)->recursion_level || g_recurlvl_mask == 0) &&              \
-            CmpVlanIds((x)->vlan_id, (y)->vlan_id))
+            CmpVlanIds((x)->vlan_id, (y)->vlan_id)) &&                                             \
+            ((x)->tunnel_id == (y)->tunnel_id)
 
 /* Since two or more flows can have the same hash key, we need to compare
  * the flow with the current packet or flow key. */
@@ -470,7 +467,8 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                 f->sp == p->l4.vars.icmpv4.emb_sport && f->dp == p->l4.vars.icmpv4.emb_dport &&
                 f->proto == ICMPV4_GET_EMB_PROTO(p) && (PacketIsIPv4(p) == FLOW_IS_IPV4(f)) &&
                 (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-                CmpVlanIds(f->vlan_id, p->vlan_id) && CmpLiveDevIds(p->livedev_id, f->livedev_id)) {
+                CmpVlanIds(f->vlan_id, p->vlan_id) && f->tunnel_id == p->tunnel_id &&
+                CmpLiveDevIds(p->livedev_id, f->livedev_id)) {
             return 1;
 
         /* check the less likely case where the ICMP error was a response to
@@ -480,7 +478,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                    f->dp == p->l4.vars.icmpv4.emb_sport && f->sp == p->l4.vars.icmpv4.emb_dport &&
                    f->proto == ICMPV4_GET_EMB_PROTO(p) && (PacketIsIPv4(p) == FLOW_IS_IPV4(f)) &&
                    (f->recursion_level == p->recursion_level || g_recurlvl_mask == 0) &&
-                   CmpVlanIds(f->vlan_id, p->vlan_id) &&
+                   CmpVlanIds(f->vlan_id, p->vlan_id) && f->tunnel_id == p->tunnel_id &&
                    CmpLiveDevIds(p->livedev_id, f->livedev_id)) {
             return 1;
         }
@@ -1100,7 +1098,7 @@ Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t ha
     }
     f->proto = key->proto;
     memcpy(&f->vlan_id[0], &key->vlan_id[0], sizeof(f->vlan_id));
-    ;
+    f->tunnel_id = key->tunnel_id;
     f->src.addr_data32[0] = key->src.addr_data32[0];
     f->src.addr_data32[1] = key->src.addr_data32[1];
     f->src.addr_data32[2] = key->src.addr_data32[2];

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -152,6 +152,7 @@ void FlowInit(ThreadVars *tv, Flow *f, const Packet *p)
 
     f->proto = p->proto;
     f->recursion_level = p->recursion_level;
+    f->tunnel_id = p->tunnel_id;
     memcpy(&f->vlan_id[0], &p->vlan_id[0], sizeof(f->vlan_id));
     f->vlan_idx = p->vlan_idx;
 

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -569,6 +569,9 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
 
     SCLogDebug("packet %" PRIu64, PcapPacketCntGet(p));
 
+    if (p->flags & PKT_SKIP_WORK) {
+        return TM_ECODE_OK;
+    }
     /* handle Flow */
     if (det_ctx != NULL && det_ctx->de_ctx->PreFlowHook != NULL) {
         const uint8_t action = det_ctx->de_ctx->PreFlowHook(tv, det_ctx, p);

--- a/src/flow.h
+++ b/src/flow.h
@@ -311,6 +311,7 @@ typedef struct FlowKey_
     uint8_t recursion_level;
     uint16_t livedev_id;
     uint16_t vlan_id[VLAN_MAX_LAYERS];
+    uint16_t tunnel_id;
 } FlowKey;
 
 typedef struct FlowAddress_ {
@@ -375,6 +376,7 @@ typedef struct Flow_
     };
     uint8_t proto; /**< ip proto of the flow */
     uint8_t recursion_level;
+    uint16_t tunnel_id;
     uint16_t vlan_id[VLAN_MAX_LAYERS];
 
     uint8_t vlan_idx;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -301,6 +301,9 @@ static void AlertJsonTunnel(const Packet *p, SCJsonBuilder *js, OutputJsonCommon
     SCJbSetUint(js, "dest_port", addr.dp);
     SCJbSetString(js, "proto", addr.proto);
 
+    if (p->tunnel_id > 0 && p->tunnel_id != PKT_TUNNEL_UNKNOWN) {
+        SCJbSetUint(js, "tunnel_id", p->tunnel_id);
+    }
     SCJbSetUint(js, "depth", p->recursion_level);
     uint64_t pcap_cnt = PcapPacketCntGet(p->root);
     if (pcap_cnt != 0) {

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -155,6 +155,9 @@ static SCJsonBuilder *CreateEveHeaderFromFlow(const Flow *f, OutputJsonCommonSet
         SCJbSetUint(jb, "ip_v", 6);
     }
 
+    if (f->tunnel_id > 0 && f->tunnel_id != PKT_TUNNEL_UNKNOWN) {
+        SCJbSetUint(jb, "tunnel_id", f->tunnel_id);
+    }
     if (SCProtoNameValid(f->proto)) {
         SCJbSetString(jb, "proto", known_proto[f->proto]);
     } else {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -895,7 +895,9 @@ SCJsonBuilder *CreateEveHeader(const Packet *p, enum SCOutputJsonLogDirection di
     } else if (PacketIsIPv6(p)) {
         SCJbSetUint(js, "ip_v", 6);
     }
-
+    if (p->tunnel_id > 0 && p->tunnel_id != PKT_TUNNEL_UNKNOWN) {
+        SCJbSetUint(js, "tunnel_id", p->tunnel_id);
+    }
     /* icmp */
     switch (p->proto) {
         case IPPROTO_ICMP:

--- a/src/util-device-private.h
+++ b/src/util-device-private.h
@@ -34,6 +34,7 @@ typedef struct LiveDevice_ {
     char dev_short[MAX_DEVNAME + 1];
     int mtu; /* MTU of the device */
     bool tenant_id_set;
+    bool skip_non_tunnel;
 
     uint16_t id;
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1815,6 +1815,14 @@ decoder:
   # has put the headers on, like when using netmap driver pickup.
   recursion-level:
     use-for-tracking: true
+  # If your packets sources are tunnels encapsulating the traffic,
+  # you can list here these tunnels and assign identifiers to them.
+  # tunnels:
+  #  - id: 1
+  #    type: erspan2
+  #    src: 192.168.1.1
+  #    dst: 192.168.1.3
+  #    session: 123
 
 ##
 ## Performance tuning and profiling


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7674

Describe changes:
- introduces configurable tunnel_id to distinguish same-looking (same 5-tuple) flows encapsulated in different tunnels
- adds a config option to "skip" the packets that are not part of a tunnel on interfaces receiving tunneled traffic
- use this new tunnel_id as a multi-tenant selector

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3241

https://github.com/OISF/suricata/pull/15746 without the ebpf/xdp part