### PR TITLE
conf-yaml: support glob patterns in include directive (v3)

### DIFF
--- a/doc/userguide/configuration/includes.rst
+++ b/doc/userguide/configuration/includes.rst
@@ -49,6 +49,29 @@ is the equivalent of::
       address-groups:
         HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
 
+Glob Patterns
+-------------
+
+Filenames in ``include`` may contain shell-style glob metacharacters
+(``*``, ``?``, ``[...]``). Patterns are expanded at startup via
+``glob(3)`` and each matching file is loaded in lexicographic order. A
+pattern that matches no files is logged as a warning and is not treated
+as an error, which allows drop-in ``conf.d/``-style directories to be
+empty.
+
+::
+
+    include:
+      - /etc/suricata/conf.d/*.yaml
+
+Relative patterns are resolved against the directory of the top-level
+configuration file, the same as literal includes.
+
+.. note:: Glob expansion requires ``glob(3)``, which is not available on
+    all platforms. On platforms without it, notably Windows, an
+    ``include`` containing glob metacharacters is skipped with a warning
+    and no files are loaded from it. Literal filenames are unaffected.
+
 .. note:: Suricata versions less than 7 required multiple ``include``
     statements to be specified to include more than one file. While
     Suricata 7.0 still supports this it will issue a deprecation

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -27,6 +27,9 @@
 #include "conf.h"
 #include "conf-yaml-loader.h"
 #include <yaml.h>
+#ifdef HAVE_GLOB_H
+#include <glob.h>
+#endif
 #include "util-path.h"
 #include "util-debug.h"
 #include "util-unittest.h"
@@ -104,18 +107,17 @@ ConfYamlSetConfDirname(const char *filename)
 }
 
 /**
- * \brief Include a file in the configuration.
+ * \brief Include a single resolved file in the configuration.
  *
  * \param parent The configuration node the included configuration will be
  *          placed at.
- * \param filename The filename to include.
+ * \param filename The fully resolved filename to include.
  *
  * \retval 0 on success, -1 on failure.
  */
-int SCConfYamlHandleInclude(SCConfNode *parent, const char *filename)
+static int ConfYamlHandleIncludeOne(SCConfNode *parent, const char *filename)
 {
     yaml_parser_t parser;
-    char include_filename[PATH_MAX];
     FILE *file = NULL;
     int ret = -1;
 
@@ -124,18 +126,9 @@ int SCConfYamlHandleInclude(SCConfNode *parent, const char *filename)
         return -1;
     }
 
-    if (PathIsAbsolute(filename)) {
-        strlcpy(include_filename, filename, sizeof(include_filename));
-    }
-    else {
-        snprintf(include_filename, sizeof(include_filename), "%s/%s",
-            conf_dirname, filename);
-    }
-
-    file = fopen(include_filename, "r");
+    file = fopen(filename, "r");
     if (file == NULL) {
-        SCLogError("Failed to open configuration include file %s: %s", include_filename,
-                strerror(errno));
+        SCLogError("Failed to open configuration include file %s: %s", filename, strerror(errno));
         goto done;
     }
 
@@ -155,6 +148,75 @@ done:
     }
 
     return ret;
