### PR TITLE
ci: authenticate GH API requests and fail on repo fetch error v2

### DIFF
--- a/.github/workflows/prepare-deps.yml
+++ b/.github/workflows/prepare-deps.yml
@@ -26,8 +26,11 @@ jobs:
           # Authenticating moves the limit to 1000+ requests/hour per repo.
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -eo pipefail
           if test "${PR_HREF}"; then
-              body=$(curl -s --header "Authorization: Bearer ${GH_TOKEN}" "${PR_HREF}" | jq -r .body | tr -d '\r')
+              body=$(curl --silent --show-error --fail \
+                  --header "Authorization: Bearer ${GH_TOKEN}" \
+                  "${PR_HREF}" | jq -r '.body' | tr -d '\r')
 
               echo "Parsing branch and PR info from:"
               echo "${body}"

--- a/.github/workflows/prepare-deps.yml
+++ b/.github/workflows/prepare-deps.yml
@@ -22,9 +22,12 @@ jobs:
           # github.event.pull_request.body has the body from the
           # initial pull request.
           PR_HREF: ${{ github.event.pull_request._links.self.href }}
+          # Unauthenticated calls get 60 requests/hour per runner's egress IP.
+          # Authenticating moves the limit to 1000+ requests/hour per repo.
+          GH_TOKEN: ${{ github.token }}
         run: |
           if test "${PR_HREF}"; then
-              body=$(curl -s "${PR_HREF}" | jq -r .body | tr -d '\r')
+              body=$(curl -s --header "Authorization: Bearer ${GH_TOKEN}" "${PR_HREF}" | jq -r .body | tr -d '\r')
 
               echo "Parsing branch and PR info from:"
               echo "${body}"


### PR DESCRIPTION
Follow-up of #15959 

Recent failure in e.g. https://github.com/OISF/suricata/pull/15940 shows that if CI fails to load PR body due to being e.g. rate-limited, it falls back to the "default" upstream SV/SU branches -- this is incorrect behavior as in turn the SV tests fail to pass.

In https://github.com/OISF/suricata/pull/15954 I confirmed that the authenticated approach gives us greater buffer from being rate-limited.

The first commit authenticates Github API request.
The second commit should prevent follow-up actions if any error during the fetch occurs.

Describe changes:
v2:
- author == comitter
- removed user-facing error output