### PR TITLE
detect/bytemath: bound shift counts - v1

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -569,6 +569,8 @@ When ``relative`` is included, there must be a previous ``content`` or ``pcre`` 
 
 Note: if ``oper`` is ``/`` and the divisor is 0, there will never be a match on the ``byte_math`` keyword.
 
+Note: if ``oper`` is ``<<`` or ``>>`` and ``rvalue`` is 64 or greater, the result is 0.
+
 The result can be stored in a result variable and referenced by
 other rule options later in the rule.
 

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -348,11 +348,21 @@ fn parse_bytemath(input: &str) -> IResult<&str, DetectByteMathData, RuleParseErr
         )));
     }
 
-    // Using left/right shift further restricts the value of nbytes. Note that
-    // validation has already ensured nbytes is in [1..10]
+    // Using left/right shift further restricts the values of nbytes and rvalue.
+    // Note that validation has already ensured nbytes is in [1..10]
     match byte_math.oper {
-        ByteMathOperator::LeftShift | ByteMathOperator::RightShift if byte_math.nbytes > 4 => {
-            return Err(make_error(format!("nbytes must be 1 through 4 (inclusive) when used with \"<<\" or \">>\"; {} is not valid", byte_math.nbytes)));
+        ByteMathOperator::LeftShift | ByteMathOperator::RightShift => {
+            if byte_math.nbytes > 4 {
+                return Err(make_error(format!("nbytes must be 1 through 4 (inclusive) when used with \"<<\" or \">>\"; {} is not valid", byte_math.nbytes)));
+            }
+            // A shift of 64 or more always yields 0. Reject the literal form;
+            // the variable form is only known at match time.
+            if 0 == (byte_math.flags & DETECT_BYTEMATH_FLAG_RVALUE_VAR) && byte_math.rvalue >= 64 {
+                return Err(make_error(format!(
+                    "rvalue must be less than 64 when used with \"<<\" or \">>\"; {} is not valid",
+                    byte_math.rvalue
+                )));
+            }
         }
         _ => {}
     };
@@ -615,6 +625,21 @@ mod tests {
         );
         assert!(
             parse_bytemath("bytes 5, offset 3933, oper <<, rvalue myrvalue, result foo").is_err()
+        );
+    }
+
+    #[test]
+    // a literal rvalue of 64 or more is rejected with rshift/lshift; a variable
+    // rvalue is resolved at match time and cannot be checked here
+    fn test_parser_shift_rvalue() {
+        assert!(parse_bytemath("bytes 4, offset 3933, oper >>, rvalue 63, result foo").is_ok());
+        assert!(parse_bytemath("bytes 4, offset 3933, oper <<, rvalue 63, result foo").is_ok());
+        assert!(parse_bytemath("bytes 4, offset 3933, oper >>, rvalue 64, result foo").is_err());
+        assert!(parse_bytemath("bytes 4, offset 3933, oper <<, rvalue 64, result foo").is_err());
+        assert!(parse_bytemath("bytes 4, offset 3933, oper >>, rvalue 100, result foo").is_err());
+        assert!(parse_bytemath("bytes 4, offset 3933, oper +, rvalue 100, result foo").is_ok());
+        assert!(
+            parse_bytemath("bytes 4, offset 3933, oper >>, rvalue myrvalue, result foo").is_ok()
         );
     }
 

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020-2022 Open Information Security Foundation
+/* Copyright (C) 2020-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -189,7 +189,11 @@ int DetectByteMathDoMatch(DetectEngineThreadCtx *det_ctx, const DetectByteMathDa
             }
             break;
         case RightShift:
-            val >>= rvalue;
+            if (rvalue < 64) {
+                val >>= rvalue;
+            } else {
+                val = 0;
+            }
             break;
     }
 
@@ -999,6 +1003,31 @@ static int DetectByteMathPacket02(void)
     PASS;
 }
 
+/**
+ * \test A payload-supplied shift count of 64 or more yields 0 instead of
+ *       shifting a uint64_t by its own width.
+ */
+static int DetectByteMathPacket03(void)
+{
+    /* byte 0 is the shift count (64), byte 1 the value shifted, byte 2 the
+     * expected result */
+    uint8_t buf[] = { 0x40, 0xff, 0x00 };
+
+    Packet *p = UTHBuildPacket(buf, sizeof(buf), IPPROTO_UDP);
+    FAIL_IF_NULL(p);
+
+    /* 0xff >> 64 is 0 */
+    FAIL_IF_NOT(UTHPacketMatchSig(p, "alert udp any any -> any any "
+                                     "(byte_extract: 1, 0, shift;"
+                                     "byte_math: bytes 1, offset 1, oper >>, rvalue shift, result "
+                                     "var;"
+                                     "byte_test: 1, =, var, 2;"
+                                     "sid:1;)"));
+    UTHFreePacket(p);
+
+    PASS;
+}
+
 static int DetectByteMathContext01(void)
 {
     DetectEngineCtx *de_ctx = NULL;
@@ -1071,6 +1100,7 @@ static void DetectByteMathRegisterTests(void)
     UtRegisterTest("DetectByteMathParseTest16", DetectByteMathParseTest16);
     UtRegisterTest("DetectByteMathPacket01", DetectByteMathPacket01);
     UtRegisterTest("DetectByteMathPacket02", DetectByteMathPacket02);
+    UtRegisterTest("DetectByteMathPacket03", DetectByteMathPacket03);
     UtRegisterTest("DetectByteMathContext01", DetectByteMathContext01);
 }
 #endif /* UNITTESTS */

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -1028,6 +1028,27 @@ static int DetectByteMathPacket03(void)
     PASS;
 }
 
