### PR TITLE
websocket: implement over HTTP2

### DIFF
--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -32,6 +32,9 @@ use crate::flow::Flow;
 use crate::frames::Frame;
 
 use crate::dns::dns::{dns_parse_request, dns_parse_response, DNSTransaction};
+use crate::websocket::websocket::{
+    WebSocketState, WebSocketTransaction, WebsocketProgress, ALPROTO_WEBSOCKET,
+};
 
 use nom7::Err;
 use std;
@@ -88,6 +91,7 @@ pub(super) static mut HTTP2_COMPRESSION_BOMB_LIMIT: u64 = 1_048_576;
 pub enum HTTP2TxType {
     HTTP2TxTypeStream = 1,
     HTTP2TxTypeGlobal = 2,
+    HTTP2TxTypeWebsocket = 3,
 }
 
 #[derive(AppLayerFrameType)]
@@ -239,46 +243,44 @@ impl HTTP2GlobalProgress {
 pub enum HTTP2Progress {
     STREAM(HTTP2StreamProgress),
     GLOBAL(HTTP2GlobalProgress),
+    WEBSOCKET, // always complete
 }
 
 impl HTTP2Progress {
     fn get(&self, direction: u8) -> i32 {
-        if let HTTP2Progress::STREAM(ref s) = self {
-            if direction == STREAM_TOSERVER {
-                return s.progress_ts as i32;
-            } else {
-                return s.progress_tc as i32;
+        match self {
+            HTTP2Progress::STREAM(ref s) => {
+                if direction == STREAM_TOSERVER {
+                    s.progress_ts as i32
+                } else {
+                    s.progress_tc as i32
+                }
             }
-        } else if let HTTP2Progress::GLOBAL(ref g) = self {
-            if direction == STREAM_TOSERVER {
-                return g.progress_ts as i32;
-            } else {
-                return g.progress_tc as i32;
+            HTTP2Progress::GLOBAL(ref g) => {
+                if direction == STREAM_TOSERVER {
+                    g.progress_ts as i32
+                } else {
+                    g.progress_tc as i32
+                }
             }
+            HTTP2Progress::WEBSOCKET => WebsocketProgress::WebsocketProgComplete as i32,
         }
-        0
     }
 
     fn is_complete(&self) -> bool {
-        let complete = if let HTTP2Progress::STREAM(ref s) = self {
-            s.is_complete()
-        } else if let HTTP2Progress::GLOBAL(ref g) = self {
-            g.is_complete()
-        } else {
-            false
-        };
-        complete
+        match self {
+            HTTP2Progress::STREAM(ref s) => s.is_complete(),
+            HTTP2Progress::GLOBAL(ref g) => g.is_complete(),
+            HTTP2Progress::WEBSOCKET => true,
+        }
     }
 
     pub fn is_complete_for_direction(&self, direction: u8) -> bool {
-        let complete = if let HTTP2Progress::STREAM(ref s) = self {
-            s.is_complete_for_direction(direction)
-        } else if let HTTP2Progress::GLOBAL(ref g) = self {
-            g.is_complete_for_direction(direction)
-        } else {
-            false
-        };
-        complete
+        match self {
+            HTTP2Progress::STREAM(ref s) => s.is_complete_for_direction(direction),
+            HTTP2Progress::GLOBAL(ref g) => g.is_complete_for_direction(direction),
+            HTTP2Progress::WEBSOCKET => true,
+        }
     }
 }
 
@@ -304,6 +306,8 @@ pub struct HTTP2Transaction {
     pub resp_line: Vec<u8>,
 
     pub doh: Option<DohHttp2Tx>,
+    pub is_websocket: Option<WebSocketState>,
+    pub websocket_tx: Option<WebSocketTransaction>,
 }
 
 impl Transaction for HTTP2Transaction {
@@ -336,6 +340,8 @@ impl HTTP2Transaction {
             req_line: Vec::new(),
             resp_line: Vec::new(),
             doh: None,
+            is_websocket: None,
+            websocket_tx: None,
         }
     }
 
@@ -371,9 +377,19 @@ impl HTTP2Transaction {
         let mut path = None;
         let mut doh = false;
         let mut host = None;
+        let mut is_connect = false;
         for block in blocks {
             if block.name.as_ref() == b"content-encoding" {
                 self.decoder.http2_encoding_fromvec(&block.value, dir);
+            } else if block.name.as_ref() == b":method" && block.value.as_ref() == b"CONNECT" {
+                is_connect = true;
+            } else if block.name.as_ref() == b":protocol"
+                && block.value.as_ref() == b"websocket"
+                && is_connect
+                && self.is_websocket.is_none()
+                && unsafe { ALPROTO_WEBSOCKET } != ALPROTO_UNKNOWN
+            {
+                self.is_websocket = Some(WebSocketState::new());
             } else if block.name.as_ref() == b"accept" {
                 //TODO? faster pattern matching
                 if block.value.as_ref() == b"application/dns-message" {
@@ -515,6 +531,14 @@ impl HTTP2Transaction {
                     }
                 }
             }
+        }
+        if let Some(ref mut wss) = &mut self.is_websocket {
+            wss.parse(
+                StreamSlice::default(),
+                dir,
+                std::ptr::null_mut(),
+                decompressed,
+            );
         }
         return Ok(());
     }
@@ -891,6 +915,16 @@ impl HTTP2State {
         // a global tx (stream id 0) does not hold files cf RFC 9113 section 5.1.1
         self.transactions.push_back(tx);
         return self.transactions.back_mut().unwrap();
+    }
+
+    fn create_websocket_tx(t: WebSocketTransaction, dir: Direction) -> HTTP2Transaction {
+        //special transaction with websocket wrapped
+        let mut tx = HTTP2Transaction::new();
+        tx.tx_data = AppLayerTxData::for_direction(dir);
+        tx.tx_data.0.tx_type = HTTP2TxType::HTTP2TxTypeWebsocket as u8;
+        tx.progress = HTTP2Progress::WEBSOCKET;
+        tx.websocket_tx = Some(t);
+        return tx;
     }
 
     pub fn find_or_create_tx(
@@ -1462,15 +1496,24 @@ impl HTTP2State {
                             )
                         };
                         let (il, ol) = (il + comp_len, ol + decomp_len);
-                        if ol > decompression::DEFAULT_BOMB_RATIO * il {
-                            if ol > unsafe { HTTP2_COMPRESSION_BOMB_LIMIT } {
-                                tx.set_event(HTTP2Event::CompressionBomb);
-                                return AppLayerResult::err();
+                        if ol > decompression::DEFAULT_BOMB_RATIO * il
+                            && ol > unsafe { HTTP2_COMPRESSION_BOMB_LIMIT }
+                        {
+                            tx.set_event(HTTP2Event::CompressionBomb);
+                            return AppLayerResult::err();
+                        }
+                        if let Some(wss) = &mut tx.is_websocket {
+                            let websocket_txs = std::mem::take(&mut wss.transactions);
+                            for t in websocket_txs {
+                                let mut ht = Self::create_websocket_tx(t, dir);
+                                ht.tx_id = self.tx_id + 1;
+                                self.tx_id += 1;
+                                self.transactions.push_back(ht);
                             }
-                            if over {
-                                self.comp_len += il;
-                                self.decomp_len += ol;
-                            }
+                        }
+                        if ol > decompression::DEFAULT_BOMB_RATIO * il && over {
+                            self.comp_len += il;
+                            self.decomp_len += ol;
                         }
                     }
                     sc_app_layer_parser_trigger_raw_stream_inspection(flow, dir as i32);
@@ -1563,6 +1606,13 @@ impl HTTP2State {
 }
 
 // C exports.
+#[no_mangle]
+pub unsafe extern "C" fn SCHttp2GetWebsocketTx(tx: &HTTP2Transaction) -> *mut std::os::raw::c_void {
+    if let Some(wtx) = &tx.websocket_tx {
+        return wtx as *const _ as *mut _;
+    }
+    std::ptr::null_mut()
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn SCDoH2GetDnsTx(
@@ -1800,6 +1850,12 @@ pub unsafe extern "C" fn SCRegisterHttp2Parser() {
             HTTP2TxType::HTTP2TxTypeGlobal as u8,
             Some(HTTP2TxGlobalProgress::ffi_id_from_name),
             Some(HTTP2TxGlobalProgress::ffi_name_from_id),
+        );
+        SCAppLayerParserRegisterGetTxSubStateFuncs(
+            ALPROTO_HTTP2,
+            HTTP2TxType::HTTP2TxTypeWebsocket as u8,
+            Some(WebsocketProgress::ffi_id_from_name),
+            Some(WebsocketProgress::ffi_name_from_id),
         );
 
         SCLogDebug!("Rust http2 parser registered.");

--- a/rust/src/websocket/detect.rs
+++ b/rust/src/websocket/detect.rs
@@ -25,12 +25,14 @@ use crate::detect::{
     helper_keyword_register_sticky_buffer, SigTableElmtStickyBuffer, SIGMATCH_INFO_BITFLAGS_UINT,
     SIGMATCH_INFO_ENUM_UINT, SIGMATCH_INFO_UINT32, SIGMATCH_INFO_UINT8,
 };
+use crate::http2::http2::{HTTP2Transaction, HTTP2TxType, SCHttp2GetWebsocketTx};
 use crate::websocket::parser::WebSocketOpcode;
 use suricata_sys::sys::{
-    DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
-    SCDetectHelperBufferMpmRegister, SCDetectHelperBufferProgressRegister,
-    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
-    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+    AppProtoEnum, DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectBufferSetActiveList,
+    SCDetectHelperBufferMpmRegister, SCDetectHelperBufferProgressMpmRegisterSubState,
+    SCDetectHelperBufferProgressRegister, SCDetectHelperBufferProgressRegisterSubState,
+    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCFlowGetAppProtocol,
+    SCSigMatchAppendSMToList, SCSigTableAppLiteElmt, SigMatchCtx, Signature,
 };
 
 use std::ffi::CStr;
@@ -104,10 +106,21 @@ unsafe extern "C" fn websocket_detect_opcode_setup(
     return 0;
 }
 
+unsafe fn websocket_detect_tx(tx: *mut c_void, f: *mut Flow) -> *mut c_void {
+    if SCFlowGetAppProtocol(f) == AppProtoEnum::ALPROTO_HTTP2 as u16 {
+        let tx = cast_pointer!(tx, HTTP2Transaction);
+        let tx = SCHttp2GetWebsocketTx(tx);
+        return tx;
+    } else {
+        return tx;
+    }
+}
+
 unsafe extern "C" fn websocket_detect_opcode_match(
-    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, _flags: u8, _state: *mut c_void,
+    _de: *mut DetectEngineThreadCtx, f: *mut Flow, _flags: u8, _state: *mut c_void,
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
+    let tx = websocket_detect_tx(tx, f);
     let tx = cast_pointer!(tx, WebSocketTransaction);
     let ctx = cast_pointer!(ctx, DetectUintData<u8>);
     return SCDetectU8Match(tx.pdu.opcode, ctx);
@@ -145,9 +158,10 @@ unsafe extern "C" fn websocket_detect_mask_setup(
 }
 
 unsafe extern "C" fn websocket_detect_mask_match(
-    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, _flags: u8, _state: *mut c_void,
+    _de: *mut DetectEngineThreadCtx, f: *mut Flow, _flags: u8, _state: *mut c_void,
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
+    let tx = websocket_detect_tx(tx, f);
     let tx = cast_pointer!(tx, WebSocketTransaction);
     let ctx = cast_pointer!(ctx, DetectUintData<u32>);
     if let Some(xorkey) = tx.pdu.mask {
@@ -188,9 +202,10 @@ unsafe extern "C" fn websocket_detect_flags_setup(
 }
 
 unsafe extern "C" fn websocket_detect_flags_match(
-    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, _flags: u8, _state: *mut c_void,
+    _de: *mut DetectEngineThreadCtx, f: *mut Flow, _flags: u8, _state: *mut c_void,
     tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
 ) -> c_int {
+    let tx = websocket_detect_tx(tx, f);
     let tx = cast_pointer!(tx, WebSocketTransaction);
     let ctx = cast_pointer!(ctx, DetectUintData<u8>);
     return SCDetectU8Match(tx.pdu.flags, ctx);
@@ -241,6 +256,14 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
         STREAM_TOSERVER | STREAM_TOCLIENT,
         1,
     );
+    _ = SCDetectHelperBufferProgressRegisterSubState(
+        b"websocket.opcode\0".as_ptr() as *const libc::c_char,
+        AppProtoEnum::ALPROTO_HTTP2 as u16,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        HTTP2TxType::HTTP2TxTypeWebsocket as u8,
+        1,
+    );
+
     let kw = SCSigTableAppLiteElmt {
         name: b"websocket.mask\0".as_ptr() as *const libc::c_char,
         desc: b"match WebSocket mask\0".as_ptr() as *const libc::c_char,
@@ -257,6 +280,14 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
         STREAM_TOSERVER | STREAM_TOCLIENT,
         1,
     );
+    _ = SCDetectHelperBufferProgressRegisterSubState(
+        b"websocket.mask\0".as_ptr() as *const libc::c_char,
+        AppProtoEnum::ALPROTO_HTTP2 as u16,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        HTTP2TxType::HTTP2TxTypeWebsocket as u8,
+        1,
+    );
+
     let kw = SCSigTableAppLiteElmt {
         name: b"websocket.flags\0".as_ptr() as *const libc::c_char,
         desc: b"match WebSocket flags\0".as_ptr() as *const libc::c_char,
@@ -273,6 +304,14 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
         STREAM_TOSERVER | STREAM_TOCLIENT,
         1,
     );
+    _ = SCDetectHelperBufferProgressRegisterSubState(
+        b"websocket.flags\0".as_ptr() as *const libc::c_char,
+        AppProtoEnum::ALPROTO_HTTP2 as u16,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        HTTP2TxType::HTTP2TxTypeWebsocket as u8,
+        1,
+    );
+
     let kw = SigTableElmtStickyBuffer {
         name: String::from("websocket.payload"),
         desc: String::from("match WebSocket payload"),
@@ -286,5 +325,13 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
         ALPROTO_WEBSOCKET,
         STREAM_TOSERVER | STREAM_TOCLIENT,
         Some(websocket_detect_payload_get_data),
+    );
+    _ = SCDetectHelperBufferProgressMpmRegisterSubState(
+        b"websocket.payload\0".as_ptr() as *const libc::c_char,
+        AppProtoEnum::ALPROTO_HTTP2 as u16,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        Some(websocket_detect_payload_get_data),
+        HTTP2TxType::HTTP2TxTypeWebsocket as u8,
+        1,
     );
 }

--- a/rust/src/websocket/logger.rs
+++ b/rust/src/websocket/logger.rs
@@ -21,7 +21,7 @@ use crate::detect::EnumString;
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 use std;
 
-fn log_websocket(
+pub(crate) fn log_websocket(
     tx: &WebSocketTransaction, js: &mut JsonBuilder, pp: bool, pb64: bool,
 ) -> Result<(), JsonError> {
     js.open_object("websocket")?;

--- a/rust/src/websocket/websocket.rs
+++ b/rust/src/websocket/websocket.rs
@@ -40,11 +40,19 @@ use std::collections::VecDeque;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 
-pub(super) static mut ALPROTO_WEBSOCKET: AppProto = ALPROTO_UNKNOWN;
+pub(crate) static mut ALPROTO_WEBSOCKET: AppProto = ALPROTO_UNKNOWN;
 
 static mut WEBSOCKET_MAX_PAYLOAD_SIZE: u32 = 0xFFFF;
 
 const WEBSOCKET_DECOMPRESS_BUF_SIZE: usize = 8192;
+
+#[repr(u8)]
+#[derive(AppLayerState, Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
+#[suricata(alstate_strip_prefix = "WebsocketProg")]
+pub enum WebsocketProgress {
+    WebsocketProgStarted = 0,
+    WebsocketProgComplete = 1,
+}
 
 #[derive(AppLayerFrameType)]
 pub enum WebSocketFrameType {
@@ -59,7 +67,7 @@ pub enum WebSocketEvent {
     ReassemblyLimitReached,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct WebSocketTransaction {
     tx_id: u64,
     pub pdu: parser::WebSocketPdu,
@@ -81,17 +89,17 @@ impl Transaction for WebSocketTransaction {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct WebSocketReassemblyBuffer {
     data: Vec<u8>,
     compress: bool,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct WebSocketState {
     state_data: AppLayerStateData,
     tx_id: u64,
-    transactions: VecDeque<WebSocketTransaction>,
+    pub transactions: VecDeque<WebSocketTransaction>,
 
     c2s_dec: Option<flate2::Decompress>,
     s2c_dec: Option<flate2::Decompress>,
@@ -147,15 +155,20 @@ impl WebSocketState {
         return tx;
     }
 
-    fn parse(
+    pub(crate) fn parse(
         &mut self, stream_slice: StreamSlice, direction: Direction, flow: *mut Flow,
+        slice_input: &[u8],
     ) -> AppLayerResult {
         let to_skip = if direction == Direction::ToClient {
             &mut self.to_skip_tc
         } else {
             &mut self.to_skip_ts
         };
-        let input = stream_slice.as_slice();
+        let input = if flow.is_null() {
+            slice_input
+        } else {
+            stream_slice.as_slice()
+        };
         let mut start = input;
         if *to_skip > 0 {
             if *to_skip >= input.len() as u64 {
@@ -172,30 +185,32 @@ impl WebSocketState {
             match parser::parse_message(start, max_pl_size) {
                 Ok((rem, pdu)) => {
                     let mut tx = self.new_tx(direction);
-                    let _pdu = Frame::new(
-                        flow,
-                        &stream_slice,
-                        start,
-                        (start.len() - rem.len() - pdu.payload.len()) as i64,
-                        WebSocketFrameType::Header as u8,
-                        Some(tx.tx_id),
-                    );
-                    let _pdu = Frame::new(
-                        flow,
-                        &stream_slice,
-                        start,
-                        (start.len() - rem.len()) as i64,
-                        WebSocketFrameType::Pdu as u8,
-                        Some(tx.tx_id),
-                    );
-                    let _pdu = Frame::new(
-                        flow,
-                        &stream_slice,
-                        &start[(start.len() - rem.len() - pdu.payload.len())..],
-                        pdu.payload.len() as i64,
-                        WebSocketFrameType::Data as u8,
-                        Some(tx.tx_id),
-                    );
+                    if !flow.is_null() {
+                        let _pdu = Frame::new(
+                            flow,
+                            &stream_slice,
+                            start,
+                            (start.len() - rem.len() - pdu.payload.len()) as i64,
+                            WebSocketFrameType::Header as u8,
+                            Some(tx.tx_id),
+                        );
+                        let _pdu = Frame::new(
+                            flow,
+                            &stream_slice,
+                            start,
+                            (start.len() - rem.len()) as i64,
+                            WebSocketFrameType::Pdu as u8,
+                            Some(tx.tx_id),
+                        );
+                        let _pdu = Frame::new(
+                            flow,
+                            &stream_slice,
+                            &start[(start.len() - rem.len() - pdu.payload.len())..],
+                            pdu.payload.len() as i64,
+                            WebSocketFrameType::Data as u8,
+                            Some(tx.tx_id),
+                        );
+                    }
                     start = rem;
                     if pdu.to_skip > 0 {
                         if direction == Direction::ToClient {
@@ -287,7 +302,7 @@ impl WebSocketState {
                             }
                         }
                     }
-                    if tx.pdu.fin {
+                    if tx.pdu.fin && !flow.is_null() {
                         sc_app_layer_parser_trigger_raw_stream_inspection(flow, direction as i32);
                     }
                     self.transactions.push_back(tx);
@@ -351,7 +366,7 @@ unsafe extern "C" fn websocket_parse_request(
     stream_slice: StreamSlice, _data: *mut c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, WebSocketState);
-    state.parse(stream_slice, Direction::ToServer, flow)
+    state.parse(stream_slice, Direction::ToServer, flow, &[])
 }
 
 unsafe extern "C" fn websocket_parse_response(
@@ -359,7 +374,7 @@ unsafe extern "C" fn websocket_parse_response(
     stream_slice: StreamSlice, _data: *mut c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, WebSocketState);
-    state.parse(stream_slice, Direction::ToClient, flow)
+    state.parse(stream_slice, Direction::ToClient, flow, &[])
 }
 
 unsafe extern "C" fn websocket_state_get_tx(state: *mut c_void, tx_id: u64) -> *mut c_void {

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -913,6 +913,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn SCDetectHelperBufferProgressMpmRegisterSubState(
+        name: *const ::std::os::raw::c_char, alproto: AppProto, direction: u8,
+        GetData: InspectionSingleBufferGetDataPtr, sub_state: u8, progress: u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn SCDetectHelperMultiBufferMpmRegister(
         name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
         alproto: AppProto, direction: u8, GetData: InspectionMultiBufferGetDataPtr,

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1343,6 +1343,8 @@ uint8_t AppLayerParserGetSubStateCompletion(const AppProto alproto, const uint8_
         return 4;
     } else if (sub_state == 2) {
         return 1;
+    } else if (sub_state == 3) {
+        return 1;
     } else {
         BUG_ON(1);
     }
@@ -1366,6 +1368,8 @@ const char *AppLayerParserGetSubStateName(const AppProto alproto, const uint8_t 
         return "stream";
     } else if (sub_state == 2) {
         return "global";
+    } else if (sub_state == 3) {
+        return "websocket";
     } else {
         BUG_ON(1);
     }

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -113,6 +113,9 @@ static inline bool AppProtoEquals(AppProto sigproto, AppProto alproto)
             return (alproto == ALPROTO_HTTP1) || (alproto == ALPROTO_HTTP2);
         case ALPROTO_DCERPC:
             return (alproto == ALPROTO_SMB);
+        // a websocket signature can match in a HTTP2 flow
+        case ALPROTO_WEBSOCKET:
+            return (alproto == ALPROTO_HTTP2);
     }
     return false;
 }

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -123,6 +123,26 @@ int SCDetectHelperBufferProgressMpmRegister(const char *name, const char *desc, 
     return DetectBufferTypeGetByName(name);
 }
 
+int SCDetectHelperBufferProgressMpmRegisterSubState(const char *name, AppProto alproto,
+        uint8_t direction, InspectionSingleBufferGetDataPtr GetData, uint8_t sub_state,
+        uint8_t progress)
+{
+    DEBUG_VALIDATE_BUG_ON(AppLayerParserSupportsSubStates(alproto) && sub_state == 0);
+    if (direction & STREAM_TOSERVER) {
+        DetectAppLayerInspectEngineRegisterSingleSubState(name, alproto, SIG_FLAG_TOSERVER,
+                sub_state, progress, DetectEngineInspectBufferSingle, GetData);
+        DetectAppLayerMpmRegisterSingleSubState(name, SIG_FLAG_TOSERVER, 2,
+                PrefilterSingleMpmRegister, GetData, alproto, sub_state, progress);
+    }
+    if (direction & STREAM_TOCLIENT) {
+        DetectAppLayerInspectEngineRegisterSingleSubState(name, alproto, SIG_FLAG_TOCLIENT,
+                sub_state, progress, DetectEngineInspectBufferSingle, GetData);
+        DetectAppLayerMpmRegisterSingleSubState(name, SIG_FLAG_TOCLIENT, 2,
+                PrefilterSingleMpmRegister, GetData, alproto, sub_state, progress);
+    }
+    return DetectBufferTypeGetByName(name);
+}
+
 int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc,
         AppProto alproto, uint8_t direction, InspectionMultiBufferGetDataPtr GetData,
         uint8_t progress)

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -91,6 +91,9 @@ int SCDetectRegisterMpmGeneric(const char *name, const char *desc, AppProto alpr
         uint8_t direction, InspectionBufferGetDataPtr GetData, uint8_t progress);
 int SCDetectHelperBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionSingleBufferGetDataPtr GetData, uint8_t progress);
+int SCDetectHelperBufferProgressMpmRegisterSubState(const char *name, AppProto alproto,
+        uint8_t direction, InspectionSingleBufferGetDataPtr GetData, uint8_t sub_state,
+        uint8_t progress);
 int SCDetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData);
 int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc,

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -181,6 +181,14 @@ void DetectAppLayerMpmRegisterSingle(const char *name, int direction, int priori
             tx_min_progress);
 }
 
+void DetectAppLayerMpmRegisterSingleSubState(const char *name, int direction, int priority,
+        PrefilterRegisterFunc PrefilterRegister, InspectionSingleBufferGetDataPtr GetData,
+        AppProto alproto, uint8_t sub_state, uint8_t tx_min_progress)
+{
+    RegisterInternal(name, direction, priority, PrefilterRegister, NULL, GetData, NULL, alproto,
+            sub_state, tx_min_progress);
+}
+
 void DetectAppLayerMpmMultiRegister(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionMultiBufferGetDataPtr GetData,
         AppProto alproto, uint8_t tx_min_progress)

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -93,6 +93,9 @@ void DetectAppLayerMpmRegisterSubState(const char *name, int direction, int prio
 void DetectAppLayerMpmRegisterSingle(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionSingleBufferGetDataPtr GetData,
         AppProto alproto, uint8_t tx_min_progress);
+void DetectAppLayerMpmRegisterSingleSubState(const char *name, int direction, int priority,
+        PrefilterRegisterFunc PrefilterRegister, InspectionSingleBufferGetDataPtr GetData,
+        AppProto alproto, uint8_t sub_state, uint8_t tx_min_progress);
 void DetectAppLayerMpmMultiRegister(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionMultiBufferGetDataPtr GetData,
         AppProto alproto, uint8_t tx_min_progress);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -341,6 +341,29 @@ void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alprot
     AppLayerInspectEngineRegisterInternal(
             name, alproto, dir, 0, (uint8_t)progress, Callback, NULL, GetData, NULL);
 }
+void DetectAppLayerInspectEngineRegisterSingleSubState(const char *name, AppProto alproto,
+        uint32_t dir, uint8_t substate, uint8_t progress, InspectEngineFuncPtr Callback,
+        InspectionSingleBufferGetDataPtr GetData)
+{
+    /* before adding, check that we don't add a duplicate entry, which will
+     * propagate all the way into the packet runtime if allowed. */
+    DetectEngineAppInspectionEngine *t = g_app_inspect_engines;
+    while (t != NULL) {
+        const uint32_t t_direction = t->dir == 0 ? SIG_FLAG_TOSERVER : SIG_FLAG_TOCLIENT;
+        const int sm_list = DetectBufferTypeGetByName(name);
+
+        if (t->sm_list == sm_list && t->alproto == alproto && t_direction == dir &&
+                t->progress == progress && t->v2.Callback == Callback &&
+                t->v2.GetDataSingle == GetData) {
+            DEBUG_VALIDATE_BUG_ON(1);
+            return;
+        }
+        t = t->next;
+    }
+
+    AppLayerInspectEngineRegisterInternal(
+            name, alproto, dir, substate, (uint8_t)progress, Callback, NULL, GetData, NULL);
+}
 
 /* copy an inspect engine with transforms to a new list id. */
 static void DetectAppLayerInspectEngineCopy(

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -172,6 +172,9 @@ void DetectAppLayerInspectEngineRegisterSubState(const char *name, AppProto alpr
 
 void DetectAppLayerInspectEngineRegisterSingle(const char *name, AppProto alproto, uint32_t dir,
         uint8_t progress, InspectEngineFuncPtr Callback2, InspectionSingleBufferGetDataPtr GetData);
+void DetectAppLayerInspectEngineRegisterSingleSubState(const char *name, AppProto alproto,
+        uint32_t dir, uint8_t substate, uint8_t progress, InspectEngineFuncPtr Callback2,
+        InspectionSingleBufferGetDataPtr GetData);
 
 void DetectAppLayerMultiRegisterSubState(const char *name, AppProto alproto, uint32_t dir,
         uint8_t sub_state, uint8_t progress, InspectionMultiBufferGetDataPtr GetData, int priority);

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -355,6 +355,7 @@ static void AlertAddAppLayer(const Packet *p, SCJsonBuilder *jb, const uint64_t 
     EveJsonSimpleAppLayerLogger *al = SCEveJsonSimpleGetLogger(proto);
     void *state = FlowGetAppState(p->flow);
     void *tx = NULL;
+    void *wtx = NULL;
     if (state) {
         tx = AppLayerParserGetTx(p->flow->proto, proto, state, tx_id);
     }
@@ -368,6 +369,14 @@ static void AlertAddAppLayer(const Packet *p, SCJsonBuilder *jb, const uint64_t 
         SCJbGetMark(jb, &mark);
         switch (proto) {
             // first check some protocols need special options for alerts logging
+            case ALPROTO_HTTP2:
+                wtx = SCHttp2GetWebsocketTx(tx);
+                if (wtx == NULL) {
+                    break;
+                } else {
+                    tx = wtx;
+                }
+                // fallthrough
             case ALPROTO_WEBSOCKET:
                 if (option_flags &
                         (LOG_JSON_WEBSOCKET_PAYLOAD | LOG_JSON_WEBSOCKET_PAYLOAD_BASE64)) {

--- a/src/output.c
+++ b/src/output.c
@@ -82,6 +82,7 @@
 #include "output-filestore.h"
 #include "output-json-arp.h"
 #include "output-json-llmnr.h"
+#include "rust.h"
 
 typedef struct RootLogger_ {
     OutputLogFunc LogFunc;
@@ -1030,6 +1031,38 @@ error:
     return TM_ECODE_FAILED;
 }
 
+static int Http2WebsocketLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f,
+        void *state, void *tx, uint64_t tx_id)
+{
+    OutputJsonThreadCtx *thread = thread_data;
+    EveJsonSimpleAppLayerLogger *al = SCEveJsonSimpleGetLogger(ALPROTO_WEBSOCKET);
+    if (al == NULL) {
+        return TM_ECODE_FAILED;
+    }
+
+    SCJsonBuilder *js = CreateEveHeader(p, LOG_DIR_PACKET, "websocket", NULL, thread->ctx);
+    if (unlikely(js == NULL)) {
+        return TM_ECODE_FAILED;
+    }
+
+    tx = SCHttp2GetWebsocketTx(tx);
+    if (tx == NULL) {
+        return TM_ECODE_FAILED;
+    }
+    if (!al->LogTx(tx, js)) {
+        goto error;
+    }
+
+    OutputJsonBuilderBuffer(tv, p, p->flow, js, thread);
+    SCJbFree(js);
+
+    return TM_ECODE_OK;
+
+error:
+    SCJbFree(js);
+    return TM_ECODE_FAILED;
+}
+
 static int JsonGenericDirPacketLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f,
         void *state, void *tx, uint64_t tx_id)
 {
@@ -1105,6 +1138,10 @@ void OutputRegisterLoggers(void)
             "eve-log.http2", OutputJsonLogInitSub, ALPROTO_HTTP2, HTTP2TxTypeGlobal,
             JsonGenericDirFlowLogger, HTTP2ProgGlobalComplete, HTTP2ProgGlobalComplete,
             JsonLogThreadInit, JsonLogThreadDeinit);
+    OutputRegisterTxSubModuleWithProgressSubState(LOGGER_JSON_TX, "eve-log",
+            "LogHttp2Log::websocket", "eve-log.websocket", OutputJsonLogInitSub, ALPROTO_HTTP2,
+            HTTP2TxTypeWebsocket, Http2WebsocketLogger, 1, 1, JsonLogThreadInit,
+            JsonLogThreadDeinit);
     /* tls log */
     JsonTlsLogRegister();
     LogTlsStoreRegister();


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/6729

Describe changes:
- draft websocket over http2

TODOs:
- Agree on the design and output
- SV test
- doc update
- commit segmentation and messages

Tested so far with
`suricata -c suricata.yaml -k none -r wss_h2.pcap -S ../suricata-verify/tests/websocket/test.rules -l log`

https://github.com/OISF/suricata/pull/15915 with compilation ok without C23 extension

Note : websocket frames do not work (as dns frames fo not work for HTTP2) as we do not work over raw tcp content (but compressed + reassembled http2 data)