### PR TITLE
Http zstd 7904 v6

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -82,6 +82,7 @@ jobs:
       # flags handling.
       - run: |
           scan-build-22 --status-bugs --exclude "$(pwd)/rust/" \
+                --exclude "$HOME/\.cargo/registry/src/" \
                 -o scan-build-report/ \
                 -enable-checker core.BitwiseShift \
                 -enable-checker core.CallAndMessage \

--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -238,6 +238,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -727,6 +729,15 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "kerberos-parser"
@@ -1546,6 +1557,7 @@ dependencies = [
  "hkdf",
  "humantime",
  "ipsec-parser",
+ "jobserver",
  "kerberos-parser",
  "lazy_static",
  "ldap-parser",
@@ -1579,6 +1591,7 @@ dependencies = [
  "uuid",
  "widestring",
  "x509-parser",
+ "zstd",
 ]
 
 [[package]]
@@ -1613,6 +1626,7 @@ dependencies = [
  "nom 8.0.0",
  "rstest",
  "time",
+ "zstd",
 ]
 
 [[package]]
@@ -2114,3 +2128,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -52,6 +52,7 @@ num-traits = "~0.2.19"
 widestring = "~0.4.3"
 flate2 = { version = "~1.0.35", features = ["zlib"] }
 brotli = "~8.0.1"
+zstd = "~0.13.3"
 hkdf = "~0.12.4"
 aes = "~0.8.4"
 aes-gcm = "~0.10.3"
@@ -96,3 +97,6 @@ htp = { package = "suricata-htp", path = "./htp", version = "@PACKAGE_VERSION@" 
 [dev-dependencies]
 test-case = "~3.3.1"
 suricata-ffi = { path = "./ffi", version = "@PACKAGE_VERSION@", features = ["testing"] }
+
+[build-dependencies.jobserver]
+version = "=0.1.32"

--- a/rust/htp/Cargo.toml.in
+++ b/rust/htp/Cargo.toml.in
@@ -28,6 +28,7 @@ nom = "8.0.0"
 lzma-rs = { version = "0.2.0", features = ["stream"] }
 flate2 = { version = "~1.0.35", features = ["zlib-default"], default-features = false }
 brotli = "~8.0.1"
+zstd = "0.13.3"
 lazy_static = "1.5.0"
 time = "~0.3.41"
 

--- a/rust/htp/src/decompressors.rs
+++ b/rust/htp/src/decompressors.rs
@@ -4,6 +4,7 @@ use std::{
     io::{Cursor, Write},
     time::Instant,
 };
+use zstd;
 
 /// Buffer compression output to this chunk size.
 const ENCODING_CHUNK_SIZE: usize = 8192;
@@ -213,6 +214,8 @@ pub(crate) enum HtpContentEncoding {
     Lzma,
     /// Brotli compression.
     Brotli,
+    /// Zstd compression.
+    Zstd,
 }
 
 //a cursor turning EOF into blocking errors
@@ -309,6 +312,7 @@ impl Decompressor {
             | HtpContentEncoding::Deflate
             | HtpContentEncoding::Zlib
             | HtpContentEncoding::Brotli
+            | HtpContentEncoding::Zstd
             | HtpContentEncoding::Lzma => Ok(Decompressor::new(Box::new(InnerDecompressor::new(
                 encoding, self.inner, options,
             )?))),
@@ -756,6 +760,33 @@ impl BufWriter for BrotliBufWriter {
     }
 }
 
+/// Simple wrapper around an lzma implementation
+struct ZstdBufWriter<'a>(zstd::stream::write::Decoder<'a, BlockingCursor>);
+
+impl Write for ZstdBufWriter<'_> {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        self.0.write(data)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl BufWriter for ZstdBufWriter<'_> {
+    fn get_mut(&mut self) -> Option<&mut BlockingCursor> {
+        Some(self.0.get_mut())
+    }
+
+    fn finish(self: Box<Self>) -> std::io::Result<BlockingCursor> {
+        Ok(self.0.into_inner())
+    }
+
+    fn try_finish(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 /// Structure that represents each decompressor in the chain.
 struct InnerDecompressor {
     /// Decoder implementation that will write to a temporary buffer.
@@ -796,6 +827,20 @@ impl InnerDecompressor {
                 ))),
                 false,
             )),
