### PR TITLE
util/file: fix integer overflow in inspect window comparison

### DIFF
--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -88,6 +88,7 @@
 #include "util-hashlist.h"
 #include "util-pool.h"
 #include "util-byte.h"
+#include "util-file.h"
 #include "util-proto-name.h"
 #include "util-macset.h"
 #include "util-flow-rate.h"
@@ -221,6 +222,7 @@ static void RegisterUnittests(void)
     SourceWinDivertRegisterTests();
 #endif
     SCProtoNameRegisterTests();
+    FileRegisterTests();
     UtilCIDRTests();
     OutputJsonStatsRegisterTests();
     CoredumpConfigRegisterTests();

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -378,17 +378,17 @@ static int FilePruneFile(File *file, const StreamingBufferConfig *cfg)
          * do some house keeping here */
         if (file->inspect_window != 0 && file->inspect_min_size != 0) {
             const uint64_t file_offset = StreamingBufferGetOffset(file->sb);
-            uint32_t window = file->inspect_window;
+            uint64_t window = file->inspect_window;
             if (file_offset == 0)
-                window = MAX(window, file->inspect_min_size);
+                window = MAX(window, (uint64_t)file->inspect_min_size);
 
             uint64_t file_size = FileDataSize(file);
             uint64_t data_size = file_size - file_offset;
 
-            SCLogDebug("window %"PRIu32", file_size %"PRIu64", data_size %"PRIu64,
-                    window, file_size, data_size);
+            SCLogDebug("window %" PRIu64 ", file_size %" PRIu64 ", data_size %" PRIu64, window,
+                    file_size, data_size);
 
-            if (data_size > (window * 3)) {
+            if (data_size > window * 3) {
                 file->content_inspected = MAX(file->content_inspected, file->size - window);
                 SCLogDebug("file->content_inspected now %" PRIu64, file->content_inspected);
             }

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -1192,3 +1192,49 @@ static void FileEndSha256(File *ff)
         ff->flags |= FILE_SHA256;
     }
 }
+
+#ifdef UNITTESTS
+#include "util-unittest.h"
+
+/**
+ * \test the inspect window guard must not wrap around
+ *
+ * `window * 3` used to be computed in uint32_t arithmetic. The guard is there
+ * to make sure `file->size > window`, so on wrap around `file->size - window`
+ * underflows and content_inspected ends up bogus.
+ */
+static int FilePruneInspectWindowOverflowTest(void)
+{
+    const int detect_disabled = g_detect_disabled;
+    g_detect_disabled = 0;
+
+    StreamingBufferConfig sbcfg = STREAMING_BUFFER_CONFIG_INITIALIZER;
+    FileContainer *ffc = FileContainerAlloc();
+    FAIL_IF_NULL(ffc);
+
+    uint8_t data[64];
+    memset(data, 'A', sizeof(data));
+
+    FAIL_IF(FileOpenFileWithId(ffc, &sbcfg, 0, (const uint8_t *)"f", 1, NULL, 0,
+                    FILE_NOMAGIC | FILE_NOMD5 | FILE_NOSHA1 | FILE_NOSHA256) != 0);
+    FAIL_IF_NULL(ffc->tail);
+
+    /* 0xAAAAAAAB * 3 is 1 when truncated to 32 bits */
+    FileSetInspectSizes(ffc->tail, 0xAAAAAAABU, 1);
+    FAIL_IF(FileAppendData(ffc, &sbcfg, data, sizeof(data)) != 0);
+
+    FilePrune(ffc, &sbcfg);
+
+    FAIL_IF_NULL(ffc->head);
+    FAIL_IF(ffc->head->content_inspected != 0);
+
+    FileContainerFree(ffc, &sbcfg);
+    g_detect_disabled = detect_disabled;
+    PASS;
+}
+
+void FileRegisterTests(void)
+{
+    UtRegisterTest("FilePruneInspectWindowOverflowTest", FilePruneInspectWindowOverflowTest);
+}
+#endif /* UNITTESTS */

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -267,6 +267,10 @@ void FilePrintFlags(const File *file);
 
 void FilesPrune(FileContainer *fc, const StreamingBufferConfig *sbcfg, const bool trunc);
 
+#ifdef UNITTESTS
+void FileRegisterTests(void);
+#endif
+
 #endif // SURICATA_BINDGEN_H
 
 #endif /* SURICATA_UTIL_FILE_H */


### PR DESCRIPTION
Ticket: [8678](https://redmine.openinfosecfoundation.org/issues/8678)

Replaces #15720.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8678

Describe changes:

In `FilePruneFile()` (`src/util-file.c`) the expression `window * 3` was computed in
uint32_t arithmetic before being compared with the uint64_t `data_size`. `window` is now
declared as uint64_t, as suggested by @lukashino, so the multiplication cannot wrap and no
cast is needed at the comparison.

### Why this matters

The `window * 3` guard is what makes the next line safe:

```c
if (data_size > (window * 3)) {
    file->content_inspected = MAX(file->content_inspected, file->size - window);
}
```

It guarantees `file->size > window`, so `file->size - window` does not underflow. When the
multiplication wraps, that guarantee is gone.

### Reachability

`content-inspect-window` is parsed with `ParseSizeStringU32()`, so any value up to
`UINT32_MAX` is accepted (`app-layer.protocols.smtp.content-inspect-window`, and the same
for HTTP `request-body-inspect-window` / `response-body-inspect-window`).

The worst case is not a large window but a specific one. With
`content-inspect-window: 2863311531` (`0xAAAAAAAB`):

```
0xAAAAAAAB * 3 = 0x200000001 -> 0x00000001 truncated to 32 bits
```

The threshold collapses from ~8 GB to **1 byte**, so it is met by any non-empty file.
`file->content_inspected` then becomes `file->size - 0xAAAAAAAB`, which underflows to
roughly 1.8e19 for any file smaller than 2.6 GB.

From there `content_inspected` is used in `FilePruneFile()` itself (`left_edge`) and in
`DetectFiledataInspect()` (`new_data = file_size - cur_file->content_inspected`, and the
offset computation below it), so file_data inspection stops working for the rest of the
file. So this is not only an incorrect limit, it silently disables inspection.

### Test

Because the threshold collapses to 1 byte, reproducing needs no large amount of data.
`FilePruneInspectWindowOverflowTest` opens a file, appends 64 bytes with an inspect window
of `0xAAAAAAAB` and checks that `content_inspected` stays 0. Without the fix it is
18446744070846240149.

`src/util-file.c` had no unit tests so far, so the test section and `FileRegisterTests()`
are added along with it.
