### PR TITLE
Detect http trailers 8256 v14

### DIFF
--- a/src/detect-dns-response.c
+++ b/src/detect-dns-response.c
@@ -336,7 +336,8 @@ static int DetectDnsResponsePrefilterMpmRegister(DetectEngineCtx *de_ctx, SigGro
 
     return PrefilterAppendTxEngineSubState(de_ctx, sgh, DetectDnsResponsePrefilterTx,
             mpm_reg->app_v2.alproto, mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
-            pectx, DetectDnsResponsePrefilterMpmFree, mpm_reg->pname);
+            mpm_reg->app_v2.tx_min_progress, pectx, DetectDnsResponsePrefilterMpmFree,
+            mpm_reg->pname);
 }
 
 static void SCDetectMdnsResponseRrnameRegister(void)

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1460,10 +1460,15 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
             SCJbSetString(ctx.js, "direction", direction);
             SCJbSetBool(ctx.js, "is_mpm", app->mpm);
             SCJbSetString(ctx.js, "app_proto", AppProtoToString(app->alproto));
-            SCJbSetUint(ctx.js, "progress", app->progress);
             if (app->sub_state)
                 SCJbSetString(ctx.js, "sub_state",
                         AppLayerParserGetSubStateName(app->alproto, app->sub_state));
+            if (app->max_progress != app->min_progress) {
+                SCJbSetUint(ctx.js, "min_progress", app->min_progress);
+                SCJbSetUint(ctx.js, "max_progress", app->max_progress);
+            } else {
+                SCJbSetUint(ctx.js, "progress", app->min_progress);
+            }
 
             if (app->v2.transforms != NULL) {
                 SCJbOpenArray(ctx.js, "transforms");

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -143,20 +143,20 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
             /* if engine needs tx state to be higher, break out. */
             if (engine->ctx.app.tx_min_progress > tx->tx_progress)
                 break;
-            if (tx->tx_progress > engine->ctx.app.tx_min_progress) {
+            if (tx->tx_progress > engine->ctx.app.tx_max_progress) {
                 SCLogDebug("tx->tx_progress %u > engine->ctx.app.tx_min_progress %d",
-                        tx->tx_progress, engine->ctx.app.tx_min_progress);
+                        tx->tx_progress, engine->ctx.app.tx_max_progress);
 
                 /* if state value is at or beyond engine state, we can skip it. It means we ran at
                  * least once already. */
-                if (tx->detect_progress > engine->ctx.app.tx_min_progress) {
+                if (tx->detect_progress > engine->ctx.app.tx_max_progress) {
                     SCLogDebug("tx already marked progress as beyond engine: %u > %u",
-                            tx->detect_progress, engine->ctx.app.tx_min_progress);
+                            tx->detect_progress, engine->ctx.app.tx_max_progress);
                     goto next;
                 } else {
                     SCLogDebug("tx->tx_progress %u > engine->ctx.app.tx_min_progress %d: "
                                "tx->detect_progress %u",
-                            tx->tx_progress, engine->ctx.app.tx_min_progress, tx->detect_progress);
+                            tx->tx_progress, engine->ctx.app.tx_max_progress, tx->detect_progress);
                 }
             }
 #ifdef DEBUG
@@ -373,7 +373,8 @@ int PrefilterAppendPayloadEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
 
 int PrefilterAppendTxEngineSubState(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
         PrefilterTxFn PrefilterTxFunc, AppProto alproto, uint8_t sub_state,
-        const int8_t tx_min_progress, void *pectx, void (*FreeFunc)(void *pectx), const char *name)
+        const int8_t tx_min_progress, const int8_t tx_max_progress, void *pectx,
+        void (*FreeFunc)(void *pectx), const char *name)
 {
     BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
     if (sgh == NULL || PrefilterTxFunc == NULL || pectx == NULL)
@@ -388,6 +389,7 @@ int PrefilterAppendTxEngineSubState(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
     e->pectx = pectx;
     e->alproto = alproto;
     e->tx_min_progress = tx_min_progress;
+    e->tx_max_progress = tx_max_progress;
     e->sub_state = sub_state;
     e->Free = FreeFunc;
 
@@ -413,8 +415,8 @@ int PrefilterAppendTxEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
         PrefilterTxFn PrefilterTxFunc, AppProto alproto, const int8_t tx_min_progress, void *pectx,
         void (*FreeFunc)(void *pectx), const char *name)
 {
-    return PrefilterAppendTxEngineSubState(
-            de_ctx, sgh, PrefilterTxFunc, alproto, 0, tx_min_progress, pectx, FreeFunc, name);
+    return PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterTxFunc, alproto, 0,
+            tx_min_progress, tx_min_progress, pectx, FreeFunc, name);
 }
 
 int PrefilterAppendFrameEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