+}
+
+/**
+ * \brief Include a file or glob pattern in the configuration.
+ *
+ * Relative paths are resolved against the directory of the top-level config
+ * file. If the input contains glob metacharacters (\c *, \c ?, \c [) the
+ * pattern is expanded via glob(3) and each match is included in lexicographic
+ * order. A pattern that matches no files is logged as a warning and not
+ * treated as an error, to support drop-in `conf.d/` directories.
+ *
+ * Glob expansion needs glob(3). On platforms without it, notably Windows, a
+ * pattern is logged as a warning and skipped instead of being opened as a
+ * literal filename.
+ *
+ * \param parent The configuration node the included configuration will be
+ *          placed at.
+ * \param filename The filename or glob pattern to include.
+ *
+ * \retval 0 on success, -1 on failure.
+ */
+int SCConfYamlHandleInclude(SCConfNode *parent, const char *filename)
+{
+    char include_filename[PATH_MAX];
+
+    if (PathIsAbsolute(filename)) {
+        strlcpy(include_filename, filename, sizeof(include_filename));
+    } else {
+        snprintf(include_filename, sizeof(include_filename), "%s/%s", conf_dirname, filename);
+    }
+
+    const bool is_pattern = strpbrk(filename, "*?[") != NULL;
+
+#ifdef HAVE_GLOB_H
+    if (is_pattern) {
+        glob_t globbuf;
+        int gret = glob(include_filename, 0, NULL, &globbuf);
+
+        if (gret == GLOB_NOMATCH) {
+            SCLogWarning("No files match include pattern %s", include_filename);
+            return 0;
+        } else if (gret != 0) {
+            SCLogError(
+                    "Failed to expand include pattern %s: %s", include_filename, strerror(errno));
+            return -1;
+        }
+
+        int ret = 0;
+        for (size_t i = 0; i < (size_t)globbuf.gl_pathc; i++) {
+            const char *path = globbuf.gl_pathv[i];
+            SCLogInfo("Including configuration file %s (matched %s).", path, filename);
+            if (ConfYamlHandleIncludeOne(parent, path) != 0) {
+                ret = -1;
+                break;
+            }
+        }
+        globfree(&globbuf);
+        return ret;
+    }
+#else
+    if (is_pattern) {
+        SCLogWarning("Glob patterns in include are not supported on this platform, "
+                     "skipping include %s",
+                include_filename);
+        return 0;
+    }
+#endif
+
+    return ConfYamlHandleIncludeOne(parent, include_filename);
 }
 
 /**


### PR DESCRIPTION
Continuation of #15574 (v3). See "Changes since #15574" below.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8427

Previous PR: #15574

## Describe changes:

`SCConfYamlHandleInclude` now expands shell-style glob patterns (`*`, `?`, `[`) via `glob(3)` when the include path contains them. Each match is loaded in lexicographic (sorted) order; literal paths bypass `glob()` and take the existing per-file path. A pattern matching zero files is logged as a warning, not an error, so drop-in `conf.d/`-style directories may be empty. The precedent for the `glob(3)` shape and `HAVE_GLOB_H` gating is `rule-files:` in `src/detect-engine-loader.c`.

### Changes since #15574

Addresses @jasonish's review: *"Document and accept that globbing doesn't work on Windows for now. Ideally with a warning message if the patterns are found."*

- Windows has no `glob.h`, so `HAVE_GLOB_H` is undefined and an include pattern fell through to be opened as a literal filename, failing with a confusing errno:

  ```
  Error: conf-yaml-loader: Failed to open configuration include file .../*-order.yaml: Invalid argument
  ```

  A pattern is now detected regardless of `HAVE_GLOB_H` and, on platforms without `glob(3)`, logged and skipped instead:

  ```
  Warning: conf-yaml-loader: Glob patterns in include are not supported on this platform, skipping include .../*.yaml
  ```

  Literal includes are unaffected, including the existing hard error for a missing literal file.

- Documented the platform limitation in `doc/userguide/configuration/includes.rst` and in the function's doxygen comment.

- Rebased onto current `main`.

**Skip vs. error.** An unsupported pattern is a warning that continues, reading "accept that globbing doesn't work on Windows" as a documented platform limitation rather than a startup failure. The tradeoff is that a Windows user gets a partially-loaded config with only a warning. Happy to make it a hard error with an explicit message instead if you prefer that.

The suricata-verify test skips on builds without `glob(3)` by probing `src/autoconf.h` for `HAVE_GLOB_H`, so it no longer depends on the Windows runner incidentally failing the probe redirect.

#### Verification

Built with `HAVE_GLOB_H` undefined to exercise the Windows path directly:

| case | before | after |
| --- | --- | --- |
| pattern include, no `glob(3)` | `Error: Failed to open ... Invalid argument`, exit 1 | `Warning: ... not supported on this platform`, exit 0 |

On a normal build: all matched files load in lexicographic order, a no-match pattern still warns without failing, literal includes still work, a missing literal file still errors, and all 9 `ConfYaml` unit tests pass. suricata-verify: `===> config-includes-glob-order: OK`, and `SKIPPED` on a build with `HAVE_GLOB_H` undefined.

The Windows CI failures on #15574 dated 2026-06-07 also predate the suricata-verify test rewrite of 2026-06-12, which removed the `suricata.yaml` that broke suricata-verify's setup step; the `Ubuntu 24.04 (afpacket IPS tests in namespaces)` failure there was a transient Codecov CLI GPG error, unrelated to the change.

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3250
