### PR TITLE
smtp: treat a mid-session helo/ehlo like a rset - v5


### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1415,7 +1415,17 @@ static int SMTPProcessRequest(
             if (r == -1) {
                 SCReturnInt(-1);
             }
-            state->current_command = SMTP_COMMAND_OTHER_CMD;
+            if (state->curr_tx->mail_from != NULL || !TAILQ_EMPTY(&state->curr_tx->rcpt_to_list) ||
+                    state->curr_tx->progress_ts != SMTP_REQUEST_STARTED) {
+                /* Mid-session HELO/EHLO resets the state as if a RSET
+                 * had been issued (RFC 5321 4.1.4). The progress check
+                 * catches a transaction with no envelope but an attempted
+                 * DATA or BDAT, such as a rejected envelope-less DATA. */
+                state->bdat_chunk_idx = 0;
+                state->current_command = SMTP_COMMAND_RSET;
+            } else {
+                state->current_command = SMTP_COMMAND_OTHER_CMD;
+            }
         } else if (line->len >= 9 && SCMemcmpLowercase("mail from", line->buf, 9) == 0) {
             r = SMTPParseCommandMAILFROM(state, line);
             if (r == -1) {

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1352,7 +1352,13 @@ static int SMTPProcessRequest(
         int r = 0;
         SCAppLayerParserTriggerRawStreamInspection(f, STREAM_TOSERVER);
 
-        if (line->len >= 8 && SCMemcmpLowercase("starttls", line->buf, 8) == 0) {
+        if (tx == NULL) {
+            DEBUG_VALIDATE_BUG_ON(!no_new_tx);
+            const bool is_rset = SCMemcmpLowercase("rset", line->buf, 4) == 0;
+            if (is_rset)
+                state->bdat_chunk_idx = 0;
+            state->current_command = is_rset ? SMTP_COMMAND_RSET : SMTP_COMMAND_QUIT;
+        } else if (line->len >= 8 && SCMemcmpLowercase("starttls", line->buf, 8) == 0) {
             state->current_command = SMTP_COMMAND_STARTTLS;
         } else if (line->len >= 4 && SCMemcmpLowercase("data", line->buf, 4) == 0) {
             state->current_command = SMTP_COMMAND_DATA;


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8715

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3248

Changes from last PR:
- Fix scan build error (false positive)
