### PR TITLE
detect: allow bypass keyword for fw rules in firewall mode (only) - v2

### DIFF
--- a/doc/userguide/rules/bypass-keyword.rst
+++ b/doc/userguide/rules/bypass-keyword.rst
@@ -13,8 +13,10 @@ The ``bypass`` keyword is considered a post-match keyword.
 
 .. note::
 
-   ``bypass`` cannot be used in firewall mode, not even with Threat Detection
-   rules, as this could lead to bypassing the firewall altogether.
+   In firewall mode, ``bypass`` can only be used in firewall rules. If a threat
+   detection rule uses the ``bypass`` keyword and you want to run Suricata in
+   firewall mode, the engine will error out. This is to prevent a threat detection
+   rule, from bypassing the firewall altogether.
 
 bypass
 ------
@@ -26,3 +28,16 @@ Bypass a flow on matching http traffic.
   alert http any any -> any any (http.host; \
   content:"suricata.io"; :example-rule-emphasis:`bypass;` \
   sid:10001; rev:1;)
+
+firewall mode
+-------------
+
+`bypass` is only accepted with a specific combination of `action` and `scope`: `accept: flow`
+
+Not accepted:
+    - Action: `config`
+    - Action: `reject`
+    - Action: `drop`
+    - Scope: `packet`
+    - Scope: `tx`
+    - Scope: `hook`

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -24,6 +24,7 @@ pub const SIGMATCH_INFO_ENUM_UINT: u32 = 524288;
 pub const SIGMATCH_INFO_BITFLAGS_UINT: u32 = 1048576;
 pub const SIGMATCH_BAN_FIREWALL_RULE: u32 = 2097152;
 pub const SIGMATCH_BAN_FIREWALL_MODE: u32 = 4194304;
+pub const SIGMATCH_BAN_TD_FIREWALL_MODE: u32 = 8388608;
 pub type __intmax_t = ::std::os::raw::c_long;
 pub type intmax_t = __intmax_t;
 #[repr(u32)]

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -64,7 +64,7 @@ void DetectBypassRegister(void)
     sigmatch_table[DETECT_BYPASS].Match = DetectBypassMatch;
     sigmatch_table[DETECT_BYPASS].Setup = DetectBypassSetup;
     sigmatch_table[DETECT_BYPASS].Free  = NULL;
-    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_SUPPORT_FIREWALL | SIGMATCH_BAN_TD_FIREWALL_MODE;
+    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_SUPPORT_FIREWALL | SIGMATCH_BAN_TD_FIREWALL_MODE | SIGMATCH_BAN_FIREWALL_SCOPE_PACKET;
 }
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -68,7 +68,8 @@ void DetectBypassRegister(void)
                                           SIGMATCH_BAN_TD_FIREWALL_MODE |
                                           SIGMATCH_BAN_FIREWALL_SCOPE_PACKET |
                                           SIGMATCH_BAN_ACTION_CONFIG | SIGMATCH_BAN_ACTION_DROP |
-                                          SIGMATCH_BAN_ACTION_REJECT | SIGMATCH_BAN_FIREWALL_SCOPE_TX;
+                                          SIGMATCH_BAN_ACTION_REJECT | SIGMATCH_BAN_FIREWALL_SCOPE_TX |
+                                          SIGMATCH_BAN_FIREWALL_SCOPE_HOOK;
 }
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -67,7 +67,8 @@ void DetectBypassRegister(void)
     sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_SUPPORT_FIREWALL |
                                           SIGMATCH_BAN_TD_FIREWALL_MODE |
                                           SIGMATCH_BAN_FIREWALL_SCOPE_PACKET |
-                                          SIGMATCH_BAN_ACTION_CONFIG | SIGMATCH_BAN_ACTION_DROP;
+                                          SIGMATCH_BAN_ACTION_CONFIG | SIGMATCH_BAN_ACTION_DROP |
+                                          SIGMATCH_BAN_ACTION_REJECT;
 }
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -64,12 +64,11 @@ void DetectBypassRegister(void)
     sigmatch_table[DETECT_BYPASS].Match = DetectBypassMatch;
     sigmatch_table[DETECT_BYPASS].Setup = DetectBypassSetup;
     sigmatch_table[DETECT_BYPASS].Free  = NULL;
