### PR TITLE
modbus: add per-value detection keywords - ticket 8131 v1

### DIFF
--- a/doc/userguide/rules/modbus-keyword.rst
+++ b/doc/userguide/rules/modbus-keyword.rst
@@ -129,3 +129,162 @@ V1.0b, the MODBUS slave device addresses on serial line are assigned from 1 to
 
 Paper and presentation (in french) on Modbus support are available :
 http://www.ssi.gouv.fr/agence/publication/detection-dintrusion-dans-les-systemes-industriels-suricata-et-le-cas-modbus/
+
+Per-value keywords
+------------------
+
+The following keywords match on single values of a Modbus transaction,
+mirroring the fields logged in the EVE ``modbus`` event. They all use
+:ref:`unsigned integers <rules-integer-keywords>` and support ranges and
+negation. In to-server direction they match on the request; in to-client
+direction they match on the response.
+
+Unlike the ``address`` option of the ``modbus`` keyword above, the
+address keywords below match the raw protocol value as it is logged,
+without the +1 offset, and match only the starting address of an access
+rather than the whole accessed range.
+
+modbus.unit_id
+~~~~~~~~~~~~~~
+
+Match on the Modbus unit identifier, the address of a slave device
+connected on a sub-network behind a bridge or gateway.
+
+modbus.unit_id uses an :ref:`unsigned 8-bits integer <rules-integer-keywords>`.
+
+Examples::
+
+  modbus.unit_id:10;
+  modbus.unit_id:>247;
+
+modbus.transaction_id
+~~~~~~~~~~~~~~~~~~~~~
+
+Match on the Modbus/TCP transaction identifier used to pair requests
+and responses.
+
+modbus.transaction_id uses an
+:ref:`unsigned 16-bits integer <rules-integer-keywords>`.
+
+Example::
+
+  modbus.transaction_id:1;
+
+modbus.protocol_id
+~~~~~~~~~~~~~~~~~~
+
+Match on the Modbus/TCP protocol identifier. The specification requires
+this field to be 0, so a non-zero value is an anomaly.
+
+modbus.protocol_id uses an
+:ref:`unsigned 16-bits integer <rules-integer-keywords>`.
+
+Example::
+
+  modbus.protocol_id:!0;
+
+modbus.function
+~~~~~~~~~~~~~~~
+
+Match on the Modbus function code, as it is logged in ``function_raw``.
+Error responses carry the request function code with the highest bit
+set (e.g. 136 for a failed function 8), so ``modbus.function:>127;``
+matches any error response.
+
+modbus.function uses an :ref:`unsigned 8-bits integer <rules-integer-keywords>`.
+
+Examples::
+
+  modbus.function:8;
+  modbus.function:>127;
+
+modbus.subfunction
+~~~~~~~~~~~~~~~~~~
+
+Match on the subfunction code of Modbus Diagnostics (function 8)
+messages.
+
+modbus.subfunction uses an
+:ref:`unsigned 16-bits integer <rules-integer-keywords>`.
+
+Example::
+
+  modbus.function:8; modbus.subfunction:4;
+
+modbus.exception_code
+~~~~~~~~~~~~~~~~~~~~~
+
+Match on the exception code of Modbus error responses.
+
+modbus.exception_code uses an
+:ref:`unsigned 8-bits integer <rules-integer-keywords>`.
+
+Example::
+
+  modbus.exception_code:11;
+
+modbus.read.address
+~~~~~~~~~~~~~~~~~~~
+
+Match on the starting address of Modbus read requests.
+
+modbus.read.address uses an
+:ref:`unsigned 16-bits integer <rules-integer-keywords>`.
+
+Example::
+
+  modbus.read.address:1000;
+
+modbus.read.quantity
+~~~~~~~~~~~~~~~~~~~~
+
+Match on the quantity of items in Modbus read requests.
+
+modbus.read.quantity uses an
+:ref:`unsigned 16-bits integer <rules-integer-keywords>`.
+
+Example::
+
+  modbus.read.quantity:>1000;
+
+modbus.write.address
+~~~~~~~~~~~~~~~~~~~~
+
+Match on the starting address of Modbus write accesses. In to-client
+direction this matches the address echoed in write responses.
+
+modbus.write.address uses an
+:ref:`unsigned 16-bits integer <rules-integer-keywords>`.
+
+Example::
+
+  modbus.write.address:500;
+
+modbus.write.quantity
+~~~~~~~~~~~~~~~~~~~~~
+
+Match on the quantity of items in Modbus multiple-write requests. In
+to-client direction this matches the quantity echoed in multiple-write
+responses.
+
+modbus.write.quantity uses an
+:ref:`unsigned 16-bits integer <rules-integer-keywords>`.
+
+Example::
+
+  modbus.write.quantity:>100;
+
+modbus.write.value
+~~~~~~~~~~~~~~~~~~
+
+Match on the value of Modbus single-write accesses. In to-client
+direction this matches the value echoed in single-write responses.
+Multiple-write responses are not matched, as they echo a quantity
+rather than a value (see ``modbus.write.quantity``).
+
+modbus.write.value uses an
+:ref:`unsigned 16-bits integer <rules-integer-keywords>`.
+
+Example::
+
+  modbus.write.address:500; modbus.write.value:>200;

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4076,7 +4076,12 @@
                                     "type": "string"
                                 },
                                 "raw": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "modbus.subfunction"
