### PR TITLE
ubsan: pass unit and SV tests with -fsanitize=implicit-conversion - v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -996,9 +996,9 @@ jobs:
       - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow" ./configure --disable-shared
       - run: make check
       - run: make distclean
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-qa-simulation --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address,implicit-conversion -fno-sanitize-recover=implicit-conversion -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-qa-simulation --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
         env:
-          LDFLAGS: "-fsanitize=address"
+          LDFLAGS: "-fsanitize=address,implicit-conversion"
           ac_cv_func_realloc_0_nonnull: "yes"
           ac_cv_func_malloc_0_nonnull: "yes"
       - run: make -j ${{ env.CPUS }}

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1969,10 +1969,10 @@ static int RandomGetWrap(void)
     unsigned long r;
 
     do {
-        r = RandomGet();
+        r = (unsigned long)RandomGet();
     } while(r >= ULONG_MAX - (ULONG_MAX % RAND_MAX));
 
-    return r % RAND_MAX;
+    return (int)(r % RAND_MAX);
 }
 
 /*
@@ -1988,24 +1988,30 @@ static void HTPConfigSetDefaultsPhase2(const char *name, HTPCfgRec *cfg_prec)
         int rdrange = cfg_prec->randomize_range;
 
         long int r = RandomGetWrap();
-        cfg_prec->request.inspect_min_size += (int)(cfg_prec->request.inspect_min_size *
-                                                    ((double)r / RAND_MAX - 0.5) * rdrange / 100);
+        /* the fuzz delta can be negative: cast it back explicitly so the
+         * unsigned wrap-around addition is intentional */
+        cfg_prec->request.inspect_min_size +=
+                (uint32_t)(int)(cfg_prec->request.inspect_min_size * ((double)r / RAND_MAX - 0.5) *
+                                rdrange / 100);
 
         r = RandomGetWrap();
-        cfg_prec->request.inspect_window += (int)(cfg_prec->request.inspect_window *
-                                                  ((double)r / RAND_MAX - 0.5) * rdrange / 100);
+        cfg_prec->request.inspect_window +=
+                (uint32_t)(int)(cfg_prec->request.inspect_window * ((double)r / RAND_MAX - 0.5) *
+                                rdrange / 100);
         SCLogConfig("'%s' server has 'request-body-minimal-inspect-size' set to"
                     " %u and 'request-body-inspect-window' set to %u after"
                     " randomization.",
                 name, cfg_prec->request.inspect_min_size, cfg_prec->request.inspect_window);
 
         r = RandomGetWrap();
-        cfg_prec->response.inspect_min_size += (int)(cfg_prec->response.inspect_min_size *
-                                                     ((double)r / RAND_MAX - 0.5) * rdrange / 100);
+        cfg_prec->response.inspect_min_size +=
+                (uint32_t)(int)(cfg_prec->response.inspect_min_size * ((double)r / RAND_MAX - 0.5) *
+                                rdrange / 100);
 
         r = RandomGetWrap();
