### PR TITLE
firewall: add default-policy to policy config v1

### DIFF
--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -62,7 +62,7 @@ Application layer tables
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 If applayer is available, rules from the following tables apply. The tables for the
-application layer are per app layer protocol and per protocol state. e.g. ``http:request_line``.
+application layer are per app layer protocol and per protocol state. e.g. ``http1:request_line``.
 
 
 .. table::
@@ -349,29 +349,57 @@ The example below accepts ARP again, using this mechanism.
 Default policies
 ================
 
-Each hook has a default policy. By default ``packet:filter`` enforces a ``drop:packet`` policy and the
-``app:filter`` hooks applies ``drop:flow``.
+Each hook has a default policy applied to traffic that no firewall rule handled.
+By default ``packet.filter`` enforces ``drop:packet``, ``packet.pre-flow`` and
+``packet.pre-stream`` enforce ``accept:hook``, and every ``app`` hook enforces
+``drop:flow``.
 
-The policies can be configured in ``firewall`` block in the config.
-
-Example for ``packet:filter``, to use reject instead of drop::
-
-    firewall:
-      policies:
-        packet-filter: [ "reject:packet" ]
-
-
-Example for DNS::
+Defaults are configured in the ``firewall.policies`` block. A ``default-policy``
+may be given at several levels; for any hook the most specific present setting
+wins::
 
     firewall:
       policies:
-        dns:
-          request-started: ["accept:hook"]
+        default-policy: ["accept:hook"]     # global fallback (all hooks)
+        packet:
+          default-policy: ["drop:packet"]   # fallback for packet hooks
+          filter:     ["drop:packet"]
+          pre-flow:   ["accept:hook"]
+          pre-stream: ["accept:hook"]
+        app:
+          default-policy: ["drop:flow"]     # fallback for all app hooks
+          dns:
+            default-policy: ["drop:flow"]   # fallback for dns hooks
+            request-started: ["accept:hook"]
+            request-complete: ["drop:flow", "alert"]
+            response-started: ["accept:tx"]
 
-          # Drop and alert on all DNS requests that are not allowed in
-          # firewall.rules.
-          request-complete: ["drop:flow", "alert"]
+Protocols whose hooks are grouped into sub states, such as HTTP/2, take an extra
+level for the sub state name::
 
-          # Accept all responses.
-          response-started: ["accept:tx"]
+    firewall:
+      policies:
+        app:
+          http2:
+            default-policy: ["drop:flow"]   # fallback for all http2 hooks
+            stream:
+              default-policy: ["drop:flow"] # fallback for http2 stream hooks
+              request-started: ["accept:hook"]
+            global:
+              request-started: ["accept:hook"]
 
+Precedence:
+
+* packet hook: ``packet.<hook>`` > ``packet.default-policy`` >
+  ``policies.default-policy`` > built-in
+* app hook: ``app.<proto>.<hook>`` > ``app.<proto>.default-policy`` >
+  ``app.default-policy`` > ``policies.default-policy`` > built-in
+* app hook in a sub state: ``app.<proto>.<sub state>.<hook>`` >
+  ``app.<proto>.<sub state>.default-policy`` > ``app.<proto>.default-policy`` >
+  ``app.default-policy`` > ``policies.default-policy`` > built-in
+
+An action scope must be valid for the hook it is applied to. For example,
+defining ``accept:tx`` as a global default policy will fail to start Suricata,
+because ``packet`` policies do not accept ``tx``.
+Cover such hooks with a more specific setting so the incompatible default never
+reaches them.

--- a/doc/userguide/firewall/firewall-example.rst
+++ b/doc/userguide/firewall/firewall-example.rst
@@ -67,35 +67,36 @@ In the example below: the config auto accepts various hooks, leaving just ``http
 
     firewall:
       policies:
-        http:
-          request-started:
-            - "accept:hook"
-          request-line:
-            - "drop:flow"
-            - "alert"
-          request-headers:
-            - "drop:flow"
-            - "alert"
-          request-body:
-            - "accept:hook"
-          request-trailer:
-            - "accept:hook"
-          request-complete:
-            - "accept:hook"
+        app:
+          http1:
+            request-started:
+              - "accept:hook"
+            request-line:
+              - "drop:flow"
+              - "alert"
+            request-headers:
+              - "drop:flow"
+              - "alert"
+            request-body:
+              - "accept:hook"
+            request-trailer:
+              - "accept:hook"
+            request-complete:
+              - "accept:hook"
 
-          response-started:
-            - "accept:hook"
-          response-line:
-            - "drop:flow"
-            - "alert"
-          response-headers:
-            - "accept:hook"
-          response-body:
-            - "accept:hook"
-          response-trailer:
-            - "accept:hook"
-          response-complete:
-            - "accept:hook"
+            response-started:
+              - "accept:hook"
+            response-line:
+              - "drop:flow"
+              - "alert"
+            response-headers:
+              - "accept:hook"
+            response-body:
+              - "accept:hook"
+            response-trailer:
+              - "accept:hook"
+            response-complete:
+              - "accept:hook"
 
 
 ::

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -109,9 +109,25 @@ typedef struct SignatureParser_ {
     char opts[DETECT_MAX_RULE_SIZE];
 } SignatureParser;
 
