### PR TITLE
quic: allow new Client Initial on reused flow

### DIFF
--- a/rust/src/quic/quic.rs
+++ b/rust/src/quic/quic.rs
@@ -134,6 +134,7 @@ pub struct QuicState {
     crypto_fraglen_ts: u32,
     hello_tc: bool,
     hello_ts: bool,
+    client_scid: Option<Vec<u8>>,
     has_retried: bool,
     transactions: VecDeque<QuicTransaction>,
 }
@@ -150,6 +151,7 @@ impl Default for QuicState {
             crypto_fraglen_ts: 0,
             hello_tc: false,
             hello_ts: false,
+            client_scid: None,
             has_retried: false,
             transactions: VecDeque::new(),
         }
@@ -343,6 +345,20 @@ impl QuicState {
         while !buf.is_empty() {
             match QuicHeader::from_bytes(buf, DEFAULT_DCID_LEN) {
                 Ok((rest, header)) => {
+                    let new_client_initial = to_server
+                        && header.ty == QuicType::Initial
+                        && self.client_scid.as_deref() != Some(header.scid.as_slice());
+                    if new_client_initial {
+                        self.client_scid = Some(header.scid.clone());
+                        self.keys = quic_keys_initial(u32::from(header.version), &header.dcid);
+                        self.crypto_frag_tc.clear();
+                        self.crypto_frag_ts.clear();
+                        self.crypto_fraglen_tc = 0;
+                        self.crypto_fraglen_ts = 0;
+                        self.hello_tc = false;
+                        self.hello_ts = false;
+                        self.has_retried = false;
+                    }
                     if (to_server && self.hello_ts) || (!to_server && self.hello_tc) {
                         // payload is encrypted, stop parsing here
                         return true;


### PR DESCRIPTION
## Contribution style

- [x] I have read the contributing guidelines.

## Contribution agreement

- [x] I have signed the Open Information Security Foundation contribution agreement.

## Changes

- [ ] User Guide update (not applicable; no user-facing configuration changes)
- [ ] JSON schema update (not applicable; no logging schema changes)
- [x] Public Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8776

Describe changes:

- Track the client SCID used by the current QUIC Client Initial on a UDP flow.
- When a Client Initial with a different SCID is received on the same flow, reset only the Initial parsing state and derive Initial keys from its DCID.
- Allow the later ClientHello and SNI to be parsed instead of being skipped by the existing hello-direction guard.

This is the minimal replacement for #15975. It preserves the existing QUIC flow and post-Initial handling while allowing a reused UDP five-tuple to inspect a later QUIC connection. The public reproducer and Suricata-Verify test are available in OISF/suricata-verify#3324.

Validation:

- Rust formatting check passed.
- Rust library tests passed (620 tests).
- The QUIC Suricata-Verify suite, including the new five-tuple reuse test, passed with 20 passed, 0 failed, and 1 version-dependent skip.
- On unpatched Suricata `main`, the new test fails the second-SNI and matching-alert checks as expected.
- Linux, macOS, Windows, and FreeBSD builds passed in the personal-fork matrix; unrelated personal-repository workflow failures were limited to credentials, hard-coded repository paths, or external download failures.

SV_REPO=https://github.com/jiangshaoqi/suricata-verify
SV_BRANCH=bug-8776-quic-five-tuple-reuse
SU_REPO=
SU_BRANCH=
