### PR TITLE
detect/ipv6: classify ipv6 ranges as like_ip_only

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -513,6 +513,7 @@ static int DetectAddressParseString(DetectAddress *dd, const char *str)
             dd->ip2.addr_data32[2] |=~ netmask[2];
             dd->ip2.addr_data32[3] |=~ netmask[3];
         } else if ((ip2 = strchr(ip, '-')) != NULL)  {
+            dd->flags |= ADDRESS_FLAG_RANGE;
             /* 2001::1-2001::4 range format */
             ip[ip2 - ip] = '\0';
             ip2++;
@@ -652,6 +653,9 @@ static int DetectAddressSetup(DetectAddressHead *gh, const char *s)
             }
         }
     }
+    if (ad->flags & ADDRESS_FLAG_RANGE) {
+        gh->contains_range = true;
+    }
 
     int r = DetectAddressInsert(NULL, gh, ad);
     if (r < 0) {
@@ -747,8 +751,8 @@ static int DetectAddressParseInternal(const DetectEngineCtx *de_ctx, DetectAddre
                      * applicable. Then insert the result into the ghn list. */
                     SCLogDebug("negated block");
 
-                    DetectAddressHead tmp_gh = { NULL, NULL };
-                    DetectAddressHead tmp_ghn = { NULL, NULL };
+                    DetectAddressHead tmp_gh = { NULL, NULL, false };
+                    DetectAddressHead tmp_ghn = { NULL, NULL, false };
 
                     if (DetectAddressParse2(de_ctx, &tmp_gh, &tmp_ghn, address, 0, var_list, recur) < 0) {
                         DetectAddressHeadCleanup(&tmp_gh);
@@ -1288,6 +1292,7 @@ typedef struct DetectAddressMap_ {
     char *string;
     DetectAddressHead *address;
     bool contains_negation;
+    bool contains_range;
 } DetectAddressMap;
 
 static uint32_t DetectAddressMapHashFunc(HashListTable *ht, void *data, uint16_t datalen)
@@ -1342,7 +1347,7 @@ void DetectAddressMapFree(DetectEngineCtx *de_ctx)
 }
 
 static bool DetectAddressMapAdd(DetectEngineCtx *de_ctx, const char *string,
-        DetectAddressHead *address, bool contains_negation)
+        DetectAddressHead *address, bool contains_negation, bool contains_range)
 {
     DetectAddressMap *map = SCCalloc(1, sizeof(*map));
     if (map == NULL)
@@ -1355,6 +1360,7 @@ static bool DetectAddressMapAdd(DetectEngineCtx *de_ctx, const char *string,
     }
     map->address = address;
     map->contains_negation = contains_negation;
+    map->contains_range = contains_range;
 
     if (HashListTableAdd(de_ctx->address_table, map, 0) != 0) {
         SCFree(map->string);
@@ -1368,7 +1374,7 @@ static bool DetectAddressMapAdd(DetectEngineCtx *de_ctx, const char *string,
 static const DetectAddressMap *DetectAddressMapLookup(DetectEngineCtx *de_ctx,
                                                 const char *string)
 {
-    DetectAddressMap map = { (char *)string, NULL, false };
+    DetectAddressMap map = { (char *)string, NULL, false, false };
 
     const DetectAddressMap *res = HashListTableLookup(de_ctx->address_table,
             &map, 0);
@@ -1389,8 +1395,8 @@ static const DetectAddressMap *DetectAddressMapLookup(DetectEngineCtx *de_ctx,
  * \retval  0 On success. Did not contain negation.
  * \retval -1 On failure.
  */
-int DetectAddressParse(const DetectEngineCtx *de_ctx,
-                       DetectAddressHead *gh, const char *str)
+int DetectAddressParse(
+        const DetectEngineCtx *de_ctx, DetectAddressHead *gh, const char *str, bool *contains_range)
 {
     SCLogDebug("gh %p, str %s", gh, str);
 
@@ -1416,6 +1422,9 @@ int DetectAddressParse(const DetectEngineCtx *de_ctx,
                ghn->ipv4_head);
 
     bool contains_negation = (ghn->ipv4_head != NULL || ghn->ipv6_head != NULL);
+    if (contains_range != NULL) {
+        *contains_range = (gh->contains_range == true || ghn->contains_range == true);
+    }
 
     /* merge the 'not' address groups */
     if (DetectAddressMergeNot(gh, ghn) < 0) {
@@ -1429,13 +1438,20 @@ int DetectAddressParse(const DetectEngineCtx *de_ctx,
     return contains_negation ? 1 : 0;
 }
 
-const DetectAddressHead *DetectParseAddress(DetectEngineCtx *de_ctx,
-        const char *string, bool *contains_negation)
+const DetectAddressHead *DetectParseAddress(
+        DetectEngineCtx *de_ctx, const char *string, bool *contains_negation, bool *contains_range)
 {
+    DEBUG_VALIDATE_BUG_ON(contains_range == NULL);
+    if (contains_range == NULL) {
+        SCLogError("contain_range should not be NULL");
+        return NULL;
+    }
+
     const DetectAddressMap *res = DetectAddressMapLookup(de_ctx, string);
     if (res != NULL) {
         SCLogDebug("found: %s :: %p", string, res);
         *contains_negation = res->contains_negation;
+        *contains_range = res->contains_range;
         return res->address;
     }
 
@@ -1445,7 +1461,7 @@ const DetectAddressHead *DetectParseAddress(DetectEngineCtx *de_ctx,
     if (head == NULL)
         return NULL;
 
-    const int r = DetectAddressParse(de_ctx, head, string);
+    const int r = DetectAddressParse(de_ctx, head, string, contains_range);
     if (r < 0) {
         DetectAddressHeadFree(head);
         return NULL;
@@ -1455,7 +1471,8 @@ const DetectAddressHead *DetectParseAddress(DetectEngineCtx *de_ctx,
         *contains_negation = false;
     }
 
-    if (!DetectAddressMapAdd((DetectEngineCtx *)de_ctx, string, head, *contains_negation)) {
+    if (!DetectAddressMapAdd(
+                (DetectEngineCtx *)de_ctx, string, head, *contains_negation, *contains_range)) {
         DetectAddressHeadFree(head);
         return NULL;
     }
@@ -2274,7 +2291,7 @@ static int AddressTestParse23(void)
 {
     DetectAddressHead *gh = DetectAddressHeadInit();
     FAIL_IF_NULL(gh);
-    int r = DetectAddressParse(NULL, gh, "any");
+    int r = DetectAddressParse(NULL, gh, "any", NULL);
     FAIL_IF_NOT(r == 0);
     DetectAddressHeadFree(gh);
     PASS;
@@ -2284,7 +2301,7 @@ static int AddressTestParse24(void)
 {
     DetectAddressHead *gh = DetectAddressHeadInit();
     FAIL_IF_NULL(gh);
-    int r = DetectAddressParse(NULL, gh, "Any");
+    int r = DetectAddressParse(NULL, gh, "Any", NULL);
     FAIL_IF_NOT(r == 0);
     DetectAddressHeadFree(gh);
     PASS;
@@ -2294,7 +2311,7 @@ static int AddressTestParse25(void)
 {
     DetectAddressHead *gh = DetectAddressHeadInit();
     FAIL_IF_NULL(gh);
-    int r = DetectAddressParse(NULL, gh, "ANY");
+    int r = DetectAddressParse(NULL, gh, "ANY", NULL);
     FAIL_IF_NOT(r == 0);
     DetectAddressHeadFree(gh);
     PASS;
@@ -2309,8 +2326,8 @@ static int AddressTestParse26(void)
     int r = DetectAddressParse(NULL, gh,
             "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[["
             "1.2.3.4"
-            "]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]"
-            );
+            "]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]",
+            NULL);
     FAIL_IF_NOT(r == 0);
     DetectAddressHeadFree(gh);
     gh = DetectAddressHeadInit();
@@ -2319,8 +2336,8 @@ static int AddressTestParse26(void)
     r = DetectAddressParse(NULL, gh,
             "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[["
             "1.2.3.4"
-            "]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]"
-            );
+            "]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]",
+            NULL);
     FAIL_IF(r == 0);
     DetectAddressHeadFree(gh);
     PASS;
@@ -3117,7 +3134,7 @@ static int AddressTestAddressGroupSetup01(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "1.2.3.4");
+        int r = DetectAddressParse(NULL, gh, "1.2.3.4", NULL);
         if (r == 0)
             result = 1;
 
@@ -3132,7 +3149,7 @@ static int AddressTestAddressGroupSetup02(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "1.2.3.4");
+        int r = DetectAddressParse(NULL, gh, "1.2.3.4", NULL);
         if (r == 0 && gh->ipv4_head != NULL)
             result = 1;
 
@@ -3147,11 +3164,11 @@ static int AddressTestAddressGroupSetup03(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "1.2.3.4");
+        int r = DetectAddressParse(NULL, gh, "1.2.3.4", NULL);
         if (r == 0 && gh->ipv4_head != NULL) {
             DetectAddress *prev_head = gh->ipv4_head;
 
-            r = DetectAddressParse(NULL, gh, "1.2.3.3");
+            r = DetectAddressParse(NULL, gh, "1.2.3.3", NULL);
             if (r == 0 && gh->ipv4_head != prev_head &&
                 gh->ipv4_head != NULL && gh->ipv4_head->next == prev_head) {
                 result = 1;
@@ -3169,16 +3186,16 @@ static int AddressTestAddressGroupSetup04(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "1.2.3.4");
+        int r = DetectAddressParse(NULL, gh, "1.2.3.4", NULL);
         if (r == 0 && gh->ipv4_head != NULL) {
             DetectAddress *prev_head = gh->ipv4_head;
 
-            r = DetectAddressParse(NULL, gh, "1.2.3.3");
+            r = DetectAddressParse(NULL, gh, "1.2.3.3", NULL);
             if (r == 0 && gh->ipv4_head != prev_head &&
                 gh->ipv4_head != NULL && gh->ipv4_head->next == prev_head) {
                 DetectAddress *ph = gh->ipv4_head;
 
-                r = DetectAddressParse(NULL, gh, "1.2.3.2");
+                r = DetectAddressParse(NULL, gh, "1.2.3.2", NULL);
                 if (r == 0 && gh->ipv4_head != ph &&
                     gh->ipv4_head != NULL && gh->ipv4_head->next == ph) {
                     result = 1;
@@ -3197,16 +3214,16 @@ static int AddressTestAddressGroupSetup05(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "1.2.3.2");
+        int r = DetectAddressParse(NULL, gh, "1.2.3.2", NULL);
         if (r == 0 && gh->ipv4_head != NULL) {
             DetectAddress *prev_head = gh->ipv4_head;
 
-            r = DetectAddressParse(NULL, gh, "1.2.3.3");
+            r = DetectAddressParse(NULL, gh, "1.2.3.3", NULL);
             if (r == 0 && gh->ipv4_head == prev_head &&
                 gh->ipv4_head != NULL && gh->ipv4_head->next != prev_head) {
                 DetectAddress *ph = gh->ipv4_head;
 
-                r = DetectAddressParse(NULL, gh, "1.2.3.4");
+                r = DetectAddressParse(NULL, gh, "1.2.3.4", NULL);
                 if (r == 0 && gh->ipv4_head == ph &&
                     gh->ipv4_head != NULL && gh->ipv4_head->next != ph) {
                     result = 1;
@@ -3225,11 +3242,11 @@ static int AddressTestAddressGroupSetup06(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "1.2.3.2");
+        int r = DetectAddressParse(NULL, gh, "1.2.3.2", NULL);
         if (r == 0 && gh->ipv4_head != NULL) {
             DetectAddress *prev_head = gh->ipv4_head;
 
-            r = DetectAddressParse(NULL, gh, "1.2.3.2");
+            r = DetectAddressParse(NULL, gh, "1.2.3.2", NULL);
             if (r == 0 && gh->ipv4_head == prev_head &&
                 gh->ipv4_head != NULL && gh->ipv4_head->next == NULL) {
                 result = 1;
@@ -3247,9 +3264,9 @@ static int AddressTestAddressGroupSetup07(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "10.0.0.0/8");
+        int r = DetectAddressParse(NULL, gh, "10.0.0.0/8", NULL);
         if (r == 0 && gh->ipv4_head != NULL) {
-            r = DetectAddressParse(NULL, gh, "10.10.10.10");
+            r = DetectAddressParse(NULL, gh, "10.10.10.10", NULL);
             if (r == 0 && gh->ipv4_head != NULL &&
                 gh->ipv4_head->next != NULL &&
                 gh->ipv4_head->next->next != NULL) {
@@ -3268,9 +3285,9 @@ static int AddressTestAddressGroupSetup08(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "10.10.10.10");
+        int r = DetectAddressParse(NULL, gh, "10.10.10.10", NULL);
         if (r == 0 && gh->ipv4_head != NULL) {
-            r = DetectAddressParse(NULL, gh, "10.0.0.0/8");
+            r = DetectAddressParse(NULL, gh, "10.0.0.0/8", NULL);
             if (r == 0 && gh->ipv4_head != NULL &&
                 gh->ipv4_head->next != NULL &&
                 gh->ipv4_head->next->next != NULL) {
@@ -3289,9 +3306,9 @@ static int AddressTestAddressGroupSetup09(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "10.10.10.0/24");
+        int r = DetectAddressParse(NULL, gh, "10.10.10.0/24", NULL);
         if (r == 0 && gh->ipv4_head != NULL) {
-            r = DetectAddressParse(NULL, gh, "10.10.10.10-10.10.11.1");
+            r = DetectAddressParse(NULL, gh, "10.10.10.10-10.10.11.1", NULL);
             if (r == 0 && gh->ipv4_head != NULL &&
                 gh->ipv4_head->next != NULL &&
                 gh->ipv4_head->next->next != NULL) {
@@ -3310,9 +3327,9 @@ static int AddressTestAddressGroupSetup10(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "10.10.10.10-10.10.11.1");
+        int r = DetectAddressParse(NULL, gh, "10.10.10.10-10.10.11.1", NULL);
         if (r == 0 && gh->ipv4_head != NULL) {
-            r = DetectAddressParse(NULL, gh, "10.10.10.0/24");
+            r = DetectAddressParse(NULL, gh, "10.10.10.0/24", NULL);
             if (r == 0 && gh->ipv4_head != NULL &&
                 gh->ipv4_head->next != NULL &&
                 gh->ipv4_head->next->next != NULL) {
@@ -3331,11 +3348,11 @@ static int AddressTestAddressGroupSetup11(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "10.10.10.10-10.10.11.1");
+        int r = DetectAddressParse(NULL, gh, "10.10.10.10-10.10.11.1", NULL);
         if (r == 0) {
-            r = DetectAddressParse(NULL, gh, "10.10.10.0/24");
+            r = DetectAddressParse(NULL, gh, "10.10.10.0/24", NULL);
             if (r == 0) {
-                r = DetectAddressParse(NULL, gh, "0.0.0.0/0");
+                r = DetectAddressParse(NULL, gh, "0.0.0.0/0", NULL);
                 if (r == 0) {
                     DetectAddress *one = gh->ipv4_head, *two = one->next,
                         *three = two->next, *four = three->next,
@@ -3370,11 +3387,11 @@ static int AddressTestAddressGroupSetup12 (void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "10.10.10.10-10.10.11.1");
+        int r = DetectAddressParse(NULL, gh, "10.10.10.10-10.10.11.1", NULL);
         if (r == 0) {
-            r = DetectAddressParse(NULL, gh, "0.0.0.0/0");
+            r = DetectAddressParse(NULL, gh, "0.0.0.0/0", NULL);
             if (r == 0) {
-                r = DetectAddressParse(NULL, gh, "10.10.10.0/24");
+                r = DetectAddressParse(NULL, gh, "10.10.10.0/24", NULL);
                 if (r == 0) {
                     DetectAddress *one = gh->ipv4_head, *two = one->next,
                         *three = two->next, *four = three->next,
@@ -3409,11 +3426,11 @@ static int AddressTestAddressGroupSetup13(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "0.0.0.0/0");
+        int r = DetectAddressParse(NULL, gh, "0.0.0.0/0", NULL);
         if (r == 0) {
-            r = DetectAddressParse(NULL, gh, "10.10.10.10-10.10.11.1");
+            r = DetectAddressParse(NULL, gh, "10.10.10.10-10.10.11.1", NULL);
             if (r == 0) {
-                r = DetectAddressParse(NULL, gh, "10.10.10.0/24");
+                r = DetectAddressParse(NULL, gh, "10.10.10.0/24", NULL);
                 if (r == 0) {
                     DetectAddress *one = gh->ipv4_head, *two = one->next,
                         *three = two->next, *four = three->next,
@@ -3447,7 +3464,7 @@ static int AddressTestAddressGroupSetupIPv414(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
     FAIL_IF_NULL(gh);
 
-    int r = DetectAddressParse(NULL, gh, "!1.2.3.4");
+    int r = DetectAddressParse(NULL, gh, "!1.2.3.4", NULL);
     FAIL_IF_NOT(r == 1);
 
     DetectAddress *one = gh->ipv4_head;
@@ -3473,7 +3490,7 @@ static int AddressTestAddressGroupSetupIPv415(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
     FAIL_IF_NULL(gh);
 
-    int r = DetectAddressParse(NULL, gh, "!0.0.0.0");
+    int r = DetectAddressParse(NULL, gh, "!0.0.0.0", NULL);
     FAIL_IF_NOT(r == 1);
 
     DetectAddress *one = gh->ipv4_head;
@@ -3495,7 +3512,7 @@ static int AddressTestAddressGroupSetupIPv416(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
     FAIL_IF_NULL(gh);
 
-    int r = DetectAddressParse(NULL, gh, "!255.255.255.255");
+    int r = DetectAddressParse(NULL, gh, "!255.255.255.255", NULL);
     FAIL_IF_NOT(r == 1);
 
     DetectAddress *one = gh->ipv4_head;
@@ -3518,7 +3535,7 @@ static int AddressTestAddressGroupSetup14(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2001::1");
+        int r = DetectAddressParse(NULL, gh, "2001::1", NULL);
         if (r == 0)
             result = 1;
 
@@ -3533,7 +3550,7 @@ static int AddressTestAddressGroupSetup15(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2001::1");
+        int r = DetectAddressParse(NULL, gh, "2001::1", NULL);
         if (r == 0 && gh->ipv6_head != NULL)
             result = 1;
 
@@ -3548,11 +3565,11 @@ static int AddressTestAddressGroupSetup16(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2001::4");
+        int r = DetectAddressParse(NULL, gh, "2001::4", NULL);
         if (r == 0 && gh->ipv6_head != NULL) {
             DetectAddress *prev_head = gh->ipv6_head;
 
-            r = DetectAddressParse(NULL, gh, "2001::3");
+            r = DetectAddressParse(NULL, gh, "2001::3", NULL);
             if (r == 0 && gh->ipv6_head != prev_head &&
                 gh->ipv6_head != NULL && gh->ipv6_head->next == prev_head) {
                 result = 1;
@@ -3570,16 +3587,16 @@ static int AddressTestAddressGroupSetup17(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2001::4");
+        int r = DetectAddressParse(NULL, gh, "2001::4", NULL);
         if (r == 0 && gh->ipv6_head != NULL) {
             DetectAddress *prev_head = gh->ipv6_head;
 
-            r = DetectAddressParse(NULL, gh, "2001::3");
+            r = DetectAddressParse(NULL, gh, "2001::3", NULL);
             if (r == 0 && gh->ipv6_head != prev_head &&
                 gh->ipv6_head != NULL && gh->ipv6_head->next == prev_head) {
                 DetectAddress *ph = gh->ipv6_head;
 
-                r = DetectAddressParse(NULL, gh, "2001::2");
+                r = DetectAddressParse(NULL, gh, "2001::2", NULL);
                 if (r == 0 && gh->ipv6_head != ph &&
                     gh->ipv6_head != NULL && gh->ipv6_head->next == ph) {
                     result = 1;
@@ -3598,16 +3615,16 @@ static int AddressTestAddressGroupSetup18(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2001::2");
+        int r = DetectAddressParse(NULL, gh, "2001::2", NULL);
         if (r == 0 && gh->ipv6_head != NULL) {
             DetectAddress *prev_head = gh->ipv6_head;
 
-            r = DetectAddressParse(NULL, gh, "2001::3");
+            r = DetectAddressParse(NULL, gh, "2001::3", NULL);
             if (r == 0 && gh->ipv6_head == prev_head &&
                 gh->ipv6_head != NULL && gh->ipv6_head->next != prev_head) {
                 DetectAddress *ph = gh->ipv6_head;
 
-                r = DetectAddressParse(NULL, gh, "2001::4");
+                r = DetectAddressParse(NULL, gh, "2001::4", NULL);
                 if (r == 0 && gh->ipv6_head == ph &&
                     gh->ipv6_head != NULL && gh->ipv6_head->next != ph) {
                     result = 1;
@@ -3626,11 +3643,11 @@ static int AddressTestAddressGroupSetup19(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2001::2");
+        int r = DetectAddressParse(NULL, gh, "2001::2", NULL);
         if (r == 0 && gh->ipv6_head != NULL) {
             DetectAddress *prev_head = gh->ipv6_head;
 
-            r = DetectAddressParse(NULL, gh, "2001::2");
+            r = DetectAddressParse(NULL, gh, "2001::2", NULL);
             if (r == 0 && gh->ipv6_head == prev_head &&
                 gh->ipv6_head != NULL && gh->ipv6_head->next == NULL) {
                 result = 1;
@@ -3648,9 +3665,9 @@ static int AddressTestAddressGroupSetup20(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2000::/3");
+        int r = DetectAddressParse(NULL, gh, "2000::/3", NULL);
         if (r == 0 && gh->ipv6_head != NULL) {
-            r = DetectAddressParse(NULL, gh, "2001::4");
+            r = DetectAddressParse(NULL, gh, "2001::4", NULL);
             if (r == 0 && gh->ipv6_head != NULL &&
                 gh->ipv6_head->next != NULL &&
                 gh->ipv6_head->next->next != NULL) {
@@ -3669,9 +3686,9 @@ static int AddressTestAddressGroupSetup21(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2001::4");
+        int r = DetectAddressParse(NULL, gh, "2001::4", NULL);
         if (r == 0 && gh->ipv6_head != NULL) {
-            r = DetectAddressParse(NULL, gh, "2000::/3");
+            r = DetectAddressParse(NULL, gh, "2000::/3", NULL);
             if (r == 0 && gh->ipv6_head != NULL &&
                 gh->ipv6_head->next != NULL &&
                 gh->ipv6_head->next->next != NULL) {
@@ -3690,9 +3707,9 @@ static int AddressTestAddressGroupSetup22(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2000::/3");
+        int r = DetectAddressParse(NULL, gh, "2000::/3", NULL);
         if (r == 0 && gh->ipv6_head != NULL) {
-            r = DetectAddressParse(NULL, gh, "2001::4-2001::6");
+            r = DetectAddressParse(NULL, gh, "2001::4-2001::6", NULL);
             if (r == 0 && gh->ipv6_head != NULL &&
                 gh->ipv6_head->next != NULL &&
                 gh->ipv6_head->next->next != NULL) {
@@ -3711,9 +3728,9 @@ static int AddressTestAddressGroupSetup23(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2001::4-2001::6");
+        int r = DetectAddressParse(NULL, gh, "2001::4-2001::6", NULL);
         if (r == 0 && gh->ipv6_head != NULL) {
-            r = DetectAddressParse(NULL, gh, "2000::/3");
+            r = DetectAddressParse(NULL, gh, "2000::/3", NULL);
             if (r == 0 && gh->ipv6_head != NULL &&
                 gh->ipv6_head->next != NULL &&
                 gh->ipv6_head->next->next != NULL) {
@@ -3732,11 +3749,11 @@ static int AddressTestAddressGroupSetup24(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2001::4-2001::6");
+        int r = DetectAddressParse(NULL, gh, "2001::4-2001::6", NULL);
         if (r == 0) {
-            r = DetectAddressParse(NULL, gh, "2001::/3");
+            r = DetectAddressParse(NULL, gh, "2001::/3", NULL);
             if (r == 0) {
-                r = DetectAddressParse(NULL, gh, "::/0");
+                r = DetectAddressParse(NULL, gh, "::/0", NULL);
                 if (r == 0) {
                     DetectAddress *one = gh->ipv6_head, *two = one->next,
                         *three = two->next, *four = three->next,
@@ -3802,11 +3819,11 @@ static int AddressTestAddressGroupSetup25(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "2001::4-2001::6");
+        int r = DetectAddressParse(NULL, gh, "2001::4-2001::6", NULL);
         if (r == 0) {
-            r = DetectAddressParse(NULL, gh, "::/0");
+            r = DetectAddressParse(NULL, gh, "::/0", NULL);
             if (r == 0) {
-                r = DetectAddressParse(NULL, gh, "2001::/3");
+                r = DetectAddressParse(NULL, gh, "2001::/3", NULL);
                 if (r == 0) {
                     DetectAddress *one = gh->ipv6_head, *two = one->next,
                         *three = two->next, *four = three->next,
@@ -3872,11 +3889,11 @@ static int AddressTestAddressGroupSetup26(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "::/0");
+        int r = DetectAddressParse(NULL, gh, "::/0", NULL);
         if (r == 0) {
-            r = DetectAddressParse(NULL, gh, "2001::4-2001::6");
+            r = DetectAddressParse(NULL, gh, "2001::4-2001::6", NULL);
             if (r == 0) {
-                r = DetectAddressParse(NULL, gh, "2001::/3");
+                r = DetectAddressParse(NULL, gh, "2001::/3", NULL);
                 if (r == 0) {
                     DetectAddress *one = gh->ipv6_head, *two = one->next,
                         *three = two->next, *four = three->next,
@@ -3942,7 +3959,7 @@ static int AddressTestAddressGroupSetup27(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[1.2.3.4]");
+        int r = DetectAddressParse(NULL, gh, "[1.2.3.4]", NULL);
         if (r == 0)
             result = 1;
 
@@ -3957,7 +3974,7 @@ static int AddressTestAddressGroupSetup28(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[1.2.3.4,4.3.2.1]");
+        int r = DetectAddressParse(NULL, gh, "[1.2.3.4,4.3.2.1]", NULL);
         if (r == 0)
             result = 1;
 
@@ -3972,7 +3989,7 @@ static int AddressTestAddressGroupSetup29(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[1.2.3.4,4.3.2.1,10.10.10.10]");
+        int r = DetectAddressParse(NULL, gh, "[1.2.3.4,4.3.2.1,10.10.10.10]", NULL);
         if (r == 0)
             result = 1;
 
@@ -3987,7 +4004,8 @@ static int AddressTestAddressGroupSetup30(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[[1.2.3.4,2.3.4.5],4.3.2.1,[10.10.10.10,11.11.11.11]]");
+        int r = DetectAddressParse(
+                NULL, gh, "[[1.2.3.4,2.3.4.5],4.3.2.1,[10.10.10.10,11.11.11.11]]", NULL);
         if (r == 0)
             result = 1;
 
@@ -4002,7 +4020,9 @@ static int AddressTestAddressGroupSetup31(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[[1.2.3.4,[2.3.4.5,3.4.5.6]],4.3.2.1,[10.10.10.10,[11.11.11.11,12.12.12.12]]]");
+        int r = DetectAddressParse(NULL, gh,
+                "[[1.2.3.4,[2.3.4.5,3.4.5.6]],4.3.2.1,[10.10.10.10,[11.11.11.11,12.12.12.12]]]",
+                NULL);
         if (r == 0)
             result = 1;
 
@@ -4017,7 +4037,10 @@ static int AddressTestAddressGroupSetup32(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[[1.2.3.4,[2.3.4.5,[3.4.5.6,4.5.6.7]]],4.3.2.1,[10.10.10.10,[11.11.11.11,[12.12.12.12,13.13.13.13]]]]");
+        int r = DetectAddressParse(NULL, gh,
+                "[[1.2.3.4,[2.3.4.5,[3.4.5.6,4.5.6.7]]],4.3.2.1,[10.10.10.10,[11.11.11.11,[12.12."
+                "12.12,13.13.13.13]]]]",
+                NULL);
         if (r == 0)
             result = 1;
 
@@ -4032,7 +4055,7 @@ static int AddressTestAddressGroupSetup33(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "![1.1.1.1,[2.2.2.2,[3.3.3.3,4.4.4.4]]]");
+        int r = DetectAddressParse(NULL, gh, "![1.1.1.1,[2.2.2.2,[3.3.3.3,4.4.4.4]]]", NULL);
         if (r == 1)
             result = 1;
 
@@ -4047,7 +4070,7 @@ static int AddressTestAddressGroupSetup34(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[1.0.0.0/8,![1.1.1.1,[1.2.1.1,1.3.1.1]]]");
+        int r = DetectAddressParse(NULL, gh, "[1.0.0.0/8,![1.1.1.1,[1.2.1.1,1.3.1.1]]]", NULL);
         if (r == 1)
             result = 1;
 
@@ -4062,7 +4085,7 @@ static int AddressTestAddressGroupSetup35(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[1.0.0.0/8,[2.0.0.0/8,![1.1.1.1,2.2.2.2]]]");
+        int r = DetectAddressParse(NULL, gh, "[1.0.0.0/8,[2.0.0.0/8,![1.1.1.1,2.2.2.2]]]", NULL);
         if (r == 1)
             result = 1;
 
@@ -4077,7 +4100,7 @@ static int AddressTestAddressGroupSetup36 (void)
 
     DetectAddressHead *gh = DetectAddressHeadInit();
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[1.0.0.0/8,[2.0.0.0/8,[3.0.0.0/8,!1.1.1.1]]]");
+        int r = DetectAddressParse(NULL, gh, "[1.0.0.0/8,[2.0.0.0/8,[3.0.0.0/8,!1.1.1.1]]]", NULL);
         if (r == 1)
             result = 1;
 
@@ -4092,7 +4115,7 @@ static int AddressTestAddressGroupSetup37(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[0.0.0.0/0,::/0]");
+        int r = DetectAddressParse(NULL, gh, "[0.0.0.0/0,::/0]", NULL);
         if (r == 0)
             result = 1;
 
@@ -4111,7 +4134,7 @@ static int AddressTestAddressGroupSetup38(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "![192.168.0.0/16,!192.168.14.0/24]");
+        int r = DetectAddressParse(NULL, gh, "![192.168.0.0/16,!192.168.14.0/24]", NULL);
         if (r == 1) {
             if (UTHValidateDetectAddressHead(gh, 3, expectations))
                 result = 1;
@@ -4132,7 +4155,7 @@ static int AddressTestAddressGroupSetup39(void)
     DetectAddressHead *gh = DetectAddressHeadInit();
 
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[![192.168.0.0/16,!192.168.14.0/24]]");
+        int r = DetectAddressParse(NULL, gh, "[![192.168.0.0/16,!192.168.14.0/24]]", NULL);
         if (r == 1) {
             if (UTHValidateDetectAddressHead(gh, 3, expectations))
                 result = 1;
@@ -4152,7 +4175,7 @@ static int AddressTestAddressGroupSetup40(void)
     int result = 0;
     DetectAddressHead *gh = DetectAddressHeadInit();
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[![192.168.0.0/16,[!192.168.14.0/24]]]");
+        int r = DetectAddressParse(NULL, gh, "[![192.168.0.0/16,[!192.168.14.0/24]]]", NULL);
         if (r == 1) {
             if (UTHValidateDetectAddressHead(gh, 3, expectations))
                 result = 1;
@@ -4172,7 +4195,7 @@ static int AddressTestAddressGroupSetup41(void)
     int result = 0;
     DetectAddressHead *gh = DetectAddressHeadInit();
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[![192.168.0.0/16,![192.168.14.0/24]]]");
+        int r = DetectAddressParse(NULL, gh, "[![192.168.0.0/16,![192.168.14.0/24]]]", NULL);
         if (r == 1) {
             if (UTHValidateDetectAddressHead(gh, 3, expectations))
                 result = 1;
@@ -4190,7 +4213,7 @@ static int AddressTestAddressGroupSetup42(void)
     int result = 0;
     DetectAddressHead *gh = DetectAddressHeadInit();
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[2001::/3]");
+        int r = DetectAddressParse(NULL, gh, "[2001::/3]", NULL);
         if (r == 0) {
             if (UTHValidateDetectAddressHead(gh, 1, expectations))
                 result = 1;
@@ -4209,7 +4232,7 @@ static int AddressTestAddressGroupSetup43(void)
     int result = 0;
     DetectAddressHead *gh = DetectAddressHeadInit();
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[2001::/3,!3000::/5]");
+        int r = DetectAddressParse(NULL, gh, "[2001::/3,!3000::/5]", NULL);
         if (r == 1) {
             if (UTHValidateDetectAddressHead(gh, 2, expectations))
                 result = 1;
@@ -4227,7 +4250,7 @@ static int AddressTestAddressGroupSetup44(void)
     int result = 0;
     DetectAddressHead *gh = DetectAddressHeadInit();
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "3ffe:ffff:7654:feda:1245:ba98:3210:4562/96");
+        int r = DetectAddressParse(NULL, gh, "3ffe:ffff:7654:feda:1245:ba98:3210:4562/96", NULL);
         if (r == 0) {
             if (UTHValidateDetectAddressHead(gh, 1, expectations))
                 result = 1;
@@ -4243,7 +4266,7 @@ static int AddressTestAddressGroupSetup45(void)
     int result = 0;
     DetectAddressHead *gh = DetectAddressHeadInit();
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[192.168.1.3,!192.168.0.0/16]");
+        int r = DetectAddressParse(NULL, gh, "[192.168.1.3,!192.168.0.0/16]", NULL);
         if (r != 0) {
             result = 1;
         }
@@ -4263,7 +4286,8 @@ static int AddressTestAddressGroupSetup46(void)
     int result = 0;
     DetectAddressHead *gh = DetectAddressHeadInit();
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[![192.168.0.0/16,![192.168.1.0/24,192.168.3.0/24]]]");
+        int r = DetectAddressParse(
+                NULL, gh, "[![192.168.0.0/16,![192.168.1.0/24,192.168.3.0/24]]]", NULL);
         if (r == 1) {
             if (UTHValidateDetectAddressHead(gh, 4, expectations))
                 result = 1;
@@ -4286,7 +4310,8 @@ static int AddressTestAddressGroupSetup47(void)
     int result = 0;
     DetectAddressHead *gh = DetectAddressHeadInit();
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[![192.168.0.0/16,![192.168.1.0/24,192.168.3.0/24],!192.168.5.0/24]]");
+        int r = DetectAddressParse(NULL, gh,
+                "[![192.168.0.0/16,![192.168.1.0/24,192.168.3.0/24],!192.168.5.0/24]]", NULL);
         if (r == 1) {
             if (UTHValidateDetectAddressHead(gh, 5, expectations))
                 result = 1;
@@ -4308,7 +4333,8 @@ static int AddressTestAddressGroupSetup48(void)
     int result = 0;
     DetectAddressHead *gh = DetectAddressHeadInit();
     if (gh != NULL) {
-        int r = DetectAddressParse(NULL, gh, "[192.168.0.0/16,![192.168.1.0/24,192.168.3.0/24],!192.168.5.0/24]");
+        int r = DetectAddressParse(NULL, gh,
+                "[192.168.0.0/16,![192.168.1.0/24,192.168.3.0/24],!192.168.5.0/24]", NULL);
         if (r == 1) {
             if (UTHValidateDetectAddressHead(gh, 4, expectations))
                 result = 1;

--- a/src/detect-engine-address.h
+++ b/src/detect-engine-address.h
@@ -27,7 +27,7 @@
 DetectAddress *DetectAddressInit(void);
 void DetectAddressFree(DetectAddress *);
 DetectAddress *DetectAddressCopy(DetectAddress *);
-int DetectAddressParse(const DetectEngineCtx *, DetectAddressHead *, const char *);
+int DetectAddressParse(const DetectEngineCtx *, DetectAddressHead *, const char *, bool *);
 void DetectAddressHeadCleanup(DetectAddressHead *);
 void DetectAddressCleanupList(DetectAddress *head);
 
@@ -46,7 +46,7 @@ void DetectAddressTests(void);
 
 int DetectAddressMapInit(DetectEngineCtx *de_ctx);
 void DetectAddressMapFree(DetectEngineCtx *de_ctx);
-const DetectAddressHead *DetectParseAddress(DetectEngineCtx *de_ctx,
-        const char *string, bool *contains_negation);
+const DetectAddressHead *DetectParseAddress(
+        DetectEngineCtx *de_ctx, const char *string, bool *contains_negation, bool *contains_range);
 
 #endif /* SURICATA_DETECT_ADDRESS_H */

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -245,6 +245,11 @@ int SignatureIsIPOnly(DetectEngineCtx *de_ctx, const Signature *s)
         /* Rule is IP only, but contains negated addresses. */
         return 2;
     }
+    if (s->init_data->src_contains_range || s->init_data->dst_contains_range) {
+        /* Rule is IP only, but contains range of addresses. */
+        return 2;
+    }
+
     if (!(de_ctx->flags & DE_QUIET)) {
         SCLogDebug("IP-ONLY (%" PRIu32 "): source %s, dest %s", s->id,
                    s->flags & SIG_FLAG_SRC_ANY ? "ANY" : "SET",

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1120,7 +1120,7 @@ static int SigParseAddress(DetectEngineCtx *de_ctx,
             s->flags |= SIG_FLAG_SRC_ANY;
 
         s->init_data->src = DetectParseAddress(de_ctx, addrstr,
-                &s->init_data->src_contains_negation);
+                &s->init_data->src_contains_negation, &s->init_data->src_contains_range);
         if (s->init_data->src == NULL)
             goto error;
     } else {
@@ -1128,7 +1128,7 @@ static int SigParseAddress(DetectEngineCtx *de_ctx,
             s->flags |= SIG_FLAG_DST_ANY;
 
         s->init_data->dst = DetectParseAddress(de_ctx, addrstr,
-                &s->init_data->dst_contains_negation);
+                &s->init_data->dst_contains_negation, &s->init_data->dst_contains_range);
         if (s->init_data->dst == NULL)
             goto error;
     }

--- a/src/detect.h
+++ b/src/detect.h
@@ -160,6 +160,7 @@ enum {
 };
 
 #define ADDRESS_FLAG_NOT            0x01 /**< address is negated */
+#define ADDRESS_FLAG_RANGE          0x02 /**< address has range */
 
 /** \brief address structure for use in the detection engine.
  *
@@ -183,6 +184,8 @@ typedef struct DetectAddress_ {
 typedef struct DetectAddressHead_ {
     DetectAddress *ipv4_head;
     DetectAddress *ipv6_head;
+
+    bool contains_range;
 } DetectAddressHead;
 
 
@@ -607,6 +610,9 @@ typedef struct SignatureInitData_ {
      * skip it for ip-only */
     bool src_contains_negation;
     bool dst_contains_negation;
+    /* see if the address contains range and skip it from iponly engine */
+    bool src_contains_range;
+    bool dst_contains_range;
 
     /** see if any of the sigmatches supports an enabled prefilter */
     bool has_possible_prefilter;

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -245,8 +245,8 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
         orig_de->seconds = parsed_seconds;
         orig_de->new_action = parsed_new_action;
         orig_de->timeout = parsed_timeout;
-        if (DetectAddressParse((const DetectEngineCtx *)de_ctx, &orig_de->addrs, (char *)th_ip) <
-                0) {
+        if (DetectAddressParse(
+                    (const DetectEngineCtx *)de_ctx, &orig_de->addrs, (char *)th_ip, NULL) < 0) {
             SCLogError("failed to parse %s", th_ip);
             goto error;
         }


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/16038

Changes since v4:
- rebased on top of latest main
- error handling as per review

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8847

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3282