+/** Valid action scopes per firewall hook class. Single source of truth for both
+ *  scope validation and the human-readable "a/b/c" hint in error messages. */
+static const uint8_t fw_packet_hook_scopes[] = {
+    ACTION_SCOPE_PACKET,
+    ACTION_SCOPE_HOOK,
+    ACTION_SCOPE_FLOW,
+};
+static const uint8_t fw_app_hook_scopes[] = {
+    ACTION_SCOPE_FLOW,
+    ACTION_SCOPE_TX,
+    ACTION_SCOPE_HOOK,
+};
+
 const char *DetectListToHumanString(int list)
 {
-#define CASE_CODE_STRING(E, S)  case E: return S; break
+#define CASE_CODE_STRING(E, S)                                                                     \
+    case E:                                                                                        \
+        return S;                                                                                  \
+        break
     switch (list) {
         CASE_CODE_STRING(DETECT_SM_LIST_MATCH, "packet");
         CASE_CODE_STRING(DETECT_SM_LIST_PMATCH, "payload");
@@ -4138,6 +4154,10 @@ static int AddAppPolicySignature(struct DetectFirewallAppPolicy *pol)
     return 0;
 }
 
+/**
+ * \brief Parse a policy config key into a DetectFirewallPolicy struct.
+ * \return 1 if a policy was found and parsed, 0 if no policy was configured, -1 on parse error
+ */
 static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *pol)
 {
     SCConfNode *policy_actions = SCConfGetNode(policy_name);
@@ -4161,31 +4181,186 @@ static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *p
     return 1;
 }
 
