### PR TITLE
Smb raw inspection/v6

### DIFF
--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -17,7 +17,10 @@
 
 // written by Victor Julien
 
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
 use crate::dcerpc::dcerpc::*;
+use crate::direction::Direction;
+use crate::flow::Flow;
 use crate::smb::dcerpc_records::*;
 use crate::smb::events::*;
 use crate::smb::smb::{cfg_max_stub_size, *};
@@ -180,7 +183,7 @@ impl SMBState {
 /// return bool indicating whether an tx has been created/updated.
 ///
 pub fn smb_write_dcerpc_record(
-    state: &mut SMBState, vercmd: SMBVerCmdStat, hdr: SMBCommonHdr, data: &[u8],
+    state: &mut SMBState, flow: *mut Flow, vercmd: SMBVerCmdStat, hdr: SMBCommonHdr, data: &[u8],
 ) -> bool {
     let mut bind_ifaces: Option<Vec<DCERPCIface>> = None;
     let mut is_bind = false;
@@ -228,6 +231,10 @@ pub fn smb_write_dcerpc_record(
                                 if dcer.last_frag {
                                     SCLogDebug!("last frag set, so request side of DCERPC closed");
                                     tx.request_done = true;
+                                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                                        flow,
+                                        Direction::ToServer as i32,
+                                    );
                                 } else {
                                     SCLogDebug!(
                                         "NOT last frag, so request side of DCERPC remains open"
@@ -280,6 +287,10 @@ pub fn smb_write_dcerpc_record(
                             }
                             if dcer.last_frag {
                                 tx.request_done = true;
+                                sc_app_layer_parser_trigger_raw_stream_inspection(
+                                    flow,
+                                    Direction::ToServer as i32,
+                                );
                             } else {
                                 SCLogDebug!(
                                     "NOT last frag, so request side of DCERPC remains open"
@@ -289,6 +300,10 @@ pub fn smb_write_dcerpc_record(
                         _ => {
                             tx.set_event(SMBEvent::MalformedData);
                             tx.request_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                flow,
+                                Direction::ToServer as i32,
+                            );
                         }
                     }
                 }
@@ -350,14 +365,26 @@ pub fn smb_write_dcerpc_record(
                         }
                     }
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToServer as i32,
+                    );
                 }
                 21..=255 => {
                     tx.set_event(SMBEvent::MalformedData);
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToServer as i32,
+                    );
                 }
                 _ => {
                     // valid type w/o special processing
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToServer as i32,
+                    );
                 }
             }
         }
