### PR TITLE
fw: adjust policy schema to the new format v2

### DIFF
--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -349,29 +349,32 @@ The example below accepts ARP again, using this mechanism.
 Default policies
 ================
 
-Each hook has a default policy. By default ``packet:filter`` enforces a ``drop:packet`` policy and the
-``app:filter`` hooks applies ``drop:flow``.
+Each hook has a default policy. By default ``packet.filter`` enforces a ``drop:packet`` policy and the
+``app`` hooks apply ``drop:flow``.
 
-The policies can be configured in ``firewall`` block in the config.
+The policies can be configured in ``firewall`` block in the config. Packet hooks
+live under ``packet`` and app-layer hooks under ``app``, keyed by protocol.
 
-Example for ``packet:filter``, to use reject instead of drop::
+Example for ``packet.filter``, to use reject instead of drop::
 
     firewall:
       policies:
-        packet-filter: [ "reject:packet" ]
+        packet:
+          filter: [ "reject:packet" ]
 
 
 Example for DNS::
 
     firewall:
       policies:
-        dns:
-          request-started: ["accept:hook"]
+        app:
+          dns:
+            request-started: ["accept:hook"]
 
-          # Drop and alert on all DNS requests that are not allowed in
-          # firewall.rules.
-          request-complete: ["drop:flow", "alert"]
+            # Drop and alert on all DNS requests that are not allowed in
+            # firewall.rules.
+            request-complete: ["drop:flow", "alert"]
 
-          # Accept all responses.
-          response-started: ["accept:tx"]
+            # Accept all responses.
+            response-started: ["accept:tx"]
 

--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -62,7 +62,7 @@ Application layer tables
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 If applayer is available, rules from the following tables apply. The tables for the
-application layer are per app layer protocol and per protocol state. e.g. ``http:request_line``.
+application layer are per app layer protocol and per protocol state. e.g. ``http1:request_line``.
 
 
 .. table::

--- a/doc/userguide/firewall/firewall-example.rst
+++ b/doc/userguide/firewall/firewall-example.rst
@@ -67,7 +67,7 @@ In the example below: the config auto accepts various hooks, leaving just ``http
 
     firewall:
       policies:
-        http:
+        http1:
           request-started:
             - "accept:hook"
           request-line:

--- a/doc/userguide/firewall/firewall-example.rst
+++ b/doc/userguide/firewall/firewall-example.rst
@@ -67,35 +67,36 @@ In the example below: the config auto accepts various hooks, leaving just ``http
 
     firewall:
       policies:
-        http1:
-          request-started:
-            - "accept:hook"
-          request-line:
-            - "drop:flow"
-            - "alert"
-          request-headers:
-            - "drop:flow"
-            - "alert"
-          request-body:
-            - "accept:hook"
-          request-trailer:
-            - "accept:hook"
-          request-complete:
-            - "accept:hook"
+        app:
+          http1:
+            request-started:
+              - "accept:hook"
+            request-line:
+              - "drop:flow"
+              - "alert"
+            request-headers:
+              - "drop:flow"
+              - "alert"
+            request-body:
+              - "accept:hook"
+            request-trailer:
+              - "accept:hook"
+            request-complete:
+              - "accept:hook"
 
