### PR TITLE
smtp: treat a mid-session helo/ehlo like a rset - v4


### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1232,6 +1232,8 @@ static int SMTPParseCommandHELO(SMTPState *state, const SMTPLine *line)
 
 static int SMTPParseCommandMAILFROM(SMTPState *state, const SMTPLine *line)
 {
+    if (state->curr_tx == NULL)
+        return -1;
     if (state->curr_tx->mail_from) {
         SMTPSetEvent(state, SMTP_DECODER_EVENT_DUPLICATE_FIELDS);
         return 0;
@@ -1356,6 +1358,9 @@ static int SMTPProcessRequest(
             state->current_command = SMTP_COMMAND_STARTTLS;
         } else if (line->len >= 4 && SCMemcmpLowercase("data", line->buf, 4) == 0) {
             state->current_command = SMTP_COMMAND_DATA;
+            if (state->curr_tx == NULL) {
+                SCReturnInt(-1);
+            }
             SMTPSetProgressTS(tx, SMTP_REQUEST_DATA);
             if (state->curr_tx->is_data) {
                 // We did not receive a confirmation from server
@@ -1413,6 +1418,9 @@ static int SMTPProcessRequest(
                                              SCMemcmpLowercase("ehlo", line->buf, 4) == 0)) {
             r = SMTPParseCommandHELO(state, line);
             if (r == -1) {
+                SCReturnInt(-1);
+            }
+            if (state->curr_tx == NULL) {
                 SCReturnInt(-1);
             }
             if (state->curr_tx->mail_from != NULL || !TAILQ_EMPTY(&state->curr_tx->rcpt_to_list) ||

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1415,7 +1415,17 @@ static int SMTPProcessRequest(
             if (r == -1) {
                 SCReturnInt(-1);
             }
-            state->current_command = SMTP_COMMAND_OTHER_CMD;
+            if (state->curr_tx->mail_from != NULL || !TAILQ_EMPTY(&state->curr_tx->rcpt_to_list) ||
+                    state->curr_tx->progress_ts != SMTP_REQUEST_STARTED) {
+                /* Mid-session HELO/EHLO resets the state as if a RSET
+                 * had been issued (RFC 5321 4.1.4). The progress check
+                 * catches a transaction with no envelope but an attempted
+                 * DATA or BDAT, such as a rejected envelope-less DATA. */
+                state->bdat_chunk_idx = 0;
+                state->current_command = SMTP_COMMAND_RSET;
+            } else {
+                state->current_command = SMTP_COMMAND_OTHER_CMD;
+            }
         } else if (line->len >= 9 && SCMemcmpLowercase("mail from", line->buf, 9) == 0) {
             r = SMTPParseCommandMAILFROM(state, line);
             if (r == -1) {


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8715

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3248

Rebased and PR history cleaned up.