-        cfg_prec->response.inspect_window += (int)(cfg_prec->response.inspect_window *
-                                                   ((double)r / RAND_MAX - 0.5) * rdrange / 100);
+        cfg_prec->response.inspect_window +=
+                (uint32_t)(int)(cfg_prec->response.inspect_window * ((double)r / RAND_MAX - 0.5) *
+                                rdrange / 100);
 
         SCLogConfig("'%s' server has 'response-body-minimal-inspect-size' set to"
                     " %u and 'response-body-inspect-window' set to %u after"

--- a/src/counters.c
+++ b/src/counters.c
@@ -792,7 +792,7 @@ static int StatsOutput(ThreadVars *tv)
             switch (pc->type) {
                 case STATS_TYPE_FUNC:
                     if (pc->Func != NULL)
-                        thread_table[pc->gid].value = pc->Func();
+                        thread_table[pc->gid].value = (int64_t)pc->Func();
                     break;
                 case STATS_TYPE_AVERAGE:
                     DEBUG_VALIDATE_BUG_ON(i + 1 >= max_id); // help scan-build

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -153,7 +153,9 @@ static inline uint16_t IPV4Checksum(const uint16_t *pkt, uint16_t hlen, uint16_t
     csum += pkt[0] + pkt[1] + pkt[2] + pkt[3] + pkt[4] + pkt[6] + pkt[7] +
         pkt[8] + pkt[9];
 
-    hlen -= 20;
+    /* hlen can be less than 20 for a malformed header: the wrapped value
+     * matches none of the fixed-size branches below, like hlen 0 */
+    hlen = (uint16_t)(hlen - 20);
     pkt += 10;
 
     if (hlen == 0) {

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -250,7 +250,9 @@ static int DecodeTCPPacket(
         return -1;
     }
 
-    uint8_t tcp_opt_len = hlen - TCP_HEADER_LEN;
+    /* hlen can be less than TCP_HEADER_LEN for a malformed header: the
+     * wrapped value is over TCP_OPTLENMAX and rejected below */
+    uint8_t tcp_opt_len = (uint8_t)(hlen - TCP_HEADER_LEN);
     if (unlikely(tcp_opt_len > TCP_OPTLENMAX)) {
         ENGINE_SET_INVALID_EVENT(p, TCP_INVALID_OPTLEN);
         return -1;

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -130,11 +130,11 @@ static void DefragTrackerInit(DefragTracker *dt, Packet *p)
 
     if (PacketIsIPv4(p)) {
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
-        dt->id = (int32_t)IPV4_GET_RAW_IPID(ip4h);
+        dt->id = IPV4_GET_RAW_IPID(ip4h);
         dt->af = AF_INET;
     } else {
         DEBUG_VALIDATE_BUG_ON(!PacketIsIPv6(p));
-        dt->id = (int32_t)IPV6_EXTHDR_GET_FH_ID(p);
+        dt->id = IPV6_EXTHDR_GET_FH_ID(p);
         dt->af = AF_INET6;
     }
     dt->proto = PacketGetIPProto(p);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -582,7 +582,6 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
         hlen = IPV4_GET_RAW_HLEN(ip4h);
         data_offset = (uint16_t)((uint8_t *)ip4h + hlen - GET_PKT_DATA(p));
         data_len = IPV4_GET_RAW_IPLEN(ip4h) - hlen;
-        frag_end = frag_offset + data_len;
         ip_hdr_offset = (uint16_t)((uint8_t *)ip4h - GET_PKT_DATA(p));
 
         /* Ignore fragment if the end of packet extends past the
@@ -591,6 +590,8 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
             ENGINE_SET_EVENT(p, IPV4_FRAG_PKT_TOO_LARGE);
             return NULL;
         }
+        /* the check above ensures the sum fits in frag_end */
+        frag_end = (uint16_t)(frag_offset + data_len);
     }
     else if (tracker->af == AF_INET6) {
         const IPV6Hdr *ip6h = PacketGetIPv6(p);
@@ -598,7 +599,15 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
         frag_offset = IPV6_EXTHDR_GET_FH_OFFSET(p);
         data_offset = p->l3.vars.ip6.eh.fh_data_offset;
         data_len = p->l3.vars.ip6.eh.fh_data_len;
-        frag_end = frag_offset + data_len;
+
+        /* Ignore fragment if the end of packet extends past the
+         * maximum size of a packet. */
+        if (frag_offset + data_len > IPV6_MAXPACKET) {
+            ENGINE_SET_EVENT(p, IPV6_FRAG_PKT_TOO_LARGE);
+            return NULL;
+        }
+        /* the check above ensures the sum fits in frag_end */
+        frag_end = (uint16_t)(frag_offset + data_len);
         ip_hdr_offset = (uint16_t)((uint8_t *)ip6h - GET_PKT_DATA(p));
         frag_hdr_offset = p->l3.vars.ip6.eh.fh_header_offset;
 
@@ -619,13 +628,6 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
             ip6_nh_set_offset = p->l3.vars.ip6.eh.fh_prev_hdr_offset;
             ip6_nh_set_value = IPV6_EXTHDR_GET_FH_NH(p);
             SCLogDebug("offset %d, value %u", ip6_nh_set_offset, ip6_nh_set_value);
-        }
-
-        /* Ignore fragment if the end of packet extends past the
-         * maximum size of a packet. */
-        if (frag_offset + data_len > IPV6_MAXPACKET) {
-            ENGINE_SET_EVENT(p, IPV6_FRAG_PKT_TOO_LARGE);
-            return NULL;
         }
     }
     else {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -642,7 +642,7 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
 
     if (!RB_EMPTY(&tracker->fragment_tree)) {
         Frag key = {
-            .offset = frag_offset - 1,
+            .offset = frag_offset ? frag_offset - 1 : 0,
         };
         next = RB_NFIND(IP_FRAGMENTS, &tracker->fragment_tree, &key);
         if (next == NULL) {
@@ -3135,6 +3135,129 @@ static int DefragBsdMissingFragmentIpv6Test(void)
     PASS;
 }
 
+/**
+ * \test Reassemble a datagram whose first fragment (offset 0) arrives last,
+ *       after higher-offset fragments are already in the tree.
+ *
+ * This exercises the RB_NFIND seek key in DefragInsertFrag for frag_offset == 0
+ * against a non-empty fragment tree. That path is the one reported in ticket
+ * 8232 (the search key used to underflow to 65535 for the first fragment);
+ * reassembly must still produce the datagram in offset order.
+ */
+static int DefragOutOfOrderFirstFragmentTest(void)
+{
+    Packet *p1 = NULL, *p2 = NULL, *p3 = NULL, *p4 = NULL;
+    Packet *reassembled = NULL;
+    int id = 8232;
+
+    DefragInit();
+    default_policy = DEFRAG_POLICY_BSD;
+
+    /* Four non-overlapping fragments; the last one delivered is offset 0. */
+    p1 = BuildIpv4TestPacket(IPPROTO_ICMP, id, 24 >> 3, 0, 'D', 8);
+    FAIL_IF_NULL(p1);
+    p2 = BuildIpv4TestPacket(IPPROTO_ICMP, id, 8 >> 3, 1, 'B', 8);
+    FAIL_IF_NULL(p2);
+    p3 = BuildIpv4TestPacket(IPPROTO_ICMP, id, 16 >> 3, 1, 'C', 8);
+    FAIL_IF_NULL(p3);
+    p4 = BuildIpv4TestPacket(IPPROTO_ICMP, id, 0, 1, 'A', 8);
+    FAIL_IF_NULL(p4);
+
+    /* Deliver out of order: last fragment first, first fragment last. */
+    FAIL_IF(Defrag(&test_tv, &test_dtv, p1) != NULL);
+    FAIL_IF(Defrag(&test_tv, &test_dtv, p2) != NULL);
+    FAIL_IF(Defrag(&test_tv, &test_dtv, p3) != NULL);
+
+    reassembled = Defrag(&test_tv, &test_dtv, p4);
+    FAIL_IF_NULL(reassembled);
+
+    FAIL_IF(IPV4_GET_RAW_HLEN(PacketGetIPv4(reassembled)) != 20);
+    FAIL_IF(IPV4_GET_RAW_IPLEN(PacketGetIPv4(reassembled)) != 20 + 32);
+
+    for (int i = 20 + 0; i < 20 + 8; i++)
+        FAIL_IF(GET_PKT_DATA(reassembled)[i] != 'A');
+    for (int i = 20 + 8; i < 20 + 16; i++)
+        FAIL_IF(GET_PKT_DATA(reassembled)[i] != 'B');
+    for (int i = 20 + 16; i < 20 + 24; i++)
+        FAIL_IF(GET_PKT_DATA(reassembled)[i] != 'C');
+    for (int i = 20 + 24; i < 20 + 32; i++)
+        FAIL_IF(GET_PKT_DATA(reassembled)[i] != 'D');
+
+    PacketFree(p1);
+    PacketFree(p2);
+    PacketFree(p3);
+    PacketFree(p4);
+    PacketFree(reassembled);
+
+    DefragDestroy();
+    PASS;
+}
+
+/**
+ * \test A new fragment lands at the same offset as one already in the tree,
+ *       while a preceding fragment overlaps it from the left.
+ *
+ * The BSD-policy seek needs prev to start at the immediately preceding
+ * fragment (offset < frag_offset). The RB tree comparator never returns 0, so
+ * RB_NFIND is strictly-greater: searching with key == frag_offset would land on
+ * the fragment *after* the same-offset node and set prev to the same-offset
+ * node, skipping the left-overlapping fragment. The key must therefore be
+ * frag_offset - 1. This datagram distinguishes the two: with the correct key
+ * the 16..24 region resolves to 'D', with key == frag_offset it wrongly
+ * resolves to 'B'.
+ */
+static int DefragSameOffsetPrecedingOverlapTest(void)
+{
+    Packet *packets[5] = { NULL };
+    Packet *reassembled = NULL;
+    uint16_t id = 8232;
+
+    DefragInit();
+    default_policy = DEFRAG_POLICY_BSD;
+
+    /* B: 8..24, delivered first so it keeps offset 8 (the later A only sets its
+     * ltrim; BSD would otherwise bake the trim into the stored offset). */
+    FAIL_IF_NOT(BuildIpv4TestPacketWithContent(
+            &packets[0], IPPROTO_ICMP, id, 8 >> 3, 1, (uint8_t *)"BBBBBBBBBBBBBBBB", 16));
+    /* A: 0..16 (extends past offset 8, overlapping B/D from the left). */
+    FAIL_IF_NOT(BuildIpv4TestPacketWithContent(
+            &packets[1], IPPROTO_ICMP, id, 0, 1, (uint8_t *)"AAAAAAAAAAAAAAAA", 16));
+    /* C: 24..32, a node strictly greater than offset 8 so RB_NFIND(8) finds it. */
+    FAIL_IF_NOT(BuildIpv4TestPacketWithContent(
+            &packets[2], IPPROTO_ICMP, id, 24 >> 3, 1, (uint8_t *)"CCCCCCCC", 8));
+    /* D: 8..24, same offset as B; must be reconciled against A, not skip it. */
+    FAIL_IF_NOT(BuildIpv4TestPacketWithContent(
+            &packets[3], IPPROTO_ICMP, id, 8 >> 3, 1, (uint8_t *)"DDDDDDDDDDDDDDDD", 16));
+    /* E: 32..40, final fragment, triggers reassembly. */
+    FAIL_IF_NOT(BuildIpv4TestPacketWithContent(
+            &packets[4], IPPROTO_ICMP, id, 32 >> 3, 0, (uint8_t *)"EEEEEEEE", 8));
+
+    for (int i = 0; i < 4; i++)
+        FAIL_IF(Defrag(&test_tv, &test_dtv, packets[i]) != NULL);
+    reassembled = Defrag(&test_tv, &test_dtv, packets[4]);
+    FAIL_IF_NULL(reassembled);
+
+    FAIL_IF(IPV4_GET_RAW_IPLEN(PacketGetIPv4(reassembled)) != 20 + 40);
+
+    // clang-format off
+    const uint8_t expected[] = {
+        'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A',
+        'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A',
+        'D', 'D', 'D', 'D', 'D', 'D', 'D', 'D',
+        'C', 'C', 'C', 'C', 'C', 'C', 'C', 'C',
+        'E', 'E', 'E', 'E', 'E', 'E', 'E', 'E',
+    };
+    // clang-format on
+    FAIL_IF(memcmp(expected, GET_PKT_DATA(reassembled) + 20, sizeof(expected)) != 0);
+
+    for (int i = 0; i < 5; i++)
+        PacketFree(packets[i]);
+    PacketFree(reassembled);
+
+    DefragDestroy();
+    PASS;
+}
+
 #endif /* UNITTESTS */
 
 void DefragRegisterTests(void)
@@ -3187,5 +3310,7 @@ void DefragRegisterTests(void)
             DefragBsdSubsequentOverlapsStartOfOriginalIpv6Test_2);
     UtRegisterTest("DefragBsdMissingFragmentIpv4Test", DefragBsdMissingFragmentIpv4Test);
     UtRegisterTest("DefragBsdMissingFragmentIpv6Test", DefragBsdMissingFragmentIpv6Test);
+    UtRegisterTest("DefragOutOfOrderFirstFragmentTest", DefragOutOfOrderFirstFragmentTest);
+    UtRegisterTest("DefragSameOffsetPrecedingOverlapTest", DefragSameOffsetPrecedingOverlapTest);
 #endif /* UNITTESTS */
 }

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -170,10 +170,10 @@ bool DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
      * the packet from that point.
      */
     ptr = payload + offset;
-    len = payload_len - offset;
+    len = (int32_t)payload_len - offset;
     if (flags & DETECT_BYTEJUMP_RELATIVE) {
         ptr += det_ctx->buffer_offset;
-        len -= det_ctx->buffer_offset;
+        len -= (int32_t)det_ctx->buffer_offset;
 
         SCLogDebug("[relative] after: ptr %p [len %d]", ptr, len);
 
@@ -232,7 +232,9 @@ bool DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         }
     }
 
-    val += data->post_offset;
+    /* post_offset can be negative: do the addition in the signed domain and
+     * cast back, keeping the two's complement wrap-around */
+    val = (uint64_t)((int64_t)val + data->post_offset);
     SCLogDebug("val: %" PRIi64 " post_offset: %" PRIi32, val, data->post_offset);
 
     const uint8_t *jumpptr;

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -185,7 +185,7 @@ int DetectBytetestDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
                    "data->offset %"PRIi32"", det_ctx->buffer_offset, data->offset);
 
         ptr = payload + det_ctx->buffer_offset;
-        len = payload_len - det_ctx->buffer_offset;
+        len = (int32_t)(payload_len - det_ctx->buffer_offset);
 
         ptr += offset;
         len -= offset;
@@ -199,7 +199,7 @@ int DetectBytetestDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         SCLogDebug("absolute, data->offset %"PRIi32"", data->offset);
 
         ptr = payload + offset;
-        len = payload_len - offset;
+        len = (int32_t)payload_len - offset;
     }
 
     /* Validate that the to-be-extracted is within the packet

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1433,7 +1433,10 @@ static inline int CreatePortList(DetectEngineCtx *de_ctx, const uint8_t *unique_
             if ((p1 && p1->single) && p2->single) {
                 SCPortIntervalFindOverlappingRanges(de_ctx, port, port, &it->tree, list);
                 SCPortIntervalFindOverlappingRanges(de_ctx, port2, port2, &it->tree, list);
-                port = port2 + 1;
+                /* port2 + 1 promotes to int: cast the possible wrap-around at
+                 * port2 == UINT16_MAX back explicitly; when it wraps, port2 was
+                 * the last unique point and the value is never used */
+                port = (uint16_t)(port2 + 1);
             } else if (p1 && p1->single) {
                 SCPortIntervalFindOverlappingRanges(de_ctx, port, port, &it->tree, list);
                 if ((port2 > port + 1)) {
@@ -1441,7 +1444,7 @@ static inline int CreatePortList(DetectEngineCtx *de_ctx, const uint8_t *unique_
                             de_ctx, port + 1, port2 - 1, &it->tree, list);
                     port = port2;
                 } else {
-                    port = port + 1;
+                    port = (uint16_t)(port + 1);
                 }
             } else if (p2->single) {
                 /* If port2 is boundary and less or equal to port + 1, create a range
@@ -1451,14 +1454,14 @@ static inline int CreatePortList(DetectEngineCtx *de_ctx, const uint8_t *unique_
                 }
                 /* Deal with port2 as it is a single port */
                 SCPortIntervalFindOverlappingRanges(de_ctx, port2, port2, &it->tree, list);
-                port = port2 + 1;
+                port = (uint16_t)(port2 + 1);
             } else {
                 if ((port2 > port + 1)) {
                     SCPortIntervalFindOverlappingRanges(de_ctx, port, port2 - 1, &it->tree, list);
                     port = port2;
                 } else {
                     SCPortIntervalFindOverlappingRanges(de_ctx, port, port2, &it->tree, list);
-                    port = port2 + 1;
+                    port = (uint16_t)(port2 + 1);
                 }
             }
             /* if the current port matches the p2->port, assign it to p1 so that

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -163,7 +163,7 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
                     if (distance < 0 && (uint32_t)(abs(distance)) > offset)
                         offset = 0;
                     else
-                        offset += distance;
+                        offset += (uint32_t)distance;
 
                     SCLogDebug("cd->distance %"PRIi32", offset %"PRIu32", depth %"PRIu32,
                                distance, offset, depth);
@@ -172,13 +172,15 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
                 if (cd->flags & DETECT_CONTENT_WITHIN) {
                     if (cd->flags & DETECT_CONTENT_WITHIN_VAR) {
                         // This cast is wrong if a 64-bit value was extracted for within
-                        if ((int32_t)depth > (int32_t)(prev_buffer_offset + det_ctx->byte_values[cd->within] + distance)) {
-                            depth = prev_buffer_offset +
-                                    (uint32_t)det_ctx->byte_values[cd->within] + distance;
+                        const uint32_t within = (uint32_t)det_ctx->byte_values[cd->within];
+                        if ((int32_t)depth >
+                                (int32_t)(prev_buffer_offset + within + (uint32_t)distance)) {
+                            depth = prev_buffer_offset + within + (uint32_t)distance;
                         }
                     } else {
-                        if ((int32_t)depth > (int32_t)(prev_buffer_offset + cd->within + distance)) {
-                            depth = prev_buffer_offset + cd->within + distance;
+                        if ((int32_t)depth > (int32_t)(prev_buffer_offset + (uint32_t)cd->within +
+                                                       (uint32_t)distance)) {
+                            depth = prev_buffer_offset + (uint32_t)cd->within + (uint32_t)distance;
                         }
 
                         SCLogDebug("cd->within %"PRIi32", det_ctx->buffer_offset %"PRIu32", depth %"PRIu32,

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -194,7 +194,9 @@ static int InsertRange(
             new->netmask--;
         }
         new->ip[0] = htonl(first);
-        first += 1UL << (32 - new->netmask);
+        /* the 64-bit sum wraps to 0 when the block ends at 255.255.255.255,
+         * which terminates the loop via the first != 0 check */
+        first = (uint32_t)(first + (1UL << (32 - new->netmask)));
         dd = IPOnlyCIDRItemInsert(dd, new);
     }
     // update head of list

