### PR TITLE
defrag: fix defrag.memuse counter reporting memcap

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -948,7 +948,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         }
         if (other_last_sec == 0 || other_last_sec < (uint32_t)SCTIME_SECS(ts)) {
             if (ftd->instance == 0) {
-                StatsSetUI64(th_v, ftd->counter_defrag_memuse, DefragTrackerGetMemcap());
+                StatsSetUI64(th_v, ftd->counter_defrag_memuse, DefragTrackerGetMemuse());
                 uint32_t defrag_cnt = DefragTimeoutHash(ts);
                 if (defrag_cnt) {
                     StatsAddUI64(th_v, ftd->counter_defrag_timeout, defrag_cnt);


### PR DESCRIPTION
Continuation of #15978 

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8773

Describe changes:
- Cherry-pick fix from `main` (see RM 8752, https://github.com/OISF/suricata/pull/15970)

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