-    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_SUPPORT_FIREWALL |
-                                          SIGMATCH_BAN_TD_FIREWALL_MODE |
-                                          SIGMATCH_BAN_FIREWALL_SCOPE_PACKET |
-                                          SIGMATCH_BAN_ACTION_CONFIG | SIGMATCH_BAN_ACTION_DROP |
-                                          SIGMATCH_BAN_ACTION_REJECT | SIGMATCH_BAN_FIREWALL_SCOPE_TX |
-                                          SIGMATCH_BAN_FIREWALL_SCOPE_HOOK;
+    sigmatch_table[DETECT_BYPASS].flags =
+            SIGMATCH_NOOPT | SIGMATCH_SUPPORT_FIREWALL | SIGMATCH_BAN_TD_FIREWALL_MODE |
+            SIGMATCH_BAN_FIREWALL_SCOPE_PACKET | SIGMATCH_BAN_ACTION_CONFIG |
+            SIGMATCH_BAN_ACTION_DROP | SIGMATCH_BAN_ACTION_REJECT | SIGMATCH_BAN_FIREWALL_SCOPE_TX |
+            SIGMATCH_BAN_FIREWALL_SCOPE_HOOK;
 }
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -64,7 +64,7 @@ void DetectBypassRegister(void)
     sigmatch_table[DETECT_BYPASS].Match = DetectBypassMatch;
     sigmatch_table[DETECT_BYPASS].Setup = DetectBypassSetup;
     sigmatch_table[DETECT_BYPASS].Free  = NULL;
-    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_SUPPORT_FIREWALL | SIGMATCH_BAN_TD_FIREWALL_MODE | SIGMATCH_BAN_FIREWALL_SCOPE_PACKET;
+    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_SUPPORT_FIREWALL | SIGMATCH_BAN_TD_FIREWALL_MODE | SIGMATCH_BAN_FIREWALL_SCOPE_PACKET | SIGMATCH_BAN_ACTION_CONFIG;
 }
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -64,7 +64,10 @@ void DetectBypassRegister(void)
     sigmatch_table[DETECT_BYPASS].Match = DetectBypassMatch;
     sigmatch_table[DETECT_BYPASS].Setup = DetectBypassSetup;
     sigmatch_table[DETECT_BYPASS].Free  = NULL;
-    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_SUPPORT_FIREWALL | SIGMATCH_BAN_TD_FIREWALL_MODE | SIGMATCH_BAN_FIREWALL_SCOPE_PACKET | SIGMATCH_BAN_ACTION_CONFIG;
+    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_SUPPORT_FIREWALL |
+                                          SIGMATCH_BAN_TD_FIREWALL_MODE |
+                                          SIGMATCH_BAN_FIREWALL_SCOPE_PACKET |
+                                          SIGMATCH_BAN_ACTION_CONFIG | SIGMATCH_BAN_ACTION_DROP;
 }
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -68,7 +68,7 @@ void DetectBypassRegister(void)
                                           SIGMATCH_BAN_TD_FIREWALL_MODE |
                                           SIGMATCH_BAN_FIREWALL_SCOPE_PACKET |
                                           SIGMATCH_BAN_ACTION_CONFIG | SIGMATCH_BAN_ACTION_DROP |
-                                          SIGMATCH_BAN_ACTION_REJECT;
+                                          SIGMATCH_BAN_ACTION_REJECT | SIGMATCH_BAN_FIREWALL_SCOPE_TX;
 }
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -64,7 +64,7 @@ void DetectBypassRegister(void)
     sigmatch_table[DETECT_BYPASS].Match = DetectBypassMatch;
     sigmatch_table[DETECT_BYPASS].Setup = DetectBypassSetup;
     sigmatch_table[DETECT_BYPASS].Free  = NULL;
-    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_BAN_FIREWALL_MODE;
+    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT | SIGMATCH_SUPPORT_FIREWALL | SIGMATCH_BAN_TD_FIREWALL_MODE;
 }
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -344,6 +344,12 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
         printf("banned from firewall mode");
         prev = 1;
     }
+    if (flags & SIGMATCH_BAN_TD_FIREWALL_MODE) {
+        if (prev == 1)
+            printf("%c", sep);
+        printf("banned from threat detection rules in firewall mode");
+        prev = 1;
+    }
     if (e->Transform) {
         if (prev == 1)
             printf("%c", sep);

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -350,6 +350,12 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
         printf("banned from threat detection rules in firewall mode");
         prev = 1;
     }
