### PR TITLE
plugin/ndpi: migrate to nDPI 5.0 API

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -786,16 +786,16 @@ jobs:
 
       - name: Build and install nDPI
         run: |
-          curl -OL https://github.com/ntop/nDPI/archive/refs/tags/4.14.tar.gz
-          tar xvf 4.14.tar.gz
-          cd nDPI-4.14
+          curl -OL https://github.com/ntop/nDPI/archive/refs/tags/5.0.tar.gz
+          tar xvf 5.0.tar.gz
+          cd nDPI-5.0
           ./autogen.sh
           ./configure
           make -j ${{ env.CPUS }}
 
       - run: tar zxvf suricata-*.tar.gz --strip-components=1
       - name: ./configure
-        run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-ndpi --with-ndpi=$(pwd)/nDPI-4.14 --enable-debug --enable-qa-simulation
+        run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-ndpi --with-ndpi=$(pwd)/nDPI-5.0 --enable-debug --enable-qa-simulation
       - run: make -j ${{ env.CPUS }}
       - run: make install
       - run: make install-conf

--- a/configure.ac
+++ b/configure.ac
@@ -2299,6 +2299,26 @@ fi
     fi
 
     if test "x$enable_ndpi" = "xyes"; then
+        AC_MSG_CHECKING(for nDPI version >= 5.0)
+        have_recent_ndpi="no"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+                #include "ndpi_api.h"
+            ],[
+                #if NDPI_MAJOR < 5
+                #error "Outdated nDPI, need at least version 5.0"
+                #endif
+            ])], [have_recent_ndpi="yes"])
+        if test "x$have_recent_ndpi" != "xyes"; then
+            AC_MSG_RESULT(no)
+            echo
+            echo "   ERROR! nDPI version < 5.0 is not supported, get a newer one"
+            echo
+            exit 1
+        fi
+        AC_MSG_RESULT(yes)
+    fi
+
+    if test "x$enable_ndpi" = "xyes"; then
         AM_CONDITIONAL([BUILD_NDPI], [true])
         ndpi_comment=""
     else

--- a/doc/userguide/plugins/ndpi.rst
+++ b/doc/userguide/plugins/ndpi.rst
@@ -6,6 +6,8 @@ nDPI
 Installation
 ************
 
+The nDPI plugin requires nDPI 5.0 or later.
+
 Before using nDPI, Suricata must be built with nDPI support, for
 example:
 

--- a/plugins/ndpi/ndpi.c
+++ b/plugins/ndpi/ndpi.c
@@ -167,19 +167,16 @@ static void OnFlowUpdate(ThreadVars *tv, Flow *f, Packet *p, void *_data)
         flowctx->detected_l7_protocol = ndpi_detection_process_packet(
                 threadctx->ndpi, flowctx->ndpi_flow, ip_ptr, ip_len, time_ms, NULL);
 
-        if (ndpi_is_protocol_detected(flowctx->detected_l7_protocol) != 0) {
-            if (!ndpi_is_proto_unknown(flowctx->detected_l7_protocol.proto)) {
-                if (!ndpi_extra_dissection_possible(threadctx->ndpi, flowctx->ndpi_flow))
-                    flowctx->detection_completed = true;
-            }
-        } else {
+        if (flowctx->detected_l7_protocol.state == NDPI_STATE_CLASSIFIED ||
+                flowctx->detected_l7_protocol.state == NDPI_STATE_MONITORING) {
+            flowctx->detection_completed = true;
+        } else if (flowctx->detected_l7_protocol.state == NDPI_STATE_INSPECTING ||
+                   flowctx->detected_l7_protocol.state == NDPI_STATE_PARTIAL) {
+            /* INSPECTING or PARTIAL — bound work per flow by giving up after N packets */
             uint16_t max_num_pkts = (f->proto == IPPROTO_UDP) ? 8 : 24;
-
             if ((f->todstpktcnt + f->tosrcpktcnt) > max_num_pkts) {
-                uint8_t proto_guessed;
-
                 flowctx->detected_l7_protocol =
-                        ndpi_detection_giveup(threadctx->ndpi, flowctx->ndpi_flow, &proto_guessed);
+                        ndpi_detection_giveup(threadctx->ndpi, flowctx->ndpi_flow);
                 flowctx->detection_completed = true;
             }
         }
@@ -213,9 +210,6 @@ static void OnThreadInit(ThreadVars *tv, void *_data)
     if (context->ndpi == NULL) {
         FatalError("Failed to initialize nDPI detection module");
     }
-    NDPI_PROTOCOL_BITMASK protos;
-    NDPI_BITMASK_SET_ALL(protos);
-    ndpi_set_protocol_detection_bitmask2(context->ndpi, &protos);
     ndpi_finalize_initialization(context->ndpi);
     SCThreadSetStorageById(tv, thread_storage_id, context);
 }
