### PR TITLE
ci: authenticate GH API requests and fail on repo fetch error v1

### DIFF
--- a/.github/workflows/prepare-deps.yml
+++ b/.github/workflows/prepare-deps.yml
@@ -26,8 +26,21 @@ jobs:
           # Authenticating moves the limit to 1000+ requests/hour per repo.
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -eo pipefail
           if test "${PR_HREF}"; then
-              body=$(curl -s --header "Authorization: Bearer ${GH_TOKEN}" "${PR_HREF}" | jq -r .body | tr -d '\r')
+              read_failed=no
+              pull_request=$(curl --silent --show-error --fail \
+                  --header "Authorization: Bearer ${GH_TOKEN}" \
+                  "${PR_HREF}") || read_failed=yes
+
+              if [ "${read_failed}" = yes ]; then
+                  # Avoid false SV runs when the PR body may contain specific
+                  # SV/SU instructions.
+                  echo "::error::Could not read the pull request description from ${PR_HREF}. Rerun the full pipeline to try again."
+                  exit 1
+              fi
+
+              body=$(echo "${pull_request}" | jq -r '.body' | tr -d '\r')
 
               echo "Parsing branch and PR info from:"
               echo "${body}"

--- a/.github/workflows/prepare-deps.yml
+++ b/.github/workflows/prepare-deps.yml
@@ -22,9 +22,12 @@ jobs:
           # github.event.pull_request.body has the body from the
           # initial pull request.
           PR_HREF: ${{ github.event.pull_request._links.self.href }}
+          # Unauthenticated calls get 60 requests/hour per runner's egress IP.
+          # Authenticating moves the limit to 1000+ requests/hour per repo.
+          GH_TOKEN: ${{ github.token }}
         run: |
           if test "${PR_HREF}"; then
-              body=$(curl -s "${PR_HREF}" | jq -r .body | tr -d '\r')
+              body=$(curl -s --header "Authorization: Bearer ${GH_TOKEN}" "${PR_HREF}" | jq -r .body | tr -d '\r')
 
               echo "Parsing branch and PR info from:"
               echo "${body}"


### PR DESCRIPTION
In a recent failure in e.g. https://github.com/OISF/suricata/pull/15940 where CI fails to load PR body due to being (likely) rate-limited and as a result falls back to the "default" upstream SV/SU branches, I tried to experiment with how we could be sure that the correct SV branch is picked up.

In https://github.com/OISF/suricata/pull/15954 I confirmed that the authenticated approach gives us greater buffer from being rate-limited.

The second commit should prevent follow-up actions if any error during the fetch occurs.