+                                        ]
+                                    }
                                 }
                             }
                         },
@@ -4087,7 +4092,12 @@
                             "type": "string"
                         },
                         "function_raw": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "modbus.function"
+                                ]
+                            }
                         },
                         "mei": {
                             "type": "object",
@@ -4105,35 +4115,84 @@
                             }
                         },
                         "protocol_id": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "modbus.protocol_id"
+                                ]
+                            }
                         },
                         "read": {
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
                                 "address": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "modbus.read.address"
+                                        ]
+                                    }
                                 },
                                 "quantity": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "modbus.read.quantity"
+                                        ]
+                                    }
                                 }
                             }
                         },
                         "transaction_id": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "modbus.transaction_id"
+                                ]
+                            }
                         },
                         "unit_id": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "modbus.unit_id"
+                                ]
+                            }
                         },
                         "write": {
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
                                 "address": {
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "modbus.write.address"
+                                        ]
+                                    }
+                                },
+                                "and_mask": {
+                                    "type": "integer"
+                                },
+                                "or_mask": {
                                     "type": "integer"
                                 },
                                 "data": {
-                                    "type": "integer"
+                                    "type": ["integer", "string"],
+                                    "suricata": {
+                                        "keywords": [
+                                            "modbus.write.value"
+                                        ]
+                                    }
+                                },
+                                "quantity": {
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "modbus.write.quantity"
+                                        ]
+                                    }
                                 }
                             }
                         }
@@ -4163,7 +4222,12 @@
                                     "type": "string"
                                 },
                                 "raw": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "modbus.subfunction"
+                                        ]
+                                    }
                                 }
                             }
                         },
@@ -4178,7 +4242,12 @@
                                     "type": "string"
                                 },
                                 "raw": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "modbus.exception_code"
+                                        ]
+                                    }
                                 }
                             }
                         },
@@ -4186,10 +4255,20 @@
                             "type": "string"
                         },
                         "function_raw": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "modbus.function"
+                                ]
+                            }
                         },
                         "protocol_id": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "modbus.protocol_id"
+                                ]
+                            }
                         },
                         "read": {
                             "type": "object",
@@ -4201,20 +4280,47 @@
                             }
                         },
                         "transaction_id": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "modbus.transaction_id"
