### PR TITLE
app-layer/smtp: set event when file data append fails

### DIFF
--- a/rules/smtp-events.rules
+++ b/rules/smtp-events.rules
@@ -31,4 +31,5 @@ alert smtp any any -> any any (msg:"SURICATA SMTP duplicate fields"; flow:establ
 alert smtp any any -> any any (msg:"SURICATA SMTP unparsable content"; flow:established,to_server; app-layer-event:smtp.unparsable_content; flowint:smtp.anomaly.count,+,1; classtype:protocol-command-decode; sid:2220019; rev:1;)
 alert smtp any any -> any any (msg:"SURICATA SMTP filename truncated"; flow:established,to_server; app-layer-event:smtp.mime_long_filename; flowint:smtp.anomaly.count,+,1; classtype:protocol-command-decode; sid:2220020; rev:1;)
 alert smtp any any -> any any (msg:"SURICATA SMTP failed protocol change"; flow:established,to_client; app-layer-event:smtp.failed_protocol_change; flowint:smtp.anomaly.count,+,1; classtype:protocol-command-decode; sid:2220021; rev:2;)
-# next sid 2220022
+alert smtp any any -> any any (msg:"SURICATA SMTP file data append failed"; flow:established,to_server; app-layer-event:smtp.file_append_failed; flowint:smtp.anomaly.count,+,1; classtype:protocol-command-decode; sid:2220022; rev:1;)
+# next sid 2220023

--- a/rust/src/mime/smtp.rs
+++ b/rust/src/mime/smtp.rs
@@ -182,6 +182,7 @@ pub const MIME_ANOM_LONG_HEADER_VALUE: u32 = 0x20;
 //unused pub const MIME_ANOM_MALFORMED_MSG: u32 = 0x40;
 pub const MIME_ANOM_LONG_BOUNDARY: u32 = 0x80;
 pub const MIME_ANOM_LONG_FILENAME: u32 = 0x100;
+pub const MIME_ANOM_FILE_APPEND_FAILED: u32 = 0x200;
 
 fn mime_smtp_process_headers(ctx: &mut MimeStateSMTP) -> (u32, bool) {
     let mut sections_values = Vec::new();
@@ -466,8 +467,11 @@ fn mime_smtp_parse_line(
                                 if base64::decode_rfc2045(decoder, &v, &mut dec, &mut dec_len)
                                     .is_ok()
                                 {
-                                    unsafe {
-                                        FileAppendData(ctx.files, ctx.sbcfg, dec.as_ptr(), dec_len);
+                                    if unsafe {
+                                        FileAppendData(ctx.files, ctx.sbcfg, dec.as_ptr(), dec_len)
+                                    } == -1
+                                    {
+                                        warnings |= MIME_ANOM_FILE_APPEND_FAILED;
                                     }
                                 }
                             }
@@ -479,9 +483,9 @@ fn mime_smtp_parse_line(
                     }
                     ctx.restart();
                     if toclose {
-                        return (MimeSmtpParserResult::MimeSmtpFileClose, 0);
+                        return (MimeSmtpParserResult::MimeSmtpFileClose, warnings);
                     }
-                    return (MimeSmtpParserResult::MimeSmtpNeedsMore, 0);
+                    return (MimeSmtpParserResult::MimeSmtpNeedsMore, warnings);
                 }
             }
             if ctx.filename.is_empty() {
@@ -525,17 +529,22 @@ fn mime_smtp_parse_line(
                 MimeSmtpEncoding::Plain => {
                     mime_smtp_find_url_strings(ctx, full);
                     if ctx.bufeolen > 0 {
-                        unsafe {
+                        if unsafe {
                             FileAppendData(
                                 ctx.files,
                                 ctx.sbcfg,
                                 ctx.bufeol.as_ptr(),
                                 ctx.bufeol.len() as u32,
-                            );
+                            )
+                        } == -1
+                        {
+                            warnings |= MIME_ANOM_FILE_APPEND_FAILED;
                         }
                     }
-                    unsafe {
-                        FileAppendData(ctx.files, ctx.sbcfg, i.as_ptr(), i.len() as u32);
+                    if unsafe { FileAppendData(ctx.files, ctx.sbcfg, i.as_ptr(), i.len() as u32) }
+                        == -1
+                    {
+                        warnings |= MIME_ANOM_FILE_APPEND_FAILED;
                     }
                     ctx.bufeolen = (full.len() - i.len()) as u8;
                     if ctx.bufeolen > 0 {
@@ -555,8 +564,11 @@ fn mime_smtp_parse_line(
                             let mut dec_len = 0;
                             if base64::decode_rfc2045(decoder, i, &mut dec, &mut dec_len).is_ok() {
                                 mime_smtp_find_url_strings(ctx, &dec);
-                                unsafe {
-                                    FileAppendData(ctx.files, ctx.sbcfg, dec.as_ptr(), dec_len);
+                                if unsafe {
+                                    FileAppendData(ctx.files, ctx.sbcfg, dec.as_ptr(), dec_len)
+                                } == -1
+                                {
+                                    warnings |= MIME_ANOM_FILE_APPEND_FAILED;
                                 }
                             } else {
                                 warnings |= MIME_ANOM_INVALID_BASE64;
@@ -639,13 +651,16 @@ fn mime_smtp_parse_line(
                             quoted_buffer.extend_from_slice(&full[i.len()..]);
                         }
                         mime_smtp_find_url_strings(ctx, &quoted_buffer);
-                        unsafe {
+                        if unsafe {
                             FileAppendData(
                                 ctx.files,
                                 ctx.sbcfg,
                                 quoted_buffer.as_ptr(),
                                 quoted_buffer.len() as u32,
-                            );
+                            )
+                        } == -1
+                        {
+                            warnings |= MIME_ANOM_FILE_APPEND_FAILED;
                         }
                     }
                 }

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -150,6 +150,7 @@ SCEnumCharMap smtp_decoder_event_table[] = {
     { "DUPLICATE_FIELDS", SMTP_DECODER_EVENT_DUPLICATE_FIELDS },
     { "UNPARSABLE_CONTENT", SMTP_DECODER_EVENT_UNPARSABLE_CONTENT },
     { "TRUNCATED_LINE", SMTP_DECODER_EVENT_TRUNCATED_LINE },
+    { "FILE_APPEND_FAILED", SMTP_DECODER_EVENT_FILE_APPEND_FAILED },
     { NULL, -1 },
 };
 
@@ -851,7 +852,11 @@ static int SMTPProcessCommandDATA(
     } else if (smtp_config.raw_extraction) {
         // message not over, store the line. This is a substitution of
         // ProcessDataChunk
-        FileAppendData(&tx->files_ts, &smtp_config.sbcfg, line->buf, line->len + line->delim_len);
+        // -2 means the file is not stored, which is not an error
+        if (FileAppendData(&tx->files_ts, &smtp_config.sbcfg, line->buf,
+                    line->len + line->delim_len) == -1) {
+            SMTPSetEvent(state, SMTP_DECODER_EVENT_FILE_APPEND_FAILED);
+        }
     }
 
     /* If DATA, then parse out a MIME message */

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -785,6 +785,9 @@ static void SetMimeEvents(SMTPState *state, uint32_t events)
     if (events & MIME_ANOM_LONG_FILENAME) {
         SMTPSetEvent(state, SMTP_DECODER_EVENT_MIME_LONG_FILENAME);
     }
+    if (events & MIME_ANOM_FILE_APPEND_FAILED) {
+        SMTPSetEvent(state, SMTP_DECODER_EVENT_FILE_APPEND_FAILED);
+    }
 }
 
 static inline void SMTPTransactionComplete(SMTPTransaction *tx)

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -61,6 +61,8 @@ enum {
     SMTP_DECODER_EVENT_UNPARSABLE_CONTENT,
     /* For line >= 4KB */
     SMTP_DECODER_EVENT_TRUNCATED_LINE,
+    /* File data could not be appended, extraction is incomplete */
+    SMTP_DECODER_EVENT_FILE_APPEND_FAILED,
 };
 
 typedef struct SMTPString_ {


### PR DESCRIPTION
Ticket: [8679](https://redmine.openinfosecfoundation.org/issues/8679)

Replaces #15721.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8679

Describe changes:

v1 only logged the ignored `FileAppendData()` return value. Following @catenacyber's
suggestion this now sets a decoder event instead, and following @lukashino's comment the
Rust callers are covered as well.

- New `smtp.file_append_failed` event, with a rule in `rules/smtp-events.rules`.
- `SMTPProcessCommandDATA()` sets it when `FileAppendData()` returns -1 in the
  raw extraction branch. -2 means "no store for this file", which is normal operation,
  so it does not raise the event.
- `rust/src/mime/smtp.rs` ignored the return value in five places. They now raise
  `MIME_ANOM_FILE_APPEND_FAILED`, which `SetMimeEvents()` maps to the same event. Two
  `return` statements on the boundary path returned a hardcoded `0` for the warnings, they
  now return the accumulated value so a failure on the base64 flush path is not lost.
  Nothing else assigns to `warnings` between the start of the `MimeSmtpBody` arm and those
  returns, so this only adds the new flag and does not change what is reported today.

### What this gives us

When the append fails the file goes to `FILE_STATE_ERROR` (or is already truncated), so
extraction and inspection stop there. Right now nothing surfaces that: the logs of a mail
whose attachment was cut short look exactly like the logs of a fully extracted one, and
file_data based rules silently have less data to match on. The event makes that visible.

The -1 return is reached when the file is no longer in `FILE_STATE_OPENED` while still being
stored, for example after `FileTruncateAllOpenFiles()` on reassembly depth or memcap, and
when `StreamingBufferAppend()` fails under memory pressure.

I did not add a test for this one, since triggering the failure needs a truncation or an
allocation failure scenario rather than a specific input. Happy to add a suricata-verify
test with a small `stream.reassembly.depth` if you want one.

### Left out on purpose

`rust/src/filecontainer.rs` `file_append()` already returns the result of
`FileAppendDataById()` to its callers. Whether every caller acts on it is a separate
question from this ticket, so I left it alone rather than growing the scope here.