-static int DoParseAppSubStatePolicy(const char *prefix, const AppProto app_proto,
-        const uint8_t sub_state, const char *sub_state_name, const uint8_t state,
-        const char *hookname, const uint8_t complete_state, const int direction,
+static bool FirewallScopeValidForClass(uint8_t scope, enum DetectFirewallPolicyClass pol_class)
+{
+    const uint8_t *set = (pol_class == DETECT_FIREWALL_POLICY_CLASS_PACKET) ? fw_packet_hook_scopes
+                                                                            : fw_app_hook_scopes;
+    const size_t n = (pol_class == DETECT_FIREWALL_POLICY_CLASS_PACKET)
+                             ? ARRAY_SIZE(fw_packet_hook_scopes)
+                             : ARRAY_SIZE(fw_app_hook_scopes);
+    for (size_t i = 0; i < n; i++) {
+        if (set[i] == scope) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * \brief Render the valid scopes for a hook class to a string.
+ */
+static void FirewallScopeHintForClass(
+        enum DetectFirewallPolicyClass pol_class, char *out, size_t out_size)
+{
+    const uint8_t *set = (pol_class == DETECT_FIREWALL_POLICY_CLASS_PACKET) ? fw_packet_hook_scopes
+                                                                            : fw_app_hook_scopes;
+    const size_t n = (pol_class == DETECT_FIREWALL_POLICY_CLASS_PACKET)
+                             ? ARRAY_SIZE(fw_packet_hook_scopes)
+                             : ARRAY_SIZE(fw_app_hook_scopes);
+    out[0] = '\0';
+    for (size_t i = 0; i < n; i++) {
+        if (i > 0) {
+            strlcat(out, "/", out_size);
+        }
+        strlcat(out, ActionScopeToString((enum ActionScope)set[i]), out_size);
+    }
+}
+
+/**
+ * \brief Assemble a firewall.policies config path, fatal on truncation.
+ */
+static void ATTR_FMT_PRINTF(3, 4)
+        FirewallPolicyPath(char *out_buf, size_t out_buf_sz, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    int r = vsnprintf(out_buf, out_buf_sz, fmt, ap);
+    va_end(ap);
+    if (r < 0 || (size_t)r >= out_buf_sz)
+        FatalError("internal error: failed to assemble firewall policy config string");
+}
+
+/**
+ * \brief Resolve a firewall policy from the list of config paths.
+ *
+ * Paths are most-specific-first. The first path that has a policy configured
+ * wins with its action scope validated against the target hook class.
+ *
+ * \retval 1 a config source was used and stored in \p out
+ * \retval 0 no source present, \p out is unmodified
+ * \retval -1 parse error, e.g. an empty policy, or invalid scope for the target class
+ */
+static int ResolveFirewallPolicy(struct DetectFirewallPolicy *out,
+        enum DetectFirewallPolicyClass pol_class, const char *const *paths, const int npaths)
+{
+    for (int i = 0; i < npaths; i++) {
+        if (paths[i] == NULL) {
+            continue;
+        }
+        struct DetectFirewallPolicy tmp = { 0 };
+        int r = DoParsePolicy(paths[i], &tmp);
+        if (r < 0) {
+            return -1;
+        }
+        if (r == 1) {
+            if (tmp.action == 0) {
+                SCLogError("%s: policy is set but empty", paths[i]);
+                return -1;
+            }
+            if (!FirewallScopeValidForClass(tmp.action_scope, pol_class)) {
+                char hint[32];
+                FirewallScopeHintForClass(pol_class, hint, sizeof(hint));
+                SCLogError("%s: action scope (\"%s\") is not valid.  Valid scopes: %s", paths[i],
+                        ActionScopeToString(tmp.action_scope), hint);
+                return -1;
+            }
+            *out = tmp;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/**
+ * \brief Generic start/complete hook alias for an app progress state, in config
+ *        form (hyphens), or NULL for intermediate states.
+ */
+static const char *FirewallAppGenericHookName(
+        const uint8_t state, const uint8_t complete_state, const int direction)
+{
+    if (state == 0)
+        return (direction == STREAM_TOSERVER) ? "request-started" : "response-started";
+    if (state == complete_state)
+        return (direction == STREAM_TOSERVER) ? "request-complete" : "response-complete";
+    return NULL;
+}
+
+/** \brief Copy a progress state name into config-key form ('_' -> '-'). */
+static void FirewallHookNameNormalize(const char *in, char *out, size_t out_size)
+{
+    strlcpy(out, in, out_size);
+    for (size_t i = 0; out[i] != '\0'; i++) {
+        if (out[i] == '_')
+            out[i] = '-';
+    }
+}
+
+/**
+ *  \brief Resolve and store one app-layer hook default policy.
+ *
+ *  Handles both plain hooks (\p sub_state_name NULL) and sub state hooks, which
+ *  only differ by an extra path segment. The policy is resolved most-specific
+ *  first, e.g. for a sub state hook:
+ *
+ *    <prefix>.app.<proto>.<sub state>.<hook>
+ *    <prefix>.app.<proto>.<sub state>.<generic hook alias>
+ *    <prefix>.app.<proto>.<sub state>.default-policy
+ *    <prefix>.app.<proto>.default-policy
+ *    <prefix>.app.default-policy
+ *    <prefix>.default-policy
+ */
+static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const uint8_t sub_state,
+        const char *sub_state_name, const char *hookname, const uint8_t state,
+        const uint8_t complete_state, const int direction,
         struct DetectFirewallPolicies *fw_policies)
 {
-    char policy_name[256];
-    BUG_ON(sub_state_name == NULL);
-    BUG_ON(hookname == NULL);
+    const char *app_name = (app_proto == ALPROTO_HTTP1) ? "http1" : AppProtoToString(app_proto);
+    // Generic serves for the first and the last state, NULL otherwise
+    const char *generic = FirewallAppGenericHookName(state, complete_state, direction);
 
-    char *nname = SCStrdup(hookname);
-    if (nname == NULL)
-        return -1;
-    for (int i = 0; nname[i] != '\0'; i++) {
-        if (nname[i] == '_')
-            nname[i] = '-';
+    char primary[64];
+    if (hookname != NULL) {
+        FirewallHookNameNormalize(hookname, primary, sizeof(primary));
+    } else if (generic != NULL) {
+        strlcpy(primary, generic, sizeof(primary));
+    } else {
+        return 0;
     }
 
-    const char *app_name = AppProtoToString(app_proto);
-    int r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s.%s", prefix, app_name,
-            sub_state_name, nname);
-    SCLogDebug("policy_name %s", policy_name);
-    SCFree(nname);
-    if (r < 0 || (size_t)r >= sizeof(policy_name)) {
-        FatalError("internal error: failed to assemble firewall policy config string");
+    /* the node the hooks of this protocol live under; sub state protocols get
+     * an extra segment, so their hooks don't collide across sub states. */
+    char scope[256];
+    if (sub_state_name != NULL) {
+        char sub[64];
+        FirewallHookNameNormalize(sub_state_name, sub, sizeof(sub));
+        FirewallPolicyPath(scope, sizeof(scope), "%s.app.%s.%s", prefix, app_name, sub);
+    } else {
+        FirewallPolicyPath(scope, sizeof(scope), "%s.app.%s", prefix, app_name);
     }
+
+    char primary_key[320], generic_key[320], hook_dflt[320], proto_dflt[320], app_dflt[320],
+            global_dflt[320];
+    FirewallPolicyPath(primary_key, sizeof(primary_key), "%s.%s", scope, primary);
+    if (generic != NULL && strcmp(primary, generic) != 0)
+        FirewallPolicyPath(generic_key, sizeof(generic_key), "%s.%s", scope, generic);
+    else
+        generic_key[0] = '\0';
+    FirewallPolicyPath(hook_dflt, sizeof(hook_dflt), "%s.default-policy", scope);
+    FirewallPolicyPath(
+            proto_dflt, sizeof(proto_dflt), "%s.app.%s.default-policy", prefix, app_name);
+    FirewallPolicyPath(app_dflt, sizeof(app_dflt), "%s.app.default-policy", prefix);
+    FirewallPolicyPath(global_dflt, sizeof(global_dflt), "%s.default-policy", prefix);
+
+    const char *paths[] = {
+        primary_key,
+        generic_key[0] != '\0' ? generic_key : NULL,
+        hook_dflt,
+        /* without a sub state, `scope` is already the protocol node, so
+         * hook_dflt and proto_dflt are the same path. */
+        sub_state_name != NULL ? proto_dflt : NULL,
+        app_dflt,
+        global_dflt,
+    };
 
     struct DetectFirewallAppPolicy *app_pol = SCCalloc(1, sizeof(*app_pol));
     if (app_pol == NULL)
@@ -4195,100 +4370,13 @@ static int DoParseAppSubStatePolicy(const char *prefix, const AppProto app_proto
     app_pol->sub_state = sub_state;
     app_pol->progress = state;
     app_pol->direction = (uint8_t)direction;
-    /* init to drop:flow by default, will be overwritten by DoParsePolicy if there
-     * is a config for this hook. */
+    /* built-in default, overwritten by ResolveFirewallPolicy if any of the
+     * config paths above has a policy. */
     app_pol->policy.action = ACTION_DROP;
     app_pol->policy.action_scope = ACTION_SCOPE_FLOW;
 
-    r = DoParsePolicy(policy_name, &app_pol->policy);
-    if (r < 0) {
-        SCFree(app_pol);
-        return -1;
-    }
-
-    if (HashTableAdd(fw_policies->app_policies, app_pol, 0) != 0) {
-        FatalError("internal error: insert policy into hash table");
-    }
-    /* for policies with an alert action, create a policy sig */
-    if (r == 1 && app_pol->policy.action & ACTION_ALERT) {
-        SCLogDebug("adding policy signature");
-        return AddAppPolicySignature(app_pol);
-    }
-    SCLogDebug("r %d", r);
-    return r;
-}
-
-static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const char *hookname,
-        const uint8_t state, const uint8_t complete_state, const int direction,
-        struct DetectFirewallPolicies *fw_policies)
-{
-    char policy_name[256];
-    const char *in_name = hookname;
-    if (hookname == NULL) {
-        if (state == 0) {
-            if (direction == STREAM_TOSERVER)
-                hookname = "request-started";
-            else
-                hookname = "response-started";
-        } else if (state == complete_state) {
-            if (direction == STREAM_TOSERVER)
-                hookname = "request-complete";
-            else
-                hookname = "response-complete";
-        }
-        if (hookname == NULL)
-            return 0;
-    }
-    char *nname = SCStrdup(hookname);
-    if (nname == NULL)
-        return -1;
-    for (int i = 0; nname[i] != '\0'; i++) {
-        if (nname[i] == '_')
-            nname[i] = '-';
-    }
-
-    const char *app_name = AppProtoToString(app_proto);
-    int r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s", prefix, app_name, nname);
-    SCFree(nname);
-    if (r < 0 || (size_t)r >= sizeof(policy_name)) {
-        FatalError("internal error: failed to assemble firewall policy config string");
-    }
-
-    struct DetectFirewallAppPolicy *app_pol = SCCalloc(1, sizeof(*app_pol));
-    if (app_pol == NULL)
-        return -1;
-
-    app_pol->alproto = app_proto;
-    app_pol->sub_state = 0;
-    app_pol->progress = state;
-    app_pol->direction = (uint8_t)direction;
-    /* init to drop:flow by default, will be overwritten by DoParsePolicy if there
-     * is a config for this hook. */
-    app_pol->policy.action = ACTION_DROP;
-    app_pol->policy.action_scope = ACTION_SCOPE_FLOW;
-
-    r = DoParsePolicy(policy_name, &app_pol->policy);
-    if (r == 0 && in_name != NULL) {
-        if (state == 0) {
-            if (direction == STREAM_TOSERVER)
-                hookname = "request-started";
-            else
-                hookname = "response-started";
-        } else if (state == complete_state) {
-            if (direction == STREAM_TOSERVER)
-                hookname = "request-complete";
-            else
-                hookname = "response-complete";
-        }
-        if (hookname == NULL)
-            return 0;
-        r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s", prefix, app_name, hookname);
-        if (r < 0 || (size_t)r >= sizeof(policy_name)) {
-            FatalError("internal error: failed to assemble firewall policy config string");
-        }
-
-        r = DoParsePolicy(policy_name, &app_pol->policy);
-    }
+    int r = ResolveFirewallPolicy(
+            &app_pol->policy, DETECT_FIREWALL_POLICY_CLASS_APP, paths, (int)ARRAY_SIZE(paths));
     if (r < 0) {
         SCFree(app_pol);
         return -1;
@@ -4299,7 +4387,7 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
     }
 
     /* for policies with an alert action, create a policy sig */
-    if (r == 1 && app_pol->policy.action & ACTION_ALERT) {
+    if (r == 1 && (app_pol->policy.action & ACTION_ALERT)) {
         SCLogDebug("adding policy signature");
         return AddAppPolicySignature(app_pol);
     }
@@ -4333,10 +4421,50 @@ int DetectFirewallInitDefaultPolicies(DetectEngineCtx *de_ctx)
     return 0;
 }
 
+/**
+ *  \brief Resolve and store one packet-hook default policy.
+ */
+static int DetectFirewallLoadPacketPolicy(struct DetectFirewallPolicies *fw_policies,
+        const char *prefix, enum DetectFirewallPacketPolicies id, const char *leaf)
+{
+    char specific[256], pkt_dflt[256], global_dflt[256];
+    FirewallPolicyPath(specific, sizeof(specific), "%s.packet.%s", prefix, leaf);
+    FirewallPolicyPath(pkt_dflt, sizeof(pkt_dflt), "%s.packet.default-policy", prefix);
+    FirewallPolicyPath(global_dflt, sizeof(global_dflt), "%s.default-policy", prefix);
+
+    struct DetectFirewallPolicy *pol = &fw_policies->pkt[id]; // built-in default
+    const char *paths[] = { specific, pkt_dflt, global_dflt };
+    int r = ResolveFirewallPolicy(
+            pol, DETECT_FIREWALL_POLICY_CLASS_PACKET, paths, (int)ARRAY_SIZE(paths));
+    if (r < 0) {
+        return -1;
+    }
+    if (r == 1 && (pol->action & ACTION_ALERT)) {
+        return AddPktPolicySignature(fw_policies, pol, id);
+    }
+    return 0;
+}
+
+/**
+ * \brief Load the packet-hook default policies.
+ */
+static int DetectFirewallLoadPacketPolicies(
+        struct DetectFirewallPolicies *fw_policies, const char *prefix)
+{
+    if (DetectFirewallLoadPacketPolicy(
+                fw_policies, prefix, DETECT_FIREWALL_POLICY_PACKET_FILTER, "filter") < 0)
+        return -1;
+    if (DetectFirewallLoadPacketPolicy(
+                fw_policies, prefix, DETECT_FIREWALL_POLICY_PRE_FLOW, "pre-flow") < 0)
+        return -1;
+    if (DetectFirewallLoadPacketPolicy(
+                fw_policies, prefix, DETECT_FIREWALL_POLICY_PRE_STREAM, "pre-stream") < 0)
+        return -1;
+    return 0;
+}
+
 int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
 {
-    int r;
-    char policy_name[256];
     char prefix[96] = "firewall.policies";
     if (strlen(de_ctx->config_prefix) > 0) {
         snprintf(prefix, sizeof(prefix), "%s.firewall.policies", de_ctx->config_prefix);
@@ -4346,42 +4474,8 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
     if (fw_policies == NULL)
         return -1;
 
-    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-filter", prefix);
-    if (r < 0 || (size_t)r >= sizeof(policy_name)) {
-        FatalError("internal error: failed to assemble firewall policy config string");
-    }
-    r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER]);
-    if (r < 0)
+    if (DetectFirewallLoadPacketPolicies(fw_policies, prefix) < 0)
         return -1;
-    if (fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER].action & ACTION_ALERT)
-        if (AddPktPolicySignature(fw_policies,
-                    &fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER],
-                    DETECT_FIREWALL_POLICY_PACKET_FILTER) < 0)
-            return -1;
-
-    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-flow", prefix);
-    if (r < 0 || (size_t)r >= sizeof(policy_name)) {
-        FatalError("internal error: failed to assemble firewall policy config string");
-    }
-    r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW]);
-    if (r < 0)
-        return -1;
-    if (fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW].action & ACTION_ALERT)
-        if (AddPktPolicySignature(fw_policies, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW],
-                    DETECT_FIREWALL_POLICY_PRE_FLOW) < 0)
-            return -1;
-
-    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-stream", prefix);
-    if (r < 0 || (size_t)r >= sizeof(policy_name)) {
-        FatalError("internal error: failed to assemble firewall policy config string");
-    }
-    r = DoParsePolicy(policy_name, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM]);
-    if (r < 0)
-        return -1;
-    if (fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM].action & ACTION_ALERT)
-        if (AddPktPolicySignature(fw_policies, &fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_STREAM],
-                    DETECT_FIREWALL_POLICY_PRE_STREAM) < 0)
-            return -1;
 
     for (AppProto a = 0; a < g_alproto_max; a++) {
         if (!AppProtoIsValid(a))
@@ -4409,8 +4503,8 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
                     BUG_ON(state_name == NULL);
                     SCLogDebug("protocol %s: sub state:%s state:%s", AppProtoToString(a),
                             sub_state_name, state_name);
-                    if (DoParseAppSubStatePolicy(prefix, a, s, sub_state_name, state, state_name,
-                                max_state, STREAM_TOSERVER, fw_policies) < 0)
+                    if (DoParseAppPolicy(prefix, a, s, sub_state_name, state_name, state, max_state,
+                                STREAM_TOSERVER, fw_policies) < 0)
                         return -1;
                 }
                 /* to_client */