+                                ]
+                            }
                         },
                         "unit_id": {
-                            "type": "integer"
+                            "type": "integer",
+                            "suricata": {
+                                "keywords": [
+                                    "modbus.unit_id"
+                                ]
+                            }
                         },
                         "write": {
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
                                 "address": {
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "modbus.write.address"
+                                        ]
+                                    }
+                                },
+                                "and_mask": {
+                                    "type": "integer"
+                                },
+                                "or_mask": {
                                     "type": "integer"
                                 },
                                 "data": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "suricata": {
+                                        "keywords": [
+                                            "modbus.write.value",
+                                            "modbus.write.quantity"
+                                        ]
+                                    }
                                 }
                             }
                         }

--- a/rust/src/modbus/detect.rs
+++ b/rust/src/modbus/detect.rs
@@ -476,6 +476,12 @@ static mut G_MODBUS_TRANSACTION_ID_KW_ID: u16 = 0;
 static mut G_MODBUS_TRANSACTION_ID_BUFFER_ID: c_int = 0;
 static mut G_MODBUS_PROTOCOL_ID_KW_ID: u16 = 0;
 static mut G_MODBUS_PROTOCOL_ID_BUFFER_ID: c_int = 0;
+static mut G_MODBUS_FUNCTION_KW_ID: u16 = 0;
+static mut G_MODBUS_FUNCTION_BUFFER_ID: c_int = 0;
+static mut G_MODBUS_SUBFUNCTION_KW_ID: u16 = 0;
+static mut G_MODBUS_SUBFUNCTION_BUFFER_ID: c_int = 0;
+static mut G_MODBUS_EXCEPTION_CODE_KW_ID: u16 = 0;
+static mut G_MODBUS_EXCEPTION_CODE_BUFFER_ID: c_int = 0;
 
 /// Get the message matching the direction of the packet under inspection:
 /// the request for to-server, the response for to-client.
@@ -616,6 +622,157 @@ unsafe extern "C" fn protocol_id_free(_de: *mut DetectEngineCtx, ctx: *mut c_voi
     SCDetectU16Free(ctx);
 }
 