--- a/src/detect-engine-prefilter-common.c
+++ b/src/detect-engine-prefilter-common.c
@@ -161,20 +161,18 @@ static void ApplyToU8Hash(PrefilterPacketU8HashCtx *ctx, PrefilterPacketHeaderVa
             }
         case PREFILTER_U8HASH_MODE_LT:
             {
-                uint8_t x = v.u8[1] - 1;
-                do {
-                    SigsArray *sa = ctx->array[x];
-                    sa->sigs[sa->offset++] = s->iid;
-                } while (x--);
+            for (int x = v.u8[1] - 1; x >= 0; x--) {
+                SigsArray *sa = ctx->array[x];
+                sa->sigs[sa->offset++] = s->iid;
+            }
 
                 break;
         }
         case DetectUintModeLte: {
-            uint8_t x = v.u8[1];
-            do {
+            for (int x = v.u8[1]; x >= 0; x--) {
                 SigsArray *sa = ctx->array[x];
                 sa->sigs[sa->offset++] = s->iid;
-            } while (x--);
+            }
 
             break;
         }

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -260,7 +260,7 @@ static void LogTlsLogPem(LogTlsStoreLogThread *aft, const Packet *p, SSLState *s
     }
 
     /* Reset the store flag */
-    connp->cert_log_flag &= ~SSL_TLS_LOG_PEM;
+    connp->cert_log_flag &= ~(uint32_t)SSL_TLS_LOG_PEM;
     SCReturn;
 
 end_fwrite_fp:

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -353,7 +353,7 @@ static int FrameJson(ThreadVars *tv, JsonFrameLogThread *aft, const Packet *p)
                 continue;
 
             int64_t abs_offset = (int64_t)frame->offset + (int64_t)STREAM_BASE_OFFSET(stream);