+    if (flags & SIGMATCH_BAN_FIREWALL_SCOPE_PACKET) {
+        if (prev == 1)
+            printf("%c", sep);
+        printf("banned from firewall rules with \'packet\' scope");
+        prev = 1;
+    }
     if (e->Transform) {
         if (prev == 1)
             printf("%c", sep);

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -354,6 +354,8 @@ extern int DETECT_TBLSIZE_IDX;
 #define SIGMATCH_BAN_FIREWALL_RULE (1UL << (21))
 /** keyword cannot be used in firewall mode */
 #define SIGMATCH_BAN_FIREWALL_MODE (1UL << (22))
+/** keyword cannot be used in td rules with firewall mode */
+#define SIGMATCH_BAN_TD_FIREWALL_MODE (1UL << (23))
 
 int SigTableList(const char *keyword);
 void SigTableCleanup(void);

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -358,7 +358,7 @@ extern int DETECT_TBLSIZE_IDX;
 #define SIGMATCH_BAN_TD_FIREWALL_MODE (1UL << (23))
 /** keyword cannot be used in combination with indicated action scope */
 #define SIGMATCH_BAN_FIREWALL_SCOPE_PACKET (1UL << (24))
-// #define SIGMATCH_BAN_SCOPE_FLOW (1UL << (25))
+#define SIGMATCH_BAN_FIREWALL_SCOPE_HOOK (1UL << (25))
 #define SIGMATCH_BAN_FIREWALL_SCOPE_TX (1UL << (26))
 /** keyword cannot be used in combination with given action */
 #define SIGMATCH_BAN_ACTION_DROP (1UL << (27))

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -358,12 +358,12 @@ extern int DETECT_TBLSIZE_IDX;
 #define SIGMATCH_BAN_TD_FIREWALL_MODE (1UL << (23))
 /** keyword cannot be used in combination with indicated action scope */
 #define SIGMATCH_BAN_FIREWALL_SCOPE_PACKET (1UL << (24))
-//#define SIGMATCH_BAN_SCOPE_FLOW (1UL << (25))
-//#define SIGMATCH_BAN_SCOPE_TX (1UL << (26))
+// #define SIGMATCH_BAN_SCOPE_FLOW (1UL << (25))
+// #define SIGMATCH_BAN_SCOPE_TX (1UL << (26))
 /** keyword cannot be used in combination with given action */
-//#define SIGMATCH_BAN_ACTION_DROP (1UL << (27))
-//#define SIGMATCH_BAN_ACTION_REJECT (1UL << (28))
-//#define SIGMATCH_BAN_ACTION_CONFIG (1UL << (29))
+#define SIGMATCH_BAN_ACTION_DROP (1UL << (27))
+// #define SIGMATCH_BAN_ACTION_REJECT (1UL << (28))
+#define SIGMATCH_BAN_ACTION_CONFIG (1UL << (29))
 
 int SigTableList(const char *keyword);
 void SigTableCleanup(void);

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -362,7 +362,7 @@ extern int DETECT_TBLSIZE_IDX;
 // #define SIGMATCH_BAN_SCOPE_TX (1UL << (26))
 /** keyword cannot be used in combination with given action */
 #define SIGMATCH_BAN_ACTION_DROP (1UL << (27))
-// #define SIGMATCH_BAN_ACTION_REJECT (1UL << (28))
+#define SIGMATCH_BAN_ACTION_REJECT (1UL << (28))
 #define SIGMATCH_BAN_ACTION_CONFIG (1UL << (29))
 
 int SigTableList(const char *keyword);

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -356,6 +356,14 @@ extern int DETECT_TBLSIZE_IDX;
 #define SIGMATCH_BAN_FIREWALL_MODE (1UL << (22))
 /** keyword cannot be used in td rules with firewall mode */
 #define SIGMATCH_BAN_TD_FIREWALL_MODE (1UL << (23))
+/** keyword cannot be used in combination with indicated action scope */
+#define SIGMATCH_BAN_FIREWALL_SCOPE_PACKET (1UL << (24))
+//#define SIGMATCH_BAN_SCOPE_FLOW (1UL << (25))
+//#define SIGMATCH_BAN_SCOPE_TX (1UL << (26))
+/** keyword cannot be used in combination with given action */
+//#define SIGMATCH_BAN_ACTION_DROP (1UL << (27))
+//#define SIGMATCH_BAN_ACTION_REJECT (1UL << (28))
+//#define SIGMATCH_BAN_ACTION_CONFIG (1UL << (29))
 
 int SigTableList(const char *keyword);
 void SigTableCleanup(void);

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -359,7 +359,7 @@ extern int DETECT_TBLSIZE_IDX;
 /** keyword cannot be used in combination with indicated action scope */
 #define SIGMATCH_BAN_FIREWALL_SCOPE_PACKET (1UL << (24))
 // #define SIGMATCH_BAN_SCOPE_FLOW (1UL << (25))
-// #define SIGMATCH_BAN_SCOPE_TX (1UL << (26))
+#define SIGMATCH_BAN_FIREWALL_SCOPE_TX (1UL << (26))
 /** keyword cannot be used in combination with given action */
 #define SIGMATCH_BAN_ACTION_DROP (1UL << (27))
 #define SIGMATCH_BAN_ACTION_REJECT (1UL << (28))

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -358,10 +358,10 @@ extern int DETECT_TBLSIZE_IDX;
 #define SIGMATCH_BAN_TD_FIREWALL_MODE (1UL << (23))
 /** keyword cannot be used in combination with indicated action scope */
 #define SIGMATCH_BAN_FIREWALL_SCOPE_PACKET (1UL << (24))
-#define SIGMATCH_BAN_FIREWALL_SCOPE_HOOK (1UL << (25))
-#define SIGMATCH_BAN_FIREWALL_SCOPE_TX (1UL << (26))
+#define SIGMATCH_BAN_FIREWALL_SCOPE_HOOK   (1UL << (25))
+#define SIGMATCH_BAN_FIREWALL_SCOPE_TX     (1UL << (26))
 /** keyword cannot be used in combination with given action */
-#define SIGMATCH_BAN_ACTION_DROP (1UL << (27))
+#define SIGMATCH_BAN_ACTION_DROP   (1UL << (27))
 #define SIGMATCH_BAN_ACTION_REJECT (1UL << (28))
 #define SIGMATCH_BAN_ACTION_CONFIG (1UL << (29))
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -978,6 +978,12 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
         goto error;
     }
 
