### PR TITLE
8.0.x: github-ci: suppress RUSTSEC-2026-0253

### DIFF
--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -91,5 +91,7 @@ jobs:
           IGNORES+=(--ignore RUSTSEC-2026-0009)
           # rand, vla tls-parser
           IGNORES+=(--ignore RUSTSEC-2026-0097)
+          # lru, doesn't affect us
+          IGNORES+=(--ignore RUSTSEC-2026-0253)
 
           cargo audit -D warnings "${IGNORES[@]}"


### PR DESCRIPTION
RUSTSEC-2026-0253 in the lru crate requires that items we put in the
lru have a drop implementation that may panic, and we catch
that panic. The current items we put in the lru cache do not have a drop
implementation, and we treat panic's as fatal so will not run into the
issue presented in RUSTSEC-2026-0253.
