### PR TITLE
dag: stats registration causes compilation errors with --enable-dag

### DIFF
--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -104,8 +104,8 @@ typedef struct ErfDagThreadVars_ {
     LiveDevice *livedev;
 
     uint64_t bytes;
-    uint16_t packets;
-    uint16_t drops;
+    StatsCounterId packets;
+    StatsCounterId drops;
 
     /* Current location in the DAG stream input buffer.
      */
@@ -283,8 +283,8 @@ TmEcode ReceiveErfDagThreadInit(ThreadVars *tv, const void *initdata, void **dat
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    ewtn->packets = StatsRegisterCounter("capture.dag_packets", tv);
-    ewtn->drops = StatsRegisterCounter("capture.dag_drops", tv);
+    ewtn->packets = StatsRegisterCounter("capture.dag_packets", &tv->stats);
+    ewtn->drops = StatsRegisterCounter("capture.dag_drops", &tv->stats);
 
     ewtn->tv = tv;
     *data = (void *)ewtn;


### PR DESCRIPTION
Bug: 8812

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [X] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [X] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [X] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- Update source-erf-dag for counter API changes
- Fixes main build with --enable-dag

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