+            HtpContentEncoding::Zstd => {
+                if let Ok(mut z) = zstd::stream::write::Decoder::new(buf) {
+                    // 8 Mbytes max window like chromium to avoid overallocating
+                    if z.window_log_max(23).is_ok() {
+                        Ok((Box::new(ZstdBufWriter(z)), false))
+                    } else {
+                        Err(std::io::Error::other(
+                            "failed to set max window for zstd decoder",
+                        ))
+                    }
+                } else {
+                    Err(std::io::Error::other("failed to create zstd decoder"))
+                }
+            }
             HtpContentEncoding::Lzma => {
                 if let Some(options) = options.lzma {
                     Ok((
@@ -996,6 +1041,7 @@ impl Decompress for InnerDecompressor {
                 // For other encodings, we retry with deflate, zlib and gzip
                 HtpContentEncoding::Lzma => HtpContentEncoding::Deflate,
                 HtpContentEncoding::Brotli => HtpContentEncoding::Deflate,
+                HtpContentEncoding::Zstd => HtpContentEncoding::Deflate,
                 HtpContentEncoding::None => {
                     return Err(std::io::Error::other("expected a valid encoding"))
                 }

--- a/rust/htp/src/request.rs
+++ b/rust/htp/src/request.rs
@@ -1044,6 +1044,7 @@ impl ConnectionParser {
             | HtpContentEncoding::Deflate
             | HtpContentEncoding::Zlib
             | HtpContentEncoding::Brotli
+            | HtpContentEncoding::Zstd
             | HtpContentEncoding::Lzma => {
                 // Send data buffer to the decompressor if it exists
                 if req.request_decompressor.is_none() && data.is_none() {
@@ -1130,6 +1131,8 @@ impl ConnectionParser {
                 HtpContentEncoding::Brotli
             } else if ce.cmp_nocase_nozero(b"lzma") {
                 HtpContentEncoding::Lzma
+            } else if ce.cmp_nocase_nozero(b"zstd") {
+                HtpContentEncoding::Zstd
             } else if ce.cmp_nocase_nozero(b"inflate") || ce.cmp_nocase_nozero(b"none") {
                 HtpContentEncoding::None
             } else {
@@ -1158,6 +1161,7 @@ impl ConnectionParser {
             | HtpContentEncoding::Deflate
             | HtpContentEncoding::Zlib
             | HtpContentEncoding::Brotli
+            | HtpContentEncoding::Zstd
             | HtpContentEncoding::Lzma => {
                 self.request_prepend_decompressor(request_content_encoding_processing)?;
             }

--- a/rust/htp/src/response.rs
+++ b/rust/htp/src/response.rs
@@ -1063,6 +1063,7 @@ impl ConnectionParser {
             | HtpContentEncoding::Deflate
             | HtpContentEncoding::Zlib
             | HtpContentEncoding::Brotli
+            | HtpContentEncoding::Zstd
             | HtpContentEncoding::Lzma => {
                 // Send data buffer to the decompressor if it exists
                 if resp.response_decompressor.is_none() && data.is_none() {
@@ -1144,6 +1145,8 @@ impl ConnectionParser {
                 HtpContentEncoding::Lzma
             } else if ce.cmp_nocase_nozero(b"br") {
                 HtpContentEncoding::Brotli
+            } else if ce.cmp_nocase_nozero(b"zstd") {
+                HtpContentEncoding::Zstd
             } else if ce.cmp_nocase_nozero(b"inflate") || ce.cmp_nocase_nozero(b"none") {
                 HtpContentEncoding::None
             } else {
@@ -1164,6 +1167,7 @@ impl ConnectionParser {
             | HtpContentEncoding::Deflate
             | HtpContentEncoding::Zlib
             | HtpContentEncoding::Brotli
+            | HtpContentEncoding::Zstd
             | HtpContentEncoding::Lzma => {
                 self.response_prepend_decompressor(response_content_encoding_processing)?;
             }

--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -21,7 +21,8 @@ use brotli;
 use flate2::read::{DeflateDecoder, GzDecoder};
 use std;
 use std::io;
-use std::io::{Cursor, Read, Write};
+use std::io::{BufReader, Cursor, Read, Write};
+use zstd;
 
 pub const HTTP2_DECOMPRESSION_CHUNK_SIZE: usize = 0x1000; // 4096
 
@@ -34,7 +35,8 @@ pub enum HTTP2ContentEncoding {
     Gzip = 1,
     Br = 2,
     Deflate = 3,
-    Unrecognized = 4,
+    Zstd = 4,
+    Unrecognized = 5,
 }
 
 //a cursor turning EOF into blocking errors
@@ -91,6 +93,9 @@ pub enum HTTP2Decompresser {
     // This one is not so large, at 88 bytes as of doing this, but box
     // for consistency.
     Deflate(Box<DeflateDecoder<HTTP2cursor>>),
+
+    // usage of 'static, alternative could be trait instead of enum
+    Zstd(Box<zstd::stream::read::Decoder<'static, BufReader<HTTP2cursor>>>),
 }
 
 impl std::fmt::Debug for HTTP2Decompresser {
@@ -100,6 +105,7 @@ impl std::fmt::Debug for HTTP2Decompresser {
             HTTP2Decompresser::Gzip(_) => write!(f, "GZIP"),
             HTTP2Decompresser::Brotli(_) => write!(f, "BROTLI"),
             HTTP2Decompresser::Deflate(_) => write!(f, "DEFLATE"),
+            HTTP2Decompresser::Zstd(_) => write!(f, "ZSTD"),
         }
     }
 }
@@ -131,6 +137,12 @@ impl GetMutCursor for DeflateDecoder<HTTP2cursor> {
 impl GetMutCursor for brotli::Decompressor<HTTP2cursor> {
     fn get_mut(&mut self) -> &mut HTTP2cursor {
         return self.get_mut();
+    }
+}
+
+impl GetMutCursor for zstd::stream::read::Decoder<'_, BufReader<HTTP2cursor>> {
+    fn get_mut(&mut self) -> &mut HTTP2cursor {
+        return self.get_mut().get_mut();
     }
 }
 
@@ -203,6 +215,19 @@ impl HTTP2DecoderHalf {
                     HTTP2cursor::new(),
                     HTTP2_DECOMPRESSION_CHUNK_SIZE,
                 )));
+            } else if input.eq_ignore_ascii_case(b"zstd") {
+                self.encoding = HTTP2ContentEncoding::Zstd;
+                if let Ok(mut z) = zstd::stream::read::Decoder::new(HTTP2cursor::new()) {
+                    if z.window_log_max(23).is_ok() {
+                        self.decoder = HTTP2Decompresser::Zstd(Box::new(z));
+                    } else {
+                        SCLogWarning!("Failed to set zstd window log max");
+                        self.decoder = HTTP2Decompresser::Unassigned;
+                    }
+                } else {
+                    SCLogWarning!("Failed to create zstd decoder");
+                    self.decoder = HTTP2Decompresser::Unassigned;
+                }
             } else {
                 self.encoding = HTTP2ContentEncoding::Unrecognized;
             }
@@ -228,6 +253,19 @@ impl HTTP2DecoderHalf {
             }
             HTTP2Decompresser::Brotli(ref mut br_decoder) => {
                 let r = http2_decompress(&mut *br_decoder.as_mut(), input, output);
+                match r {
+                    Err(_) => {
+                        self.decoder = HTTP2Decompresser::Unassigned;
+                    }
+                    Ok(o) => {
+                        self.output_len += o.len() as u64;
+                    }
+                }
+                self.input_len += input.len() as u64;
+                return r;
+            }
+            HTTP2Decompresser::Zstd(ref mut zstd_decoder) => {
+                let r = http2_decompress(&mut *zstd_decoder.as_mut(), input, output);
                 match r {
                     Err(_) => {
                         self.decoder = HTTP2Decompresser::Unassigned;

--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -189,15 +189,15 @@ impl HTTP2DecoderHalf {
     pub fn http2_encoding_fromvec(&mut self, input: &[u8]) {
         //use first encoding...
         if self.encoding == HTTP2ContentEncoding::Unknown {
-            if input == b"gzip" {
+            if input.eq_ignore_ascii_case(b"gzip") {
                 self.encoding = HTTP2ContentEncoding::Gzip;
                 self.decoder =
                     HTTP2Decompresser::Gzip(Box::new(GzDecoder::new(HTTP2cursor::new())));
-            } else if input == b"deflate" {
+            } else if input.eq_ignore_ascii_case(b"deflate") {
                 self.encoding = HTTP2ContentEncoding::Deflate;
                 self.decoder =
                     HTTP2Decompresser::Deflate(Box::new(DeflateDecoder::new(HTTP2cursor::new())));
-            } else if input == b"br" {
+            } else if input.eq_ignore_ascii_case(b"br") {
                 self.encoding = HTTP2ContentEncoding::Br;
                 self.decoder = HTTP2Decompresser::Brotli(Box::new(brotli::Decompressor::new(
                     HTTP2cursor::new(),


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7904

Describe changes:
- adds zstd crate
- use it in http1
- use it in http2
- http2: test content-encoding without case sensitivity

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3240

https://github.com/OISF/suricata/pull/15902 based on top of https://github.com/OISF/suricata/pull/15905 with dedicated ticket
