### PR TITLE
defrag: fix defrag.memuse counter reporting memcap

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -39,6 +39,12 @@ Upgrading to 8.0.6
 
 Deprecations
 ~~~~~~~~~~~~~
+<<<<<<< HEAD
+- An SMB flow that reaches its transaction limit
+  (``app-layer.protocols.smb.max-tx``) is now put into an application-layer
+  error state instead of force-completing older transactions. Such a flow is
+  then handled according to ``app-layer.error-policy`` (for example, dropped in
+  IPS mode), and the ``too_many_transactions`` event is raised.
 
 - The ``flowbits`` ``toggle`` command is now deprecated and will be removed in
   Suricata 9.0.

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -948,7 +948,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         }
         if (other_last_sec == 0 || other_last_sec < (uint32_t)SCTIME_SECS(ts)) {
             if (ftd->instance == 0) {
-                StatsSetUI64(th_v, ftd->counter_defrag_memuse, DefragTrackerGetMemcap());
+                StatsSetUI64(th_v, ftd->counter_defrag_memuse, DefragTrackerGetMemuse());
                 uint32_t defrag_cnt = DefragTimeoutHash(ts);
                 if (defrag_cnt) {
                     StatsAddUI64(th_v, ftd->counter_defrag_timeout, defrag_cnt);


### PR DESCRIPTION

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8773

Describe changes:
- Cherry-pick fix from `main` (see RM 8752, https://github.com/OISF/suricata/pull/15970)

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