@@ -4422,8 +4516,8 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
                     BUG_ON(state_name == NULL);
                     SCLogDebug("protocol %s: to_client: sub state:%s state:%s", AppProtoToString(a),
                             sub_state_name, state_name);
-                    if (DoParseAppSubStatePolicy(prefix, a, s, sub_state_name, state, state_name,
-                                max_state, STREAM_TOCLIENT, fw_policies) < 0)
+                    if (DoParseAppPolicy(prefix, a, s, sub_state_name, state_name, state, max_state,
+                                STREAM_TOCLIENT, fw_policies) < 0)
                         return -1;
                 }
             }
@@ -4434,8 +4528,8 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
             for (uint8_t state = 0; state <= complete_state_ts; state++) {
                 const char *name =
                         AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOSERVER);
-                if (DoParseAppPolicy(prefix, a, name, state, complete_state_ts, STREAM_TOSERVER,
-                            fw_policies) < 0)
+                if (DoParseAppPolicy(prefix, a, 0, NULL, name, state, complete_state_ts,
+                            STREAM_TOSERVER, fw_policies) < 0)
                     return -1;
             }
             const uint8_t complete_state_tc =
@@ -4444,8 +4538,8 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
             for (uint8_t state = 0; state <= complete_state_tc; state++) {
                 const char *name =
                         AppLayerParserGetStateNameById(IPPROTO_TCP, a, state, STREAM_TOCLIENT);
-                if (DoParseAppPolicy(prefix, a, name, state, complete_state_tc, STREAM_TOCLIENT,
-                            fw_policies) < 0)
+                if (DoParseAppPolicy(prefix, a, 0, NULL, name, state, complete_state_tc,
+                            STREAM_TOCLIENT, fw_policies) < 0)
                     return -1;
             }
         }