-            int64_t win = STREAM_APP_PROGRESS(stream) - abs_offset;
+            int64_t win = (int64_t)STREAM_APP_PROGRESS(stream) - abs_offset;
 
             /* skip frame if threshold not yet reached, esp if frame length is
              * still unknown. */

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -467,10 +467,10 @@ static int RandomGetWrap(void)
     unsigned long r;
 
     do {
-        r = RandomGet();
+        r = (unsigned long)RandomGet();
     } while(r >= ULONG_MAX - (ULONG_MAX % RAND_MAX));
 
-    return r % RAND_MAX;
+    return (int)(r % RAND_MAX);
 }
 
 static const char *UrgentPolicyToString(enum TcpStreamUrgentHandling pol)

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1076,7 +1076,7 @@ void StreamTcpSetOSPolicy(TcpStream *stream, Packet *p)
                         (stream)->last_ack, (stream)->next_seq);                                   \
             } else {                                                                               \
                 SCLogDebug("next_seq (%u) <> last_ack now %d", (stream)->next_seq,                 \
-                        (int)(stream)->next_seq - (ack));                                          \
+                        (int)((stream)->next_seq - (ack)));                                        \
             }                                                                                      \
             (stream)->last_ack = (ack);                                                            \
             StreamTcpSackPruneList((stream));                                                      \