+    if (EngineModeIsFirewall() && !s->init_data->firewall_rule &&
+            (st->flags & SIGMATCH_BAN_TD_FIREWALL_MODE) != 0) {
+        SCLogError("keyword \'%s\' is not allowed in threat detection rules with firewall mode",
+                optname);
+        goto error;
+    }
     int setup_ret = 0;
 
     /* Validate double quoting, trimming trailing white space along the way. */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -868,6 +868,25 @@ static int DetectSetupDirection(Signature *s, char **str, bool only_dir)
     return 0;
 }
 
+/** \brief called only with firewall rules, to validate options
+*/
+static bool SigParseFirewallRuleAllowed(uint32_t sig_flags, char *optname)
+{
+    if ((sig_flags & SIGMATCH_BAN_FIREWALL_RULE) != 0) {
+        SCLogError("keyword \'%s\' is not allowed with firewall rules", optname);
+        return false;
+    }
+    if ((sig_flags & SIGMATCH_BAN_FIREWALL_MODE) != 0) {
+        SCLogError("keyword \'%s\' is not allowed in firewall mode", optname);
+        return false;
+    }
+    if ((sig_flags & SIGMATCH_SUPPORT_FIREWALL) == 0) {
+        SCLogWarning("keyword \'%s\' has not been tested for firewall rules", optname);
+    }
+    /* for most cases, firewall rules should be allowed */
+    return true;
+}
+
 static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, char *output,
         size_t output_size, bool requires)
 {
@@ -968,8 +987,7 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 #undef URL
     }
 
-    if (s->init_data->firewall_rule && (st->flags & SIGMATCH_BAN_FIREWALL_RULE) != 0) {
-        SCLogError("keyword \'%s\' is not allowed with firewall rules", optname);
+    if (s->init_data->firewall_rule && !SigParseFirewallRuleAllowed(st->flags, optname)) {
         goto error;
     }
 
@@ -1004,8 +1022,10 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
             goto error;
         }
 
