### PR TITLE
detect-engine-mpm: change transforms->cnt to uint8_t

### DIFF
--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -242,7 +242,7 @@ static void AppendTransformsToPname(
          * use it to construct the 'profile' name for the engine */
         char xforms[DETECT_PROFILE_NAME_LEN + 1];
         memset(xforms, 0, DETECT_PROFILE_NAME_LEN + 1);
-        for (int i = 0; i < transforms->cnt; i++) {
+        for (uint8_t i = 0; i < transforms->cnt; i++) {
             char ttstr[64];
             (void)snprintf(ttstr, sizeof(ttstr), "%s,",
                     sigmatch_table[transforms->transforms[i].transform].name);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1829,7 +1829,7 @@ void DetectBufferTypeCloseRegistration(void)
 }
 
 int DetectEngineBufferTypeGetByIdTransforms(
-        DetectEngineCtx *de_ctx, const int id, TransformData *transforms, int transform_cnt)
+        DetectEngineCtx *de_ctx, const int id, TransformData *transforms, uint8_t transform_cnt)
 {
     const DetectBufferType *base_map = DetectEngineBufferTypeGetById(de_ctx, id);
     if (!base_map) {

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -61,7 +61,7 @@ bool DetectEngineBufferTypeSupportsMultiInstanceGetById(
 bool DetectEngineBufferTypeSupportsFramesGetById(const DetectEngineCtx *de_ctx, const int id);
 const char *DetectEngineBufferTypeGetDescriptionById(const DetectEngineCtx *de_ctx, const int id);
 int DetectEngineBufferTypeGetByIdTransforms(
-        DetectEngineCtx *de_ctx, const int id, TransformData *transforms, int transform_cnt);
+        DetectEngineCtx *de_ctx, const int id, TransformData *transforms, uint8_t transform_cnt);
 void DetectEngineBufferRunSetupCallback(const DetectEngineCtx *de_ctx, const int id, Signature *s);
 bool DetectEngineBufferRunValidateCallback(
         const DetectEngineCtx *de_ctx, const int id, const Signature *s, const char **sigerror);

--- a/src/detect.h
+++ b/src/detect.h
@@ -390,7 +390,7 @@ typedef struct TransformData_ {
 
 typedef struct DetectEngineTransforms {
     TransformData transforms[DETECT_TRANSFORMS_MAX];
-    int cnt;
+    uint8_t cnt;
 } DetectEngineTransforms;
 
 /** callback for getting the buffer we need to prefilter/inspect */


### PR DESCRIPTION
Changing the `cnt` type to `uint8_t` eliminates negative values and prevents out-of-bounds array access (`xforms[-1]`). This issue was flagged by the Svace static analyzer.

Ticket: 8690
https://redmine.openinfosecfoundation.org/issues/8690