### PR TITLE
Dcerpc ptype/v2

### DIFF
--- a/doc/userguide/rules/dcerpc-keywords.rst
+++ b/doc/userguide/rules/dcerpc-keywords.rst
@@ -59,6 +59,53 @@ Examples::
 
 dcerpc.opnum can since suricata 9 use an :ref:`unsigned 16-bits integer <rules-integer-keywords>`.
 
+dcerpc.ptype
+------------
+
+Match on the PDU type of a DCERPC header. On a to_server match the request PDU
+type is used, on a to_client match the response PDU type is used.
+
+The format of the keyword::
+
+  dcerpc.ptype:<u8>;
+  dcerpc.ptype:[>,<,!,=]<u8>;
+
+The PDU type values are:
+
+===== =====================
+Value PDU type
+===== =====================
+0     request
+1     ping
+2     response
+3     fault
+4     working
+5     nocall
+6     reject
+7     ack
+8     cl_cancel
+9     fack
+10    cancel_ack
+11    bind
+12    bind_ack
+13    bind_nak
+14    alter_context
+15    alter_context_resp
+16    auth3
+17    shutdown
+18    co_cancel
+19    orphaned
+20    rts
+===== =====================
+
+Examples::
+
+  dcerpc.ptype:11;
+  dcerpc.ptype:!0;
+  dcerpc.ptype:>10;
+
+dcerpc.ptype uses an :ref:`unsigned 8-bits integer <rules-integer-keywords>`.
+
 dcerpc.stub_data
 ----------------
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -450,7 +450,12 @@
                     }
                 },
                 "request": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "dcerpc.ptype"
