### PR TITLE
unix-socket: close socket and remove socket file on shutdown

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -93,6 +93,7 @@ typedef struct UnixCommand_ {
     int socket;
     struct sockaddr_un client_addr;
     int select_max;
+    char sockettarget[PATH_MAX];
     TAILQ_HEAD(, Command_) commands;
     TAILQ_HEAD(, Task_) tasks;
     TAILQ_HEAD(, UnixClient_) clients;
@@ -133,6 +134,10 @@ static int UnixNew(UnixCommand * this)
         strlcpy(sockettarget, SOCKET_TARGET, sizeof(sockettarget));
         check_dir = 1;
     }
+
+    /* Remember the socket path so it can be removed again on shutdown */
+    strlcpy(this->sockettarget, sockettarget, sizeof(this->sockettarget));
+
     SCLogInfo("unix socket '%s'", sockettarget);
 
     if (check_dir) {
@@ -634,6 +639,22 @@ static int UnixMain(UnixCommand * this)
     if (suricata_ctl_flags & SURICATA_STOP) {
         TAILQ_FOREACH_SAFE (uclient, &this->clients, next, tclient) {
             UnixCommandClose(this, uclient->fd);
+        }
+
+        /* Close the socket and remove the socket file.
+         * Guarded by this->socket so this only runs once, even though
+         * UnixMain() keeps getting called in the management loop while
+         * shutdown is still in progress. */
+        if (this->socket != -1) {
+            close(this->socket);
+            this->socket = -1;
+            if (unlink(this->sockettarget) != 0 && errno != ENOENT) {
+                SCLogWarning("unable to remove unix socket file %s: %s", this->sockettarget,
+                        strerror(errno));
+            } else {
+                SCLogDebug("unix socket file '%s' removed", this->sockettarget);
+            }
+            SCLogInfo("unix socket '%s' closed", this->sockettarget);
         }
         return 1;
     }


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made -> not needed
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes -> not needed
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8799

Describe changes:
- Preserve socket path (`sockettarget`) in struct `UnixCommand_`, because this is needed on shutdown to close the socket
- Implement a logic to close the command socket on Suricata shutdown and set `this->socket = -1` to mark it uninitialized.
- unlink the socket file to remove the remaining socket file
- Ensure that the closing procedure is executed only once, when `UnixMain()` is called multiple times in the while-loop of `UnixManager()`
- Created by the aid of AI, but I fully understand the changes and tested it myself

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
  - I have no idea about how to test proper closing of the socket in suricata-verify.
- Leave unused overrides blank or remove.

Thanks for your feedback and the review!
Regards,
Andreas