@@ -736,7 +738,8 @@ struct TxNonPFData {
     AppProto alproto;
     uint8_t sub_state;
     int dir;      /**< 0: toserver, 1: toclient */
-    uint8_t progress; /**< progress state value to register at */
+    uint8_t min_progress; /**< progress state value to register at */
+    uint8_t max_progress; /**< progress state value to register at */
     int sig_list; /**< special handling: normally 0, but for special cases (app-layer-state,
                      app-layer-event) use the list id to create separate engines */
     uint32_t sigs_cnt;
@@ -747,7 +750,8 @@ struct TxNonPFData {
 static uint32_t TxNonPFHash(HashListTable *h, void *data, uint16_t _len)
 {
     struct TxNonPFData *d = data;
-    return (d->alproto + d->sub_state + d->progress + d->dir + d->sig_list) % h->array_size;
+    return (d->alproto + d->sub_state + d->min_progress + d->max_progress + d->dir + d->sig_list) %
+           h->array_size;
 }
 
 static char TxNonPFCompare(void *data1, uint16_t _len1, void *data2, uint16_t len2)
@@ -755,7 +759,8 @@ static char TxNonPFCompare(void *data1, uint16_t _len1, void *data2, uint16_t le
     struct TxNonPFData *d1 = data1;
     struct TxNonPFData *d2 = data2;
     return d1->alproto == d2->alproto && d1->sub_state == d2->sub_state &&
-           d1->progress == d2->progress && d1->dir == d2->dir && d1->sig_list == d2->sig_list;
+           d1->min_progress == d2->min_progress && d1->max_progress == d2->max_progress &&
+           d1->dir == d2->dir && d1->sig_list == d2->sig_list;
 }
 
 static void TxNonPFFree(void *data)
@@ -766,8 +771,8 @@ static void TxNonPFFree(void *data)
 }
 
 static int TxNonPFAddSig(DetectEngineCtx *de_ctx, HashListTable *tx_engines_hash,
-        const AppProto alproto, const uint8_t sub_state, const int dir, const uint8_t progress,
-        const int sig_list, const char *name, const Signature *s)
+        const AppProto alproto, const uint8_t sub_state, const int dir, const uint8_t min_progress,
+        const uint8_t max_progress, const int sig_list, const char *name, const Signature *s)
 {
     const uint32_t max_sids = DetectEngineGetMaxSigId(de_ctx);
 
@@ -775,7 +780,8 @@ static int TxNonPFAddSig(DetectEngineCtx *de_ctx, HashListTable *tx_engines_hash
         .alproto = alproto,
         .sub_state = sub_state,
         .dir = dir,
-        .progress = progress,
+        .min_progress = min_progress,
+        .max_progress = max_progress,
         .sig_list = sig_list,
         .sigs_cnt = 0,
         .sigs = NULL,
@@ -807,7 +813,8 @@ static int TxNonPFAddSig(DetectEngineCtx *de_ctx, HashListTable *tx_engines_hash
     add->dir = dir;
     add->sub_state = sub_state;
     add->alproto = alproto;
-    add->progress = progress;
+    add->min_progress = min_progress;
+    add->max_progress = max_progress;
     add->sig_list = sig_list;
     add->sigs = SCCalloc(max_sids, sizeof(struct PrefilterNonPFDataSig));
     if (add->sigs == NULL) {
@@ -988,7 +995,7 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
                 const uint8_t direction = dir == 0 ? STREAM_TOSERVER : STREAM_TOCLIENT;
                 const int sm_list =
                         DetectEngineAppHookToSmlist(s->alproto, sub_state, state, direction);
-                if (TxNonPFAddSig(de_ctx, tx_engines_hash, s->alproto, sub_state, dir, state,
+                if (TxNonPFAddSig(de_ctx, tx_engines_hash, s->alproto, sub_state, dir, state, state,
                             sm_list, pname, s) != 0) {
                     goto error;
                 }
@@ -1061,7 +1068,8 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
                         sig_list = app_state_list_id;
                     const uint8_t sub_state = app->sub_state;
                     if (TxNonPFAddSig(de_ctx, tx_engines_hash, app->alproto, sub_state, app->dir,
-                                app->min_progress, sig_list, buf->name, s) != 0) {
+                                app->min_progress, app->max_progress, sig_list, buf->name,
+                                s) != 0) {
                         goto error;
                     }
                     tx_non_pf = true;
@@ -1083,6 +1091,7 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
 
             uint8_t sub_state = s->init_data->hook.t.app.sub_state;
             if (TxNonPFAddSig(de_ctx, tx_engines_hash, s->alproto, sub_state, dir,
+                        s->init_data->hook.t.app.app_progress,
                         s->init_data->hook.t.app.app_progress, s->init_data->hook.sm_list, pname,
                         s) != 0) {
                 goto error;
@@ -1151,8 +1160,8 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
             b = HashListTableGetListNext(b)) {
         struct TxNonPFData *t = HashListTableGetListData(b);
         SCLogDebug("%s engine for %s hook %d has %u non-pf sigs",
-                t->dir == 0 ? "toserver" : "toclient", AppProtoToString(t->alproto), t->progress,
-                t->sigs_cnt);
+                t->dir == 0 ? "toserver" : "toclient", AppProtoToString(t->alproto),
+                t->min_progress, t->sigs_cnt);
 
         if (((sgh->init->direction & SIG_FLAG_TOSERVER) && t->dir == 1) ||
                 ((sgh->init->direction & SIG_FLAG_TOCLIENT) && t->dir == 0)) {
@@ -1161,8 +1170,9 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
         }
 
         /* register special progress value to indicate we need to run it all the time */
-        DEBUG_VALIDATE_BUG_ON(t->progress > INT8_MAX);
-        int8_t engine_progress = (int8_t)t->progress;
+        DEBUG_VALIDATE_BUG_ON(t->max_progress > INT8_MAX);
+        DEBUG_VALIDATE_BUG_ON(t->max_progress < t->min_progress);
+        int8_t engine_progress = (int8_t)t->min_progress;
         if (t->sig_list == app_state_list_id) {
             SCLogDebug("engine %s for state list", t->engine_name);
             engine_progress = -1;
@@ -1177,7 +1187,8 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
             data->array[i] = t->sigs[i].sid;
         }
         if (PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterTxNonPF, t->alproto, t->sub_state,
-                    engine_progress, (void *)data, PrefilterNonPFDataFree, t->engine_name) < 0) {
+                    engine_progress, (int8_t)t->max_progress, (void *)data, PrefilterNonPFDataFree,
+                    t->engine_name) < 0) {
             SCFree(data);
             goto error;
         }
@@ -1356,6 +1367,7 @@ int PrefilterSetupRuleGroup(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
             e->local_id = local_id++;
             e->alproto = el->alproto;
             e->ctx.app.tx_min_progress = el->tx_min_progress;
+            e->ctx.app.tx_max_progress = el->tx_max_progress;
             e->ctx.app.sub_state = el->sub_state;
             e->cb.PrefilterTx = el->PrefilterTx;
             e->pectx = el->pectx;
@@ -1685,8 +1697,8 @@ int PrefilterGenericMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmC
 
     SCLogDebug("mpm_reg %s sub_state %u", mpm_reg->name, mpm_reg->app_v2.sub_state);
     int r = PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterMpm, mpm_reg->app_v2.alproto,
-            mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress, pectx,
-            PrefilterGenericMpmFree, mpm_reg->pname);
+            mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
+            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterGenericMpmFree, mpm_reg->pname);
     if (r != 0) {
         SCFree(pectx);
     }
@@ -1708,7 +1720,7 @@ int PrefilterSingleMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCt
     SCLogDebug("mpm_reg %s sub_state %u", mpm_reg->name, mpm_reg->app_v2.sub_state);
     int r = PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterMpmTxSingle,
             mpm_reg->app_v2.alproto, mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
-            pectx, PrefilterGenericMpmFree, mpm_reg->pname);
+            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterGenericMpmFree, mpm_reg->pname);
     if (r != 0) {
         SCFree(pectx);
     }
