### PR TITLE
source/netmap: fix multi-slot packet over-read (v2)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2766,9 +2766,10 @@ jobs:
           path: prep
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-netmap --enable-debug
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-netmap --enable-debug --enable-unittests
       - run: make -j ${{ env.CPUS }}
       - run: ./src/suricata --build-info | grep -E "Netmap support:\s+yes"
+      - run: ./src/suricata -u -U Netmap
 
   ubuntu-22-04-minimal-recommended-build:
     name: Ubuntu 22.04 (Minimal/Recommended Build)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1175,6 +1175,7 @@ EXTRA_DIST = \
 	tests/detect-template.c \
 	tests/detect-transform-pcrexform.c \
 	tests/detect-ttl.c \
+	tests/source-netmap.c \
 	tests/source-pcap.c \
 	tests/app-layer-htp-file.c \
 	tests/detect-engine-alert.c \

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -150,6 +150,10 @@ typedef struct NetmapThreadVars_
     int copy_mode;
     ChecksumValidationMode checksum_mode;
 
+    /* buffer used to join a packet that is split across several netmap slots */
+    uint8_t *coalesce_buf;
+    uint32_t coalesce_size;
+
     /* counters */
     uint64_t pkts;
     uint64_t bytes;
@@ -526,6 +530,14 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, const void *initdata, voi
     ntv->checksum_mode = aconf->in.checksum_mode;
     ntv->copy_mode = aconf->in.copy_mode;
 
+    /* room for the biggest packet we can handle, used to join split packets */
+    ntv->coalesce_size = MAX_PAYLOAD_SIZE;
+    ntv->coalesce_buf = SCMalloc(ntv->coalesce_size);
+    if (unlikely(ntv->coalesce_buf == NULL)) {
+        SCLogError("Memory allocation failed");
+        goto error_ntv;
+    }
+
     /* enable zero-copy mode for workers runmode */
     char const *active_runmode = RunmodeGetActive();
     if (strcmp("workers", active_runmode) == 0) {
@@ -588,6 +600,7 @@ error_src:
     NetmapClose(ntv->ifsrc);
 
 error_ntv:
+    SCFree(ntv->coalesce_buf);
     SCFree(ntv);
 
 error:
@@ -663,7 +676,11 @@ static void NetmapReleasePacket(Packet *p)
     PacketFreeOrRelease(p);
 }
 