@@ -238,15 +232,6 @@ static int DetectnDPIProtocolPacketMatch(
     }
 
     const DetectnDPIProtocolData *data = (const DetectnDPIProtocolData *)ctx;
-
-    /* if the sig is PD-only we only match when PD packet flags are set */
-    /*
-    if (s->type == SIG_TYPE_PDONLY &&
-            (p->flags & (PKT_PROTO_DETECT_TS_DONE | PKT_PROTO_DETECT_TC_DONE)) == 0) {
-        SCLogDebug("packet %"PRIu64": flags not set", PcapPacketCntGet(p));
-        SCReturnInt(0);
-    }
-    */
 
     if (!flowctx->detection_completed) {
         SCLogDebug("packet %" PRIu64 ": ndpi protocol not yet detected", PcapPacketCntGet(p));
@@ -272,15 +257,12 @@ static DetectnDPIProtocolData *DetectnDPIProtocolParse(const char *arg, bool neg
     struct ndpi_detection_module_struct *ndpi_struct;
     ndpi_master_app_protocol l7_protocol;
     char *l7_protocol_name = (char *)arg;
-    NDPI_PROTOCOL_BITMASK all;
 
     /* convert protocol name (string) to ID */
     ndpi_struct = ndpi_init_detection_module(NULL);
     if (unlikely(ndpi_struct == NULL))
         return NULL;
 
-    NDPI_BITMASK_SET_ALL(all);
-    ndpi_set_protocol_detection_bitmask2(ndpi_struct, &all);
     ndpi_finalize_initialization(ndpi_struct);
 
     l7_protocol = ndpi_get_protocol_by_name(ndpi_struct, l7_protocol_name);
@@ -401,15 +383,12 @@ static DetectnDPIRiskData *DetectnDPIRiskParse(const char *arg, bool negate)
     DetectnDPIRiskData *data;
     struct ndpi_detection_module_struct *ndpi_struct;
     ndpi_risk risk_mask;
-    NDPI_PROTOCOL_BITMASK all;
 
     /* convert list of risk names (string) to mask */
     ndpi_struct = ndpi_init_detection_module(NULL);
     if (unlikely(ndpi_struct == NULL))
         return NULL;
 
-    NDPI_BITMASK_SET_ALL(all);
-    ndpi_set_protocol_detection_bitmask2(ndpi_struct, &all);
     ndpi_finalize_initialization(ndpi_struct);
     ndpi_exit_detection_module(ndpi_struct);
 


### PR DESCRIPTION
Switch to nDPI 5's state-based detection-complete check and the updated ndpi_detection_giveup() signature. Drop the now-removed ndpi_set_protocol_detection_bitmask2 call sites. Add a configure.ac probe; nDPI 4.x is no longer supported. (Not sure if you prefer supporting both versions with shims, let me know)

Update the GitHub CI plugins build to use nDPI 5.0.

Ticket: #8077

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [✅] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [✅] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [✅] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [✅] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [✅] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