@@ -1762,8 +1774,8 @@ int PrefilterMultiGenericMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
 
     SCLogDebug("mpm_reg %s sub_state %u", mpm_reg->name, mpm_reg->app_v2.sub_state);
     int r = PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterMultiMpm, mpm_reg->app_v2.alproto,
-            mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress, pectx,
-            PrefilterMultiGenericMpmFree, mpm_reg->pname);
+            mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
+            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterMultiGenericMpmFree, mpm_reg->pname);
     if (r != 0) {
         SCFree(pectx);
     }

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -1061,7 +1061,7 @@ static int SetupNonPrefilter(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
                         sig_list = app_state_list_id;
                     const uint8_t sub_state = app->sub_state;
                     if (TxNonPFAddSig(de_ctx, tx_engines_hash, app->alproto, sub_state, app->dir,
-                                app->progress, sig_list, buf->name, s) != 0) {
+                                app->min_progress, sig_list, buf->name, s) != 0) {
                         goto error;
                     }
                     tx_non_pf = true;

--- a/src/detect-engine-prefilter.h
+++ b/src/detect-engine-prefilter.h
@@ -68,7 +68,8 @@ int PrefilterAppendPayloadEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
         PrefilterPktFn PrefilterFunc, void *pectx, void (*FreeFunc)(void *pectx), const char *name);
 int PrefilterAppendTxEngineSubState(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
         PrefilterTxFn PrefilterTxFunc, AppProto alproto, uint8_t sub_state,
-        const int8_t tx_min_progress, void *pectx, void (*FreeFunc)(void *pectx), const char *name);
+        const int8_t tx_min_progress, const int8_t tx_max_progress, void *pectx,
+        void (*FreeFunc)(void *pectx), const char *name);
 int PrefilterAppendTxEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
         PrefilterTxFn PrefilterTxFunc, const AppProto alproto, const int8_t tx_min_progress,
         void *pectx, void (*FreeFunc)(void *pectx), const char *name);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -198,8 +198,9 @@ void DetectPktInspectEngineRegister(const char *name,
  *
  *  \note errors are fatal */
 static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alproto, uint32_t dir,
-        uint8_t sub_state, uint8_t progress, InspectEngineFuncPtr Callback,
-        InspectionBufferGetDataPtr GetData, InspectionSingleBufferGetDataPtr GetDataSingle,
+        uint8_t sub_state, uint8_t min_progress, uint8_t max_progress,
+        InspectEngineFuncPtr Callback, InspectionBufferGetDataPtr GetData,
+        InspectionSingleBufferGetDataPtr GetDataSingle,
         InspectionMultiBufferGetDataPtr GetMultiData)
 {
     /* ignore special case unknown */
@@ -207,7 +208,8 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
         DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
         DEBUG_VALIDATE_BUG_ON(!AppLayerParserSupportsSubStates(alproto) && sub_state != 0);
     }