+                        ]
+                    }
                 },
                 "res": {
                     "type": "object",
@@ -465,7 +470,12 @@
                     }
                 },
                 "response": {
-                    "type": "string"
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "dcerpc.ptype"
+                        ]
+                    }
                 },
                 "rpc_version": {
                     "type": "string"

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -278,13 +278,13 @@ pub struct Uuid {
     pub node: Vec<u8>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct DCERPCHdr {
     pub rpc_vers: u8,
     pub rpc_vers_minor: u8,
     pub hdrtype: u8,
     pub pfc_flags: u8,
-    pub packed_drep: Vec<u8>,
+    pub packed_drep: [u8; 4],
     pub frag_length: u16,
     pub auth_length: u16,
     pub call_id: u32,

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -205,6 +205,8 @@ pub struct DCERPCTransaction {
     pub resp_lost: bool,
     pub req_cmd: u8,
     pub resp_cmd: u8,
+    pub req_seen: bool,
+    pub resp_seen: bool,
     pub activityuuid: Vec<u8>,
     pub seqnum: u32,
     pub tx_data: AppLayerTxData,
@@ -585,6 +587,7 @@ impl DCERPCState {
                 }
                 let mut tx = self.create_tx(hdr);
                 tx.req_cmd = hdr.hdrtype;
+                tx.req_seen = true;
                 tx.req_done = true;
                 if let Some(flow) = self.flow {
                     sc_app_layer_parser_trigger_raw_stream_inspection(
@@ -762,6 +765,7 @@ impl DCERPCState {
                 match transaction {
                     Some(ref mut tx) => {
                         tx.req_cmd = hdr_type;
+                        tx.req_seen = true;
                         tx.ctxid = request.ctxid;
                         tx.opnum = request.opnum;
                         tx.first_request_seen = request.first_request_seen;
@@ -769,6 +773,7 @@ impl DCERPCState {
                     None => {
                         let mut tx = self.create_tx(hdr);
                         tx.req_cmd = hdr_type;
+                        tx.req_seen = true;
                         tx.ctxid = request.ctxid;
                         tx.opnum = request.opnum;
                         tx.first_request_seen = request.first_request_seen;
@@ -949,10 +954,12 @@ impl DCERPCState {
                         self.get_tx_by_call_id(current_call_id, Direction::ToClient, hdrtype)
                     {
                         tx.resp_cmd = hdrtype;
+                        tx.resp_seen = true;
                         tx
                     } else {
                         let mut tx = self.create_tx(&hdr);
                         tx.resp_cmd = hdrtype;
+                        tx.resp_seen = true;
                         self.transactions.push_back(tx);
                         self.transactions.back_mut().unwrap()
                     };
@@ -980,10 +987,12 @@ impl DCERPCState {
                     match transaction {
                         Some(tx) => {
                             tx.resp_cmd = hdrtype;
+                            tx.resp_seen = true;
                         }
                         None => {
                             let mut tx = self.create_tx(&hdr);
                             tx.resp_cmd = hdrtype;
+                            tx.resp_seen = true;
                             self.transactions.push_back(tx);
                         }
                     };
@@ -1017,8 +1026,10 @@ impl DCERPCState {
                     let mut tx = self.create_tx(&hdr);
                     if direction == Direction::ToServer {
                         tx.req_cmd = hdrtype;
+                        tx.req_seen = true;
                     } else {
                         tx.resp_cmd = hdrtype;
+                        tx.resp_seen = true;
                     }
                     tx.req_done = true;
                     tx.resp_done = true;

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -997,9 +997,37 @@ impl DCERPCState {
                         return AppLayerResult::err();
                     }
                 }
+                DCERPC_TYPE_PING
+                | DCERPC_TYPE_FAULT
+                | DCERPC_TYPE_WORKING
+                | DCERPC_TYPE_NOCALL
+                | DCERPC_TYPE_REJECT
+                | DCERPC_TYPE_ACK
+                | DCERPC_TYPE_CL_CANCEL
+                | DCERPC_TYPE_FACK
+                | DCERPC_TYPE_CANCEL_ACK
+                | DCERPC_TYPE_BINDNAK
+                | DCERPC_TYPE_AUTH3
+                | DCERPC_TYPE_SHUTDOWN
+                | DCERPC_TYPE_CO_CANCEL
+                | DCERPC_TYPE_ORPHANED
+                | DCERPC_TYPE_RTS => {
+                    /* Create tx even on unhandled PDU types to be able to
+                     * at least issue a match on header only fields */
+                    let mut tx = self.create_tx(&hdr);
+                    if direction == Direction::ToServer {
+                        tx.req_cmd = hdrtype;
+                    } else {
+                        tx.resp_cmd = hdrtype;
+                    }
+                    tx.req_done = true;
+                    tx.resp_done = true;
+                    self.transactions.push_back(tx);
+                    // recognized DCERPC PDU types that we do not process
+                    SCLogDebug!("Unhandled packet type: {:?}", hdrtype);
+                }
                 _ => {
                     SCLogDebug!("Unrecognized packet type: {:?}", hdrtype);
-                    // skip unrecognized packet types such as AUTH3
                 }
             }
             consumed += fraglen as u32;

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -221,9 +221,9 @@ impl DCERPCTransaction {
         return Self {
             stub_data_buffer_ts: Vec::new(),
             stub_data_buffer_tc: Vec::new(),
-            req_cmd: DCERPC_TYPE_REQUEST,
-            resp_cmd: DCERPC_TYPE_RESPONSE,
             activityuuid: Vec::new(),
+            req_cmd: DCERPC_TYPE_UNKNOWN,
+            resp_cmd: DCERPC_TYPE_UNKNOWN,
             tx_data: AppLayerTxData::new(),
             ..Default::default()
         };
@@ -445,8 +445,8 @@ impl DCERPCState {
                         if tx.req_done || tx.req_lost {
                             continue;
                         }
-                        let resp_cmd = get_resp_type_for_req(cmd);
-                        if resp_cmd != tx.resp_cmd {
+                        /* do not match if the transaction's command does not match expected */
+                        if tx.req_cmd != cmd && get_req_type_for_resp(tx.resp_cmd) != cmd {
                             continue;
                         }
                     }
@@ -454,8 +454,8 @@ impl DCERPCState {
                         if tx.resp_done || tx.resp_lost {
                             continue;
                         }
-                        let req_cmd = get_req_type_for_resp(cmd);
-                        if req_cmd != tx.req_cmd {
+                        /* do not match if the transaction's command does not match expected */
+                        if tx.resp_cmd != cmd && get_resp_type_for_req(tx.req_cmd) != cmd {
                             continue;
                         }
                     }

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -191,6 +191,7 @@ impl DCERPCUDPState {
             match hdr.pkt_type {
                 DCERPC_TYPE_REQUEST => {
                     tx.req_cmd = hdr.pkt_type;
+                    tx.req_seen = true;
                     tx.frag_cnt_ts = tx.frag_cnt_ts.saturating_add(1);
                     if input.len() + tx.stub_data_buffer_ts.len() < max_size {
                         tx.stub_data_buffer_ts.extend_from_slice(input);
@@ -205,6 +206,7 @@ impl DCERPCUDPState {
                 }
                 DCERPC_TYPE_RESPONSE => {
                     tx.resp_cmd = hdr.pkt_type;
+                    tx.resp_seen = true;
                     tx.frag_cnt_tc = tx.frag_cnt_tc.saturating_add(1);
                     if input.len() + tx.stub_data_buffer_tc.len() < max_size {
                         tx.stub_data_buffer_tc.extend_from_slice(input);

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -190,6 +190,7 @@ impl DCERPCUDPState {
             let max_size = cfg_max_stub_size() as usize;
             match hdr.pkt_type {
                 DCERPC_TYPE_REQUEST => {
+                    tx.req_cmd = hdr.pkt_type;
                     tx.frag_cnt_ts = tx.frag_cnt_ts.saturating_add(1);
                     if input.len() + tx.stub_data_buffer_ts.len() < max_size {
                         tx.stub_data_buffer_ts.extend_from_slice(input);
@@ -203,6 +204,7 @@ impl DCERPCUDPState {
                     return true;
                 }
                 DCERPC_TYPE_RESPONSE => {
+                    tx.resp_cmd = hdr.pkt_type;
                     tx.frag_cnt_tc = tx.frag_cnt_tc.saturating_add(1);
                     if input.len() + tx.stub_data_buffer_tc.len() < max_size {
                         tx.stub_data_buffer_tc.extend_from_slice(input);

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -22,7 +22,9 @@ use super::dcerpc::{
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{detect_match_uint, detect_parse_uint, DetectUintData};
 use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer};
-use crate::smb::detect::{smb_tx_get_stub_data, smb_tx_match_dce_iface, smb_tx_match_dce_opnum};
+use crate::smb::detect::{
+    smb_tx_get_stub_data, smb_tx_match_dce_iface, smb_tx_match_dce_opnum, smb_tx_match_dce_ptype,
+};
 use crate::smb::smb::ALPROTO_SMB;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_void};
@@ -439,9 +441,85 @@ unsafe extern "C" fn dcerpc_tx_get_stub_data(
     return buffer;
 }
 
+fn parse_dcerpc_ptype(arg: &str) -> Option<DetectUintData<u8>> {
+    if let Ok((_, ctx)) = detect_parse_uint::<u8>(arg) {
+        return Some(ctx);
+    }
+    None
+}
+
+unsafe extern "C" fn dcerpc_ptype_parse(carg: *const c_char) -> *mut c_void {
+    if let Ok(arg) = CStr::from_ptr(carg).to_str() {
+        if let Some(detect) = parse_dcerpc_ptype(arg) {
+            return Box::into_raw(Box::new(detect)) as *mut _;
+        }
+    }
+    return std::ptr::null_mut();
+}
+
+unsafe extern "C" fn dcerpc_ptype_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const libc::c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_DCERPC) != 0 {
+        return -1;
+    }
+    let ctx = dcerpc_ptype_parse(raw);
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_DCERPC_PTYPE_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_DCERPC_GENERIC_BUFFER_ID,
+    )
+    .is_null()
+    {
+        dcerpc_ptype_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe fn dcerpc_tx_match_dce_ptype(tx: *mut c_void, ctx: *const SigMatchCtx, flags: u8) -> c_int {
+    let tx = cast_pointer!(tx, DCERPCTransaction);
+    let du8 = cast_pointer!(ctx, DetectUintData<u8>);
+
+    if flags & STREAM_TOSERVER != 0 {
+        if tx.req_seen && detect_match_uint(du8, tx.req_cmd) {
+            return 1;
+        }
+    } else if tx.resp_seen && detect_match_uint(du8, tx.resp_cmd) {
+        return 1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn dcerpc_ptype_match(
+    _de: *mut DetectEngineThreadCtx, f: *mut crate::flow::Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    if SCFlowGetAppProtocol(f) == ALPROTO_DCERPC {
+        return dcerpc_tx_match_dce_ptype(tx, ctx, flags);
+    }
+    if smb_tx_match_dce_ptype(tx, ctx, flags) != 1 {
+        return 0;
+    }
+
+    return 1;
+}
+
+unsafe extern "C" fn dcerpc_ptype_free(_de: *mut DetectEngineCtx, ptr: *mut c_void) {
+    if !ptr.is_null() {
+        std::mem::drop(Box::from_raw(ptr as *mut DetectUintData<u8>));
+    }
+}
+
 static mut G_DCERPC_OPNUM_KW_ID: u16 = 0;
 static mut G_DCERPC_GENERIC_BUFFER_ID: c_int = 0;
 static mut G_DCERPC_IFACE_KW_ID: u16 = 0;
+static mut G_DCERPC_PTYPE_KW_ID: u16 = 0;
 static mut G_DCERPC_STUB_BUFFER_ID: c_int = 0;
 
 #[no_mangle]
@@ -489,6 +567,17 @@ pub unsafe extern "C" fn SCDetectDcerpcRegister() {
         G_DCERPC_IFACE_KW_ID,
         b"dce_iface\0".as_ptr() as *const libc::c_char,
     );
+
+    let kw = SCSigTableAppLiteElmt {
+        name: b"dcerpc.ptype\0".as_ptr() as *const libc::c_char,
+        desc: b"match on the PDU type in a DCERPC header\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/dcerpc-keywords.html#dcerpc-ptype\0".as_ptr() as *const libc::c_char,
+        AppLayerTxMatch: Some(dcerpc_ptype_match),
+        Setup: Some(dcerpc_ptype_setup),
+        Free: Some(dcerpc_ptype_free),
+        flags: 0,
+    };
+    G_DCERPC_PTYPE_KW_ID = SCDetectHelperKeywordRegister(&kw);
 
     let kw_stub = SigTableElmtStickyBuffer {
         name: String::from("dcerpc.stub_data"),

--- a/rust/src/dcerpc/parser.rs
+++ b/rust/src/dcerpc/parser.rs
@@ -233,7 +233,12 @@ pub(super) fn parse_dcerpc_header(i: &[u8]) -> IResult<&[u8], DCERPCHdr> {
         rpc_vers_minor,
         hdrtype,
         pfc_flags,
-        packed_drep: packed_drep.to_vec(),
+        packed_drep: [
+            packed_drep[0],
+            packed_drep[1],
+            packed_drep[2],
+            packed_drep[3],
+        ],
         frag_length,
         auth_length,
         call_id,

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -19,7 +19,7 @@ use super::smb::ALPROTO_SMB;
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::dcerpc::dcerpc::DCERPC_TYPE_REQUEST;
 use crate::dcerpc::detect::{DCEIfaceData, DCEOpnumData, DETECT_DCE_OPNUM_RANGE_UNINITIALIZED};
-use crate::detect::uint::detect_match_uint;
+use crate::detect::uint::{detect_match_uint, DetectUintData};
 use crate::detect::{helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer};
 use crate::direction::Direction;
 use crate::smb::smb::*;
@@ -119,6 +119,25 @@ pub(crate) unsafe extern "C" fn smb_tx_match_dce_opnum(
                     }
                 }
             }
+        }
+    }
+
+    return 0;
+}
+
+pub(crate) unsafe extern "C" fn smb_tx_match_dce_ptype(
+    tx: *mut c_void, ctx: *const SigMatchCtx, flags: u8,
+) -> u8 {
+    let tx = cast_pointer!(tx, SMBTransaction);
+    let du8 = cast_pointer!(ctx, DetectUintData<u8>);
+
+    if let Some(SMBTransactionTypeData::DCERPC(ref x)) = tx.type_data {
+        if flags & STREAM_TOSERVER != 0 {
+            if x.req_set && detect_match_uint(du8, x.req_cmd) {
+                return 1;
+            }
+        } else if x.res_set && detect_match_uint(du8, x.res_cmd) {
+            return 1;
         }
     }
 


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/15904

Changes since v1:
- new feature of logging and matching on unhandled packet types added to make `dcerpc.ptype` keyword useful

Link to tickets:
- https://redmine.openinfosecfoundation.org/issues/8733
- https://redmine.openinfosecfoundation.org/issues/8759
- https://redmine.openinfosecfoundation.org/issues/8762

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3244

Note: Higher number of DCERPC transactions in QA lab results are expected.
