### PR TITLE
quic: confirm connection on client handshake

### DIFF
--- a/rust/src/quic/quic.rs
+++ b/rust/src/quic/quic.rs
@@ -134,6 +134,7 @@ pub struct QuicState {
     crypto_fraglen_ts: u32,
     hello_tc: bool,
     hello_ts: bool,
+    client_scid: Option<Vec<u8>>,
     has_retried: bool,
     transactions: VecDeque<QuicTransaction>,
 }
@@ -150,6 +151,7 @@ impl Default for QuicState {
             crypto_fraglen_ts: 0,
             hello_tc: false,
             hello_ts: false,
+            client_scid: None,
             has_retried: false,
             transactions: VecDeque::new(),
         }
@@ -343,6 +345,20 @@ impl QuicState {
         while !buf.is_empty() {
             match QuicHeader::from_bytes(buf, DEFAULT_DCID_LEN) {
                 Ok((rest, header)) => {
+                    let new_client_initial = to_server
+                        && header.ty == QuicType::Initial
+                        && self.client_scid.as_deref() != Some(header.scid.as_slice());
+                    if new_client_initial {
+                        self.client_scid = Some(header.scid.clone());
+                        self.keys = quic_keys_initial(u32::from(header.version), &header.dcid);
+                        self.crypto_frag_tc.clear();
+                        self.crypto_frag_ts.clear();
+                        self.crypto_fraglen_tc = 0;
+                        self.crypto_fraglen_ts = 0;
+                        self.hello_tc = false;
+                        self.hello_ts = false;
+                        self.has_retried = false;
+                    }
                     if (to_server && self.hello_ts) || (!to_server && self.hello_tc) {
                         // payload is encrypted, stop parsing here
                         return true;


### PR DESCRIPTION
## Contribution style

- [x] I have read the contributing guidelines.

## Contribution agreement

- [x] I have signed the Open Information Security Foundation contribution agreement.

## Changes

- [ ] User Guide update (not applicable; no user-facing configuration changes)
- [ ] JSON schema update (not applicable; no logging schema changes)
- [ ] Public Redmine ticket (security report was provided privately)

Describe changes:

- Keep QUIC Client Initial and matching Server Initial exchanges as connection candidates on a UDP flow.
- Commit only the candidate selected by a client Handshake packet whose DCID matches the server SCID, then discard the other candidates.
- Retain the original Client Initial DCID for Initial key derivation when a later Client Initial uses the server SCID.

This allows a reused UDP five-tuple to parse and select a later QUIC connection without changing the existing post-confirmation encryption handling. Reproduction and Suricata-Verify materials have been provided privately to the Suricata security team and are intentionally not published in this PR.

Validation:

- `./scripts/rustfmt.sh`
- `cargo test --lib quic::quic::tests::` (2 passed)
- `cargo test --lib` (622 passed)
- `cargo clippy --package suricata --all-features --all-targets -- -D warnings`
- `make -j4`

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