-static void NetmapProcessPacket(NetmapThreadVars *ntv, const struct nm_pkthdr *ph)
+/* Build a Packet from a netmap frame and send it up the pipeline. ph->buf must
+ * hold ph->len readable bytes. force_copy is set for multi-slot packets that we
+ * put in ntv->coalesce_buf, since that buffer gets reused by the next packet and
+ * cannot be handed out zero-copy. */
+static void NetmapProcessPacket(NetmapThreadVars *ntv, const struct nm_pkthdr *ph, bool force_copy)
 {
     if (ntv->bpf_prog.bf_len) {
         struct pcap_pkthdr pkthdr = { {0, 0}, ph->len, ph->len };
@@ -684,7 +701,7 @@ static void NetmapProcessPacket(NetmapThreadVars *ntv, const struct nm_pkthdr *p
     ntv->pkts++;
     ntv->bytes += ph->len;
 
-    if (ntv->flags & NETMAP_FLAG_ZERO_COPY) {
+    if ((ntv->flags & NETMAP_FLAG_ZERO_COPY) && !force_copy) {
         if (PacketSetData(p, (uint8_t *)ph->buf, ph->len) == -1) {
             TmqhOutputPacketpool(ntv->tv, p);
             return;
@@ -705,6 +722,78 @@ static void NetmapProcessPacket(NetmapThreadVars *ntv, const struct nm_pkthdr *p
     (void)TmThreadsSlotProcessPkt(ntv->tv, ntv->slot, p);
 }
 
+/* Read the packet sitting at ring->cur into hdr and move the ring past the
+ * slots it used. A packet can be split over several slots whose buffers are
+ * not next to each other in memory, so when there is more than one slot we
+ * copy them into ntv->coalesce_buf and point hdr there. That way the caller
+ * always gets one buffer with the whole frame and never reads past the first
+ * slot. force_copy is set when we used the coalesce buffer. Returns false and
+ * drops the packet when the slot chain is broken or too long for the buffer. */
+static bool NetmapReadOnePacket(
+        struct netmap_ring *ring, NetmapThreadVars *ntv, struct nm_pkthdr *hdr, bool *force_copy)
+{
+    u_int i = ring->cur;
+    struct netmap_slot *slot = &ring->slot[i];
+
+    memset(hdr, 0, sizeof(*hdr));
+    hdr->ts = ring->ts;
+    hdr->slot = slot;
+    hdr->buf = (u_char *)NETMAP_BUF(ring, slot->buf_idx);
+    hdr->len = hdr->caplen = slot->len;
+    *force_copy = false;
+
+    bool dropped = false;
+
+    if (slot->flags & NS_MOREFRAG) {
+        /* a packet cannot use more slots than we currently own */
+        uint32_t avail = nm_ring_space(ring);
+        uint32_t total = 0;
+        uint32_t nfrags = 0;
+        bool malformed = false;
+
+        /* copy each fragment slot into one buffer. keep walking the chain even
+         * after a problem so the whole frame is consumed as a single unit and
+         * the ring always moves forward. */
+        for (;;) {
+            uint32_t slen = slot->len;
+            if (!malformed) {
+                if (slen > ntv->coalesce_size - total) {
+                    /* frame is bigger than we can hold */
+                    malformed = true;
+                } else {
+                    memcpy(ntv->coalesce_buf + total, (u_char *)NETMAP_BUF(ring, slot->buf_idx),
+                            slen);
+                    total += slen;
+                }
+            }
+            nfrags++;
+
+            if (!(slot->flags & NS_MOREFRAG))
+                break;
+            if (nfrags >= avail) {
+                /* the chain never ended inside the slots we own */
+                malformed = true;
+                break;
+            }
+            i = nm_ring_next(ring, i);
+            slot = &ring->slot[i];
+        }
+
+        if (malformed) {
+            ntv->drops++;
+            dropped = true;
+        } else {
+            hdr->buf = ntv->coalesce_buf;
+            hdr->len = hdr->caplen = total;
+            *force_copy = true;
+        }
+    }
+
+    /* release the slots we walked back to the kernel */
+    ring->head = ring->cur = nm_ring_next(ring, i);
+    return !dropped;
+}
+
 /**
  * \brief Copy netmap rings data into Packet structures.
  * \param *d nmport_d (or nm_desc) netmap if structure.
@@ -713,12 +802,8 @@ static void NetmapProcessPacket(NetmapThreadVars *ntv, const struct nm_pkthdr *p
  */
 static TmEcode NetmapReadPackets(struct nmport_d *d, int cnt, NetmapThreadVars *ntv)
 {
-    struct nm_pkthdr hdr;
     int last_ring = d->last_rx_ring - d->first_rx_ring + 1;
     int cur_ring, got = 0, cur_rx_ring = d->cur_rx_ring;
-
-    memset(&hdr, 0, sizeof(hdr));
-    hdr.flags = NM_MORE_PKTS;
 
     if (cnt == 0)
         cnt = -1;
@@ -733,52 +818,16 @@ static TmEcode NetmapReadPackets(struct nmport_d *d, int cnt, NetmapThreadVars *
 
         /* cycle through the non-empty ring slots to fetch their data */
         for (; !nm_ring_empty(ring) && cnt != got; got++) {
-            u_int idx, i;
-            u_char *oldbuf;
-            struct netmap_slot *slot;
+            struct nm_pkthdr hdr;
+            bool force_copy;
 
-            if (hdr.buf) { /* from previous round */
-                NetmapProcessPacket(ntv, &hdr);
-            }
-
-            i = ring->cur;
-            slot = &ring->slot[i];
-            idx = slot->buf_idx;
             d->cur_rx_ring = cur_rx_ring;
-            hdr.slot = slot;
-            oldbuf = hdr.buf = (u_char *)NETMAP_BUF(ring, idx);
-            hdr.len = hdr.caplen = slot->len;
-
-            /* loop through the ring slots to get packet data */
-            while (slot->flags & NS_MOREFRAG) {
-                /* packet can be fragmented across multiple slots, */
-                /* so loop until we find the slot with the flag    */
-                /* cleared, signalling the end of the packet data. */
-                u_char *nbuf;
-                u_int oldlen = slot->len;
-                i = nm_ring_next(ring, i);
-                slot = &ring->slot[i];
-                hdr.len += slot->len;
-                nbuf = (u_char *)NETMAP_BUF(ring, slot->buf_idx);
-
-                if (oldbuf != NULL && nbuf - oldbuf == ring->nr_buf_size &&
-                        oldlen == ring->nr_buf_size) {
-                    hdr.caplen += slot->len;
-                    oldbuf = nbuf;
-                } else {
-                    oldbuf = NULL;
-                }
+            if (NetmapReadOnePacket(ring, ntv, &hdr, &force_copy)) {
+                NetmapProcessPacket(ntv, &hdr, force_copy);
             }
-
-            hdr.ts = ring->ts;
-            ring->head = ring->cur = nm_ring_next(ring, i);
         }
     }
 
-    if (hdr.buf) { /* from previous round */
-        hdr.flags = 0;
-        NetmapProcessPacket(ntv, &hdr);
-    }
     return got;
 }
 
@@ -894,6 +943,7 @@ static TmEcode ReceiveNetmapThreadDeinit(ThreadVars *tv, void *data)
         SCBPFFree(&ntv->bpf_prog);
     }
 
+    SCFree(ntv->coalesce_buf);
     SCFree(ntv);
 
     SCReturnInt(TM_ECODE_OK);
@@ -960,6 +1010,10 @@ static TmEcode DecodeNetmapThreadDeinit(ThreadVars *tv, void *data)
     SCReturnInt(TM_ECODE_OK);
 }
 
+#ifdef UNITTESTS
+#include "tests/source-netmap.c"
+#endif
+
 /**
  * \brief Registration Function for ReceiveNetmap.
  */
@@ -972,6 +1026,9 @@ void TmModuleReceiveNetmapRegister(void)
     tmm_modules[TMM_RECEIVENETMAP].ThreadDeinit = ReceiveNetmapThreadDeinit;
     tmm_modules[TMM_RECEIVENETMAP].cap_flags = SC_CAP_NET_RAW;
     tmm_modules[TMM_RECEIVENETMAP].flags = TM_FLAG_RECEIVE_TM;
+#ifdef UNITTESTS
+    tmm_modules[TMM_RECEIVENETMAP].RegisterTests = NetmapRegisterTests;
+#endif
 }
 
 /**

--- a/src/tests/source-netmap.c
+++ b/src/tests/source-netmap.c
@@ -1,0 +1,292 @@
+/* Copyright (C) 2026 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "../suricata-common.h"
+#include "../util-unittest.h"
+
+/* Build a fake rx ring in one block of memory. The ring header and its slots
+ * come first and the packet buffers follow, so NETMAP_BUF(ring, k) lands on
+ * buffer number k. num_slots and nr_buf_size are const in the real struct, so
+ * we write them through a plain pointer as the memory itself is not const. */
+static struct netmap_ring *NetmapTestRingNew(uint32_t num_slots, uint32_t buf_size)
+{
+    size_t slots_end =
+            offsetof(struct netmap_ring, slot) + (size_t)num_slots * sizeof(struct netmap_slot);
+    size_t total = slots_end + (size_t)num_slots * buf_size;
+
+    struct netmap_ring *ring = SCCalloc(1, total);
+    if (ring == NULL)
+        return NULL;
+
+    *(int64_t *)(uintptr_t)&ring->buf_ofs = (int64_t)slots_end;
+    *(uint32_t *)(uintptr_t)&ring->num_slots = num_slots;
+    *(uint32_t *)(uintptr_t)&ring->nr_buf_size = buf_size;
+    ring->head = ring->cur = 0;
+    /* mark all but one slot as owned by us so nm_ring_space is not zero */
+    ring->tail = num_slots ? num_slots - 1 : 0;
+    return ring;
+}
+
+/* Point a slot at buffer buf_idx, give it a length and flags, and fill that
+ * buffer with a byte so we can check the order things get copied in. */
+static void NetmapTestSetSlot(struct netmap_ring *ring, uint32_t slot_idx, uint32_t buf_idx,
+        uint16_t len, uint16_t flags, uint8_t fill)
+{
+    ring->slot[slot_idx].buf_idx = buf_idx;
+    ring->slot[slot_idx].len = len;
+    ring->slot[slot_idx].flags = flags;
+    memset(NETMAP_BUF(ring, buf_idx), fill, len);
+}
+
+static void NetmapTestNtvInit(NetmapThreadVars *ntv, uint32_t coalesce_size)
+{
+    memset(ntv, 0, sizeof(*ntv));
+    ntv->coalesce_size = coalesce_size;
+    ntv->coalesce_buf = SCCalloc(1, coalesce_size);
+    if (ntv->coalesce_buf == NULL)
+        return;
+}
+
+/* One slot, no fragments. It should stay as is and keep pointing into the ring
+ * so zero-copy is still possible. */
+static int NetmapReadSingleSlotTest(void)
+{
+    struct netmap_ring *ring = NetmapTestRingNew(8, 2048);
+    FAIL_IF_NULL(ring);
+    NetmapThreadVars ntv;
+    NetmapTestNtvInit(&ntv, MAX_PAYLOAD_SIZE);
+    FAIL_IF_NULL(ntv.coalesce_buf);
+
+    NetmapTestSetSlot(ring, 0, 0, 100, 0, 0xAA);
+
+    struct nm_pkthdr hdr;
+    bool force_copy = true;
+    FAIL_IF_NOT(NetmapReadOnePacket(ring, &ntv, &hdr, &force_copy));
+    FAIL_IF(force_copy);
+    FAIL_IF_NOT(hdr.len == 100);
+    FAIL_IF_NOT(hdr.buf == (u_char *)NETMAP_BUF(ring, 0));
+    FAIL_IF_NOT(ring->cur == 1);
+
+    SCFree(ntv.coalesce_buf);
+    SCFree(ring);
+    PASS;
+}
+
+/* Two fragments whose buffers happen to sit next to each other. The whole frame
+ * must be rebuilt in the coalesce buffer. */
+static int NetmapReadTwoSlotAdjacentTest(void)
+{
+    struct netmap_ring *ring = NetmapTestRingNew(8, 2048);
+    FAIL_IF_NULL(ring);
+    NetmapThreadVars ntv;
+    NetmapTestNtvInit(&ntv, MAX_PAYLOAD_SIZE);
+    FAIL_IF_NULL(ntv.coalesce_buf);
+
+    NetmapTestSetSlot(ring, 0, 0, 60, NS_MOREFRAG, 0x11);
+    NetmapTestSetSlot(ring, 1, 1, 40, 0, 0x22);
+
+    struct nm_pkthdr hdr;
+    bool force_copy = false;
+    FAIL_IF_NOT(NetmapReadOnePacket(ring, &ntv, &hdr, &force_copy));
+    FAIL_IF_NOT(force_copy);
+    FAIL_IF_NOT(hdr.len == 100);
+    FAIL_IF_NOT(hdr.buf == ntv.coalesce_buf);
+    for (uint32_t i = 0; i < 60; i++)
+        FAIL_IF_NOT(ntv.coalesce_buf[i] == 0x11);
+    for (uint32_t i = 60; i < 100; i++)
+        FAIL_IF_NOT(ntv.coalesce_buf[i] == 0x22);
+    FAIL_IF_NOT(ring->cur == 2);
+
+    SCFree(ntv.coalesce_buf);
+    SCFree(ring);
+    PASS;
+}
+
+/* Two fragments whose buffers are far apart. This is the case the old code got
+ * wrong. We must still copy the real bytes of both slots in order. */
+static int NetmapReadTwoSlotNonAdjacentTest(void)
+{
+    struct netmap_ring *ring = NetmapTestRingNew(8, 2048);
+    FAIL_IF_NULL(ring);
+    NetmapThreadVars ntv;
+    NetmapTestNtvInit(&ntv, MAX_PAYLOAD_SIZE);
+    FAIL_IF_NULL(ntv.coalesce_buf);
+
+    NetmapTestSetSlot(ring, 0, 5, 60, NS_MOREFRAG, 0x33);
+    NetmapTestSetSlot(ring, 1, 2, 40, 0, 0x44);
+
+    struct nm_pkthdr hdr;
+    bool force_copy = false;
+    FAIL_IF_NOT(NetmapReadOnePacket(ring, &ntv, &hdr, &force_copy));
+    FAIL_IF_NOT(force_copy);
+    FAIL_IF_NOT(hdr.len == 100);
+    FAIL_IF_NOT(hdr.buf == ntv.coalesce_buf);
+    for (uint32_t i = 0; i < 60; i++)
+        FAIL_IF_NOT(ntv.coalesce_buf[i] == 0x33);
+    for (uint32_t i = 60; i < 100; i++)
+        FAIL_IF_NOT(ntv.coalesce_buf[i] == 0x44);
+    FAIL_IF_NOT(ring->cur == 2);
+
+    SCFree(ntv.coalesce_buf);
+    SCFree(ring);
+    PASS;
+}
+
+/* A two slot packet that wraps around the end of the ring (slot 3 then slot 0).
+ * The walk has to follow the wrap and rebuild the frame. */
+static int NetmapReadRingWrapTest(void)
+{
+    struct netmap_ring *ring = NetmapTestRingNew(4, 2048);
+    FAIL_IF_NULL(ring);
+    NetmapThreadVars ntv;
+    NetmapTestNtvInit(&ntv, MAX_PAYLOAD_SIZE);
+    FAIL_IF_NULL(ntv.coalesce_buf);
+
+    NetmapTestSetSlot(ring, 3, 3, 60, NS_MOREFRAG, 0x55);
+    NetmapTestSetSlot(ring, 0, 0, 40, 0, 0x66);
+    ring->head = ring->cur = 3;
+    /* two slots owned, 3 then 0 */
+    ring->tail = 1;
+
+    struct nm_pkthdr hdr;
+    bool force_copy = false;
+    FAIL_IF_NOT(NetmapReadOnePacket(ring, &ntv, &hdr, &force_copy));
+    FAIL_IF_NOT(force_copy);
+    FAIL_IF_NOT(hdr.len == 100);
+    FAIL_IF_NOT(hdr.buf == ntv.coalesce_buf);
+    for (uint32_t i = 0; i < 60; i++)
+        FAIL_IF_NOT(ntv.coalesce_buf[i] == 0x55);
+    for (uint32_t i = 60; i < 100; i++)
+        FAIL_IF_NOT(ntv.coalesce_buf[i] == 0x66);
+    FAIL_IF_NOT(ring->cur == 1);
+
+    SCFree(ntv.coalesce_buf);
+    SCFree(ring);
+    PASS;
+}
+
+/* An empty leading fragment must not break the copy of the following one. */
+static int NetmapReadZeroLenFragTest(void)
+{
+    struct netmap_ring *ring = NetmapTestRingNew(8, 2048);
+    FAIL_IF_NULL(ring);
+    NetmapThreadVars ntv;
+    NetmapTestNtvInit(&ntv, MAX_PAYLOAD_SIZE);
+    FAIL_IF_NULL(ntv.coalesce_buf);
+
+    NetmapTestSetSlot(ring, 0, 0, 0, NS_MOREFRAG, 0x00);
+    NetmapTestSetSlot(ring, 1, 1, 50, 0, 0x77);
+
+    struct nm_pkthdr hdr;
+    bool force_copy = false;
+    FAIL_IF_NOT(NetmapReadOnePacket(ring, &ntv, &hdr, &force_copy));
+    FAIL_IF_NOT(force_copy);
+    FAIL_IF_NOT(hdr.len == 50);
+    for (uint32_t i = 0; i < 50; i++)
+        FAIL_IF_NOT(ntv.coalesce_buf[i] == 0x77);
+    FAIL_IF_NOT(ring->cur == 2);
+
+    SCFree(ntv.coalesce_buf);
+    SCFree(ring);
+    PASS;
+}
+
+/* A frame bigger than the coalesce buffer must be dropped, not copied. */
+static int NetmapReadOverSizeTest(void)
+{
+    struct netmap_ring *ring = NetmapTestRingNew(8, 2048);
+    FAIL_IF_NULL(ring);
+    NetmapThreadVars ntv;
+    NetmapTestNtvInit(&ntv, 100);
+    FAIL_IF_NULL(ntv.coalesce_buf);
+
+    NetmapTestSetSlot(ring, 0, 0, 60, NS_MOREFRAG, 0x11);
+    NetmapTestSetSlot(ring, 1, 1, 60, 0, 0x22);
+
+    struct nm_pkthdr hdr;
+    bool force_copy = false;
+    FAIL_IF(NetmapReadOnePacket(ring, &ntv, &hdr, &force_copy));
+    FAIL_IF_NOT(ntv.drops == 1);
+    FAIL_IF_NOT(ring->cur == 2);
+
+    SCFree(ntv.coalesce_buf);
+    SCFree(ring);
+    PASS;
+}
+
+/* An oversize frame with fragments after the point where it overflows must be
+ * dropped whole, so the trailing slots are not read back as a bogus packet. */
+static int NetmapReadOverSizeTrailingFragTest(void)
+{
+    struct netmap_ring *ring = NetmapTestRingNew(8, 2048);
+    FAIL_IF_NULL(ring);
+    NetmapThreadVars ntv;
+    NetmapTestNtvInit(&ntv, 100);
+    FAIL_IF_NULL(ntv.coalesce_buf);
+
+    NetmapTestSetSlot(ring, 0, 0, 60, NS_MOREFRAG, 0x11);
+    NetmapTestSetSlot(ring, 1, 1, 60, NS_MOREFRAG, 0x22);
+    NetmapTestSetSlot(ring, 2, 2, 20, 0, 0x33);
+
+    struct nm_pkthdr hdr;
+    bool force_copy = false;
+    FAIL_IF(NetmapReadOnePacket(ring, &ntv, &hdr, &force_copy));
+    FAIL_IF_NOT(ntv.drops == 1);
+    FAIL_IF_NOT(ring->cur == 3);
+
+    SCFree(ntv.coalesce_buf);
+    SCFree(ring);
+    PASS;
+}
+
+/* A fragment chain that never ends must be dropped once we have looked at every
+ * slot we own, and the ring must still move forward so the reader cannot spin. */
+static int NetmapReadTooManyFragsTest(void)
+{
+    struct netmap_ring *ring = NetmapTestRingNew(8, 64);
+    FAIL_IF_NULL(ring);
+    NetmapThreadVars ntv;
+    NetmapTestNtvInit(&ntv, MAX_PAYLOAD_SIZE);
+    FAIL_IF_NULL(ntv.coalesce_buf);
+
+    for (uint32_t k = 0; k < 5; k++)
+        NetmapTestSetSlot(ring, k, k, 10, NS_MOREFRAG, (uint8_t)(0x10 + k));
+    ring->head = ring->cur = 0;
+    ring->tail = 5;
+
+    struct nm_pkthdr hdr;
+    bool force_copy = false;
+    FAIL_IF(NetmapReadOnePacket(ring, &ntv, &hdr, &force_copy));
+    FAIL_IF_NOT(ntv.drops == 1);
+    FAIL_IF_NOT(ring->cur == 5);
+
+    SCFree(ntv.coalesce_buf);
+    SCFree(ring);
+    PASS;
+}
+
+static void NetmapRegisterTests(void)
+{
+    UtRegisterTest("NetmapReadSingleSlotTest", NetmapReadSingleSlotTest);
+    UtRegisterTest("NetmapReadTwoSlotAdjacentTest", NetmapReadTwoSlotAdjacentTest);
+    UtRegisterTest("NetmapReadTwoSlotNonAdjacentTest", NetmapReadTwoSlotNonAdjacentTest);
+    UtRegisterTest("NetmapReadRingWrapTest", NetmapReadRingWrapTest);
+    UtRegisterTest("NetmapReadZeroLenFragTest", NetmapReadZeroLenFragTest);
+    UtRegisterTest("NetmapReadOverSizeTest", NetmapReadOverSizeTest);
+    UtRegisterTest("NetmapReadOverSizeTrailingFragTest", NetmapReadOverSizeTrailingFragTest);
+    UtRegisterTest("NetmapReadTooManyFragsTest", NetmapReadTooManyFragsTest);
+}


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8777

Previous PR: #16032

### Changes since #16032

- Check the coalesce buffer allocation in the test helper so the malloc-error-check coccinelle rule passes. No change to the fix itself.

## Describe changes:

Fixes the netmap multi-slot packet over-read from ticket #8777.

When netmap splits a packet over several ring slots, the reader used to pass the first slot buffer together with the summed length of all the slots. If those slot buffers were not next to each other in memory this read past the first buffer. It could crash the process or leak bytes from unrelated buffers into inspection, pcap output and IPS or tap forwarding, and it also let the real tail of a split packet be missed by detection.

The reader now copies a multi-slot packet slot by slot into a per-thread buffer and hands the pipeline one addressable frame. Those packets are copied into the Packet and never referenced zero-copy, because the buffer is reused for the next packet. Single-slot packets keep the zero-copy fast path. The fragment walk is bounded by the slots the ring owns and the total length is capped, so a broken or over-long chain is dropped as one unit and the ring keeps moving forward.

### Testing

Netmap needs a real device, so this cannot run under suricata-verify. The change adds unit tests that build a fake ring in memory and cover single-slot, adjacent, non-adjacent, ring-wrap, empty-fragment, over-size and never-ending chains. The netmap CI job now builds with unittests and runs them. All pass locally under AddressSanitizer.