-          response-started:
-            - "accept:hook"
-          response-line:
-            - "drop:flow"
-            - "alert"
-          response-headers:
-            - "accept:hook"
-          response-body:
-            - "accept:hook"
-          response-trailer:
-            - "accept:hook"
-          response-complete:
-            - "accept:hook"
+            response-started:
+              - "accept:hook"
+            response-line:
+              - "drop:flow"
+              - "alert"
+            response-headers:
+              - "accept:hook"
+            response-body:
+              - "accept:hook"
+            response-trailer:
+              - "accept:hook"
+            response-complete:
+              - "accept:hook"
 
 
 ::

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -73,7 +73,11 @@ pub enum AppProtoEnum {
 }
 pub type AppProto = u16;
 extern "C" {
-    #[doc = " \\brief Maps the ALPROTO_*, to its string equivalent.\n\n \\param alproto App layer protocol id.\n\n \\retval String equivalent for the alproto."]
+    #[doc = " \\brief Maps the ALPROTO_*, to its registered string equivalent.\n \\param alproto App layer protocol id.\n \\retval String equivalent for the alproto."]
+    pub fn AppProtoToStringRaw(alproto: AppProto) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    #[doc = " \\brief Maps the ALPROTO_*, to its normalized string equivalent.\n\n \\param alproto App layer protocol id.\n\n \\retval String equivalent for the alproto."]
     pub fn AppProtoToString(alproto: AppProto) -> *const ::std::os::raw::c_char;
 }
 extern "C" {

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -38,6 +38,16 @@ typedef struct AppProtoStringTuple {
 
 AppProtoStringTuple *g_alproto_strings = NULL;
 
+const char *AppProtoToStringRaw(AppProto alproto)
+{
+    const char *proto_name = NULL;
+    if (alproto < g_alproto_max) {
+        DEBUG_VALIDATE_BUG_ON(g_alproto_strings[alproto].alproto != alproto);
+        proto_name = g_alproto_strings[alproto].str;
+    }
+    return proto_name;
+}
+
 const char *AppProtoToString(AppProto alproto)
 {
     const char *proto_name = NULL;

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -178,7 +178,14 @@ static inline AppProto AppProtoCommon(AppProto sigproto, AppProto alproto)
 }
 
 /**
- * \brief Maps the ALPROTO_*, to its string equivalent.
+ * \brief Maps the ALPROTO_*, to its registered string equivalent.
+ * \param alproto App layer protocol id.
+ * \retval String equivalent for the alproto.
+ */
+const char *AppProtoToStringRaw(AppProto alproto);
+
+/**
+ * \brief Maps the ALPROTO_*, to its normalized string equivalent.
  *
  * \param alproto App layer protocol id.
  *

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -885,13 +885,11 @@ const char *DetectEngineAppHookToName(
 int DetectEngineAppHookToSmlist(
         const AppProto p, const uint8_t sub_state, const uint8_t state, const uint8_t direction)
 {
-    const char *app_proto = AppProtoToString(p);
+    const char *app_proto = AppProtoToStringRaw(p);
     if (app_proto == NULL) {
         SCLogError("unknown app_proto %u", p);
         return -1;
     }
-    if (strcmp(app_proto, "http") == 0)
-        app_proto = "http1";
 
     char generic_hook_name[256];
     if (sub_state == 0) {

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -4177,7 +4177,7 @@ static int DoParseAppSubStatePolicy(const char *prefix, const AppProto app_proto
     }
 
     const char *app_name = AppProtoToStringRaw(app_proto);
-    int r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s.%s", prefix, app_name,
+    int r = snprintf(policy_name, sizeof(policy_name), "%s.app.%s.%s.%s", prefix, app_name,
             sub_state_name, nname);
     SCLogDebug("policy_name %s", policy_name);
     SCFree(nname);
@@ -4246,7 +4246,7 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
     }
 
     const char *app_name = AppProtoToStringRaw(app_proto);
-    int r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s", prefix, app_name, nname);
+    int r = snprintf(policy_name, sizeof(policy_name), "%s.app.%s.%s", prefix, app_name, nname);
     SCFree(nname);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
         FatalError("internal error: failed to assemble firewall policy config string");
@@ -4280,7 +4280,7 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
         }
         if (hookname == NULL)
             return 0;
-        r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s", prefix, app_name, hookname);
+        r = snprintf(policy_name, sizeof(policy_name), "%s.app.%s.%s", prefix, app_name, hookname);
         if (r < 0 || (size_t)r >= sizeof(policy_name)) {
             FatalError("internal error: failed to assemble firewall policy config string");
         }
@@ -4344,7 +4344,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
     if (fw_policies == NULL)
         return -1;
 
-    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-filter", prefix);
+    r = snprintf(policy_name, sizeof(policy_name), "%s.packet.filter", prefix);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
         FatalError("internal error: failed to assemble firewall policy config string");
     }
@@ -4357,7 +4357,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
                     DETECT_FIREWALL_POLICY_PACKET_FILTER) < 0)
             return -1;
 
-    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-flow", prefix);
+    r = snprintf(policy_name, sizeof(policy_name), "%s.packet.pre-flow", prefix);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
         FatalError("internal error: failed to assemble firewall policy config string");
     }
@@ -4369,7 +4369,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
                     DETECT_FIREWALL_POLICY_PRE_FLOW) < 0)
             return -1;
 
-    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-stream", prefix);
+    r = snprintf(policy_name, sizeof(policy_name), "%s.packet.pre-stream", prefix);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
         FatalError("internal error: failed to assemble firewall policy config string");
     }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1156,14 +1156,12 @@ static bool IsBuiltIn(const char *n)
 void DetectRegisterAppLayerHookLists(void)
 {
     for (AppProto a = ALPROTO_FAILED + 1; a < g_alproto_max; a++) {
-        const char *alproto_name = AppProtoToString(a);
-        if (strcmp(alproto_name, "http") == 0)
-            alproto_name = "http1";
+        const char *alproto_name = AppProtoToStringRaw(a);
         SCLogDebug("alproto %u/%s", a, alproto_name);
 
         if (AppLayerParserSupportsSubStates(a)) {
             uint8_t max_sub_state = AppLayerParserGetMaxSubState(a);
-            SCLogDebug("%s: max sub state for %u is %u", AppProtoToString(a), a, max_sub_state);
+            SCLogDebug("%s: max sub state for %u is %u", alproto_name, a, max_sub_state);
             for (uint8_t s = 1; s <= max_sub_state; s++) {
                 const uint8_t max_state = AppLayerParserGetSubStateCompletion(
                         a, s); // TODO allow different completion per direction?

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -4176,7 +4176,7 @@ static int DoParseAppSubStatePolicy(const char *prefix, const AppProto app_proto
             nname[i] = '-';
     }
 
-    const char *app_name = AppProtoToString(app_proto);
+    const char *app_name = AppProtoToStringRaw(app_proto);
     int r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s.%s", prefix, app_name,
             sub_state_name, nname);
     SCLogDebug("policy_name %s", policy_name);
@@ -4245,7 +4245,7 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
             nname[i] = '-';
     }
 
-    const char *app_name = AppProtoToString(app_proto);
+    const char *app_name = AppProtoToStringRaw(app_proto);
     int r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s", prefix, app_name, nname);
     SCFree(nname);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {

--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -113,9 +113,7 @@ int ListAppLayerHooks(const char *conf_filename)
                 }
             }
         } else {
-            const char *alproto_name = AppProtoToString(a);
-            if (strcmp(alproto_name, "http") == 0)
-                alproto_name = "http1";
+            const char *alproto_name = AppProtoToStringRaw(a);
             SCLogDebug("alproto %u/%s", a, alproto_name);
 
             const int max_progress_ts =
@@ -164,9 +162,7 @@ int ListAppLayerFrames(const char *conf_filename)
         if (alprotos[a] != 1)
             continue;
 
-        const char *alproto_name = AppProtoToString(a);
-        if (strcmp(alproto_name, "http") == 0)
-            alproto_name = "http1";
+        const char *alproto_name = AppProtoToStringRaw(a);
         SCLogDebug("alproto %u/%s", a, alproto_name);
 
         bool tcp_stream_once = false;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -2397,11 +2397,13 @@ firewall:
   # DNS example: Drop and alert on all DNS requests that are not allowed in firewall.rules, accept all responses.
   #
   #policies:
-  #  packet-filter: ["drop:packet"]
-  #  dns:
-  #    request-started: ["accept:hook"]
-  #    request-complete: ["drop:flow", "alert"]
-  #    response-started: ["accept:tx"]
+  #  packet:
+  #    filter: ["drop:packet"]
+  #  app:
+  #    dns:
+  #      request-started: ["accept:hook"]
+  #      request-complete: ["drop:flow", "alert"]
+  #      response-started: ["accept:tx"]
 
 ##
 ## Include other configs


### PR DESCRIPTION
Patch subset, followup of #16016, is a [prerequisite for Redmine ticket 8712](https://redmine.openinfosecfoundation.org/issues/8712) that branched out from #15950

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8712

Describe changes:
v2: 
- rustbinding fixed

v1:
- new suricata.yaml policy config structure
- http policy node renamed to http1
 

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3280

# NOTE

AppProtoToStringRaw omits conversion to `http_any` but if I understand it correctly, it should not really affect the current uses in the updated functions. Mentioning this here in case I missed something.

Also, http to http1 change is "optional" but I believe it provides higher precision to FW rules.