+fn tx_get_function(tx: &ModbusTransaction, direction: u8) -> Option<u8> {
+    return tx_get_message(tx, direction).map(|msg| msg.function.raw);
+}
+
+fn tx_get_subfunction(tx: &ModbusTransaction, direction: u8) -> Option<u16> {
+    if let Some(msg) = tx_get_message(tx, direction) {
+        if let Data::Diagnostic { func, .. } = &msg.data {
+            return Some(func.raw);
+        }
+    }
+    return None;
+}
+
+fn tx_get_exception_code(tx: &ModbusTransaction, direction: u8) -> Option<u8> {
+    if let Some(msg) = tx_get_message(tx, direction) {
+        if let Data::Exception(exc) = &msg.data {
+            return Some(exc.raw);
+        }
+    }
+    return None;
+}
+
+unsafe extern "C" fn function_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU8Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_FUNCTION_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_FUNCTION_BUFFER_ID,
+    )
+    .is_null()
+    {
+        function_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn function_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    if let Some(val) = tx_get_function(tx, flags) {
+        return SCDetectU8Match(val, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn function_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    SCDetectU8Free(ctx);
+}
+
+unsafe extern "C" fn subfunction_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU16Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_SUBFUNCTION_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_SUBFUNCTION_BUFFER_ID,
+    )
+    .is_null()
+    {
+        subfunction_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn subfunction_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    if let Some(val) = tx_get_subfunction(tx, flags) {
+        return SCDetectU16Match(val, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn subfunction_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    SCDetectU16Free(ctx);
+}
+
+unsafe extern "C" fn exception_code_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU8Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_EXCEPTION_CODE_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_EXCEPTION_CODE_BUFFER_ID,
+    )
+    .is_null()
+    {
+        exception_code_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn exception_code_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    if let Some(val) = tx_get_exception_code(tx, flags) {
+        return SCDetectU8Match(val, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn exception_code_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    SCDetectU8Free(ctx);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectModbusRegister() {
     let kw = SCSigTableAppLiteElmt {
@@ -662,6 +819,54 @@ pub unsafe extern "C" fn SCDetectModbusRegister() {
     G_MODBUS_PROTOCOL_ID_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_MODBUS_PROTOCOL_ID_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"modbus.protocol_id\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.function\0".as_ptr() as *const c_char,
+        desc: b"match on Modbus function code\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-function\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(function_match),
+        Setup: Some(function_setup),
+        Free: Some(function_free),
+        flags: SIGMATCH_INFO_UINT8,
+    };
+    G_MODBUS_FUNCTION_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_FUNCTION_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.function\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.subfunction\0".as_ptr() as *const c_char,
+        desc: b"match on Modbus diagnostic subfunction code\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-subfunction\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(subfunction_match),
+        Setup: Some(subfunction_setup),
+        Free: Some(subfunction_free),
+        flags: SIGMATCH_INFO_UINT16,
+    };
+    G_MODBUS_SUBFUNCTION_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_SUBFUNCTION_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.subfunction\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.exception_code\0".as_ptr() as *const c_char,
+        desc: b"match on Modbus exception code in error responses\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-exception-code\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(exception_code_match),
+        Setup: Some(exception_code_setup),
+        Free: Some(exception_code_free),
+        flags: SIGMATCH_INFO_UINT8,
+    };
+    G_MODBUS_EXCEPTION_CODE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_EXCEPTION_CODE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.exception_code\0".as_ptr() as *const c_char,
         ALPROTO_MODBUS,
         STREAM_TOSERVER | STREAM_TOCLIENT,
         0,

--- a/rust/src/modbus/detect.rs
+++ b/rust/src/modbus/detect.rs
@@ -25,7 +25,7 @@ use crate::detect::{SIGMATCH_INFO_UINT16, SIGMATCH_INFO_UINT8};
 use crate::direction::Direction;
 use lazy_static::lazy_static;
 use regex::Regex;
-use sawp_modbus::{AccessType, CodeCategory, Data, Flags, FunctionCode, Message};
+use sawp_modbus::{AccessType, CodeCategory, Data, Flags, FunctionCode, Message, Read, Write};
 use std::ffi::CStr;
 use std::ops::{Range, RangeInclusive};
 use std::os::raw::{c_char, c_int, c_void};
@@ -482,6 +482,16 @@ static mut G_MODBUS_SUBFUNCTION_KW_ID: u16 = 0;
 static mut G_MODBUS_SUBFUNCTION_BUFFER_ID: c_int = 0;
 static mut G_MODBUS_EXCEPTION_CODE_KW_ID: u16 = 0;
 static mut G_MODBUS_EXCEPTION_CODE_BUFFER_ID: c_int = 0;
+static mut G_MODBUS_READ_ADDRESS_KW_ID: u16 = 0;
+static mut G_MODBUS_READ_ADDRESS_BUFFER_ID: c_int = 0;
+static mut G_MODBUS_READ_QUANTITY_KW_ID: u16 = 0;
+static mut G_MODBUS_READ_QUANTITY_BUFFER_ID: c_int = 0;
+static mut G_MODBUS_WRITE_ADDRESS_KW_ID: u16 = 0;
+static mut G_MODBUS_WRITE_ADDRESS_BUFFER_ID: c_int = 0;
+static mut G_MODBUS_WRITE_QUANTITY_KW_ID: u16 = 0;
+static mut G_MODBUS_WRITE_QUANTITY_BUFFER_ID: c_int = 0;
+static mut G_MODBUS_WRITE_VALUE_KW_ID: u16 = 0;
+static mut G_MODBUS_WRITE_VALUE_BUFFER_ID: c_int = 0;
 
 /// Get the message matching the direction of the packet under inspection:
 /// the request for to-server, the response for to-client.
@@ -773,6 +783,303 @@ unsafe extern "C" fn exception_code_free(_de: *mut DetectEngineCtx, ctx: *mut c_
     SCDetectU8Free(ctx);
 }
 
+fn tx_get_read(tx: &ModbusTransaction, direction: u8) -> Option<&Read> {
+    if let Some(msg) = tx_get_message(tx, direction) {
+        match &msg.data {
+            Data::Read(read) | Data::ReadWrite { read, .. } => return Some(read),
+            _ => {}
+        }
+    }
+    return None;
+}
+
+fn tx_get_write(tx: &ModbusTransaction, direction: u8) -> Option<&Write> {
+    if let Some(msg) = tx_get_message(tx, direction) {
+        match &msg.data {
+            Data::Write(write) | Data::ReadWrite { write, .. } => return Some(write),
+            _ => {}
+        }
+    }
+    return None;
+}
+
+fn tx_get_read_address(tx: &ModbusTransaction, direction: u8) -> Option<u16> {
+    if let Some(Read::Request { address, .. }) = tx_get_read(tx, direction) {
+        return Some(*address);
+    }
+    return None;
+}
+
+fn tx_get_read_quantity(tx: &ModbusTransaction, direction: u8) -> Option<u16> {
+    if let Some(Read::Request { quantity, .. }) = tx_get_read(tx, direction) {
+        return Some(*quantity);
+    }
+    return None;
+}
+
+fn tx_get_write_address(tx: &ModbusTransaction, direction: u8) -> Option<u16> {
+    if let Some(write) = tx_get_write(tx, direction) {
+        match write {
+            Write::MultReq { address, .. }
+            | Write::Mask { address, .. }
+            | Write::Other { address, .. } => {
+                return Some(*address);
+            }
+        }
+    }
+    return None;
+}
+
+fn tx_get_write_quantity(tx: &ModbusTransaction, direction: u8) -> Option<u16> {
+    if let Some(msg) = tx_get_message(tx, direction) {
+        match &msg.data {
+            Data::Write(Write::MultReq { quantity, .. })
+            | Data::ReadWrite {
+                write: Write::MultReq { quantity, .. },
+                ..
+            } => {
+                return Some(*quantity);
+            }
+            // multiple-write responses echo the quantity in Write::Other
+            Data::Write(Write::Other { data, .. }) => {
+                if msg.access_type.contains(AccessType::MULTIPLE) {
+                    return Some(*data);
+                }
+            }
+            _ => {}
+        }
+    }
+    return None;
+}
+
+fn tx_get_write_value(tx: &ModbusTransaction, direction: u8) -> Option<u16> {
+    if let Some(msg) = tx_get_message(tx, direction) {
+        if let Data::Write(Write::Other { data, .. }) = &msg.data {
+            // multiple-write responses echo the quantity in Write::Other,
+            // only match the value of single writes
+            if msg.access_type.contains(AccessType::SINGLE) {
+                return Some(*data);
+            }
+        }
+    }
+    return None;
+}
+
+unsafe extern "C" fn read_address_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU16Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_READ_ADDRESS_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_READ_ADDRESS_BUFFER_ID,
+    )
+    .is_null()
+    {
+        read_address_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn read_address_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    if let Some(val) = tx_get_read_address(tx, flags) {
+        return SCDetectU16Match(val, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn read_address_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    SCDetectU16Free(ctx);
+}
+
+unsafe extern "C" fn read_quantity_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU16Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_READ_QUANTITY_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_READ_QUANTITY_BUFFER_ID,
+    )
+    .is_null()
+    {
+        read_quantity_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn read_quantity_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    if let Some(val) = tx_get_read_quantity(tx, flags) {
+        return SCDetectU16Match(val, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn read_quantity_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    SCDetectU16Free(ctx);
+}
+
+unsafe extern "C" fn write_address_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU16Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_WRITE_ADDRESS_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_WRITE_ADDRESS_BUFFER_ID,
+    )
+    .is_null()
+    {
+        write_address_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn write_address_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    if let Some(val) = tx_get_write_address(tx, flags) {
+        return SCDetectU16Match(val, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn write_address_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    SCDetectU16Free(ctx);
+}
+
+unsafe extern "C" fn write_quantity_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU16Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_WRITE_QUANTITY_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_WRITE_QUANTITY_BUFFER_ID,
+    )
+    .is_null()
+    {
+        write_quantity_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn write_quantity_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    if let Some(val) = tx_get_write_quantity(tx, flags) {
+        return SCDetectU16Match(val, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn write_quantity_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    SCDetectU16Free(ctx);
+}
+
+unsafe extern "C" fn write_value_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU16Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_WRITE_VALUE_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_WRITE_VALUE_BUFFER_ID,
+    )
+    .is_null()
+    {
+        write_value_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn write_value_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    if let Some(val) = tx_get_write_value(tx, flags) {
+        return SCDetectU16Match(val, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn write_value_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    SCDetectU16Free(ctx);
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectModbusRegister() {
     let kw = SCSigTableAppLiteElmt {
@@ -867,6 +1174,86 @@ pub unsafe extern "C" fn SCDetectModbusRegister() {
     G_MODBUS_EXCEPTION_CODE_KW_ID = SCDetectHelperKeywordRegister(&kw);
     G_MODBUS_EXCEPTION_CODE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
         b"modbus.exception_code\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.read.address\0".as_ptr() as *const c_char,
+        desc: b"match on address of Modbus read requests\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-read-address\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(read_address_match),
+        Setup: Some(read_address_setup),
+        Free: Some(read_address_free),
+        flags: SIGMATCH_INFO_UINT16,
+    };
+    G_MODBUS_READ_ADDRESS_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_READ_ADDRESS_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.read.address\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.read.quantity\0".as_ptr() as *const c_char,
+        desc: b"match on quantity of Modbus read requests\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-read-quantity\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(read_quantity_match),
+        Setup: Some(read_quantity_setup),
+        Free: Some(read_quantity_free),
+        flags: SIGMATCH_INFO_UINT16,
+    };
+    G_MODBUS_READ_QUANTITY_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_READ_QUANTITY_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.read.quantity\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.write.address\0".as_ptr() as *const c_char,
+        desc: b"match on address of Modbus write accesses\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-write-address\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(write_address_match),
+        Setup: Some(write_address_setup),
+        Free: Some(write_address_free),
+        flags: SIGMATCH_INFO_UINT16,
+    };
+    G_MODBUS_WRITE_ADDRESS_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_WRITE_ADDRESS_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.write.address\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.write.quantity\0".as_ptr() as *const c_char,
+        desc: b"match on quantity of Modbus multiple-write requests\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-write-quantity\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(write_quantity_match),
+        Setup: Some(write_quantity_setup),
+        Free: Some(write_quantity_free),
+        flags: SIGMATCH_INFO_UINT16,
+    };
+    G_MODBUS_WRITE_QUANTITY_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_WRITE_QUANTITY_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.write.quantity\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.write.value\0".as_ptr() as *const c_char,
+        desc: b"match on value of Modbus single-write accesses\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-write-value\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(write_value_match),
+        Setup: Some(write_value_setup),
+        Free: Some(write_value_free),
+        flags: SIGMATCH_INFO_UINT16,
+    };
+    G_MODBUS_WRITE_VALUE_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_WRITE_VALUE_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.write.value\0".as_ptr() as *const c_char,
         ALPROTO_MODBUS,
         STREAM_TOSERVER | STREAM_TOCLIENT,
         0,

--- a/rust/src/modbus/detect.rs
+++ b/rust/src/modbus/detect.rs
@@ -15,14 +15,26 @@
  * 02110-1301, USA.
  */
 
-use super::modbus::ModbusTransaction;
+use super::modbus::{ModbusTransaction, ALPROTO_MODBUS};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::detect::uint::{
+    DetectUintData, SCDetectU16Free, SCDetectU16Match, SCDetectU16Parse, SCDetectU8Free,
+    SCDetectU8Match, SCDetectU8Parse,
+};
+use crate::detect::{SIGMATCH_INFO_UINT16, SIGMATCH_INFO_UINT8};
+use crate::direction::Direction;
 use lazy_static::lazy_static;
 use regex::Regex;
 use sawp_modbus::{AccessType, CodeCategory, Data, Flags, FunctionCode, Message};
 use std::ffi::CStr;
 use std::ops::{Range, RangeInclusive};
-use std::os::raw::{c_char, c_void};
+use std::os::raw::{c_char, c_int, c_void};
 use std::str::FromStr;
+use suricata_sys::sys::{
+    DetectEngineCtx, DetectEngineThreadCtx, Flow, SCDetectHelperBufferProgressRegister,
+    SCDetectHelperKeywordRegister, SCDetectSignatureSetAppProto, SCSigMatchAppendSMToList,
+    SCSigTableAppLiteElmt, SigMatchCtx, Signature,
+};
 
 lazy_static! {
     static ref ACCESS_RE: Regex = Regex::new(
@@ -456,6 +468,204 @@ fn parse_unit_id(unit_str: &str) -> Result<DetectModbusRust, ()> {
     }
 
     Ok(modbus)
+}
+
+static mut G_MODBUS_UNIT_ID_KW_ID: u16 = 0;
+static mut G_MODBUS_UNIT_ID_BUFFER_ID: c_int = 0;
+static mut G_MODBUS_TRANSACTION_ID_KW_ID: u16 = 0;
+static mut G_MODBUS_TRANSACTION_ID_BUFFER_ID: c_int = 0;
+static mut G_MODBUS_PROTOCOL_ID_KW_ID: u16 = 0;
+static mut G_MODBUS_PROTOCOL_ID_BUFFER_ID: c_int = 0;
+
+/// Get the message matching the direction of the packet under inspection:
+/// the request for to-server, the response for to-client.
+fn tx_get_message(tx: &ModbusTransaction, direction: u8) -> Option<&Message> {
+    let direction: Direction = direction.into();
+    if direction == Direction::ToServer {
+        return tx.request.as_ref();
+    }
+    return tx.response.as_ref();
+}
+
+unsafe extern "C" fn unit_id_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU8Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_UNIT_ID_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_UNIT_ID_BUFFER_ID,
+    )
+    .is_null()
+    {
+        unit_id_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn unit_id_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    if let Some(msg) = tx_get_message(tx, flags) {
+        return SCDetectU8Match(msg.unit_id, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn unit_id_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    SCDetectU8Free(ctx);
+}
+
+unsafe extern "C" fn transaction_id_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU16Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_TRANSACTION_ID_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_TRANSACTION_ID_BUFFER_ID,
+    )
+    .is_null()
+    {
+        transaction_id_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn transaction_id_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    if let Some(msg) = tx_get_message(tx, flags) {
+        return SCDetectU16Match(msg.transaction_id, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn transaction_id_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    SCDetectU16Free(ctx);
+}
+
+unsafe extern "C" fn protocol_id_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0 {
+        return -1;
+    }
+    let ctx = SCDetectU16Parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_MODBUS_PROTOCOL_ID_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_MODBUS_PROTOCOL_ID_BUFFER_ID,
+    )
+    .is_null()
+    {
+        protocol_id_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn protocol_id_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, ModbusTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    if let Some(msg) = tx_get_message(tx, flags) {
+        return SCDetectU16Match(msg.protocol_id, ctx);
+    }
+    return 0;
+}
+
+unsafe extern "C" fn protocol_id_free(_de: *mut DetectEngineCtx, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u16>);
+    SCDetectU16Free(ctx);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectModbusRegister() {
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.unit_id\0".as_ptr() as *const c_char,
+        desc: b"match on Modbus unit identifier\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-unit-id\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(unit_id_match),
+        Setup: Some(unit_id_setup),
+        Free: Some(unit_id_free),
+        flags: SIGMATCH_INFO_UINT8,
+    };
+    G_MODBUS_UNIT_ID_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_UNIT_ID_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.unit_id\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.transaction_id\0".as_ptr() as *const c_char,
+        desc: b"match on Modbus transaction identifier\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-transaction-id\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(transaction_id_match),
+        Setup: Some(transaction_id_setup),
+        Free: Some(transaction_id_free),
+        flags: SIGMATCH_INFO_UINT16,
+    };
+    G_MODBUS_TRANSACTION_ID_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_TRANSACTION_ID_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.transaction_id\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
+    let kw = SCSigTableAppLiteElmt {
+        name: b"modbus.protocol_id\0".as_ptr() as *const c_char,
+        desc: b"match on Modbus protocol identifier\0".as_ptr() as *const c_char,
+        url: b"/rules/modbus-keyword.html#modbus-protocol-id\0".as_ptr() as *const c_char,
+        AppLayerTxMatch: Some(protocol_id_match),
+        Setup: Some(protocol_id_setup),
+        Free: Some(protocol_id_free),
+        flags: SIGMATCH_INFO_UINT16,
+    };
+    G_MODBUS_PROTOCOL_ID_KW_ID = SCDetectHelperKeywordRegister(&kw);
+    G_MODBUS_PROTOCOL_ID_BUFFER_ID = SCDetectHelperBufferProgressRegister(
+        b"modbus.protocol_id\0".as_ptr() as *const c_char,
+        ALPROTO_MODBUS,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
+        0,
+    );
 }
 
 #[cfg(test)]

--- a/rust/src/modbus/modbus.rs
+++ b/rust/src/modbus/modbus.rs
@@ -34,7 +34,7 @@ use suricata_sys::sys::{
 pub const REQUEST_FLOOD: usize = 500; // Default unreplied Modbus requests are considered a flood
 pub const MODBUS_PARSER: sawp_modbus::Modbus = sawp_modbus::Modbus { probe_strict: true };
 
-static mut ALPROTO_MODBUS: AppProto = ALPROTO_UNKNOWN;
+pub(super) static mut ALPROTO_MODBUS: AppProto = ALPROTO_UNKNOWN;
 
 #[derive(AppLayerEvent)]
 enum ModbusEvent {

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -757,6 +757,7 @@ void SigTableSetup(void)
     SCDetectDHCPRegister();
     SCDetectWebsocketRegister();
     SCDetectEnipRegister();
+    SCDetectModbusRegister();
     SCDetectMqttRegister();
     SCDetectRfbRegister();
     SCDetectSipRegister();


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in doc/userguide/) to reflect the changes made
- [x] I have updated the JSON schema (in etc/schema.json) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8131

Describe changes:
- add per-value uint keywords for fields already in the EVE modbus log: modbus.unit_id, modbus.transaction_id, modbus.protocol_id, modbus.function, modbus.subfunction, modbus.exception_code, modbus.read.address, modbus.read.quantity, modbus.write.address, modbus.write.quantity and modbus.write.value
- same pattern as the enip keywords: registered from Rust, ranges and negation supported, request matched to-server and response to-client; the legacy modbus option keyword is unchanged
- multiple-write responses echo a quantity where single writes echo a value, so modbus.write.quantity matches that echo and modbus.write.value only matches single writes; documented, along with the difference from the 1-based addressing of the legacy keyword
- schema: map the new keywords to their EVE fields, add the write.quantity, write.and_mask and write.or_mask properties and allow string data in multiple-write requests, which the modbus logger already emits
- suricata-verify tests in the linked SV branch: one reusing the modbus test pcap, one with a synthetic multiple/mask/single-write pcap (generator included)
- left for possible future tickets: a keyword for mei, enum string values for function and exception codes, a modbus.data sticky buffer, mask keywords

SV_REPO=https://github.com/akekulip/suricata-verify
SV_BRANCH=modbus-keywords-8131-v1
SU_REPO=
SU_BRANCH=