@@ -4461,7 +4555,502 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
 #include "detect-engine-alert.h"
 #include "packet.h"
 
-static int SigParseTest01 (void)
+/**
+ * \brief Load a config string and run Init+Load; returns the load result.
+ * \return 0 on success with DetectEngineCtx in \p de_ctx_out, -1 on failure.
+ **/
+static int FWPolicyTestLoad(const char *yaml, DetectEngineCtx **de_ctx_out)
+{
+    SCConfCreateContextBackup();
+    SCConfInit();
+    SCConfYamlLoadString(yaml, strlen(yaml));
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    int r = -1;
+    if (de_ctx != NULL) {
+        if (DetectFirewallInitDefaultPolicies(de_ctx) == 0) {
+            r = DetectFirewallLoadDefaultPolicies(de_ctx);
+        }
+    }
+    *de_ctx_out = de_ctx;
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+    return r;
+}
+
+/**
+ * \brief Look up the resolved app policy for a hook, NULL if the table has no
+ *        entry for it.
+ */
+static const struct DetectFirewallAppPolicy *FWPolicyTestApp(const DetectEngineCtx *de_ctx,
+        const AppProto alproto, const uint8_t sub_state, const uint8_t progress,
+        const uint8_t direction)
+{
+    const struct DetectFirewallAppPolicy lookup = {
+        .alproto = alproto, .sub_state = sub_state, .progress = progress, .direction = direction
+    };
+    return HashTableLookup(de_ctx->fw_policies->app_policies, (void *)&lookup, 0);
+}
+
+/** \brief FWPolicyTestApp() for a to_server hook of a protocol without sub states. */
+static const struct DetectFirewallPolicy *FWPolicyTestAppTs(
+        const DetectEngineCtx *de_ctx, const AppProto alproto, const uint8_t progress)
+{
+    const struct DetectFirewallAppPolicy *p =
+            FWPolicyTestApp(de_ctx, alproto, 0, progress, STREAM_TOSERVER);
+    return p != NULL ? &p->policy : NULL;
+}
+
+static int FWPolicyPacketSpecific01(void)
+{
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    packet:\n\
+      filter: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallPolicy *p =
+            &de_ctx->fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER];
+    FAIL_IF_NOT(p->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(p->action_scope == ACTION_SCOPE_HOOK);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyPacketLayerDefault01(void)
+{
+    /* packet.default-policy applies to all packet hooks */
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    packet:\n\
+      default-policy: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    for (int i = 0; i < DETECT_FIREWALL_POLICY_SIZE; i++) {
+        FAIL_IF_NOT(de_ctx->fw_policies->pkt[i].action & ACTION_ACCEPT);
+        FAIL_IF_NOT(de_ctx->fw_policies->pkt[i].action_scope == ACTION_SCOPE_HOOK);
+    }
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyGlobalToPacket01(void)
+{
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    default-policy: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallPolicy *p =
+            &de_ctx->fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER];
+    FAIL_IF_NOT(p->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(p->action_scope == ACTION_SCOPE_HOOK);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyPacketPrecedence01(void)
+{
+    /* specific packet.filter overrides packet.default-policy and global */
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    default-policy: [\"accept:hook\"]\n\
+    packet:\n\
+      default-policy: [\"accept:flow\"]\n\
+      filter: [\"drop:packet\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallPolicy *f =
+            &de_ctx->fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER];
+    FAIL_IF_NOT(f->action & ACTION_DROP);
+    FAIL_IF_NOT(f->action_scope == ACTION_SCOPE_PACKET);
+    /* pre-flow falls to packet.default-policy = accept:flow */
+    const struct DetectFirewallPolicy *pf =
+            &de_ctx->fw_policies->pkt[DETECT_FIREWALL_POLICY_PRE_FLOW];
+    FAIL_IF_NOT(pf->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(pf->action_scope == ACTION_SCOPE_FLOW);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyPacketScopeError01(void)
+{
+    /* global default with tx scope (app-only) reaches packet hooks */
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    default-policy: [\"accept:tx\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    int r = FWPolicyTestLoad(yaml, &de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    FAIL_IF_NOT(r == -1);
+    PASS;
+}
+
+static int FWPolicyAppProtoDefault01(void)
+{
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      dns:\n\
+        default-policy: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallPolicy *p = FWPolicyTestAppTs(de_ctx, ALPROTO_DNS, 0);
+    FAIL_IF_NULL(p);
+    FAIL_IF_NOT(p->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(p->action_scope == ACTION_SCOPE_HOOK);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyAppStartingState01(void)
+{
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      http1:\n\
+        request-started: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    /* HTP_REQUEST_PROGRESS_NOT_STARTED == 0 ("request_started"): the starting
+     * state got its configured policy end-to-end (not a built-in/constant). */
+    const struct DetectFirewallPolicy *started = FWPolicyTestAppTs(de_ctx, ALPROTO_HTTP1, 0);
+    FAIL_IF_NULL(started);
+    FAIL_IF_NOT(started->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(started->action_scope == ACTION_SCOPE_HOOK);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyAppHttpMiddleHook01(void)
+{
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      http1:\n\
+        request-line: [\"drop:flow\"]\n\
+        request-headers: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    /* HTP_REQUEST_PROGRESS_LINE == 1, HTP_REQUEST_PROGRESS_HEADERS == 2 */
+    const struct DetectFirewallPolicy *line = FWPolicyTestAppTs(de_ctx, ALPROTO_HTTP1, 1);
+    FAIL_IF_NULL(line);
+    const struct DetectFirewallPolicy *hdrs = FWPolicyTestAppTs(de_ctx, ALPROTO_HTTP1, 2);
+    FAIL_IF_NULL(hdrs);
+    FAIL_IF_NOT(line->action & ACTION_DROP);
+    FAIL_IF_NOT(line->action_scope == ACTION_SCOPE_FLOW);
+    FAIL_IF_NOT(hdrs->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(hdrs->action_scope == ACTION_SCOPE_HOOK);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyAppHttp2StartingState01(void)
+{
+    /* HTTP/2 hooks live under a sub state ("stream" is sub state 1), and its
+     * starting state is only addressable through the generic alias. */
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      http2:\n\
+        stream:\n\
+          request-started: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallAppPolicy *p =
+            FWPolicyTestApp(de_ctx, ALPROTO_HTTP2, 1, 0, STREAM_TOSERVER);
+    FAIL_IF_NULL(p);
+    FAIL_IF_NOT(p->policy.action & ACTION_ACCEPT);
+    FAIL_IF_NOT(p->policy.action_scope == ACTION_SCOPE_HOOK);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyAppSubStatePrecedence01(void)
+{
+    /* the sub state node gets its own default-policy tier, between the
+     * specific hook and the per-protocol default. */
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    default-policy: [\"accept:hook\"]\n\
+    app:\n\
+      default-policy: [\"accept:tx\"]\n\
+      http2:\n\
+        default-policy: [\"drop:flow\"]\n\
+        stream:\n\
+          default-policy: [\"accept:flow\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    /* "stream" (sub state 1) hooks take the sub state default */
+    const struct DetectFirewallAppPolicy *stream =
+            FWPolicyTestApp(de_ctx, ALPROTO_HTTP2, 1, 0, STREAM_TOSERVER);
+    FAIL_IF_NULL(stream);
+    FAIL_IF_NOT(stream->policy.action & ACTION_ACCEPT);
+    FAIL_IF_NOT(stream->policy.action_scope == ACTION_SCOPE_FLOW);
+    /* "global" (sub state 2) has no default of its own, so it falls through to
+     * the per-protocol default rather than to app/global. */
+    const struct DetectFirewallAppPolicy *global =
+            FWPolicyTestApp(de_ctx, ALPROTO_HTTP2, 2, 0, STREAM_TOSERVER);
+    FAIL_IF_NULL(global);
+    FAIL_IF_NOT(global->policy.action & ACTION_DROP);
+    FAIL_IF_NOT(global->policy.action_scope == ACTION_SCOPE_FLOW);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyAppSubStateScopeError01(void)
+{
+    /* scope validation reaches sub state hooks too */
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      http2:\n\
+        stream:\n\
+          default-policy: [\"drop:packet\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    int r = FWPolicyTestLoad(yaml, &de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    FAIL_IF_NOT(r == -1);
+    PASS;
+}
+
+static int FWPolicyAppTlsStartingReal01(void)
+{
+    /* TLS starting state (progress 0) has REAL name "client_in_progress"
+     * (TLS_STATE_CLIENT_IN_PROGRESS == 0), make sure it is addressable. */
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      tls:\n\
+        client-in-progress: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallPolicy *p = FWPolicyTestAppTs(de_ctx, ALPROTO_TLS, 0);
+    FAIL_IF_NULL(p);
+    FAIL_IF_NOT(p->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(p->action_scope == ACTION_SCOPE_HOOK);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyAppTlsStartingGeneric01(void)
+{
+    /* The loader also accepts the generic "request-started" alias for state 0
+     * via its retry fallback. */
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      tls:\n\
+        request-started: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallPolicy *p = FWPolicyTestAppTs(de_ctx, ALPROTO_TLS, 0);
+    FAIL_IF_NULL(p);
+    FAIL_IF_NOT(p->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(p->action_scope == ACTION_SCOPE_HOOK);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyAppTlsFinalStateAlias01(void)
+{
+    const uint8_t complete =
+            (uint8_t)AppLayerParserGetStateProgressCompletionStatus(ALPROTO_TLS, STREAM_TOSERVER);
+    /* the completion state's real name is "client_finished" */
+    const char *cname =
+            AppLayerParserGetStateNameById(IPPROTO_TCP, ALPROTO_TLS, complete, STREAM_TOSERVER);
+    FAIL_IF_NULL(cname);
+    FAIL_IF_NOT(strcmp(cname, "client_finished") == 0);
+
+    /* (1) real name "client-finished" -> ts[complete] */
+    const char *yaml_real = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      tls:\n\
+        client-finished: [\"drop:flow\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml_real, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallPolicy *r = FWPolicyTestAppTs(de_ctx, ALPROTO_TLS, complete);
+    FAIL_IF_NULL(r);
+    FAIL_IF_NOT(r->action & ACTION_DROP);
+    FAIL_IF_NOT(r->action_scope == ACTION_SCOPE_FLOW);
+    DetectEngineCtxFree(de_ctx);
+
+    /* (2) generic completion alias "request-complete" -> the SAME ts[complete] */
+    const char *yaml_generic = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      tls:\n\
+        request-complete: [\"accept:tx\"]\n\
+";
+    de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml_generic, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallPolicy *g = FWPolicyTestAppTs(de_ctx, ALPROTO_TLS, complete);
+    FAIL_IF_NULL(g);
+    FAIL_IF_NOT(g->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(g->action_scope == ACTION_SCOPE_TX);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyAppLayerDefault01(void)
+{
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      default-policy: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallPolicy *p = FWPolicyTestAppTs(de_ctx, ALPROTO_DNS, 0);
+    FAIL_IF_NULL(p);
+    FAIL_IF_NOT(p->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(p->action_scope == ACTION_SCOPE_HOOK);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyGlobalToApp01(void)
+{
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    default-policy: [\"accept:hook\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallPolicy *p = FWPolicyTestAppTs(de_ctx, ALPROTO_DNS, 0);
+    FAIL_IF_NULL(p);
+    FAIL_IF_NOT(p->action & ACTION_ACCEPT);
+    FAIL_IF_NOT(p->action_scope == ACTION_SCOPE_HOOK);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int FWPolicyAppScopeError01(void)
+{
+    /* global default with packet scope (packet-only) reaches app hooks -> fatal */
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    default-policy: [\"drop:packet\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    int r = FWPolicyTestLoad(yaml, &de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    FAIL_IF_NOT(r == -1);
+    PASS;
+}
+
+static int FWPolicyAppAlert01(void)
+{
+    /* alert on a default-policy attaches a policy signature to the hook */
+    const char *yaml = "\
+%YAML 1.1\n\
+---\n\
+firewall:\n\
+  policies:\n\
+    app:\n\
+      dns:\n\
+        default-policy: [\"drop:flow\", \"alert\"]\n\
+";
+    DetectEngineCtx *de_ctx = NULL;
+    FAIL_IF(FWPolicyTestLoad(yaml, &de_ctx) != 0);
+    FAIL_IF_NULL(de_ctx);
+    const struct DetectFirewallAppPolicy *p =
+            FWPolicyTestApp(de_ctx, ALPROTO_DNS, 0, 0, STREAM_TOSERVER);
+    FAIL_IF_NULL(p);
+    FAIL_IF_NOT(p->policy.action & ACTION_ALERT);
+    FAIL_IF_NULL(p->alert_signature);
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int SigParseTest01(void)
 {
     int result = 1;
     Signature *sig = NULL;
@@ -6228,6 +6817,24 @@ void SigParseRegisterTests(void)
     UtRegisterTest("SigParseTest02", SigParseTest02);
     UtRegisterTest("SigParseTest03", SigParseTest03);
     UtRegisterTest("SigParseTest04", SigParseTest04);
+    UtRegisterTest("FWPolicyPacketSpecific01", FWPolicyPacketSpecific01);
+    UtRegisterTest("FWPolicyPacketLayerDefault01", FWPolicyPacketLayerDefault01);
+    UtRegisterTest("FWPolicyGlobalToPacket01", FWPolicyGlobalToPacket01);
+    UtRegisterTest("FWPolicyPacketPrecedence01", FWPolicyPacketPrecedence01);
+    UtRegisterTest("FWPolicyPacketScopeError01", FWPolicyPacketScopeError01);
+    UtRegisterTest("FWPolicyAppProtoDefault01", FWPolicyAppProtoDefault01);
+    UtRegisterTest("FWPolicyAppStartingState01", FWPolicyAppStartingState01);
+    UtRegisterTest("FWPolicyAppHttpMiddleHook01", FWPolicyAppHttpMiddleHook01);
+    UtRegisterTest("FWPolicyAppHttp2StartingState01", FWPolicyAppHttp2StartingState01);
+    UtRegisterTest("FWPolicyAppSubStatePrecedence01", FWPolicyAppSubStatePrecedence01);
+    UtRegisterTest("FWPolicyAppSubStateScopeError01", FWPolicyAppSubStateScopeError01);
+    UtRegisterTest("FWPolicyAppTlsStartingReal01", FWPolicyAppTlsStartingReal01);
+    UtRegisterTest("FWPolicyAppTlsStartingGeneric01", FWPolicyAppTlsStartingGeneric01);
+    UtRegisterTest("FWPolicyAppTlsFinalStateAlias01", FWPolicyAppTlsFinalStateAlias01);
+    UtRegisterTest("FWPolicyAppLayerDefault01", FWPolicyAppLayerDefault01);
+    UtRegisterTest("FWPolicyGlobalToApp01", FWPolicyGlobalToApp01);
+    UtRegisterTest("FWPolicyAppScopeError01", FWPolicyAppScopeError01);
+    UtRegisterTest("FWPolicyAppAlert01", FWPolicyAppAlert01);
     UtRegisterTest("SigParseTest05", SigParseTest05);
     UtRegisterTest("SigParseTest06", SigParseTest06);
     UtRegisterTest("SigParseTest07", SigParseTest07);

--- a/src/detect.h
+++ b/src/detect.h
@@ -921,6 +921,11 @@ enum DetectEngineType
     DETECT_ENGINE_TYPE_TENANT = 3,
 };
 
+enum DetectFirewallPolicyClass {
+    DETECT_FIREWALL_POLICY_CLASS_PACKET,
+    DETECT_FIREWALL_POLICY_CLASS_APP
+};
+
 enum DetectFirewallPacketPolicies {
     DETECT_FIREWALL_POLICY_PACKET_FILTER,
     DETECT_FIREWALL_POLICY_PRE_FLOW,

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -2392,16 +2392,20 @@ firewall:
 
   # Default policies
   #
-  # Choose a default policy for each firewall hook.
-  # It is also possible to specify policies by app-layer protocol.
+  # Choose a default policy for each firewall hook. A `default-policy` covers
+  # every hook below it, so hooks that are not listed still get a policy.
+  # The most specific setting wins.
   # DNS example: Drop and alert on all DNS requests that are not allowed in firewall.rules, accept all responses.
   #
   #policies:
-  #  packet-filter: ["drop:packet"]
-  #  dns:
-  #    request-started: ["accept:hook"]
-  #    request-complete: ["drop:flow", "alert"]
-  #    response-started: ["accept:tx"]
+  #  default-policy: ["drop:flow"]
+  #  packet:
+  #    filter: ["drop:packet"]
+  #  app:
+  #    dns:
+  #      request-started: ["accept:hook"]
+  #      request-complete: ["drop:flow", "alert"]
+  #      response-started: ["accept:tx"]
 
 ##
 ## Include other configs


### PR DESCRIPTION
Add a `default-policy` setting that applies to all hooks below it. For any hook the most specific setting present wins.
The flat layout had no way to express a default covering only the packet hooks or only the app hooks, so both move under their own node: `packet-filter` becomes `packet.filter` and `<proto>` becomes `app.<proto>`.
Action scopes are now validated against the hook they reach. A global `accept:tx` arriving at a packet hook is a startup error instead of being applied silently.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8712

Describe changes:
- new suricata.yaml policy config structure
- policy hook validation and hints
- multi-layer default policy for firewall policies

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3251
