### PR TITLE
dag: check rlen is a valid length

### DIFF
--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -403,6 +403,12 @@ ProcessErfDagRecords(ErfDagThreadVars *ewtn, uint8_t *top, uint32_t *pkts_read)
         rlen = SCNtohs(dr->rlen);
         hdr_type = dr->type;
 
+        if (rlen < dag_record_size) {
+            SCLogError("Bad ERF record length %d (< dag_record_size) on stream: %d, DAG: %s",
+                    rlen, ewtn->dagstream, ewtn->dagname);
+            SCReturnInt(TM_ECODE_FAILED);
+        }
+
         /* If we don't have enough data to finish processing this ERF
          * record return and maybe next time we will.
          */


### PR DESCRIPTION
Ticket: 8797

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [X] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [X] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [X] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8797

Describe changes:
- Add check to rlen value read from ERF record to avoid potential infinite loop, must be >= dag_record_length (16)
- Similar check exists in source_erf_file already

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
