### PR TITLE
Xdp bypass vlan byte order v7

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2895,6 +2895,79 @@ jobs:
       # DPDK configuration checks
       - run: ./qa/live/dpdk/dpdk-testsuite.sh
 
+  ubuntu-xdp:
+    name: Ubuntu (xdp)
+    runs-on: ubuntu-latest
+    needs: [prepare-deps]
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
+      - run: sudo apt update
+      - run: |
+          sudo apt -y install \
+              autoconf \
+              automake \
+              build-essential \
+              cmake \
+              curl \
+              git \
+              hwloc \
+              libhwloc-dev \
+              jq \
+              make \
+              libpcre3 \
+              libpcre3-dbg \
+              libpcre3-dev \
+              libpcre2-dev \
+              libtool \
+              libpcap-dev \
+              libnet1-dev \
+              libyaml-0-2 \
+              libyaml-dev \
+              libcap-ng-dev \
+              libcap-ng0 \
+              libjansson-dev \
+              libjansson4 \
+              libnuma-dev \
+              liblz4-dev \
+              libssl-dev \
+              pkg-config \
+              python3 \
+              python3-yaml \
+              tcpreplay \
+              zlib1g \
+              zlib1g-dev \
+              clang \
+              libxdp-dev
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        with:
+          name: prep
+          path: prep
+      - name: Install Rust
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $(grep rust-version rust/Cargo.toml.in|sed 's/\"//g'|awk '{print $3}') -y
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: ./autogen.sh
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-ebpf --enable-ebpf-build
+      - run: make -j ${{ env.CPUS }}
+      - run: make check
+      - name: Running suricata-verify
+        run: python3 ./suricata-verify/run.py -q --debug-failed
+      - run: ulimit -a
+      - name: Running suricata-verify live tests
+        run: sudo python3 ./suricata-verify/run.py --live --debug-failed
+
   debian-12:
     name: Debian 12 (xdp)
     runs-on: ubuntu-latest

--- a/ebpf/xdp_filter.c
+++ b/ebpf/xdp_filter.c
@@ -523,7 +523,7 @@ int SEC("xdp") xdp_hashfilter(struct xdp_md *ctx)
             return XDP_PASS;
         h_proto = vhdr->h_vlan_encapsulated_proto;
 #if VLAN_TRACKING
-        vlan0 = vhdr->h_vlan_TCI & 0x0fff;
+        vlan0 = __constant_ntohs(vhdr->h_vlan_TCI) & 0x0fff;
 #else
         vlan0 = 0;
 #endif
@@ -537,7 +537,7 @@ int SEC("xdp") xdp_hashfilter(struct xdp_md *ctx)
             return XDP_PASS;
         h_proto = vhdr->h_vlan_encapsulated_proto;
 #if VLAN_TRACKING
-        vlan1 = vhdr->h_vlan_TCI & 0x0fff;
+        vlan1 = __constant_ntohs(vhdr->h_vlan_TCI) & 0x0fff;
 #else
         vlan1 = 0;
 #endif

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -1092,6 +1092,33 @@ static void Recycler(ThreadVars *tv, FlowRecyclerThreadData *ftd, Flow *f)
 {
     FLOWLOCK_WRLOCK(f);
 
+#ifdef CAPTURE_OFFLOAD
+    // If the flow was timed out already, we already updated the stats
+    if ((f->flow_end_flags & FLOW_END_FLAG_TIMEOUT) == 0) {
+        FlowTimeoutCounters counters = {
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        };
+        FlowBypassedTimeout(f, f->lastts, &counters);
+        // TODO use the counters to update
+        // like StatsCounterAddI64(&tv->stats, ftd->cnt.flow_bypassed_cnt_clo,
+        // (int64_t)counters.bypassed_count); same for bypassed_pkts and bypassed_bytes needs to
+        // check if the flow recycler thread can update these stats and give it access to the
+        // StatsCounterId flow_bypassed_cnt_clo and such
+    }
+#endif
+
     (void)OutputFlowLog(tv, ftd->output_thread_data, f);
 
     FlowEndCountersUpdate(tv, &ftd->fec, f);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8699

Describe changes:
- Change byte order of VLAN TCI in xdp_filter.c to fix a bypass issue.
- flow: update bypassed flows on shutdown/recycle
- adds a new ci job to run xdp/replay tests

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3243

Alternative to https://github.com/OISF/suricata/pull/15763

#15900 trying to get green QA

@adaki4 what do you think of this PR + SV PR ?