-        if (s->init_data->firewall_rule && (st->flags & SIGMATCH_SUPPORT_FIREWALL) == 0) {
-            SCLogWarning("keyword \'%s\' has not been tested for firewall rules", optname);
+        /* Is it problematic to have the check for support firewall converted into this function,
+           and thus potentially executed before this step? */
+        if (s->init_data->firewall_rule && !SigParseFirewallRuleAllowed(st->flags, optname)) {
+            goto error;
         }
 
         /* see if value is negated */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -881,6 +881,10 @@ static bool SigParseFirewallRuleAllowed(
         SCLogError("keyword \'%s\' is not allowed in firewall mode", optname);
         return false;
     }
+    if ((action & ACTION_CONFIG) != 0 && (sig_flags & SIGMATCH_BAN_ACTION_CONFIG) != 0) {
+        SCLogError("keyword \'%s\' cannot be used in combination with \'config\' action", optname);
+        return false;
+    }
     if (action_scope == (uint8_t)ACTION_SCOPE_PACKET) {
         if ((sig_flags & SIGMATCH_BAN_FIREWALL_SCOPE_PACKET) != 0) {
             SCLogError(

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2746,6 +2746,7 @@ static bool DetectRuleValidateTable(const Signature *s)
     return true;
 }
 
+/** \brief validates firewall rule action scope */
 static bool DetectFirewallRuleValidate(const DetectEngineCtx *de_ctx, const Signature *s)
 {
     if (s->init_data->hook.type == SIGNATURE_HOOK_TYPE_NOT_SET) {

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -906,6 +906,12 @@ static bool SigParseFirewallRuleAllowed(
             return false;
         }
     }
+    if (action_scope == (uint8_t)ACTION_SCOPE_HOOK) {
+        if ((sig_flags & SIGMATCH_BAN_FIREWALL_SCOPE_HOOK) != 0) {
+            SCLogError("keyword \'%s\' cannot be used in combination with \'hook\' scope", optname);
+            return false;
+        }
+    }
     if ((sig_flags & SIGMATCH_SUPPORT_FIREWALL) == 0) {
         SCLogWarning("keyword \'%s\' has not been tested for firewall rules", optname);
     }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -900,6 +900,12 @@ static bool SigParseFirewallRuleAllowed(
             return false;
         }
     }
+    if (action_scope == (uint8_t)ACTION_SCOPE_TX) {
+        if ((sig_flags & SIGMATCH_BAN_FIREWALL_SCOPE_TX) != 0) {
+            SCLogError("keyword \'%s\' cannot be used in combination with \'tx\' scope", optname);
+            return false;
+        }
+    }
     if ((sig_flags & SIGMATCH_SUPPORT_FIREWALL) == 0) {
         SCLogWarning("keyword \'%s\' has not been tested for firewall rules", optname);
     }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -869,8 +869,9 @@ static int DetectSetupDirection(Signature *s, char **str, bool only_dir)
 }
 
 /** \brief called only with firewall rules, to validate options
-*/
-static bool SigParseFirewallRuleAllowed(uint8_t action_scope, uint32_t sig_flags, char *optname)
+ */
+static bool SigParseFirewallRuleAllowed(
+        uint8_t action, uint8_t action_scope, uint32_t sig_flags, char *optname)
 {
     if ((sig_flags & SIGMATCH_BAN_FIREWALL_RULE) != 0) {
         SCLogError("keyword \'%s\' is not allowed with firewall rules", optname);
@@ -994,7 +995,8 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 #undef URL
     }
 
-    if (s->init_data->firewall_rule && !SigParseFirewallRuleAllowed(s->action_scope, st->flags, optname)) {
+    if (s->init_data->firewall_rule &&
+            !SigParseFirewallRuleAllowed(s->action, s->action_scope, st->flags, optname)) {
         goto error;
     }
 
@@ -1031,7 +1033,8 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 
         /* Is it problematic to have the check for support firewall converted into this function,
            and thus potentially executed before this step? */
-        if (s->init_data->firewall_rule && !SigParseFirewallRuleAllowed(s->action_scope, st->flags, optname)) {
+        if (s->init_data->firewall_rule &&
+                !SigParseFirewallRuleAllowed(s->action, s->action_scope, st->flags, optname)) {
             goto error;
         }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -885,6 +885,10 @@ static bool SigParseFirewallRuleAllowed(
         SCLogError("keyword \'%s\' cannot be used in combination with \'config\' action", optname);
         return false;
     }
+    if ((action & ACTION_REJECT) != 0 && (sig_flags & SIGMATCH_BAN_ACTION_REJECT) != 0) {
+        SCLogError("keyword \'%s\' cannot be used in combination with \'reject\' action", optname);
+        return false;
+    }
     if ((action & ACTION_DROP) != 0 && (sig_flags & SIGMATCH_BAN_ACTION_DROP) != 0) {
         SCLogError("keyword \'%s\' cannot be used in combination with \'drop\' action", optname);
         return false;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -870,7 +870,7 @@ static int DetectSetupDirection(Signature *s, char **str, bool only_dir)
 
 /** \brief called only with firewall rules, to validate options
 */
-static bool SigParseFirewallRuleAllowed(uint32_t sig_flags, char *optname)
+static bool SigParseFirewallRuleAllowed(uint8_t action_scope, uint32_t sig_flags, char *optname)
 {
     if ((sig_flags & SIGMATCH_BAN_FIREWALL_RULE) != 0) {
         SCLogError("keyword \'%s\' is not allowed with firewall rules", optname);
@@ -879,6 +879,13 @@ static bool SigParseFirewallRuleAllowed(uint32_t sig_flags, char *optname)
     if ((sig_flags & SIGMATCH_BAN_FIREWALL_MODE) != 0) {
         SCLogError("keyword \'%s\' is not allowed in firewall mode", optname);
         return false;
+    }
+    if (action_scope == (uint8_t)ACTION_SCOPE_PACKET) {
+        if ((sig_flags & SIGMATCH_BAN_FIREWALL_SCOPE_PACKET) != 0) {
+            SCLogError(
+                    "keyword \'%s\' cannot be used in combination with \'packet\' scope", optname);
+            return false;
+        }
     }
     if ((sig_flags & SIGMATCH_SUPPORT_FIREWALL) == 0) {
         SCLogWarning("keyword \'%s\' has not been tested for firewall rules", optname);
@@ -987,7 +994,7 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 #undef URL
     }
 
-    if (s->init_data->firewall_rule && !SigParseFirewallRuleAllowed(st->flags, optname)) {
+    if (s->init_data->firewall_rule && !SigParseFirewallRuleAllowed(s->action_scope, st->flags, optname)) {
         goto error;
     }
 
@@ -1024,7 +1031,7 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 
         /* Is it problematic to have the check for support firewall converted into this function,
            and thus potentially executed before this step? */
-        if (s->init_data->firewall_rule && !SigParseFirewallRuleAllowed(st->flags, optname)) {
+        if (s->init_data->firewall_rule && !SigParseFirewallRuleAllowed(s->action_scope, st->flags, optname)) {
             goto error;
         }
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -885,6 +885,10 @@ static bool SigParseFirewallRuleAllowed(
         SCLogError("keyword \'%s\' cannot be used in combination with \'config\' action", optname);
         return false;
     }
+    if ((action & ACTION_DROP) != 0 && (sig_flags & SIGMATCH_BAN_ACTION_DROP) != 0) {
+        SCLogError("keyword \'%s\' cannot be used in combination with \'drop\' action", optname);
+        return false;
+    }
     if (action_scope == (uint8_t)ACTION_SCOPE_PACKET) {
         if ((sig_flags & SIGMATCH_BAN_FIREWALL_SCOPE_PACKET) != 0) {
             SCLogError(


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/8459

Previous PR: https://github.com/OISF/suricata/pull/15876

Describe changes:
- add a series of keyword flags to allow controlling in which cases a keyword is allowed in firewall rules
- ban usage of `bypass` keyword with actions `drop`, `reject`, `config`, and scopes `packet`, `tx` and `hook`, basically only allowing `accept: flow` (TODO: double-check if we have enough test coverage here)
- update the bypass keyword accordingly

Still in draft as I'm still not sure this is the approach we want.

TODOs?
- We may need to add clarification around this being local bypass only?
- anything extra to document -- to be checked
- clean-up commit history. Can probably squash some commits, must rework the last clang-formatting commit
- extract action checks to dedicated function?

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3257