### PR TITLE
Fix 8690 v4

### DIFF
--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -242,7 +242,7 @@ static void AppendTransformsToPname(
          * use it to construct the 'profile' name for the engine */
         char xforms[DETECT_PROFILE_NAME_LEN + 1];
         memset(xforms, 0, DETECT_PROFILE_NAME_LEN + 1);
-        for (int i = 0; i < transforms->cnt; i++) {
+        for (uint8_t i = 0; i < transforms->cnt; i++) {
             char ttstr[64];
             (void)snprintf(ttstr, sizeof(ttstr), "%s,",
                     sigmatch_table[transforms->transforms[i].transform].name);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1829,7 +1829,7 @@ void DetectBufferTypeCloseRegistration(void)
 }
 
 int DetectEngineBufferTypeGetByIdTransforms(
-        DetectEngineCtx *de_ctx, const int id, TransformData *transforms, int transform_cnt)
+        DetectEngineCtx *de_ctx, const int id, TransformData *transforms, uint8_t transform_cnt)
 {
     const DetectBufferType *base_map = DetectEngineBufferTypeGetById(de_ctx, id);
     if (!base_map) {

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -61,7 +61,7 @@ bool DetectEngineBufferTypeSupportsMultiInstanceGetById(
 bool DetectEngineBufferTypeSupportsFramesGetById(const DetectEngineCtx *de_ctx, const int id);
 const char *DetectEngineBufferTypeGetDescriptionById(const DetectEngineCtx *de_ctx, const int id);
 int DetectEngineBufferTypeGetByIdTransforms(
-        DetectEngineCtx *de_ctx, const int id, TransformData *transforms, int transform_cnt);
+        DetectEngineCtx *de_ctx, const int id, TransformData *transforms, uint8_t transform_cnt);
 void DetectEngineBufferRunSetupCallback(const DetectEngineCtx *de_ctx, const int id, Signature *s);
 bool DetectEngineBufferRunValidateCallback(
         const DetectEngineCtx *de_ctx, const int id, const Signature *s, const char **sigerror);

--- a/src/detect.h
+++ b/src/detect.h
@@ -390,7 +390,7 @@ typedef struct TransformData_ {
 
 typedef struct DetectEngineTransforms {
     TransformData transforms[DETECT_TRANSFORMS_MAX];
-    int cnt;
+    uint8_t cnt;
 } DetectEngineTransforms;
 
 /** callback for getting the buffer we need to prefilter/inspect */

--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -92,35 +92,57 @@ int ListAppLayerHooks(const char *conf_filename)
         if (alprotos[a] != 1)
             continue;
 
-        const char *alproto_name = AppProtoToString(a);
-        if (strcmp(alproto_name, "http") == 0)
-            alproto_name = "http1";
-        SCLogDebug("alproto %u/%s", a, alproto_name);
-
-        const int max_progress_ts =
-                AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOSERVER);
-        const int max_progress_tc =
-                AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOCLIENT);
-
-        printf("%s:%s\n", alproto_name, "request_started");
-        for (int p = 0; p <= max_progress_ts; p++) {
-            const char *name = AppLayerParserGetStateNameById(
-                    IPPROTO_TCP /* TODO no ipproto */, a, p, STREAM_TOSERVER);
-            if (name != NULL && !IsBuiltIn(name)) {
-                printf("%s:%s\n", alproto_name, name);
+        if (AppLayerParserSupportsSubStates(a)) {
+            const uint8_t max_sub_state = AppLayerParserGetMaxSubState(a);
+            for (uint8_t sub_state = 1; sub_state <= max_sub_state; sub_state++) {
+                const char *sub_state_name = AppLayerParserGetSubStateName(a, sub_state);
+                const uint8_t max_progress = AppLayerParserGetSubStateCompletion(a, sub_state);
+                for (uint8_t state = 0; state <= max_progress; state++) {
+                    const char *name = AppLayerParserGetSubStateProgressName(
+                            a, sub_state, state, STREAM_TOSERVER);
+                    if (name != NULL) {
+                        printf("%s:%s:%s\n", AppProtoToString(a), sub_state_name, name);
+                    }
+                }
+                for (uint8_t state = 0; state <= max_progress; state++) {
+                    const char *name = AppLayerParserGetSubStateProgressName(
+                            a, sub_state, state, STREAM_TOCLIENT);
+                    if (name != NULL) {
+                        printf("%s:%s:%s\n", AppProtoToString(a), sub_state_name, name);
+                    }
+                }
             }
-        }
-        printf("%s:%s\n", alproto_name, "request_complete");
+        } else {
+            const char *alproto_name = AppProtoToString(a);
+            if (strcmp(alproto_name, "http") == 0)
+                alproto_name = "http1";
+            SCLogDebug("alproto %u/%s", a, alproto_name);
 
-        printf("%s:%s\n", alproto_name, "response_started");
-        for (int p = 0; p <= max_progress_tc; p++) {
-            const char *name = AppLayerParserGetStateNameById(
-                    IPPROTO_TCP /* TODO no ipproto */, a, p, STREAM_TOCLIENT);
-            if (name != NULL && !IsBuiltIn(name)) {
-                printf("%s:%s\n", alproto_name, name);
+            const int max_progress_ts =
+                    AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOSERVER);
+            const int max_progress_tc =
+                    AppLayerParserGetStateProgressCompletionStatus(a, STREAM_TOCLIENT);
+
+            printf("%s:%s\n", alproto_name, "request_started");
+            for (int p = 0; p <= max_progress_ts; p++) {
+                const char *name = AppLayerParserGetStateNameById(
+                        IPPROTO_TCP /* TODO no ipproto */, a, p, STREAM_TOSERVER);
+                if (name != NULL && !IsBuiltIn(name)) {
+                    printf("%s:%s\n", alproto_name, name);
+                }
             }
+            printf("%s:%s\n", alproto_name, "request_complete");
+
+            printf("%s:%s\n", alproto_name, "response_started");
+            for (int p = 0; p <= max_progress_tc; p++) {
+                const char *name = AppLayerParserGetStateNameById(
+                        IPPROTO_TCP /* TODO no ipproto */, a, p, STREAM_TOCLIENT);
+                if (name != NULL && !IsBuiltIn(name)) {
+                    printf("%s:%s\n", alproto_name, name);
+                }
+            }
+            printf("%s:%s\n", alproto_name, "response_complete");
         }
-        printf("%s:%s\n", alproto_name, "response_complete");
     }
     return TM_ECODE_DONE;
 }


### PR DESCRIPTION
Changing the `cnt` type to `uint8_t` eliminates negative values and prevents out-of-bounds array access (`xforms[-1]`). This issue was flagged by the Svace static analyzer.

Ticket: 8690
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8690