+/**
+ * \test A literal shift count of 64 or more is rejected at parse time.
+ */
+static int DetectByteMathParseTest17(void)
+{
+    DetectByteMathData *bmd = DetectByteMathParse(
+            NULL, "bytes 4, offset 2, oper >>, rvalue 64, result foo", NULL, NULL);
+    FAIL_IF_NOT_NULL(bmd);
+
+    bmd = DetectByteMathParse(
+            NULL, "bytes 4, offset 2, oper <<, rvalue 64, result foo", NULL, NULL);
+    FAIL_IF_NOT_NULL(bmd);
+
+    bmd = DetectByteMathParse(
+            NULL, "bytes 4, offset 2, oper >>, rvalue 63, result foo", NULL, NULL);
+    FAIL_IF_NULL(bmd);
+    DetectByteMathFree(NULL, bmd);
+
+    PASS;
+}
+
 static int DetectByteMathContext01(void)
 {
     DetectEngineCtx *de_ctx = NULL;
@@ -1098,6 +1119,7 @@ static void DetectByteMathRegisterTests(void)
     UtRegisterTest("DetectByteMathParseTest14", DetectByteMathParseTest14);
     UtRegisterTest("DetectByteMathParseTest15", DetectByteMathParseTest15);
     UtRegisterTest("DetectByteMathParseTest16", DetectByteMathParseTest16);
+    UtRegisterTest("DetectByteMathParseTest17", DetectByteMathParseTest17);
     UtRegisterTest("DetectByteMathPacket01", DetectByteMathPacket01);
     UtRegisterTest("DetectByteMathPacket02", DetectByteMathPacket02);
     UtRegisterTest("DetectByteMathPacket03", DetectByteMathPacket03);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8845

Describe changes:
- Zero the byte_math result when a right shift count reaches 64, the width of the uint64_t being shifted. The left shift case has been bounded this way since 473ca6dcf4; the right shift case was left as it was, so DetectByteMathDoMatch() shifted by whatever count it was handed. The count is reachable from the payload through byte_extract and a variable rvalue.
- Reject at rule load a literal rvalue of 64 or more paired with << or >>. rvalue was bounded only to u32::MAX. A variable rvalue still loads, since its value is not known until the rule runs; the runtime guard is what covers that path.
- Document that << and >> yield 0 for a count of 64 or more, beside the existing note about division by zero.

Verification: clean build with --enable-warnings --enable-rust-strict
--enable-unittests; C unit tests and cargo test detect::byte_math pass; both new suricata-verify tests pass and both fail on an unfixed build.

Note the second commit fails rules that load today (byte_math with a literal
shift count of 64 or more). That suits 9.0.0-beta1. It is deliberately a
separate commit from the fix so the backport question can be answered on its
own -- main-8.0.x still has the unguarded shift at src/detect-bytemath.c:191.

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3288