--- a/src/tests/source-pcap.c
+++ b/src/tests/source-pcap.c
@@ -20,13 +20,12 @@
 
 static uint32_t Upper32(uint64_t value)
 {
-    /* uint64_t -> uint32_t is defined behaviour. It slices lower 32bits. */
-    return value >> 32;
+    return (uint32_t)(value >> 32);
 }
 static uint32_t Lower32(uint64_t value)
 {
-    /* uint64_t -> uint32_t is defined behaviour. It slices lower 32bits. */
-    return value;
+    /* uint64_t -> uint32_t slices the lower 32 bits, cast makes it explicit */
+    return (uint32_t)value;
 }
 
 /* Structured test data to make it easier on my eyes */

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -942,7 +942,7 @@ static int ByteTest11 (void)
 {
     const char str[] = "-1234567890";
     int64_t val = -1234567890;
-    int64_t i64 = 0xbfbfbfbfbfbfbfbfULL;
+    int64_t i64 = (int64_t)0xbfbfbfbfbfbfbfbfULL;
     int ret = ByteExtractStringInt64(&i64, 10, sizeof(str) - 1, str);
 
     if ((ret == 11) && (i64 == val)) {
@@ -956,7 +956,7 @@ static int ByteTest12 (void)
 {
     const char str[] = "-1234567890";
     int32_t val = -1234567890;
-    int32_t i32 = 0xbfbfbfbf;
+    int32_t i32 = (int32_t)0xbfbfbfbf;
     int ret = ByteExtractStringInt32(&i32, 10, sizeof(str) - 1, str);
 
     if ((ret == 11) && (i32 == val)) {
@@ -970,7 +970,7 @@ static int ByteTest13 (void)
 {
     const char str[] = "-12345";
     int16_t val = -12345;
-    int16_t i16 = 0xbfbf;
+    int16_t i16 = (int16_t)0xbfbf;
     int ret = ByteExtractStringInt16(&i16, 10, sizeof(str) - 1, str);
 
     if ((ret == 6) && (i16 == val)) {
@@ -984,7 +984,7 @@ static int ByteTest14 (void)
 {
     const char str[] = "-123";
     int8_t val = -123;
-    int8_t i8 = 0xbf;
+    int8_t i8 = (int8_t)0xbf;
     int ret = ByteExtractStringInt8(&i8, 10, sizeof(str) - 1, str);
 
     if ((ret == 4) && (i8 == val)) {

--- a/src/util-fix_checksum.c
+++ b/src/util-fix_checksum.c
@@ -52,7 +52,9 @@ FixChecksum(uint16_t sum, uint16_t old, uint16_t new)
 {
     uint32_t l;
 
-    l = sum + old - new;
+    /* the sum can go negative: the unsigned wrap-around plus the fold below
+     * yields the correct ones' complement borrow handling */
+    l = (uint32_t)(sum + old - new);
     l = (l >> 16) + (l & 65535);
 
     return (uint16_t)(l & 65535);

--- a/src/util-lua-sandbox.c
+++ b/src/util-lua-sandbox.c
@@ -78,9 +78,10 @@ static void *LuaAlloc(void *ud, void *ptr, size_t osize, size_t nsize)
         return nptr;
     } else {
         /* Resizing existing data. */
-        ssize_t diff = nsize - osize;
+        ssize_t diff = (ssize_t)nsize - (ssize_t)osize;
 
-        if (ctx->alloc_limit != 0 && ctx->alloc_bytes + diff > ctx->alloc_limit) {
+        if (ctx->alloc_limit != 0 && diff > 0 &&
+                ctx->alloc_bytes + (size_t)diff > ctx->alloc_limit) {
             /* This request will exceed the allocation limit. Act as
              * though allocation failed. */
             ctx->memory_limit_error = true;
@@ -91,7 +92,11 @@ static void *LuaAlloc(void *ud, void *ptr, size_t osize, size_t nsize)
         if (nptr != NULL) {
             DEBUG_VALIDATE_BUG_ON((ssize_t)ctx->alloc_bytes + diff < 0);
             DEBUG_VALIDATE_BUG_ON(osize > ctx->alloc_bytes);
-            ctx->alloc_bytes += diff;
+            if (diff < 0) {
+                ctx->alloc_bytes -= (size_t)-diff;
+            } else {
+                ctx->alloc_bytes += (size_t)diff;
+            }
         }
         return nptr;
     }

--- a/src/util-lua.c
+++ b/src/util-lua.c
@@ -154,7 +154,7 @@ void LuaStateSetTX(lua_State *luastate, void *txptr, const uint64_t tx_id)
     lua_settable(luastate, LUA_REGISTRYINDEX);
 
     lua_pushlightuserdata(luastate, (void *)&lua_ext_key_tx_id);
-    lua_pushinteger(luastate, tx_id);
+    lua_pushinteger(luastate, (lua_Integer)tx_id);
     lua_settable(luastate, LUA_REGISTRYINDEX);
 }
 

--- a/src/util-mpm-ac-ks-small.c
+++ b/src/util-mpm-ac-ks-small.c
@@ -61,7 +61,7 @@ uint32_t FUNC_NAME(const SCACTileSearchCtx *ctx, MpmThreadCtx *mpm_thread_ctx,
         uint64_t index = 0;
         /* Process 4*floor(buflen/4) bytes. */
         i = 0;
-        while ((i + EXTRA) < (buflen & ~0x3)) {
+        while ((i + EXTRA) < (buflen & ~0x3u)) {
             BUF_TYPE data1 = *(BUF_TYPE* restrict)(&buf[i + 4]);
             index = SINDEX(index, state);
             state = SLOAD(state_table + index + c);

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -775,10 +775,10 @@ void SCACDestroyCtx(MpmCtx *mpm_ctx)
         return;
 
     if (mpm_ctx->init_hash != NULL) {
+        /* the init hash is never added to the mpm memory accounting when it
+         * is allocated in SCACInitCtx, so don't subtract it here either */
         SCFree(mpm_ctx->init_hash);
         mpm_ctx->init_hash = NULL;
-        mpm_ctx->memory_cnt--;
-        mpm_ctx->memory_size -= (MPM_INIT_HASH_SIZE * sizeof(MpmPattern *));
     }
 
     if (ctx->parray != NULL) {

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -997,10 +997,10 @@ void SCHSDestroyCtx(MpmCtx *mpm_ctx)
         return;
 
     if (ctx->init_hash != NULL) {
+        /* the init hash is never added to the mpm memory accounting when it
+         * is allocated in SCHSInitCtx, so don't subtract it here either */
         SCFree(ctx->init_hash);
         ctx->init_hash = NULL;
-        mpm_ctx->memory_cnt--;
-        mpm_ctx->memory_size -= (INIT_HASH_SIZE * sizeof(SCHSPattern *));
     }
 
     /* Decrement pattern database ref count, and delete it entirely if the

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -645,12 +645,12 @@ uint64_t SCGetSecondsUntil (const char *str, time_t epoch)
 
 uint64_t SCTimespecAsEpochMillis(const struct timespec* ts)
 {
-    return ts->tv_sec * 1000L + ts->tv_nsec / 1000000L;
+    return (uint64_t)(ts->tv_sec * 1000L + ts->tv_nsec / 1000000L);
 }
 
 uint64_t TimeDifferenceMicros(struct timeval t0, struct timeval t1)
 {
-    return (uint64_t)(t1.tv_sec - t0.tv_sec) * 1000000L + (t1.tv_usec - t0.tv_usec);
+    return (uint64_t)((t1.tv_sec - t0.tv_sec) * 1000000L + (t1.tv_usec - t0.tv_usec));
 }
 
 #ifdef UNITTESTS


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request. Thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8232

Previous PR: #15872

Supersedes #15403 per the review discussion there: pass all unit tests and all SV tests with `-fsanitize=implicit-conversion`, and land the fixes together with the gate (@catenacyber's "option b").

## Describe changes

Fixes every `-fsanitize=implicit-conversion` trip reached by the unit tests and the full suricata-verify suite, and turns the sanitizer on (non-recoverable) in the Fedora clang CI job so regressions abort the unit-test and SV steps.

Most fixes make an intentional two's complement wrap-around or truncation explicit with a cast, preserving byte-identical behaviour. Beyond those, the sweep surfaced real issues:

- `mpm`: the AC and HS destroy paths subtracted the (never-added) init hash size from `mpm_ctx->memory_size`, underflowing the counter when a context still owned its init hash.
- `detect/prefilter`: the u8hash LT/LTE fill loops relied on `uint8_t` wrap in `while (x--)`; rewritten as plain int loops.
- `defrag` (ticket #8232), two fixes:
  - `DefragInsertFrag` seeded the `RB_NFIND` seek key with `frag_offset - 1`, which underflows to 65535 for the first fragment (offset 0) delivered into a non-empty tree. The `- 1` is load-bearing: `DefragRbFragCompare` never returns 0, so `RB_NFIND` is strictly-greater rather than inclusive, and the `- 1` is what makes it include an existing fragment at the same offset. Dropping it makes the seek land past that node and skip the immediately-preceding (possibly left-overlapping) fragment. Guarded the offset-0 case with `frag_offset ? frag_offset - 1 : 0`, which is behaviour-preserving (the seek starts from `RB_MIN` either way) and removes the underflow. Added `DefragOutOfOrderFirstFragmentTest` and `DefragSameOffsetPrecedingOverlapTest`.
  - IPv6 `frag_end = frag_offset + data_len` narrows into a `uint16_t`. Moved the existing `IPV6_MAXPACKET` oversize check above the assignment (mirroring the IPv4 path) so the cast is provably safe; `frag_end` is not read in between, so behaviour is unchanged (oversize fragments are still dropped with `IPV6_FRAG_PKT_TOO_LARGE`).

The last commit enables the gate in CI; every commit before it keeps the tree clean under the sanitizer, so the series is bisectable.

### Changes since v3

- `defrag`: fixed the sanitizer trip the v3 CI run caught in the new unit test itself. `DefragSameOffsetPrecedingOverlapTest` set the fragment id to `82320`, but the IPv4 id field is only 16 bits and `BuildIpv4TestPacketWithContent` takes a `uint16_t`, so the value was truncated to `16784`:

  ```
  defrag.c:3222:5: runtime error: implicit conversion from type 'int' of value 82320 (32-bit, signed) to type 'uint16_t' (aka 'unsigned short') changed the value to 16784 (16-bit, unsigned)
  ```

  The id is only used as the fragment tracker key and is never asserted on, so it now uses `8232` and is declared `uint16_t`, which makes an out-of-range value a compile-time problem rather than a runtime one. All 37 defrag unit tests pass.
- Folded into the commit that added the test, so the series is still clean under the sanitizer at every step. No other commit is touched, and the tree is otherwise identical to v3; still 18 commits.

### Changes since v2

- `defrag` / #8232: reworked the two defrag commits after review feedback on the ticket. v2 dropped the `- 1` from the `RB_NFIND` key on the premise it was a no-op. That premise is wrong. The comparator never returns 0, so `RB_NFIND` is strictly greater — and dropping the `- 1` changes reassembly when a fragment lands at the same offset as an existing node while a preceding fragment overlaps from the left. The key is now guarded as `frag_offset ? frag_offset - 1 : 0`, keeping the `- 1`. Added two unit tests; `DefragSameOffsetPrecedingOverlapTest` fails under the v2 approach and passes with the guard.
- `defrag` IPv6 `frag_end`: replaced the v2 explicit-cast-plus-TODO with an actual reorder the `IPV6_MAXPACKET` check now precedes the `frag_end` assignment, so the narrowing can no longer wrap and the TODO is removed. Bit-identical behaviour.
- Rebased on the v2 series; still 18 commits.