-    BUG_ON(progress >= APP_LAYER_MAX_PROGRESS);
+    BUG_ON(max_progress >= APP_LAYER_MAX_PROGRESS);
+    BUG_ON(max_progress < min_progress);
 
     DetectBufferTypeRegister(name);
     const int sm_list = DetectBufferTypeGetByName(name);
@@ -217,8 +219,8 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
     SCLogDebug("name %s id %d", name, sm_list);
 
     if ((alproto == ALPROTO_FAILED) || (!(dir == SIG_FLAG_TOSERVER || dir == SIG_FLAG_TOCLIENT)) ||
-            (sm_list < DETECT_SM_LIST_MATCH) || (sm_list >= SHRT_MAX) || (progress >= 48) ||
-            (Callback == NULL)) {
+            (sm_list < DETECT_SM_LIST_MATCH) || (sm_list >= SHRT_MAX) ||
+            (max_progress >= APP_LAYER_MAX_PROGRESS) || (Callback == NULL)) {
         SCLogError("Invalid arguments");
         BUG_ON(1);
     } else if (Callback == DetectEngineInspectBufferGeneric && GetData == NULL) {
@@ -251,8 +253,8 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
     new_engine->sm_list = (uint16_t)sm_list;
     new_engine->sm_list_base = (uint16_t)sm_list;
     new_engine->sub_state = sub_state;
-    new_engine->min_progress = progress;
-    new_engine->max_progress = progress;
+    new_engine->min_progress = min_progress;
+    new_engine->max_progress = max_progress;
     new_engine->v2.Callback = Callback;
     if (Callback == DetectEngineInspectBufferGeneric) {
         new_engine->v2.GetData = GetData;
@@ -272,6 +274,45 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
 
         t->next = new_engine;
     }
+}
+
+/**
+ *  \brief register an app-layer inspect engine with a min and max progress
+ *
+ *  \param name the buffer name
+ *  \param alproto app-layer protocol
+ *  \param dir direction
+ *  \param progress1 first progress to run the engine
+ *  \param progress2 second progress where we can run the engine
+ *  \param Callback callback function, can be generic DetectEngineInspectBufferGeneric
+ *  \param GetData seconday callback in case of use of DetectEngineInspectBufferGeneric
+ */
+void DetectAppLayerInspectEngineRegister2(const char *name, AppProto alproto, uint32_t dir,
+        uint8_t progress1, uint8_t progress2, InspectEngineFuncPtr Callback,
+        InspectionBufferGetDataPtr GetData)
+{
+    /* before adding, check that we don't add a duplicate entry, which will
+     * propagate all the way into the packet runtime if allowed. */
+    DetectEngineAppInspectionEngine *t = g_app_inspect_engines;
+    if (progress1 >= progress2) {
+        FatalError(
+                "Bad order for progresses for %s : %d should be > %d", name, progress1, progress2);
+    }
+    while (t != NULL) {
+        const uint32_t t_direction = t->dir == 0 ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;
+        const int sm_list = DetectBufferTypeGetByName(name);
+
+        if (t->sm_list == sm_list && t->alproto == alproto && t_direction == dir &&
+                t->min_progress == progress1 && t->v2.Callback == Callback &&
+                t->v2.GetData == GetData) {
+            DEBUG_VALIDATE_BUG_ON(1);
+            return;
+        }
+        t = t->next;
+    }
+
+    AppLayerInspectEngineRegisterInternal(
+            name, alproto, dir, 0, progress1, progress2, Callback, GetData, NULL, NULL);
 }
 
 void DetectAppLayerInspectEngineRegister(const char *name, AppProto alproto, uint32_t dir,
@@ -294,7 +335,7 @@ void DetectAppLayerInspectEngineRegister(const char *name, AppProto alproto, uin
     }
 
     AppLayerInspectEngineRegisterInternal(
-            name, alproto, dir, 0, (uint8_t)progress, Callback, GetData, NULL, NULL);
+            name, alproto, dir, 0, progress, progress, Callback, GetData, NULL, NULL);
 }
 
 void DetectAppLayerInspectEngineRegisterSubState(const char *name, AppProto alproto, uint32_t dir,
@@ -318,7 +359,7 @@ void DetectAppLayerInspectEngineRegisterSubState(const char *name, AppProto alpr
     }
 
     AppLayerInspectEngineRegisterInternal(
-            name, alproto, dir, sub_state, progress, Callback, GetData, NULL, NULL);
+            name, alproto, dir, sub_state, progress, progress, Callback, GetData, NULL, NULL);
 }
 void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alproto, uint32_t dir,
         uint8_t progress, InspectEngineFuncPtr Callback, InspectionSingleBufferGetDataPtr GetData)
@@ -340,7 +381,7 @@ void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alprot
     }
 
     AppLayerInspectEngineRegisterInternal(
-            name, alproto, dir, 0, (uint8_t)progress, Callback, NULL, GetData, NULL);
+            name, alproto, dir, 0, progress, progress, Callback, NULL, GetData, NULL);
 }
 
 /* copy an inspect engine with transforms to a new list id. */