@@ -379,8 +406,8 @@ pub fn smb_write_dcerpc_record(
 /// Update TX for bind ack. Needs to update both tx and state.
 ///
 fn smb_dcerpc_response_bindack(
-    state: &mut SMBState, vercmd: SMBVerCmdStat, hdr: SMBCommonHdr, dcer: &DceRpcRecord,
-    ntstatus: u32,
+    state: &mut SMBState, flow: *mut Flow, vercmd: SMBVerCmdStat, hdr: SMBCommonHdr,
+    dcer: &DceRpcRecord, ntstatus: u32,
 ) {
     match parse_dcerpc_bindack_record(dcer.data) {
         Ok((_, bindackr)) => {
@@ -393,6 +420,10 @@ fn smb_dcerpc_response_bindack(
                     }
                     tx.vercmd.set_ntstatus(ntstatus);
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToClient as i32,
+                    );
                     true
                 }
                 None => false,
@@ -417,7 +448,7 @@ fn smb_dcerpc_response_bindack(
 }
 
 fn smb_read_dcerpc_record_error(
-    state: &mut SMBState, hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, ntstatus: u32,
+    state: &mut SMBState, flow: *mut Flow, hdr: SMBCommonHdr, vercmd: SMBVerCmdStat, ntstatus: u32,
 ) -> bool {
     let ver = vercmd.get_version();
     let cmd = if ver == 2 {
@@ -433,6 +464,7 @@ fn smb_read_dcerpc_record_error(
             SCLogDebug!("found");
             tx.set_status(ntstatus, false);
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
             true
         }
         None => {
@@ -443,7 +475,9 @@ fn smb_read_dcerpc_record_error(
     return found;
 }
 
-fn dcerpc_response_handle(tx: &mut SMBTransaction, vercmd: SMBVerCmdStat, dcer: &DceRpcRecord) {
+fn dcerpc_response_handle(
+    flow: *mut Flow, tx: &mut SMBTransaction, vercmd: SMBVerCmdStat, dcer: &DceRpcRecord,
+) {
     let (_, ntstatus) = vercmd.get_ntstatus();
     match dcer.packet_type {
         DCERPC_TYPE_RESPONSE => match parse_dcerpc_response_record(dcer.data, dcer.frag_len) {
@@ -463,6 +497,12 @@ fn dcerpc_response_handle(tx: &mut SMBTransaction, vercmd: SMBVerCmdStat, dcer: 
                 }
                 tx.vercmd.set_ntstatus(ntstatus);
                 tx.response_done = dcer.last_frag;
+                if dcer.last_frag {
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToClient as i32,
+                    );
+                }
             }
             _ => {
                 tx.set_event(SMBEvent::MalformedData);
@@ -477,6 +517,7 @@ fn dcerpc_response_handle(tx: &mut SMBTransaction, vercmd: SMBVerCmdStat, dcer: 
             }
             tx.vercmd.set_ntstatus(ntstatus);
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
             tx.set_event(SMBEvent::MalformedData);
         }
         _ => {
@@ -486,6 +527,7 @@ fn dcerpc_response_handle(tx: &mut SMBTransaction, vercmd: SMBVerCmdStat, dcer: 
             }
             tx.vercmd.set_ntstatus(ntstatus);
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
         }
     }
 }
@@ -493,12 +535,13 @@ fn dcerpc_response_handle(tx: &mut SMBTransaction, vercmd: SMBVerCmdStat, dcer: 
 /// Handle DCERPC reply record. Called for READ, TRANS, IOCTL
 ///
 pub fn smb_read_dcerpc_record(
-    state: &mut SMBState, vercmd: SMBVerCmdStat, hdr: SMBCommonHdr, guid: &[u8], indata: &[u8],
+    state: &mut SMBState, flow: *mut Flow, vercmd: SMBVerCmdStat, hdr: SMBCommonHdr, guid: &[u8],
+    indata: &[u8],
 ) -> bool {
     let (_, ntstatus) = vercmd.get_ntstatus();
 
     if ntstatus != SMB_NTSTATUS_SUCCESS && ntstatus != SMB_NTSTATUS_BUFFER_OVERFLOW {
-        return smb_read_dcerpc_record_error(state, hdr, vercmd, ntstatus);
+        return smb_read_dcerpc_record_error(state, flow, hdr, vercmd, ntstatus);
     }
 
     SCLogDebug!("lets first see if we have prior data");
@@ -540,13 +583,13 @@ pub fn smb_read_dcerpc_record(
                 }
 
                 if dcer.packet_type == DCERPC_TYPE_BINDACK {
-                    smb_dcerpc_response_bindack(state, vercmd, hdr, &dcer, ntstatus);
+                    smb_dcerpc_response_bindack(state, flow, vercmd, hdr, &dcer, ntstatus);
                     return true;
                 }
 
                 let found = match state.get_dcerpc_tx(&hdr, &vercmd, dcer.call_id) {
                     Some(tx) => {
-                        dcerpc_response_handle(tx, vercmd.clone(), &dcer);
+                        dcerpc_response_handle(flow, tx, vercmd.clone(), &dcer);
                         true
                     }
                     None => {
@@ -561,7 +604,7 @@ pub fn smb_read_dcerpc_record(
                     else {
                         return false;
                     };
-                    dcerpc_response_handle(tx, vercmd, &dcer);
+                    dcerpc_response_handle(flow, tx, vercmd, &dcer);
                 }
             }
             _ => {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1128,14 +1128,22 @@ impl SMBState {
         (name, is_dcerpc)
     }
 
-    fn post_gap_housekeeping_for_files(&mut self) {
+    fn post_gap_housekeeping_for_files(&mut self, flow: *mut Flow) {
         let mut post_gap_txs = false;
         for tx in &mut self.transactions {
             if let Some(SMBTransactionTypeData::FILE(ref mut f)) = tx.type_data {
                 if f.post_gap_ts > 0 {
                     if self.ts > f.post_gap_ts {
                         tx.request_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(
+                            flow,
+                            Direction::ToServer as i32,
+                        );
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(
+                            flow,
+                            Direction::ToClient as i32,
+                        );
                         filetracker_trunc(&mut f.file_tracker);
                     } else {
                         post_gap_txs = true;
@@ -1151,7 +1159,7 @@ impl SMBState {
      * can handle gaps. For the file transactions we set the current
      * (flow) time and prune them in 60 seconds if no update for them
      * was received. */
-    fn post_gap_housekeeping(&mut self, dir: Direction) {
+    fn post_gap_housekeeping(&mut self, flow: *mut Flow, dir: Direction) {
         if self.ts_ssn_gap && dir == Direction::ToServer {
             for tx in &mut self.transactions {
                 if tx.id >= self.tx_id {
@@ -1168,6 +1176,10 @@ impl SMBState {
                 } else {
                     SCLogDebug!("post_gap_housekeeping: tx {} marked as done TS", tx.id);
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToServer as i32,
+                    );
                 }
             }
         } else if self.tc_ssn_gap && dir == Direction::ToClient {
@@ -1186,7 +1198,15 @@ impl SMBState {
                 } else {
                     SCLogDebug!("post_gap_housekeeping: tx {} marked as done TC", tx.id);
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToServer as i32,
+                    );
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToClient as i32,
+                    );
                 }
             }
         }
@@ -1452,6 +1472,7 @@ impl SMBState {
                                     nbss_part_hdr.length - nbss_part_hdr.data.len() as u32;
                                 smb1_write_request_record(
                                     self,
+                                    flow,
                                     r,
                                     SMB1_HEADER_SIZE,
                                     SMB1_COMMAND_WRITE_ANDX,
@@ -1497,7 +1518,7 @@ impl SMBState {
                                 // stay within the NBSS record.
                                 let nbss_remaining =
                                     nbss_part_hdr.length - nbss_part_hdr.data.len() as u32;
-                                smb2_write_request_record(self, smb_record, nbss_remaining);
+                                smb2_write_request_record(self, flow, smb_record, nbss_remaining);
 
                                 self.add_nbss_ts_frames(
                                     flow,
@@ -1635,7 +1656,7 @@ impl SMBState {
                                                 nbss_hdr.length as i64,
                                             );
                                             if smb_record.is_request() {
-                                                smb1_request_record(self, smb_record);
+                                                smb1_request_record(self, flow, smb_record);
                                             } else {
                                                 // If we received a response when expecting a request, set an event
                                                 // on the PDU frame instead of handling the response.
@@ -1686,7 +1707,7 @@ impl SMBState {
                                                     nbss_data_rem.len()
                                                 );
                                                 if smb_record.is_request() {
-                                                    smb2_request_record(self, smb_record);
+                                                    smb2_request_record(self, flow, smb_record);
                                                 } else {
                                                     // If we received a response when expecting a request, set an event
                                                     // on the PDU frame instead of handling the response.
@@ -1800,9 +1821,9 @@ impl SMBState {
             }
         }
 
-        self.post_gap_housekeeping(Direction::ToServer);
+        self.post_gap_housekeeping(flow, Direction::ToServer);
         if self.check_post_gap_file_txs && !self.post_gap_files_checked {
-            self.post_gap_housekeeping_for_files();
+            self.post_gap_housekeeping_for_files(flow);
             self.post_gap_files_checked = true;
         }
         AppLayerResult::ok()
@@ -2035,6 +2056,7 @@ impl SMBState {
                                     nbss_part_hdr.length - nbss_part_hdr.data.len() as u32;
                                 smb1_read_response_record(
                                     self,
+                                    flow,
                                     r,
                                     SMB1_HEADER_SIZE,
                                     nbss_remaining,
@@ -2081,7 +2103,7 @@ impl SMBState {
                                 // stay within the NBSS record.
                                 let nbss_remaining =
                                     nbss_part_hdr.length - nbss_part_hdr.data.len() as u32;
-                                smb2_read_response_record(self, smb_record, nbss_remaining);
+                                smb2_read_response_record(self, flow, smb_record, nbss_remaining);
                                 let consumed = input.len() - output.len();
                                 return consumed;
                             }
@@ -2197,7 +2219,7 @@ impl SMBState {
                                             // see https://github.com/rust-lang/rust-clippy/issues/15158
                                             #[allow(clippy::collapsible_else_if)]
                                             if smb_record.is_response() {
-                                                smb1_response_record(self, smb_record);
+                                                smb1_response_record(self, flow, smb_record);
                                             } else {
                                                 SCLogDebug!(
                                                     "SMB1 request seen from server to client"
@@ -2240,7 +2262,7 @@ impl SMBState {
                                                 // see https://github.com/rust-lang/rust-clippy/issues/15158
                                                 #[allow(clippy::collapsible_else_if)]
                                                 if smb_record.is_response() {
-                                                    smb2_response_record(self, smb_record);
+                                                    smb2_response_record(self, flow, smb_record);
                                                 } else {
                                                     SCLogDebug!(
                                                         "SMB2 request seen from server to client"
@@ -2343,9 +2365,9 @@ impl SMBState {
                 }
             }
         }
-        self.post_gap_housekeeping(Direction::ToClient);
+        self.post_gap_housekeeping(flow, Direction::ToClient);
         if self.check_post_gap_file_txs && !self.post_gap_files_checked {
-            self.post_gap_housekeeping_for_files();
+            self.post_gap_housekeeping_for_files(flow);
             self.post_gap_files_checked = true;
         }
         self._debug_tx_stats();

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -19,7 +19,9 @@
  * - check all parsers for calls on non-SUCCESS status
  */
 
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
 use crate::direction::Direction;
+use crate::flow::Flow;
 use crate::smb::dcerpc::*;
 use crate::smb::events::*;
 use crate::smb::files::*;
@@ -148,7 +150,7 @@ pub fn smb1_check_tx(cmd: u8) -> bool {
     }
 }
 
-fn smb1_close_file(state: &mut SMBState, fid: &[u8], direction: Direction) {
+fn smb1_close_file(state: &mut SMBState, flow: *mut Flow, fid: &[u8], direction: Direction) {
     if let Some(tx) = state.get_file_tx_by_fuid(fid, direction) {
         SCLogDebug!("found tx {}", tx.id);
         if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
@@ -156,7 +158,9 @@ fn smb1_close_file(state: &mut SMBState, fid: &[u8], direction: Direction) {
                 SCLogDebug!("closing file tx {} FID {:?}", tx.id, fid);
                 filetracker_close(&mut tdf.file_tracker);
                 tx.request_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 tx.response_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                 SCLogDebug!("tx {} is done", tx.id);
             }
         }
@@ -182,7 +186,7 @@ fn smb1_command_is_andx(c: u8) -> bool {
 }
 
 fn smb1_request_record_one(
-    state: &mut SMBState, r: &SmbRecord, command: u8, andx_offset: &mut usize,
+    state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, command: u8, andx_offset: &mut usize,
 ) {
     let mut events: Vec<SMBEvent> = Vec::new();
     let mut no_response_expected = false;
@@ -203,6 +207,7 @@ fn smb1_request_record_one(
                 };
                 tx.hdr = tx_hdr;
                 tx.request_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 tx.vercmd.set_smb1_cmd(SMB1_COMMAND_RENAME);
                 true
             }
@@ -245,6 +250,10 @@ fn smb1_request_record_one(
                                             };
                                             tx.hdr = tx_hdr;
                                             tx.request_done = true;
+                                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                                flow,
+                                                Direction::ToServer as i32,
+                                            );
                                             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TRANS2);
                                             true
                                         }
@@ -285,6 +294,10 @@ fn smb1_request_record_one(
                                             };
                                             tx.hdr = tx_hdr;
                                             tx.request_done = true;
+                                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                                flow,
+                                                Direction::ToServer as i32,
+                                            );
                                             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TRANS2);
                                             true
                                         }
@@ -358,6 +371,10 @@ fn smb1_request_record_one(
                                             };
                                             tx.hdr = tx_hdr;
                                             tx.request_done = true;
+                                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                                flow,
+                                                Direction::ToServer as i32,
+                                            );
                                             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TRANS2);
                                             true
                                         }
@@ -406,6 +423,10 @@ fn smb1_request_record_one(
                                             };
                                             tx.hdr = tx_hdr;
                                             tx.request_done = true;
+                                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                                flow,
+                                                Direction::ToServer as i32,
+                                            );
                                             tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TRANS2);
                                             true
                                         }
@@ -476,11 +497,11 @@ fn smb1_request_record_one(
             false
         }
         SMB1_COMMAND_WRITE_ANDX | SMB1_COMMAND_WRITE | SMB1_COMMAND_WRITE_AND_CLOSE => {
-            smb1_write_request_record(state, r, *andx_offset, command, 0);
+            smb1_write_request_record(state, flow, r, *andx_offset, command, 0);
             true // tx handling in func
         }
         SMB1_COMMAND_TRANS => {
-            smb1_trans_request_record(state, r);
+            smb1_trans_request_record(state, flow, r);
             true
         }
         SMB1_COMMAND_NEGOTIATE_PROTOCOL => match parse_smb1_negotiate_protocol_record(r.data) {
@@ -517,6 +538,10 @@ fn smb1_request_record_one(
                         tdn.dialects = dialects;
                     }
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToServer as i32,
+                    );
                     if bad_dialects {
                         tx.set_event(SMBEvent::NegotiateMalformedDialects);
                     }
@@ -550,6 +575,10 @@ fn smb1_request_record_one(
                         return;
                     };
                     tx.vercmd.set_smb1_cmd(command);
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToServer as i32,
+                    );
                     SCLogDebug!("TS CREATE TX {} created", tx.id);
                     true
                 }
@@ -561,7 +590,7 @@ fn smb1_request_record_one(
         }
         SMB1_COMMAND_SESSION_SETUP_ANDX => {
             SCLogDebug!("SMB1_COMMAND_SESSION_SETUP_ANDX user_id {}", r.user_id);
-            smb1_session_setup_request(state, r, *andx_offset);
+            smb1_session_setup_request(state, flow, r, *andx_offset);
             true
         }
         SMB1_COMMAND_TREE_CONNECT_ANDX => {
@@ -584,6 +613,10 @@ fn smb1_request_record_one(
                         tdn.req_service = Some(tr.service.to_vec());
                     }
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToServer as i32,
+                    );
                     tx.vercmd.set_smb1_cmd(SMB1_COMMAND_TREE_CONNECT_ANDX);
                     true
                 }
@@ -610,7 +643,7 @@ fn smb1_request_record_one(
                         .put(SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID), fid.to_vec());
 
                     SCLogDebug!("closing FID {:?}/{:?}", cd.fid, fid);
-                    smb1_close_file(state, &fid, Direction::ToServer);
+                    smb1_close_file(state, flow, &fid, Direction::ToServer);
                 }
                 _ => {
                     events.push(SMBEvent::MalformedData);
@@ -648,6 +681,7 @@ fn smb1_request_record_one(
         let Some(tx) = state.new_generic_tx(1, command as u16, tx_key) else {
             return;
         };
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
         SCLogDebug!(
             "tx {} created for {}/{}",
             tx.id,
@@ -657,17 +691,18 @@ fn smb1_request_record_one(
         tx.set_events(events);
         if no_response_expected {
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
         }
     }
 }
 
-pub fn smb1_request_record(state: &mut SMBState, r: &SmbRecord) -> u32 {
+pub fn smb1_request_record(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord) -> u32 {
     SCLogDebug!("record: command {}: record {:?}", r.command, r);
 
     let mut andx_offset = SMB1_HEADER_SIZE;
     let mut command = r.command;
     loop {
-        smb1_request_record_one(state, r, command, &mut andx_offset);
+        smb1_request_record_one(state, flow, r, command, &mut andx_offset);
 
         // continue for next andx command if any
         if smb1_command_is_andx(command) {
@@ -691,7 +726,7 @@ pub fn smb1_request_record(state: &mut SMBState, r: &SmbRecord) -> u32 {
 }
 
 fn smb1_response_record_one(
-    state: &mut SMBState, r: &SmbRecord, command: u8, andx_offset: &mut usize,
+    state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, command: u8, andx_offset: &mut usize,
 ) {
     SCLogDebug!(
         "record: command {} status {} -> {:?}",
@@ -708,7 +743,7 @@ fn smb1_response_record_one(
 
     let have_tx = match command {
         SMB1_COMMAND_READ_ANDX => {
-            smb1_read_response_record(state, r, *andx_offset, 0);
+            smb1_read_response_record(state, flow, r, *andx_offset, 0);
             true // tx handling in func
         }
         SMB1_COMMAND_NEGOTIATE_PROTOCOL => {
@@ -719,6 +754,10 @@ fn smb1_response_record_one(
                         Some(tx) => {
                             tx.set_status(r.nt_status, r.is_dos_error);
                             tx.response_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                flow,
+                                Direction::ToClient as i32,
+                            );
                             SCLogDebug!("tx {} is done", tx.id);
                             let d = match tx.type_data {
                                 Some(SMBTransactionTypeData::NEGOTIATE(ref mut x)) => {
@@ -762,6 +801,10 @@ fn smb1_response_record_one(
                     }
                     tx.set_status(r.nt_status, r.is_dos_error);
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToClient as i32,
+                    );
                     SCLogDebug!("tx {} is done", tx.id);
                 }
                 return;
@@ -787,6 +830,10 @@ fn smb1_response_record_one(
                             tx.hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
                             tx.set_status(r.nt_status, r.is_dos_error);
                             tx.response_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                flow,
+                                Direction::ToClient as i32,
+                            );
                             SCLogDebug!("tx {} is done", tx.id);
                             true
                         }
@@ -841,6 +888,10 @@ fn smb1_response_record_one(
                         );
                         tx.set_status(r.nt_status, false);
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(
+                            flow,
+                            Direction::ToClient as i32,
+                        );
 
                         if let Some(SMBTransactionTypeData::CREATE(ref mut tdn)) = tx.type_data {
                             tdn.create_ts = cr.create_ts.as_unix();
@@ -865,16 +916,16 @@ fn smb1_response_record_one(
                 .pop(&SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID));
             if let Some(fid) = fid {
                 SCLogDebug!("closing FID {:?}", fid);
-                smb1_close_file(state, &fid, Direction::ToClient);
+                smb1_close_file(state, flow, &fid, Direction::ToClient);
             }
             false
         }
         SMB1_COMMAND_TRANS => {
-            smb1_trans_response_record(state, r);
+            smb1_trans_response_record(state, flow, r);
             true
         }
         SMB1_COMMAND_SESSION_SETUP_ANDX => {
-            smb1_session_setup_response(state, r, *andx_offset);
+            smb1_session_setup_response(state, flow, r, *andx_offset);
             true
         }
         SMB1_COMMAND_LOGOFF_ANDX => {
@@ -888,6 +939,7 @@ fn smb1_response_record_one(
         if let Some(tx) = state.get_last_tx(1, command as u16) {
             SCLogDebug!("last TX {} is CMD {}", tx.id, &smb1_command_string(command));
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
             SCLogDebug!("tx {} cmd {} is done", tx.id, command);
             tx.set_status(r.nt_status, r.is_dos_error);
             tx.set_events(events);
@@ -903,6 +955,8 @@ fn smb1_response_record_one(
             Some(tx) => {
                 tx.request_done = true;
                 tx.response_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
                 SCLogDebug!("tx {} cmd {} is done", tx.id, command);
                 tx.set_status(r.nt_status, r.is_dos_error);
                 tx.set_events(events);
@@ -918,11 +972,11 @@ fn smb1_response_record_one(
     }
 }
 
-pub fn smb1_response_record(state: &mut SMBState, r: &SmbRecord) -> u32 {
+pub fn smb1_response_record(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord) -> u32 {
     let mut andx_offset = SMB1_HEADER_SIZE;
     let mut command = r.command;
     loop {
-        smb1_response_record_one(state, r, command, &mut andx_offset);
+        smb1_response_record_one(state, flow, r, command, &mut andx_offset);
 
         // continue for next andx command if any
         if smb1_command_is_andx(command) {
@@ -945,7 +999,7 @@ pub fn smb1_response_record(state: &mut SMBState, r: &SmbRecord) -> u32 {
     0
 }
 
-pub fn smb1_trans_request_record(state: &mut SMBState, r: &SmbRecord) {
+pub fn smb1_trans_request_record(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord) {
     let mut events: Vec<SMBEvent> = Vec::new();
 
     match parse_smb_trans_request_record(r.data, r) {
@@ -976,17 +1030,17 @@ pub fn smb1_trans_request_record(state: &mut SMBState, r: &SmbRecord) {
                 SCLogDebug!("SMBv1 TRANS TO PIPE");
                 let hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
                 let vercmd = SMBVerCmdStat::new1(r.command);
-                smb_write_dcerpc_record(state, vercmd, hdr, rd.data.data);
+                smb_write_dcerpc_record(state, flow, vercmd, hdr, rd.data.data);
             }
         }
         _ => {
             events.push(SMBEvent::MalformedData);
         }
     }
-    smb1_request_record_generic(state, r, events);
+    smb1_request_record_generic(state, flow, r, events);
 }
 
-pub fn smb1_trans_response_record(state: &mut SMBState, r: &SmbRecord) {
+pub fn smb1_trans_response_record(state: &mut SMBState, flow: *mut Flow, r: &SmbRecord) {
     let mut events: Vec<SMBEvent> = Vec::new();
 
     match parse_smb_trans_response_record(r.data) {
@@ -1026,7 +1080,7 @@ pub fn smb1_trans_response_record(state: &mut SMBState, r: &SmbRecord) {
                 SCLogDebug!("SMBv1 TRANS TO PIPE");
                 let hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
                 let vercmd = SMBVerCmdStat::new1_with_ntstatus(r.command, r.nt_status);
-                smb_read_dcerpc_record(state, vercmd, hdr, &fid, rd.data);
+                smb_read_dcerpc_record(state, flow, vercmd, hdr, &fid, rd.data);
             }
         }
         _ => {
@@ -1035,12 +1089,13 @@ pub fn smb1_trans_response_record(state: &mut SMBState, r: &SmbRecord) {
     }
 
     // generic tx as well. Set events if needed.
-    smb1_response_record_generic(state, r, events);
+    smb1_response_record_generic(state, flow, r, events);
 }
 
 /// Handle WRITE, WRITE_ANDX, WRITE_AND_CLOSE request records
 pub fn smb1_write_request_record(
-    state: &mut SMBState, r: &SmbRecord, andx_offset: usize, command: u8, nbss_remaining: u32,
+    state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, andx_offset: usize, command: u8,
+    nbss_remaining: u32,
 ) {
     let mut events: Vec<SMBEvent> = Vec::new();
 
@@ -1103,7 +1158,7 @@ pub fn smb1_write_request_record(
                     SCLogDebug!("SMBv1 WRITE TO PIPE");
                     let hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER);
                     let vercmd = SMBVerCmdStat::new1_with_ntstatus(command, r.nt_status);
-                    smb_write_dcerpc_record(state, vercmd, hdr, rd.data);
+                    smb_write_dcerpc_record(state, flow, vercmd, hdr, rd.data);
                 } else {
                     let Some(tx) = state.new_file_tx(&file_fid, &file_name, Direction::ToServer)
                     else {
@@ -1144,18 +1199,18 @@ pub fn smb1_write_request_record(
             if command == SMB1_COMMAND_WRITE_AND_CLOSE {
                 let _name = state.guid2name_cache.pop(&file_fid);
                 SCLogDebug!("closing FID {:?}", file_fid);
-                smb1_close_file(state, &file_fid, Direction::ToServer);
+                smb1_close_file(state, flow, &file_fid, Direction::ToServer);
             }
         }
         _ => {
             events.push(SMBEvent::MalformedData);
         }
     }
-    smb1_request_record_generic(state, r, events);
+    smb1_request_record_generic(state, flow, r, events);
 }
 
 pub fn smb1_read_response_record(
-    state: &mut SMBState, r: &SmbRecord, andx_offset: usize, nbss_remaining: u32,
+    state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, andx_offset: usize, nbss_remaining: u32,
 ) {
     let mut events: Vec<SMBEvent> = Vec::new();
 
@@ -1260,7 +1315,7 @@ pub fn smb1_read_response_record(
                     } else {
                         &[]
                     };
-                    smb_read_dcerpc_record(state, vercmd, hdr, pure_fid, rd.data);
+                    smb_read_dcerpc_record(state, flow, vercmd, hdr, pure_fid, rd.data);
                 }
 
                 state.set_file_left(
@@ -1277,18 +1332,21 @@ pub fn smb1_read_response_record(
     }
 
     // generic tx as well. Set events if needed.
-    smb1_response_record_generic(state, r, events);
+    smb1_response_record_generic(state, flow, r, events);
 }
 
 /// create a tx for a command / response pair if we're
 /// configured to do so, or if this is a tx especially
 /// for setting an event.
-fn smb1_request_record_generic(state: &mut SMBState, r: &SmbRecord, events: Vec<SMBEvent>) {
+fn smb1_request_record_generic(
+    state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, events: Vec<SMBEvent>,
+) {
     if smb1_create_new_tx(r.command) || !events.is_empty() {
         let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
         let Some(tx) = state.new_generic_tx(1, r.command as u16, tx_key) else {
             return;
         };
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
         tx.set_events(events);
     }
 }
@@ -1296,11 +1354,15 @@ fn smb1_request_record_generic(state: &mut SMBState, r: &SmbRecord, events: Vec<
 /// update or create a tx for a command / response pair based
 /// on the response. We only create a tx for the response side
 /// if we didn't already update a tx, and we have to set events
-fn smb1_response_record_generic(state: &mut SMBState, r: &SmbRecord, events: Vec<SMBEvent>) {
+fn smb1_response_record_generic(
+    state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, events: Vec<SMBEvent>,
+) {
     let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
     if let Some(tx) = state.get_generic_tx(1, r.command as u16, &tx_key) {
         tx.request_done = true;
         tx.response_done = true;
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
         SCLogDebug!("tx {} cmd {} is done", tx.id, r.command);
         tx.set_status(r.nt_status, r.is_dos_error);
         tx.set_events(events);
@@ -1312,6 +1374,8 @@ fn smb1_response_record_generic(state: &mut SMBState, r: &SmbRecord, events: Vec
         };
         tx.request_done = true;
         tx.response_done = true;
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
         SCLogDebug!("tx {} cmd {} is done", tx.id, r.command);
         tx.set_status(r.nt_status, r.is_dos_error);
         tx.set_events(events);

--- a/rust/src/smb/smb1_session.rs
+++ b/rust/src/smb/smb1_session.rs
@@ -15,6 +15,9 @@
  * 02110-1301, USA.
  */
 
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
+use crate::direction::Direction;
+use crate::flow::Flow;
 use crate::smb::auth::*;
 use crate::smb::events::*;
 use crate::smb::smb::*;
@@ -60,7 +63,9 @@ pub fn smb1_session_setup_response_host_info(r: &SmbRecord, blob: &[u8]) -> Sess
     }
 }
 
-pub fn smb1_session_setup_request(state: &mut SMBState, r: &SmbRecord, andx_offset: usize) {
+pub fn smb1_session_setup_request(
+    state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, andx_offset: usize,
+) {
     SCLogDebug!("SMB1_COMMAND_SESSION_SETUP_ANDX user_id {}", r.user_id);
     #[allow(clippy::single_match)]
     match parse_smb_setup_andx_record(&r.data[andx_offset - SMB1_HEADER_SIZE..], r) {
@@ -75,6 +80,7 @@ pub fn smb1_session_setup_request(state: &mut SMBState, r: &SmbRecord, andx_offs
                 return;
             };
             tx.vercmd.set_smb1_cmd(r.command);
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
 
             if let Some(SMBTransactionTypeData::SESSIONSETUP(ref mut td)) = tx.type_data {
                 td.request_host = Some(setup.request_host);
@@ -95,7 +101,9 @@ pub fn smb1_session_setup_request(state: &mut SMBState, r: &SmbRecord, andx_offs
     }
 }
 
-fn smb1_session_setup_update_tx(tx: &mut SMBTransaction, r: &SmbRecord, andx_offset: usize) {
+fn smb1_session_setup_update_tx(
+    flow: *mut Flow, tx: &mut SMBTransaction, r: &SmbRecord, andx_offset: usize,
+) {
     match parse_smb_response_setup_andx_record(&r.data[andx_offset - SMB1_HEADER_SIZE..]) {
         Ok((rem, _setup)) => {
             if let Some(SMBTransactionTypeData::SESSIONSETUP(ref mut td)) = tx.type_data {
@@ -110,9 +118,12 @@ fn smb1_session_setup_update_tx(tx: &mut SMBTransaction, r: &SmbRecord, andx_off
     tx.hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_HEADER); // to overwrite ssn_id 0
     tx.set_status(r.nt_status, r.is_dos_error);
     tx.response_done = true;
+    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
 }
 
-pub fn smb1_session_setup_response(state: &mut SMBState, r: &SmbRecord, andx_offset: usize) {
+pub fn smb1_session_setup_response(
+    state: &mut SMBState, flow: *mut Flow, r: &SmbRecord, andx_offset: usize,
+) {
     // try exact match with session id already set (e.g. NTLMSSP AUTH phase)
     let found = r.ssn_id != 0
         && match state.get_sessionsetup_tx(SMBCommonHdr::new(
@@ -122,7 +133,7 @@ pub fn smb1_session_setup_response(state: &mut SMBState, r: &SmbRecord, andx_off
             r.multiplex_id as u64,
         )) {
             Some(tx) => {
-                smb1_session_setup_update_tx(tx, r, andx_offset);
+                smb1_session_setup_update_tx(flow, tx, r, andx_offset);
                 SCLogDebug!("smb1_session_setup_response: tx {:?}", tx);
                 true
             }
@@ -136,7 +147,7 @@ pub fn smb1_session_setup_response(state: &mut SMBState, r: &SmbRecord, andx_off
             0,
             r.multiplex_id as u64,
         )) {
-            smb1_session_setup_update_tx(tx, r, andx_offset);
+            smb1_session_setup_update_tx(flow, tx, r, andx_offset);
             SCLogDebug!("smb1_session_setup_response: tx {:?}", tx);
         } else {
             SCLogDebug!("smb1_session_setup_response: tx not found for {:?}", r);

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -17,7 +17,9 @@
 
 use nom8::Err;
 
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
 use crate::direction::Direction;
+use crate::flow::Flow;
 use crate::smb::dcerpc::*;
 use crate::smb::events::*;
 use crate::smb::files::*;
@@ -104,22 +106,25 @@ fn smb2_create_new_tx(cmd: u16) -> bool {
     }
 }
 
-fn smb2_read_response_record_generic(state: &mut SMBState, r: &Smb2Record) {
+fn smb2_read_response_record_generic(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record) {
     if smb2_create_new_tx(r.command) {
         let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
         let tx = state.get_generic_tx(2, r.command, &tx_hdr);
         if let Some(tx) = tx {
             tx.set_status(r.nt_status, false);
             tx.response_done = true;
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
         }
     }
 }
 
-pub fn smb2_read_response_record(state: &mut SMBState, r: &Smb2Record, nbss_remaining: u32) {
+pub fn smb2_read_response_record(
+    state: &mut SMBState, flow: *mut Flow, r: &Smb2Record, nbss_remaining: u32,
+) {
     let max_queue_size = unsafe { SMB_CFG_MAX_READ_QUEUE_SIZE };
     let max_queue_cnt = unsafe { SMB_CFG_MAX_READ_QUEUE_CNT };
 
-    smb2_read_response_record_generic(state, r);
+    smb2_read_response_record_generic(state, flow, r);
 
     match parse_smb2_response_read(r.data) {
         Ok((_, rd)) => {
@@ -242,7 +247,7 @@ pub fn smb2_read_response_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
                     SCLogDebug!("SMBv2 DCERPC read");
                     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
                     let vercmd = SMBVerCmdStat::new2_with_ntstatus(SMB2_COMMAND_READ, r.nt_status);
-                    smb_read_dcerpc_record(state, vercmd, hdr, &file_guid, rd.data);
+                    smb_read_dcerpc_record(state, flow, vercmd, hdr, &file_guid, rd.data);
                 } else if is_pipe {
                     SCLogDebug!("non-DCERPC pipe");
                     state.set_skip(Direction::ToClient, nbss_remaining);
@@ -307,7 +312,9 @@ pub fn smb2_read_response_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
     }
 }
 
-pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record, nbss_remaining: u32) {
+pub fn smb2_write_request_record(
+    state: &mut SMBState, flow: *mut Flow, r: &Smb2Record, nbss_remaining: u32,
+) {
     let max_queue_size = unsafe { SMB_CFG_MAX_WRITE_QUEUE_SIZE };
     let max_queue_cnt = unsafe { SMB_CFG_MAX_WRITE_QUEUE_CNT };
 
@@ -318,6 +325,7 @@ pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
             return;
         };
         tx.request_done = true;
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
     }
     match parse_smb2_request_write(r.data) {
         Ok((_, wr)) => {
@@ -426,7 +434,7 @@ pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
                     SCLogDebug!("SMBv2 DCERPC write");
                     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
                     let vercmd = SMBVerCmdStat::new2(SMB2_COMMAND_WRITE);
-                    smb_write_dcerpc_record(state, vercmd, hdr, wr.data);
+                    smb_write_dcerpc_record(state, flow, vercmd, hdr, wr.data);
                 } else if is_pipe {
                     SCLogDebug!("non-DCERPC pipe: skip rest of the record");
                     state.set_skip(Direction::ToServer, nbss_remaining);
@@ -485,7 +493,7 @@ pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
     }
 }
 
-pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
+pub fn smb2_request_record(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record) {
     SCLogDebug!(
         "SMBv2 request record, command {} tree {} session {}",
         &smb2_command_string(r.command),
@@ -517,6 +525,10 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
                             };
                             tx.hdr = tx_hdr;
                             tx.request_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                flow,
+                                Direction::ToServer as i32,
+                            );
                             tx.vercmd.set_smb2_cmd(SMB2_COMMAND_SET_INFO);
                             true
                         }
@@ -550,6 +562,10 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
                             };
                             tx.hdr = tx_hdr;
                             tx.request_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                flow,
+                                Direction::ToServer as i32,
+                            );
                             tx.vercmd.set_smb2_cmd(SMB2_COMMAND_SET_INFO);
                             true
                         }
@@ -570,7 +586,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
             have_si_tx
         }
         SMB2_COMMAND_IOCTL => {
-            smb2_ioctl_request_record(state, r);
+            smb2_ioctl_request_record(state, flow, r);
             true
         }
         SMB2_COMMAND_TREE_DISCONNECT => {
@@ -596,6 +612,10 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
                         tdn.client_guid = Some(rd.client_guid.to_vec());
                     }
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToServer as i32,
+                    );
                 }
                 true
             } else {
@@ -604,7 +624,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
             }
         }
         SMB2_COMMAND_SESSION_SETUP => {
-            smb2_session_setup_request(state, r);
+            smb2_session_setup_request(state, flow, r);
             true
         }
         SMB2_COMMAND_TREE_CONNECT => {
@@ -620,6 +640,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
                     return;
                 };
                 tx.request_done = true;
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 tx.vercmd.set_smb2_cmd(SMB2_COMMAND_TREE_CONNECT);
                 true
             } else {
@@ -666,6 +687,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
                     return;
                 };
                 tx.vercmd.set_smb2_cmd(r.command);
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 SCLogDebug!("TS CREATE TX {} created", tx.id);
                 true
             } else {
@@ -674,7 +696,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
             }
         }
         SMB2_COMMAND_WRITE => {
-            smb2_write_request_record(state, r, 0);
+            smb2_write_request_record(state, flow, r, 0);
             true // write handling creates both file tx and generic tx
         }
         SMB2_COMMAND_CLOSE => {
@@ -689,7 +711,15 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
                             }
                         }
                         tx.request_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(
+                            flow,
+                            Direction::ToServer as i32,
+                        );
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(
+                            flow,
+                            Direction::ToClient as i32,
+                        );
                         tx.set_status(SMB_NTSTATUS_SUCCESS, false);
                         true
                     } else {
@@ -703,7 +733,15 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
                             }
                         }
                         tx.request_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(
+                            flow,
+                            Direction::ToServer as i32,
+                        );
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(
+                            flow,
+                            Direction::ToClient as i32,
+                        );
                         tx.set_status(SMB_NTSTATUS_SUCCESS, false);
                         true
                     } else {
@@ -725,6 +763,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
         let Some(tx) = state.new_generic_tx(2, r.command, tx_key) else {
             return;
         };
+        sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
         SCLogDebug!(
             "TS TX {} command {} created with session_id {} tree_id {} message_id {}",
             tx.id,
@@ -737,7 +776,7 @@ pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record) {
     }
 }
 
-pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record) {
+pub fn smb2_response_record(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record) {
     SCLogDebug!(
         "SMBv2 response record, command {} status {} tree {} session {} message {}",
         &smb2_command_string(r.command),
@@ -751,11 +790,11 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record) {
 
     let have_tx = match r.command {
         SMB2_COMMAND_IOCTL => {
-            smb2_ioctl_response_record(state, r);
+            smb2_ioctl_response_record(state, flow, r);
             true
         }
         SMB2_COMMAND_SESSION_SETUP => {
-            smb2_session_setup_response(state, r);
+            smb2_session_setup_response(state, flow, r);
             true
         }
         SMB2_COMMAND_WRITE => {
@@ -776,7 +815,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record) {
         }
         SMB2_COMMAND_READ => {
             if r.nt_status == SMB_NTSTATUS_SUCCESS || r.nt_status == SMB_NTSTATUS_BUFFER_OVERFLOW {
-                smb2_read_response_record(state, r, 0);
+                smb2_read_response_record(state, flow, r, 0);
             } else if r.nt_status == SMB_NTSTATUS_END_OF_FILE {
                 SCLogDebug!("SMBv2: read response => EOF");
 
@@ -795,6 +834,10 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record) {
                     }
                     tx.set_status(r.nt_status, false);
                     tx.request_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToServer as i32,
+                    );
                 }
             } else {
                 SCLogDebug!("SMBv2 READ: status {}", r.nt_status);
@@ -824,6 +867,10 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record) {
                         );
                         tx.set_status(r.nt_status, false);
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(
+                            flow,
+                            Direction::ToClient as i32,
+                        );
 
                         if let Some(SMBTransactionTypeData::CREATE(ref mut tdn)) = tx.type_data {
                             tdn.create_ts = cr.create_ts.as_unix();
@@ -868,6 +915,10 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record) {
                             // update hdr now that we have a tree_id
                             tx.hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
                             tx.response_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                flow,
+                                Direction::ToClient as i32,
+                            );
                             tx.set_status(r.nt_status, false);
                             true
                         }
@@ -887,6 +938,10 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record) {
                 let name_key = SMBCommonHdr::from2(r, SMBHDR_TYPE_TREE);
                 if let Some(tx) = state.get_treeconnect_tx(name_key) {
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToClient as i32,
+                    );
                     tx.set_status(r.nt_status, false);
                     true
                 } else {
@@ -923,6 +978,10 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record) {
                         }
                         tx.set_status(r.nt_status, false);
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(
+                            flow,
+                            Direction::ToClient as i32,
+                        );
                         true
                     }
                     None => false,
@@ -938,6 +997,10 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record) {
                             }
                             tx.set_status(r.nt_status, false);
                             tx.response_done = true;
+                            sc_app_layer_parser_trigger_raw_stream_inspection(
+                                flow,
+                                Direction::ToClient as i32,
+                            );
                             true
                         }
                         None => false,
@@ -972,6 +1035,10 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record) {
                 );
                 if r.nt_status != SMB_NTSTATUS_PENDING {
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToClient as i32,
+                    );
                 }
                 tx.set_status(r.nt_status, false);
                 tx.set_events(events);

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -15,6 +15,9 @@
  * 02110-1301, USA.
  */
 
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
+use crate::direction::Direction;
+use crate::flow::Flow;
 use crate::smb::dcerpc::*;
 use crate::smb::events::*;
 #[cfg(feature = "debug")]
@@ -57,7 +60,7 @@ impl SMBState {
 }
 
 // IOCTL responses ASYNC don't set the tree id
-pub fn smb2_ioctl_request_record(state: &mut SMBState, r: &Smb2Record) {
+pub fn smb2_ioctl_request_record(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record) {
     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
     match parse_smb2_request_ioctl(r.data) {
         Ok((_, rd)) => {
@@ -70,7 +73,7 @@ pub fn smb2_ioctl_request_record(state: &mut SMBState, r: &Smb2Record) {
             if is_dcerpc {
                 SCLogDebug!("IOCTL request data is_pipe. Calling smb_write_dcerpc_record");
                 let vercmd = SMBVerCmdStat::new2(SMB2_COMMAND_IOCTL);
-                smb_write_dcerpc_record(state, vercmd, hdr, rd.data);
+                smb_write_dcerpc_record(state, flow, vercmd, hdr, rd.data);
             } else {
                 SCLogDebug!(
                     "IOCTL {:08x} {}",
@@ -80,6 +83,7 @@ pub fn smb2_ioctl_request_record(state: &mut SMBState, r: &Smb2Record) {
                 let Some(tx) = state.new_ioctl_tx(hdr, rd.function) else {
                     return;
                 };
+                sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
                 tx.vercmd.set_smb2_cmd(SMB2_COMMAND_IOCTL);
             }
         }
@@ -87,13 +91,14 @@ pub fn smb2_ioctl_request_record(state: &mut SMBState, r: &Smb2Record) {
             let Some(tx) = state.new_generic_tx(2, r.command, hdr) else {
                 return;
             };
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
             tx.set_event(SMBEvent::MalformedData);
         }
     };
 }
 
 // IOCTL responses ASYNC don't set the tree id
-pub fn smb2_ioctl_response_record(state: &mut SMBState, r: &Smb2Record) {
+pub fn smb2_ioctl_response_record(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record) {
     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
     match parse_smb2_response_ioctl(r.data) {
         Ok((_, rd)) => {
@@ -110,7 +115,7 @@ pub fn smb2_ioctl_response_record(state: &mut SMBState, r: &Smb2Record) {
                 SCLogDebug!("IOCTL response data is_pipe. Calling smb_read_dcerpc_record");
                 let vercmd = SMBVerCmdStat::new2_with_ntstatus(SMB2_COMMAND_IOCTL, r.nt_status);
                 SCLogDebug!("TODO passing empty GUID");
-                smb_read_dcerpc_record(state, vercmd, hdr, &[], rd.data);
+                smb_read_dcerpc_record(state, flow, vercmd, hdr, &[], rd.data);
             } else {
                 SCLogDebug!(
                     "SMB2_COMMAND_IOCTL/SMB_NTSTATUS_PENDING looking for {:?}",
@@ -120,6 +125,10 @@ pub fn smb2_ioctl_response_record(state: &mut SMBState, r: &Smb2Record) {
                     tx.set_status(r.nt_status, false);
                     if r.nt_status != SMB_NTSTATUS_PENDING {
                         tx.response_done = true;
+                        sc_app_layer_parser_trigger_raw_stream_inspection(
+                            flow,
+                            Direction::ToClient as i32,
+                        );
                     }
                 }
             }
@@ -134,6 +143,10 @@ pub fn smb2_ioctl_response_record(state: &mut SMBState, r: &Smb2Record) {
                 tx.set_status(r.nt_status, false);
                 if r.nt_status != SMB_NTSTATUS_PENDING {
                     tx.response_done = true;
+                    sc_app_layer_parser_trigger_raw_stream_inspection(
+                        flow,
+                        Direction::ToClient as i32,
+                    );
                 }
 
                 // parsing failed for 'SUCCESS' record, set event

--- a/rust/src/smb/smb2_session.rs
+++ b/rust/src/smb/smb2_session.rs
@@ -15,12 +15,15 @@
  * 02110-1301, USA.
  */
 
+use crate::core::sc_app_layer_parser_trigger_raw_stream_inspection;
+use crate::direction::Direction;
+use crate::flow::Flow;
 use crate::smb::auth::*;
 use crate::smb::events::*;
 use crate::smb::smb::*;
 use crate::smb::smb2_records::*;
 
-pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record) {
+pub fn smb2_session_setup_request(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record) {
     SCLogDebug!("SMB2_COMMAND_SESSION_SETUP: r.data.len() {}", r.data.len());
     #[allow(clippy::single_match)]
     match parse_smb2_request_session_setup(r.data) {
@@ -30,6 +33,7 @@ pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record) {
                 return;
             };
             tx.vercmd.set_smb2_cmd(r.command);
+            sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToServer as i32);
 
             if let Some(SMBTransactionTypeData::SESSIONSETUP(ref mut td)) = tx.type_data {
                 if let Some(s) = parse_secblob(setup.data) {
@@ -49,18 +53,19 @@ pub fn smb2_session_setup_request(state: &mut SMBState, r: &Smb2Record) {
     }
 }
 
-fn smb2_session_setup_update_tx(tx: &mut SMBTransaction, r: &Smb2Record) {
+fn smb2_session_setup_update_tx(flow: *mut Flow, tx: &mut SMBTransaction, r: &Smb2Record) {
     tx.hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER); // to overwrite ssn_id 0
     tx.set_status(r.nt_status, false);
     tx.response_done = true;
+    sc_app_layer_parser_trigger_raw_stream_inspection(flow, Direction::ToClient as i32);
 }
 
-pub fn smb2_session_setup_response(state: &mut SMBState, r: &Smb2Record) {
+pub fn smb2_session_setup_response(state: &mut SMBState, flow: *mut Flow, r: &Smb2Record) {
     // try exact match with session id already set (e.g. NTLMSSP AUTH phase)
     let found = r.session_id != 0
         && match state.get_sessionsetup_tx(SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER)) {
             Some(tx) => {
-                smb2_session_setup_update_tx(tx, r);
+                smb2_session_setup_update_tx(flow, tx, r);
                 SCLogDebug!("smb2_session_setup_response: tx {:?}", tx);
                 true
             }
@@ -71,7 +76,7 @@ pub fn smb2_session_setup_response(state: &mut SMBState, r: &Smb2Record) {
         if let Some(tx) =
             state.get_sessionsetup_tx(SMBCommonHdr::new(SMBHDR_TYPE_HEADER, 0, 0, r.message_id))
         {
-            smb2_session_setup_update_tx(tx, r);
+            smb2_session_setup_update_tx(flow, tx, r);
             SCLogDebug!("smb2_session_setup_response: tx {:?}", tx);
         } else {
             SCLogDebug!("smb2_session_setup_response: tx not found for {:?}", r);

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1323,7 +1323,8 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     if (s->flags & SIG_FLAG_APPLAYER) {
         SCJbAppendString(ctx.js, "applayer");
     }
-    if (s->flags & SIG_FLAG_REQUIRE_PACKET) {
+    if ((s->flags & SIG_FLAG_REQUIRE_PACKET) ||
+            (s->flags & SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD)) { // STODO add new output if accepted
         SCJbAppendString(ctx.js, "need_packet");
     }
     if (s->flags & SIG_FLAG_REQUIRE_STREAM) {
@@ -1776,7 +1777,7 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         rule_bidirectional = 1;
     }
 
-    if (s->flags & SIG_FLAG_REQUIRE_PACKET) {
+    if ((s->flags & SIG_FLAG_REQUIRE_PACKET) || (s->flags & SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD)) {
         packet_buf += 1;
     }
     if (s->flags & SIG_FLAG_FILESTORE) {

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -441,8 +441,8 @@ static int SignatureCreateMask(Signature *s)
 {
     SCEnter();
 
-    if ((s->flags & (SIG_FLAG_REQUIRE_PACKET | SIG_FLAG_REQUIRE_STREAM)) ==
-            SIG_FLAG_REQUIRE_PACKET) {
+    if ((s->flags & (SIG_FLAG_REQUIRE_PACKET | SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD)) &&
+            !(s->flags & SIG_FLAG_REQUIRE_STREAM)) {
         s->mask |= SIG_MASK_REQUIRE_REAL_PKT;
     }
     if (s->init_data->smlists[DETECT_SM_LIST_PMATCH] != NULL) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1957,6 +1957,11 @@ static int DetectEngineInspectRulePayloadMatches(
         if (pmatch == 0) {
             SCLogDebug("no match in stream, fall back to packet payload");
 
+            if ((s->flags & SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD) &&
+                    !(s->flags & SIG_FLAG_REQUIRE_PACKET)) {
+                SCLogDebug("no packet payload match required");
+                return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
+            }
             /* skip if we don't have to inspect the packet and segment was
              * added to stream */
             if (!(s->flags & SIG_FLAG_REQUIRE_PACKET) && (p->flags & PKT_STREAM_ADD)) {
@@ -1971,6 +1976,11 @@ static int DetectEngineInspectRulePayloadMatches(
             }
         }
     } else {
+        if ((s->flags & SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD) &&
+                !(s->flags & SIG_FLAG_REQUIRE_PACKET)) {
+            SCLogDebug("no packet payload match required");
+            return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
+        }
         if (DetectEngineInspectPacketPayload(de_ctx, det_ctx, s, p->flow, p) != 1) {
             return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
         }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3046,7 +3046,7 @@ static void SigConsolidateTcpBuffer(Signature *s)
                 for (const SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_MATCH]; sm != NULL;
                         sm = sm->next) {
                     if (sm->type == DETECT_STREAM_SIZE) {
-                        s->flags |= SIG_FLAG_REQUIRE_PACKET;
+                        s->flags |= SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD;
                         break;
                     }
                 }

--- a/src/detect.h
+++ b/src/detect.h
@@ -261,6 +261,8 @@ typedef struct DetectPort_ {
     BIT_U32(13) /**< signature is requiring stream match. Stream match is not optional, so no      \
                    fallback to packet payload. */
 
+#define SIG_FLAG_REQUIRE_PACKET_NO_PAYLOAD                                                         \
+    BIT_U32(14) /**< signature requires packet match but not payload match  */
 // vacancies
 
 #define SIG_FLAG_REQUIRE_FLOWVAR        BIT_U32(17) /**< signature can only match if a flowbit, flowvar or flowint is available. */


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/16007

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7863

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3164

Changes since v5:
- removed changes to flow.pkts/bytes as they're also for UDP and the new flag is only for TCP
- rebased on top of latest main

Note: An internal test failure is evaluated and explained.