### PR TITLE
Dcerpc is fragmented/v2

### DIFF
--- a/doc/userguide/rules/dcerpc-keywords.rst
+++ b/doc/userguide/rules/dcerpc-keywords.rst
@@ -68,6 +68,21 @@ Example::
 
   dcerpc.stub_data; content:"123456";
 
+dcerpc.is_fragmented
+--------------------
+
+Match on whether a DCERPC PDU is fragmented. It takes a boolean value.
+
+Syntax::
+
+  dcerpc.is_fragmented: true|false;
+
+Example:
+
+.. container:: example-rule
+
+  alert dcerpc any any -> any any (:example-rule-options:`dcerpc.is_fragmented: true;` sid: 1;)
+
 
 Additional information
 ----------------------

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -205,6 +205,8 @@ pub struct DCERPCTransaction {
     pub resp_lost: bool,
     pub req_cmd: u8,
     pub resp_cmd: u8,
+    pub req_flags: u16,
+    pub resp_flags: u16,
     pub activityuuid: Vec<u8>,
     pub seqnum: u32,
     pub tx_data: AppLayerTxData,
@@ -585,6 +587,7 @@ impl DCERPCState {
                 }
                 let mut tx = self.create_tx(hdr);
                 tx.req_cmd = hdr.hdrtype;
+                tx.req_flags = hdr.pfc_flags as u16;
                 tx.req_done = true;
                 if let Some(flow) = self.flow {
                     sc_app_layer_parser_trigger_raw_stream_inspection(
@@ -762,6 +765,7 @@ impl DCERPCState {
                 match transaction {
                     Some(ref mut tx) => {
                         tx.req_cmd = hdr_type;
+                        tx.req_flags = hdr.pfc_flags as u16;
                         tx.ctxid = request.ctxid;
                         tx.opnum = request.opnum;
                         tx.first_request_seen = request.first_request_seen;
@@ -769,6 +773,7 @@ impl DCERPCState {
                     None => {
                         let mut tx = self.create_tx(hdr);
                         tx.req_cmd = hdr_type;
+                        tx.req_flags = hdr.pfc_flags as u16;
                         tx.ctxid = request.ctxid;
                         tx.opnum = request.opnum;
                         tx.first_request_seen = request.first_request_seen;
@@ -949,10 +954,12 @@ impl DCERPCState {
                         self.get_tx_by_call_id(current_call_id, Direction::ToClient, hdrtype)
                     {
                         tx.resp_cmd = hdrtype;
+                        tx.resp_flags = hdr.pfc_flags as u16;
                         tx
                     } else {
                         let mut tx = self.create_tx(&hdr);
                         tx.resp_cmd = hdrtype;
+                        tx.resp_flags = hdr.pfc_flags as u16;
                         self.transactions.push_back(tx);
                         self.transactions.back_mut().unwrap()
                     };
@@ -980,10 +987,12 @@ impl DCERPCState {
                     match transaction {
                         Some(tx) => {
                             tx.resp_cmd = hdrtype;
+                            tx.resp_flags = hdr.pfc_flags as u16;
                         }
                         None => {
                             let mut tx = self.create_tx(&hdr);
                             tx.resp_cmd = hdrtype;
+                            tx.resp_flags = hdr.pfc_flags as u16;
                             self.transactions.push_back(tx);
                         }
                     };

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -190,6 +190,7 @@ impl DCERPCUDPState {
             let max_size = cfg_max_stub_size() as usize;
             match hdr.pkt_type {
                 DCERPC_TYPE_REQUEST => {
+                    tx.req_flags = (hdr.flags1 as u16) | ((hdr.flags2 as u16) << 8);
                     tx.frag_cnt_ts = tx.frag_cnt_ts.saturating_add(1);
                     if input.len() + tx.stub_data_buffer_ts.len() < max_size {
                         tx.stub_data_buffer_ts.extend_from_slice(input);
@@ -203,6 +204,7 @@ impl DCERPCUDPState {
                     return true;
                 }
                 DCERPC_TYPE_RESPONSE => {
+                    tx.resp_flags = (hdr.flags1 as u16) | ((hdr.flags2 as u16) << 8);
                     tx.frag_cnt_tc = tx.frag_cnt_tc.saturating_add(1);
                     if input.len() + tx.stub_data_buffer_tc.len() < max_size {
                         tx.stub_data_buffer_tc.extend_from_slice(input);

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -17,7 +17,7 @@
 
 use super::dcerpc::{
     DCERPCState, DCERPCTransaction, ALPROTO_DCERPC, DCERPC_TYPE_REQUEST, DCERPC_TYPE_RESPONSE,
-    DCERPC_UUID_ENTRY_FLAG_FF,
+    DCERPC_UUID_ENTRY_FLAG_FF, PFCL1_FRAG, PFC_FIRST_FRAG, PFC_LAST_FRAG,
 };
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{detect_match_uint, detect_parse_uint, DetectUintData};
@@ -393,6 +393,95 @@ unsafe extern "C" fn dcerpc_opnum_free(_de: *mut DetectEngineCtx, ptr: *mut c_vo
     }
 }
 
+#[derive(Debug)]
+pub struct DCERPCIsFragmentedData {
+    pub is_fragmented: bool,
+}
+
+fn parse_is_fragmented(arg: &str) -> Option<bool> {
+    match arg.trim().to_ascii_lowercase().as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+unsafe fn dcerpc_is_fragmented_parse(carg: *const c_char) -> *mut c_void {
+    let arg = match CStr::from_ptr(carg).to_str() {
+        Ok(arg) => arg,
+        Err(_) => {
+            return std::ptr::null_mut();
+        }
+    };
+    match parse_is_fragmented(arg) {
+        Some(is_fragmented) => {
+            Box::into_raw(Box::new(DCERPCIsFragmentedData { is_fragmented })) as *mut c_void
+        }
+        None => std::ptr::null_mut(),
+    }
+}
+
+unsafe extern "C" fn dcerpc_is_fragmented_match(
+    _de: *mut DetectEngineThreadCtx, _f: *mut crate::flow::Flow, flags: u8, _state: *mut c_void,
+    tx: *mut c_void, _sig: *const Signature, ctx: *const SigMatchCtx,
+) -> c_int {
+    let tx = cast_pointer!(tx, DCERPCTransaction);
+    let ctx = cast_pointer!(ctx, DCERPCIsFragmentedData);
+
+    let (frag_cnt, tx_flags) = if flags & STREAM_TOSERVER != 0 {
+        (tx.frag_cnt_ts, tx.req_flags)
+    } else {
+        (tx.frag_cnt_tc, tx.resp_flags)
+    };
+    // hack to tell if it's UDP
+    let fragmented = if !tx.activityuuid.is_empty() {
+        // For UDP, the flags1 fragment bit (0x04) explicitly marks a fragment
+        tx_flags & PFCL1_FRAG as u16 != 0
+    } else {
+        // For TCP, a request/response PDU is a single complete message only
+        // when it sets both PFC_FIRST_FRAG and PFC_LAST_FRAG; any PDU missing
+        // either flag (first, middle or last fragment) is fragmented. The
+        // frag_cnt guard keeps a direction that has seen no PDU from matching.
+        let both = (PFC_FIRST_FRAG | PFC_LAST_FRAG) as u16;
+        frag_cnt > 0 && (tx_flags & both) != both
+    };
+    if fragmented == ctx.is_fragmented {
+        return 1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn dcerpc_is_fragmented_setup(
+    de: *mut DetectEngineCtx, s: *mut Signature, raw: *const libc::c_char,
+) -> c_int {
+    if SCDetectSignatureSetAppProto(s, ALPROTO_DCERPC) != 0 {
+        return -1;
+    }
+    let ctx = dcerpc_is_fragmented_parse(raw);
+    if ctx.is_null() {
+        return -1;
+    }
+    if SCSigMatchAppendSMToList(
+        de,
+        s,
+        G_DCERPC_IS_FRAGMENTED_KW_ID,
+        ctx as *mut SigMatchCtx,
+        G_DCERPC_GENERIC_BUFFER_ID,
+    )
+    .is_null()
+    {
+        dcerpc_is_fragmented_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn dcerpc_is_fragmented_free(_de: *mut DetectEngineCtx, ptr: *mut c_void) {
+    if !ptr.is_null() {
+        std::mem::drop(Box::from_raw(ptr as *mut DCERPCIsFragmentedData));
+    }
+}
+
 unsafe extern "C" fn dcerpc_stub_data_setup(
     de_ctx: *mut DetectEngineCtx, s: *mut Signature, _str: *const c_char,
 ) -> c_int {
@@ -440,6 +529,7 @@ unsafe extern "C" fn dcerpc_tx_get_stub_data(
 }
 
 static mut G_DCERPC_OPNUM_KW_ID: u16 = 0;
+static mut G_DCERPC_IS_FRAGMENTED_KW_ID: u16 = 0;
 static mut G_DCERPC_GENERIC_BUFFER_ID: c_int = 0;
 static mut G_DCERPC_IFACE_KW_ID: u16 = 0;
 static mut G_DCERPC_STUB_BUFFER_ID: c_int = 0;
@@ -473,6 +563,17 @@ pub unsafe extern "C" fn SCDetectDcerpcRegister() {
         G_DCERPC_OPNUM_KW_ID,
         b"dce_opnum\0".as_ptr() as *const libc::c_char,
     );
+
+    let kw = SCSigTableAppLiteElmt {
+        name: b"dcerpc.is_fragmented\0".as_ptr() as *const libc::c_char,
+        desc: b"match if the DCERPC PDU is fragmented\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/dcerpc-keywords.html#dcerpc-is-fragmented\0".as_ptr() as *const libc::c_char,
+        AppLayerTxMatch: Some(dcerpc_is_fragmented_match),
+        Setup: Some(dcerpc_is_fragmented_setup),
+        Free: Some(dcerpc_is_fragmented_free),
+        flags: 0,
+    };
+    G_DCERPC_IS_FRAGMENTED_KW_ID = SCDetectHelperKeywordRegister(&kw);
 
     let kw = SCSigTableAppLiteElmt {
         name: b"dcerpc.iface\0".as_ptr() as *const libc::c_char,


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/15956

Changes since v1:
- rebased on top of latest main
- changed syntax to true|false instead of the entire list of acceptable booleans

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8736

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3276