@@ -2286,7 +2327,7 @@ void DetectAppLayerMultiRegisterSubState(const char *name, AppProto alproto, uin
         uint8_t sub_state, uint8_t progress, InspectionMultiBufferGetDataPtr GetData, int priority)
 {
     BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
-    AppLayerInspectEngineRegisterInternal(name, alproto, dir, sub_state, progress,
+    AppLayerInspectEngineRegisterInternal(name, alproto, dir, sub_state, progress, progress,
             DetectEngineInspectMultiBufferGeneric, NULL, NULL, GetData);
     DetectAppLayerMpmMultiRegisterSubState(name, dir, priority, PrefilterMultiGenericMpmRegister,
             GetData, alproto, sub_state, progress);
@@ -2298,7 +2339,7 @@ void DetectAppLayerMultiRegister(const char *name, AppProto alproto, uint32_t di
         InspectionMultiBufferGetDataPtr GetData, int priority)
 {
     BUG_ON(AppLayerParserSupportsSubStates(alproto));
-    AppLayerInspectEngineRegisterInternal(name, alproto, dir, 0, (uint8_t)progress,
+    AppLayerInspectEngineRegisterInternal(name, alproto, dir, 0, progress, progress,
             DetectEngineInspectMultiBufferGeneric, NULL, NULL, GetData);
     DetectAppLayerMpmMultiRegister(
             name, dir, priority, PrefilterMultiGenericMpmRegister, GetData, alproto, progress);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -250,8 +250,9 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
     new_engine->dir = direction;
     new_engine->sm_list = (uint16_t)sm_list;
     new_engine->sm_list_base = (uint16_t)sm_list;
-    new_engine->progress = progress;
     new_engine->sub_state = sub_state;
+    new_engine->min_progress = progress;
+    new_engine->max_progress = progress;
     new_engine->v2.Callback = Callback;
     if (Callback == DetectEngineInspectBufferGeneric) {
         new_engine->v2.GetData = GetData;
@@ -284,7 +285,7 @@ void DetectAppLayerInspectEngineRegister(const char *name, AppProto alproto, uin
         const int sm_list = DetectBufferTypeGetByName(name);
 
         if (t->sm_list == sm_list && t->alproto == alproto && t_direction == dir &&
-                t->sub_state == 0 && t->progress == progress && t->v2.Callback == Callback &&
+                t->sub_state == 0 && t->min_progress == progress && t->v2.Callback == Callback &&
                 t->v2.GetData == GetData) {
             DEBUG_VALIDATE_BUG_ON(1);
             return;
@@ -308,7 +309,7 @@ void DetectAppLayerInspectEngineRegisterSubState(const char *name, AppProto alpr
         const int sm_list = DetectBufferTypeGetByName(name);
 
         if (t->sm_list == sm_list && t->alproto == alproto && t_direction == dir &&
-                t->sub_state == sub_state && t->progress == progress &&
+                t->sub_state == sub_state && t->min_progress == progress &&
                 t->v2.Callback == Callback && t->v2.GetData == GetData) {
             DEBUG_VALIDATE_BUG_ON(1);
             return;
@@ -330,7 +331,7 @@ void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alprot
         const int sm_list = DetectBufferTypeGetByName(name);
 
         if (t->sm_list == sm_list && t->alproto == alproto && t_direction == dir &&
-                t->progress == progress && t->v2.Callback == Callback &&
+                t->min_progress == progress && t->v2.Callback == Callback &&
                 t->v2.GetDataSingle == GetData) {
             DEBUG_VALIDATE_BUG_ON(1);
             return;
@@ -361,7 +362,8 @@ static void DetectAppLayerInspectEngineCopy(
             new_engine->sm_list = (uint16_t)new_list; /* use new list id */
             DEBUG_VALIDATE_BUG_ON(sm_list < 0 || sm_list > UINT16_MAX);
             new_engine->sm_list_base = (uint16_t)sm_list;
-            new_engine->progress = t->progress;
+            new_engine->min_progress = t->min_progress;
+            new_engine->max_progress = t->max_progress;
             new_engine->sub_state = t->sub_state;
             new_engine->v2 = t->v2;
             new_engine->v2.transforms = transforms; /* assign transforms */
@@ -395,7 +397,8 @@ static void DetectAppLayerInspectEngineCopyListToDetectCtx(DetectEngineCtx *de_c
         new_engine->dir = t->dir;
         new_engine->sm_list = t->sm_list;
         new_engine->sm_list_base = t->sm_list;
-        new_engine->progress = t->progress;
+        new_engine->min_progress = t->min_progress;
+        new_engine->max_progress = t->max_progress;
         new_engine->sub_state = t->sub_state;
         new_engine->v2 = t->v2;
 
@@ -615,7 +618,8 @@ static void AppendStreamInspectEngine(
     new_engine->sm_list_base = DETECT_SM_LIST_PMATCH;
     new_engine->smd = stream;
     new_engine->v2.Callback = DetectEngineInspectStream;
-    new_engine->progress = 0;
+    new_engine->min_progress = 0;
+    new_engine->max_progress = 0;
 
     /* append */
     if (s->app_inspect == NULL) {
@@ -784,7 +788,8 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
     new_engine->sm_list_base = t->sm_list_base;
     new_engine->smd = smd;
     new_engine->match_on_null = smd ? DetectContentInspectionMatchOnAbsentBuffer(smd) : false;
-    new_engine->progress = t->progress;
+    new_engine->min_progress = t->min_progress;
+    new_engine->max_progress = t->max_progress;
     new_engine->sub_state = t->sub_state;
     new_engine->v2 = t->v2;
     SCLogDebug("sm_list %d new_engine->v2 %p/%p/%p", new_engine->sm_list, new_engine->v2.Callback,
@@ -802,7 +807,8 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
         }
 
         /* prepend engine if forced or if our engine has a lower progress. */
-    } else if (prepend || (!(*head_is_mpm) && s->app_inspect->progress > new_engine->progress)) {
+    } else if (prepend ||
+               (!(*head_is_mpm) && s->app_inspect->min_progress > new_engine->min_progress)) {
         new_engine->next = s->app_inspect;
         s->app_inspect = new_engine;
         if (new_engine->sm_list == files_id) {
@@ -817,7 +823,7 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
     } else {
         DetectEngineAppInspectionEngine *a = s->app_inspect;
         while (a->next != NULL) {
-            if (a->next && a->next->progress > new_engine->progress) {
+            if (a->next && a->next->min_progress > new_engine->min_progress) {
                 break;
             }
             a = a->next;
@@ -969,7 +975,8 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
 
             DetectEngineAppInspectionEngine t = {
                 .alproto = s->init_data->hook.t.app.alproto,
-                .progress = state,
+                .min_progress = state,
+                .max_progress = state,
                 .sub_state = s->init_data->hook.t.app.sub_state,
                 .sm_list = (uint16_t)sm_list,
                 .sm_list_base = (uint16_t)sm_list,
@@ -1052,7 +1059,8 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
 
         DetectEngineAppInspectionEngine t = {
             .alproto = s->init_data->hook.t.app.alproto,
-            .progress = s->init_data->hook.t.app.app_progress,
+            .min_progress = s->init_data->hook.t.app.app_progress,
+            .max_progress = s->init_data->hook.t.app.app_progress,
             .sub_state = s->init_data->hook.t.app.sub_state,
             .sm_list = (uint16_t)s->init_data->hook.sm_list,
             .sm_list_base = (uint16_t)s->init_data->hook.sm_list,
@@ -1085,9 +1093,9 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
 #ifdef DEBUG
     const DetectEngineAppInspectionEngine *iter = s->app_inspect;
     while (iter) {
-        SCLogDebug("%u: engine %s id %u progress %d %s", s->id,
-                DetectEngineBufferTypeGetNameById(de_ctx, iter->sm_list), iter->id, iter->progress,
-                iter->sm_list == mpm_list ? "MPM" : "");
+        SCLogDebug("%u: engine %s id %u progress %d-%d %s", s->id,
+                DetectEngineBufferTypeGetNameById(de_ctx, iter->sm_list), iter->id,
+                iter->min_progress, iter->max_progress, iter->sm_list == mpm_list ? "MPM" : "");
         iter = iter->next;
     }
 #endif
@@ -2169,8 +2177,8 @@ uint8_t DetectEngineInspectBufferSingle(DetectEngineCtx *de_ctx, DetectEngineThr
     const int list_id = engine->sm_list;
     SCLogDebug("running inspect on %d", list_id);
 
-    const bool eof =
-            (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) > engine->progress);
+    const bool eof = (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) >
+                      engine->max_progress);
 
     SCLogDebug("list %d mpm? %s transforms %p", engine->sm_list, engine->mpm ? "true" : "false",
             engine->v2.transforms);
@@ -2230,7 +2238,8 @@ uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineTh
     const int list_id = engine->sm_list;
     SCLogDebug("running inspect on %d", list_id);
 
-    const bool eof = (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) > engine->progress);
+    const bool eof = (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) >
+                      engine->max_progress);
 
     SCLogDebug("list %d mpm? %s transforms %p",
             engine->sm_list, engine->mpm ? "true" : "false", engine->v2.transforms);
@@ -2365,7 +2374,7 @@ uint8_t DetectEngineInspectMultiBufferGeneric(DetectEngineCtx *de_ctx,
     if (local_id == 0) {
         // That means we did not get even one buffer value from the multi-buffer
         const bool eof = (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) >
-                          engine->progress);
+                          engine->max_progress);
         if (eof && engine->match_on_null) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -170,6 +170,10 @@ void DetectAppLayerInspectEngineRegisterSubState(const char *name, AppProto alpr
         uint8_t type, uint8_t progress, InspectEngineFuncPtr Callback2,
         InspectionBufferGetDataPtr GetData);
 
+void DetectAppLayerInspectEngineRegister2(const char *name, AppProto alproto, uint32_t dir,
+        uint8_t progress1, uint8_t progress2, InspectEngineFuncPtr Callback2,
+        InspectionBufferGetDataPtr GetData);
+
 void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alproto, uint32_t dir,
         uint8_t progress, InspectEngineFuncPtr Callback2, InspectionSingleBufferGetDataPtr GetData);
 

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -604,7 +604,7 @@ int PrefilterMpmFiledataRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, Mpm
 
     return PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterTxFiledata,
             mpm_reg->app_v2.alproto, mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
-            pectx, PrefilterMpmFiledataFree, mpm_reg->pname);
+            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterMpmFiledataFree, mpm_reg->pname);
 }
 
 #ifdef UNITTESTS

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -499,7 +499,7 @@ uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadC
     }
     if (ffc->head == NULL) {
         const bool eof = (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) >
-                          engine->progress);
+                          engine->max_progress);
         if (eof && engine->match_on_null) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -311,7 +311,7 @@ static uint8_t DetectEngineInspectFilemagic(DetectEngineCtx *de_ctx, DetectEngin
     FileContainer *ffc = files.fc;
     if (ffc == NULL || ffc->head == NULL) {
         const bool eof = (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) >
-                          engine->progress);
+                          engine->max_progress);
         if (eof && engine->match_on_null) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -407,7 +407,7 @@ static int PrefilterMpmFilemagicRegister(DetectEngineCtx *de_ctx, SigGroupHead *
 
     return PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterTxFilemagic,
             mpm_reg->app_v2.alproto, mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
-            pectx, PrefilterMpmFilemagicFree, mpm_reg->pname);
+            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterMpmFilemagicFree, mpm_reg->pname);
 }
 
 #endif /* HAVE_MAGIC */

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -248,7 +248,7 @@ static uint8_t DetectEngineInspectFilename(DetectEngineCtx *de_ctx, DetectEngine
     FileContainer *ffc = files.fc;
     if (ffc == NULL || ffc->head == NULL) {
         const bool eof = (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) >
-                          engine->progress);
+                          engine->max_progress);
         if (eof && engine->match_on_null) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -344,7 +344,7 @@ static int PrefilterMpmFilenameRegister(DetectEngineCtx *de_ctx, SigGroupHead *s
 
     return PrefilterAppendTxEngineSubState(de_ctx, sgh, PrefilterTxFilename,
             mpm_reg->app_v2.alproto, mpm_reg->app_v2.sub_state, mpm_reg->app_v2.tx_min_progress,
-            pectx, PrefilterMpmFilenameFree, mpm_reg->pname);
+            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterMpmFilenameFree, mpm_reg->pname);
 }
 
 #ifdef UNITTESTS /* UNITTESTS */

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -312,8 +312,8 @@ static uint8_t DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
-    bool eof =
-            (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) > engine->progress);
+    bool eof = (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) >
+                engine->max_progress);
     const InspectionBuffer *buffer = HttpRequestBodyGetDataCallback(
             det_ctx, engine->v2.transforms, f, flags, txv, engine->sm_list, engine->sm_list_base);
     if (buffer == NULL || buffer->inspect == NULL) {

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -386,14 +386,16 @@ void DetectHttpHeaderRegister(void)
     sigmatch_table[DETECT_HTTP_HEADER].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_HTTP_HEADER].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerInspectEngineRegister("http_header", ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
-            HTP_REQUEST_PROGRESS_HEADERS, DetectEngineInspectBufferGeneric, GetData1);
+    DetectAppLayerInspectEngineRegister2("http_header", ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
+            HTP_REQUEST_PROGRESS_HEADERS, HTP_REQUEST_PROGRESS_TRAILER,
+            DetectEngineInspectBufferGeneric, GetData1);
     DetectAppLayerMpmRegister("http_header", SIG_FLAG_TOSERVER, 2,
             PrefilterMpmHttpHeaderRequestRegister, NULL, ALPROTO_HTTP1,
             0); /* not used, registered twice: HEADERS/TRAILER */
 
-    DetectAppLayerInspectEngineRegister("http_header", ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
-            HTP_RESPONSE_PROGRESS_HEADERS, DetectEngineInspectBufferGeneric, GetData1);
+    DetectAppLayerInspectEngineRegister2("http_header", ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
+            HTP_RESPONSE_PROGRESS_HEADERS, HTP_RESPONSE_PROGRESS_TRAILER,
+            DetectEngineInspectBufferGeneric, GetData1);
     DetectAppLayerMpmRegister("http_header", SIG_FLAG_TOCLIENT, 2,
             PrefilterMpmHttpHeaderResponseRegister, NULL, ALPROTO_HTTP1,
             0); /* not used, registered twice: HEADERS/TRAILER */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2915,15 +2915,12 @@ static int SigValidateCheckBuffers(
             }
 
             if (s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {
-                if ((s->flags & SIG_FLAG_TOSERVER) && (app->dir == 0) &&
-                        app->progress != s->init_data->hook.t.app.app_progress) {
-                    SCLogError("engine progress value %d doesn't match hook %u", app->progress,
+                bool samedir = ((s->flags & SIG_FLAG_TOSERVER) && (app->dir == 0)) ||
+                               ((s->flags & SIG_FLAG_TOCLIENT) && (app->dir == 1));
+                if (samedir && app->min_progress != s->init_data->hook.t.app.app_progress &&
+                        app->max_progress != s->init_data->hook.t.app.app_progress) {
+                    SCLogError("engine progress value %d doesn't match hook %u", app->min_progress,
                             s->init_data->hook.t.app.app_progress);
-                    SCReturnInt(0);
-                }
-                if ((s->flags & SIG_FLAG_TOCLIENT) && (app->dir == 1) &&
-                        app->progress != s->init_data->hook.t.app.app_progress) {
-                    SCLogError("engine progress value doesn't match hook");
                     SCReturnInt(0);
                 }
             }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1361,14 +1361,14 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
                         "skip because engine alproto %s sub_state %u != tx_type %u (engine "
                         "progress %u)",
                         AppProtoToString(engine->alproto), engine->sub_state, tx->tx_type,
-                        engine->progress);
+                        engine->min_progress);
                 engine = engine->next;
                 continue;
             }
             TRACE_SID_TXS(s->id, tx,
                     "inspecting engine alproto %s sub_state %u == tx_type %u (engine progress %u)",
                     AppProtoToString(engine->alproto), engine->sub_state, tx->tx_type,
-                    engine->progress);
+                    engine->min_progress);
 
             void *tx_ptr = DetectGetInnerTx(tx->tx_ptr, f->alproto, engine->alproto, flow_flags);
             if (tx_ptr == NULL) {
@@ -1387,23 +1387,33 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
 
             /* engines are sorted per progress, except that the one with
              * mpm/prefilter enabled is first */
-            if (tx->tx_progress < engine->progress) {
-                SCLogDebug("tx progress %d < engine progress %d",
-                        tx->tx_progress, engine->progress);
+            if (tx->tx_progress < engine->min_progress) {
+                SCLogDebug("tx progress %d < engine progress %d", tx->tx_progress,
+                        engine->min_progress);
                 break;
             }
             if (engine->mpm) {
-                if (tx->tx_progress > engine->progress) {
+                if (tx->tx_progress > engine->max_progress) {
                     TRACE_SID_TXS(s->id, tx,
-                            "engine->mpm: t->tx_progress %u > engine->progress %u, so set "
+                            "engine->mpm: t->tx_progress %u > engine->max_progress %u, so set "
                             "mpm_before_progress",
-                            tx->tx_progress, engine->progress);
+                            tx->tx_progress, engine->max_progress);
                     mpm_before_progress = true;
-                } else if (tx->tx_progress == engine->progress) {
+                } else if (tx->tx_progress == engine->min_progress) {
+                    // do not use >= min progress && <= max_progress here
+                    // because mpm_in_progress is used to optimize and
+                    // not store partially (so far) matching signature as next
+                    // packet with next progress will re-run mpm.
+                    // But for a rule with
+                    // a http1 header as fast_pattern/mpm
+                    // a http1 method, and some content on client body
+                    // when we are in body progress and do not match yet the content
+                    // we will not re-run http_header prefilter for headers progress
+                    // so we need to store signature
                     TRACE_SID_TXS(s->id, tx,
-                            "engine->mpm: t->tx_progress %u == engine->progress %u, so set "
+                            "engine->mpm: t->tx_progress %u == engine->min_progress %u, so set "
                             "mpm_in_progress",
-                            tx->tx_progress, engine->progress);
+                            tx->tx_progress, engine->min_progress);
                     if ((p->flags & PKT_PSEUDO_DETECTLOG_FLUSH) == 0) {
                         mpm_in_progress = true;
                     }
@@ -1422,13 +1432,14 @@ static int DetectRunTxInspectRule(ThreadVars *tv, DetectEngineCtx *de_ctx,
             } else if (engine->v2.Callback == NULL) {
                 /* TODO is this the cleanest way to support a non-app sig on a app hook? */
 
-                if (tx->tx_progress > engine->progress) {
+                if (tx->tx_progress > engine->max_progress) {
                     mpm_before_progress = true; // TODO needs a new name now
                 }
 
                 /* we don't have to store a "hook" match, also don't want to keep any state to make
                  * sure the hook gets invoked again until tx progress progresses. */
-                if ((s->flags & SIG_FLAG_FW_HOOK_LTE) == 0 && tx->tx_progress <= engine->progress) {
+                if ((s->flags & SIG_FLAG_FW_HOOK_LTE) == 0 &&
+                        tx->tx_progress <= engine->max_progress) {
                     return 1; // DETECT_ENGINE_INSPECT_SIG_MATCH;
                 }
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -423,8 +423,13 @@ typedef struct DetectEngineAppInspectionEngine_ {
     bool match_on_null;
     uint16_t sm_list;
     uint16_t sm_list_base; /**< base buffer being transformed */
-    uint8_t progress;
     uint8_t sub_state; /**< matches tx type */
+    // An app-layer inspection engine may run at different progresses.
+    // Even if most engines run at only one progress (min_progress=max_progress)
+    // http_header keyword may run for headers and trailers progress for example
+    uint8_t min_progress;
+    // max_progress allows us to not give up on matching too soon
+    uint8_t max_progress;
 
     struct {
         union {

--- a/src/detect.h
+++ b/src/detect.h
@@ -1598,6 +1598,7 @@ typedef struct PrefilterEngineList_ {
     /** Minimal Tx progress we need before running the engine. Only used
      *  with Tx Engine. Set to -1 for all states. */
     int8_t tx_min_progress;
+    int8_t tx_max_progress;
 
     uint8_t frame_type;
 
@@ -1642,6 +1643,7 @@ typedef struct PrefilterEngine_ {
             /** Minimal Tx progress we need before running the engine. Only used
              *  with Tx Engine. Set to -1 for all states. */
             int8_t tx_min_progress;
+            int8_t tx_max_progress;
             uint8_t sub_state;
         } app;
         uint8_t frame_type;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/8256

Describe changes:
- detect: http.headers works on trailers even if it is not fast_pattern

To do so :
- adds a max_progress field to `DetectEngineAppInspectionEngine`
- adds a `DetectAppLayerInspectEngineRegisterMax` function to register an app engine with a min_progress < max_progress

Needs a QA rebase line : alerts should happen only once per tx when it is about headers (even if the tx has trailers), see SV test about it

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2894

#15853 with fixed compilation for TRACE_SID_TXS