### PR TITLE
docs: add code documentation for ticket 8899

### DIFF
--- a/src/datasets.h
+++ b/src/datasets.h
@@ -15,80 +15,633 @@
  * 02110-1301, USA.
  */
 
+/**
+ * \file
+ *
+ * \author Victor Julien <victor@inliniac.net>
+ *
+ * \brief Public API for Suricata's dataset and datarep subsystem.
+ *
+ * A dataset is a named, in-memory set of values (string, md5, sha256,
+ * ipv4 or ipv6) that rules can match against via the \c dataset and
+ * \c datarep keywords. Sets can be preloaded from disk at startup,
+ * persisted on exit, and reloaded live at runtime.
+ *
+ * This header declares the ::Dataset type, the ::DatasetTypes and
+ * ::DatasetFormats enumerations, and the lifecycle, lookup and
+ * mutation entry points. The implementation lives in datasets.c.
+ */
+
 #ifndef SURICATA_DATASETS_H
 #define SURICATA_DATASETS_H
 
 // forward declaration to make things opaque to bindgen
+/**
+ * \brief Reputation value associated with a dataset entry.
+ *
+ * Opaque to bindgen; Callers pass and receive \c DataRepType
+ * values through the \c *wRep family of functions
+ * and via the \c DataRepResultType struct.
+ */
 typedef uint16_t DataRepType;
+
+/**
+ * \brief Forward declaration of the \c Dataset type.
+ */
 typedef struct Dataset Dataset;
+
+/** \name Public add operations
+ * \brief Insert a value into a dataset, with or without a reputation.
+ *
+ * These are the public, plugin-facing entry points for adding a
+ * value to a set. Each dispatches on \c set->type to a per-type
+ * worker implemented as a \c static helper in \c datasets.c.
+ *
+ * If the value is already present the existing entry is reused and
+ * the call reports \c 0 rather than storing a duplicate; no refcount
+ * is exposed at the API level.
+ *
+ * Shared parameters:
+ *   \param set      Target dataset. Must be a fully initialized set.
+ *   \param data     Value to insert, in the set's native binary form.
+ *   \param data_len Length of \p data in bytes. For the fixed-size
+ *                   types the worker validates this.
+ * These functions do not touch the global set list; per-set hash
+ * locking is handled internally.
+ *
+ * @{
+ */
+/**
+ * \brief Insert a value into a dataset.
+ *
+ * \retval  1 value added as a new entry.
+ * \retval  0 value already present.
+ * \retval -1 error (NULL set, hash insert failure, or unknown type).
+ * \retval -2 \p data_len does not match the expected size for the
+ *            set's type. Not returned by the string worker.
+ *
+ * \note The IPv6 worker accepts either 4 or 16 bytes; a 4-byte
+ *       buffer is treated as an IPv4-mapped IPv6 address. The
+ *       rep-carrying counterpart \c SCDatasetAddwRep is stricter
+ *       and requires 16.
+ *
+ * \sa SCDatasetAddwRep
+ */
 int SCDatasetAdd(Dataset *set, const uint8_t *data, const uint32_t data_len);
+
+/**
+ * \brief Insert a value together with a reputation payload.
+ *
+ * \param rep Reputation to associate with a newly inserted entry.
+ *            Dereferenced unconditionally; must not be \c NULL.
+ *
+ * \retval  1 value inserted with \p rep attached.
+ * \retval  0 value already present; the stored entry (and its
+ *            existing rep) is left untouched and \p rep is discarded.
+ * \retval -1 error (NULL set, hash insert failure, or unknown type).
+ * \retval -2 \p data_len does not match the expected size for the
+ *            set's type. Not returned by the string worker.
+ *
+ * \note On collision the incoming \p rep is \b not merged into the
+ *       stored entry: the first writer wins.
+ * \note Unlike \c SCDatasetAdd, the IPv6 path here requires exactly
+ *       16 bytes; a 4-byte (IPv4-mapped) buffer yields \c -2.
+ *
+ * \sa SCDatasetAdd
+ */
 int SCDatasetAddwRep(
         Dataset *set, const uint8_t *data, const uint32_t data_len, const DataRepType *rep);
+
+/** @} */
 
 #ifndef SURICATA_BINDGEN_H
 #include "util-thash.h"
 #include "rust.h"
 #include "datasets-reputation.h"
 
+
+/** \name Lifecycle
+ *  Initialization, teardown, persistence and live reload.
+ *  @{
+ */
+
+/**
+ * \brief Initialize the dataset subsystem from configuration.
+ *
+ * Reads the \c datasets section of suricata.yaml, creates each
+ * declared set and loads its associated file. Called once during
+ * startup, after privileges have been dropped.
+ * In case of a fatal configuration error, \c FatalError() and
+ * exits with error.
+ *
+ * \retval 0 on success.
+ */
 int DatasetsInit(void);
+
+ /** \brief Free every registered dataset and release all resources. */
 void DatasetsDestroy(void);
+
+/** \brief Persist every dataset that has a configured save path. */
 void DatasetsSave(void);
+
+/**
+ * \brief First phase of a live reload.
+ *
+ * Marks the current sets as hidden and stages replacements so that
+ * running threads can finish their in-flight lookups against the old
+ * versions. Must be paired with DatasetPostReloadCleanup().
+ */
 void DatasetReload(void);
+
+/** \brief Second phase of a live reload; frees the hidden old sets. */
 void DatasetPostReloadCleanup(void);
 
+/** @} */
+
+
+/**
+ * \brief On-disk serialization format for a dataset's load/save file.
+ */
 typedef enum {
-    DATASET_FORMAT_CSV = 0,
-    DATASET_FORMAT_JSON,   /* File contains one single JSON object */
-    DATASET_FORMAT_NDJSON, /* Newline Delimited JSON */
+    DATASET_FORMAT_CSV = 0, /**< Legacy CSV format (default). */
+    DATASET_FORMAT_JSON,    /**< File contains one single JSON object. */
+    DATASET_FORMAT_NDJSON,  /**< Newline-delimited JSON, one entry per line. */
 } DatasetFormats;
 
+/**
+ * \brief Type of value a dataset stores.
+ *
+ * ::DATASET_TYPE_NOTSET (0) is a sentinel used to mark an
+ * uninitialized set and is not a valid runtime type.
+ */
 enum DatasetTypes {
-#define DATASET_TYPE_NOTSET 0
-    DATASET_TYPE_STRING = 1,
-    DATASET_TYPE_MD5,
-    DATASET_TYPE_SHA256,
-    DATASET_TYPE_IPV4,
-    DATASET_TYPE_IPV6,
+#define DATASET_TYPE_NOTSET 0   /** Sentinel: type not yet assigned. */
+    DATASET_TYPE_STRING = 1,    /**< Arbitrary byte strings. */
+    DATASET_TYPE_MD5,           /**< 16-byte MD5 digests. */
+    DATASET_TYPE_SHA256,        /**< 32-byte SHA256 digests. */
+    DATASET_TYPE_IPV4,          /**< 4-byte IPv4 addresses. */
+    DATASET_TYPE_IPV6,          /**< 16-byte IPv6 addresses. */
 };
 
+/** \brief Maximum length of a dataset name, excluding the terminating NUL. */
 #define DATASET_NAME_MAX_LEN 63
+
+/**
+ * \brief In-memory representation of a single dataset.
+ * 
+ * Sets are linked together in a global singly-linked list protected
+ * by an internal mutex; use DatasetLock() / DatasetUnlock() when
+ * traversing that list directly. The actual value storage is
+ * delegated to the ::THashTableContext pointed to by \c hash which
+ * is initialized with type-specific hash, compare, set and free
+ * callbacks at creation time.
+ */
 typedef struct Dataset {
-    char name[DATASET_NAME_MAX_LEN + 1];
-    enum DatasetTypes type;
-    uint32_t id;
-    bool from_yaml;                     /* Mark whether the set was retrieved from YAML */
-    bool hidden;                        /* Mark the old sets hidden in case of reload */
-    bool remove_key;                    /* Mark that value key should be removed from extra data */
-    THashTableContext *hash;
+    char name[DATASET_NAME_MAX_LEN + 1];/**< NUL-terminated set name. */
+    enum DatasetTypes type;             /**< Value type stored in this set. */
+    uint32_t id;                        /**< Monotonic id. */
+    bool from_yaml;                     /**< True if declared in suricata.yaml. */
+    bool hidden;                        /**< True while superseded during a live reload. */
+    bool remove_key;                    /**< Strip value key from extra data on insert. */
+    THashTableContext *hash;            /**< Backing thread-safe hash table. */
 
-    char load[PATH_MAX];
-    char save[PATH_MAX];
+    char load[PATH_MAX];                /**< File to preload values from at startup. */
+    char save[PATH_MAX];                /**< File to persist values to on exit. */
 
-    struct Dataset *next;
+    struct Dataset *next;               /**< Next set in the global list, or NULL. */
 } Dataset;
 
+/**
+ * \brief Convert a textual type name to a ::DatasetTypes value.
+ * 
+ * Recognizes the strings used in the \c datasets section of
+ * suricata.yaml and in the \c type argument of the \c dataset rule
+ * keyword: \c "string", \c "md5", \c "sha256", \c "ipv4", \c "ipv6".
+ * The comparison is case-insensitive.
+ * 
+ * \param s NUL-terminated type name.
+ * \return The matching ::DatasetTypes enumerator, or
+        ::DATASET_TYPE_NOTSET if \p s does not match any known type.
+ */
 enum DatasetTypes DatasetGetTypeFromString(const char *s);
+
+/**
+ * \brief Link a freshly built set into the global set list.
+ *
+ * Takes ownership of the \p set : on success the pointer is now
+ * reachable via the internal list and must not be freed by the caller.
+ * On failure the caller retains ownership and is responsible for cleanup.
+ *
+ * The caller must hold the dataset lock via DatasetLock().
+ * 
+ * \param set Fully initialized set to register. Must have a unique name.
+ * \retval  0 on success.
+ * \retval -1 if the set has a NULL hash or it's too large for set memcap.
+ */
 int DatasetAppendSet(Dataset *set);
+
+/**
+ * \brief Allocate and minimally initialize a new ::Dataset.
+ *
+ * Zeros the structure and assigns a fresh unique \c id. The returned
+ * set has no type, no name, no backing hash table, and is not linked
+ * into the global list; the caller is expected to populate the
+ * remaining fields.
+ *
+ * \param name Currently unused.
+ *
+ * \retval non-NULL newly allocated set.
+ * \retval NULL     allocation failure.
+ *
+ * \sa DatasetGetOrCreate()
+ */
 Dataset *DatasetAlloc(const char *name);
+
+
+/**
+ * \brief Acquire the global dataset lock.
+ *
+ * Serializes access to the internal linked list of ::Dataset objects.
+ * Any code that walks that list, or that calls a function whose
+ * documentation says "caller must hold the dataset lock" must be inside
+ * a DatasetLock() / DatasetUnlock() pair.
+ *
+ * The lock is a plain mutex and is \b not recursive: calling
+ * DatasetLock() twice from the same thread will deadlock. It also
+ * does not protect the contents of an individual set, per-set
+ * synchronization is handled by the underlying ::THashTableContext.
+ *
+ * \sa DatasetUnlock()
+ */
 void DatasetLock(void);
+
+/**
+ * \brief Release the global dataset lock.
+ *
+ * Must be called exactly once for each successful DatasetLock() on
+ * the same thread, and only by the thread that acquired it.
+ *
+ * \sa DatasetLock()
+ */
 void DatasetUnlock(void);
+
+/**
+ * \brief Look up a set by name in the global list.
+ *
+ * Performs a linear scan of the set list and does \b not check the
+ * type of the returned set.
+ *
+ * The caller must hold the dataset lock via DatasetLock().
+ *
+ * \param name NUL-terminated set name to search for.
+ *
+ * \retval non-NULL pointer to the matching set.
+ * \retval NULL if no set with that name exists.
+ */
 Dataset *DatasetSearchByName(const char *name);
+
+/**
+ * \brief Look up a set by name and type without creating it.
+ *
+ * Acquires and releases the dataset lock internally, so the caller
+ * must \b not already hold it. A set whose name matches but whose
+ * type differs from \p type is treated as no match.
+ *
+ * \param name NUL-terminated set name to search for.
+ * \param type Required value type.
+ *
+ * \retval non-NULL pointer to the matching set.
+ * \retval NULL if no set with that name and type exists.
+ */
 Dataset *DatasetFind(const char *name, enum DatasetTypes type);
+
+/**
+ * \brief Return an existing set or fully construct a new one.
+ *
+ * This is the standard entry point used by the rule parser when it
+ * encounters a \c dataset or \c datarep keyword. It wraps
+ * DatasetGetOrCreate() with the follow-up work that the latter
+ * intentionally omits:
+ *   -# reserve or allocate the ::Dataset via DatasetGetOrCreate();
+ *   -# on a fresh allocation, initialize the backing
+ *      ::THashTableContext with the callbacks and element size
+ *      appropriate to \p type;
+ *   -# preload values from \p load, if any, via the matching
+ *      \c DatasetLoadXxx() helper;
+ *   -# link the completed set into the global list with
+ *      DatasetAppendSet().
+ *
+ * On any failure during the fresh-allocation path the partially
+ * built set is torn down before returning. On a hit the existing set
+ * is returned unchanged; \p memcap and \p hashsize are ignored in
+ * that case.
+ *
+ * Acquires and releases the dataset lock internally, so the caller
+ * must \b not already hold it.
+ *
+ * \param name     NUL-terminated set name, at most
+ *                 #DATASET_NAME_MAX_LEN bytes.
+ * \param type     Value type; must not be ::DATASET_TYPE_NOTSET when
+ *                 the set does not yet exist.
+ * \param save     Path to persist the set to on exit, or NULL /
+ *                 empty for no persistence.
+ * \param load     Path to preload values from, or NULL / empty to
+ *                 start empty.
+ * \param memcap   Memory cap in bytes; pass 0 for the configured
+ *                 default. Ignored on a hit.
+ * \param hashsize Hash-table size; pass 0 for the configured
+ *                 default. Capped by the global limits from the
+ *                 \c datasets section of suricata.yaml. Ignored on a
+ *                 hit.
+ *
+ * \retval non-NULL pointer to a fully initialized, registered set.
+ * \retval NULL on any error.
+ *
+ * \sa DatasetGetOrCreate(), DatasetFind()
+ */
 Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, const char *load,
         uint64_t memcap, uint32_t hashsize);
+
+/**
+ * \brief Reserve a ::Dataset slot: return an existing set or allocate a
+ *        skeleton for a new one.
+ *
+ * On a name hit this behaves as a pure lookup: the existing set is
+ * returned through \p ret_set, and \p save / \p load (if provided) are
+ * validated against the stored values, a mismatch is a hard error.
+ *
+ * On a name miss a new ::Dataset is allocated via DatasetAlloc() and
+ * its \c name, \c type, \c save and \c load fields are populated, but
+ * the set is \b not fully constructed: its \c hash pointer is left
+ * NULL, no values are loaded from disk, and it is not linked into the
+ * global set list. The caller is responsible for finishing
+ * initialization. On any failure of that follow-up work the caller must
+ * free the returned set.
+ *
+ * Also fills in \p memcap and \p hashsize with configured defaults
+ * when the pointed-to value is 0.
+ *
+ * The caller must hold the dataset lock via DatasetLock().
+ *
+ * \param[in]     name     NUL-terminated set name; at most
+ *                         #DATASET_NAME_MAX_LEN bytes.
+ * \param[in]     type     Value type. May be ::DATASET_TYPE_NOTSET
+ *                         only when the set is expected to already
+ *                         exist (pure lookup); required otherwise.
+ * \param[in]     save     Save-file path or NULL / empty.
+ * \param[in]     load     Load-file path or NULL / empty.
+ * \param[in,out] memcap   Memory cap; filled with default if 0.
+ * \param[in,out] hashsize Hash-table size; filled with default if 0.
+ * \param[out]    ret_set  Receives the set pointer on both creation
+ *                         and hit; untouched on error.
+ *
+ * \retval -1 on error.
+ * \retval  0 on successful allocation of a new, uninitialized set.
+ * \retval  1 if a matching set already existed and is fully usable.
+ *
+ * \sa DatasetGet() for the wrapper that also initializes the hash
+ *     table, loads the file and registers the set.
+ */
 int DatasetGetOrCreate(const char *name, enum DatasetTypes type, const char *save, const char *load,
         uint64_t *memcap, uint32_t *hashsize, Dataset **ret_set);
+
+/**
+ * \brief Delete a value from a dataset.
+ *
+ * Dispatches on \c set->type to the appropriate type-specific
+ * worker implemented as a \c static helper in \c datasets.c
+ *
+ * \param set      Target dataset. Must be a fully initialized set as
+ *                 returned by \c DatasetGet().
+ * \param data     Value to be removed, in the set's native binary form.
+ * \param data_len Length of \p data in bytes. Validated for the
+ *                 fixed-size types; see the \c -2 retval below.
+ *
+ * \retval  1 value found and removed.
+ * \retval  0 value found but currently busy (in-use / held) and
+ *            left in place. The caller may retry.
+ * \retval -1 value not found, \b or \p set is \c NULL, \b or the
+ *            set has an unknown type. These three conditions are
+ *            \b not distinguishable from the return code alone,
+ *            unlike the add family, a legitimate "not present"
+ *            result is reported via \c -1, not \c 0.
+ * \retval -2 \p data_len does not match the expected size for the
+ *            set's type. Not returned by the string worker.
+ *
+ * \note The IPv6 worker requires exactly 16 bytes. This matches
+ *       \c SCDatasetAddwRep but is stricter than \c SCDatasetAdd,
+ *       whose IPv6 worker also accepts a 4-byte buffer.
+ *
+ * This function does not touch the global set list; per-set hash
+ * locking is handled internally.
+ *
+ * \sa SCDatasetAdd, DatasetLookup
+ */
 int DatasetRemove(Dataset *set, const uint8_t *data, const uint32_t data_len);
+
+/** \name Public lookup operations
+ * \brief Test whether a value is present in a dataset, optionally
+ *        retrieving its stored reputation.
+ *
+ * These are dispatchers on \c set->type to a per-type worker implemented
+ * as a \c static helper in \c datasets.c.
+ *
+ * Shared parameters:
+ *   \param set      Target dataset. Must be a fully initialized set.
+ *   \param data     Value to look up, in the set's native binary form.
+ *   \param data_len Length of \p data in bytes. Validated for the
+ *                   fixed-size types.
+ *
+ * These functions do not touch the global set list; per-set hash
+ * locking is handled internally.
+ * @{
+ */
+
+/**
+ * \brief Test whether a value is present in a dataset.
+ *
+ * \retval  1 value found.
+ * \retval  0 value not found. This is a normal negative result, not
+ *            an error.
+ * \retval -1 \p set is \c NULL, the set has an unknown type, \b or
+ *            \p data_len does not match the set's type. The string
+ *            worker has no length check.
+ *
+ * \note The IPv6 worker accepts either 4 or 16 bytes; a 4-byte
+ *       buffer matches stored entries whose trailing 12 bytes are
+ *       zero. Matches \c SCDatasetAdd's permissive behavior.
+ *
+ * \sa DatasetLookupwRep
+ */
 int DatasetLookup(Dataset *set, const uint8_t *data, const uint32_t data_len);
+
+/**
+ * \brief Look up a value and retrieve its stored reputation.
+ *
+ * \param rep Present for symmetry with \c SCDatasetAddwRep. Does not
+ *            select which entry is matched, but the string worker
+ *            dereferences it; must not be \c NULL.
+ *
+ * \return On a hit: \c .found is \c true and \c .rep is the
+ *         reputation \b stored with the entry, not the input \p rep.
+ *         On a miss, \c NULL \p set, unknown \c set->type, or
+ *         \p data_len mismatch: <tt>{ .found = false, .rep = 0 }</tt>;
+ *         errors and misses are \b not distinguishable from the
+ *         return value alone.
+ *
+ * \note The IPv6 worker accepts 4 or 16 bytes.
+ *
+ * \sa DatasetLookup, SCDatasetAddwRep
+ */
 DataRepResultType DatasetLookupwRep(Dataset *set, const uint8_t *data, const uint32_t data_len,
         const DataRepType *rep);
+/** @} */
 
+/**
+ * \brief Populate \p memcap and \p hashsize with the engine's
+ *        default dataset limits, honoring YAML overrides under
+ *        \c datasets.defaults.
+ *
+ * Reads \c datasets.defaults.memcap and \c datasets.defaults.hashsize
+ * from the running configuration and writes them through the
+ * out-parameters. The two are handled asymmetrically:
+ *
+ * \param memcap   Out. If the YAML key is absent, \p *memcap is left
+ *                 untouched, the caller must preinitialize it to a
+ *                 sensible starting value. If the key is present but
+ *                 unparseable, \p *memcap is set to \c 0 and a
+ *                 warning is logged.
+ * \param hashsize Out. Always initialized to
+ *                 \c DATASETS_HASHSIZE_DEFAULT before the YAML
+ *                 lookup; a parseable key replaces the default,
+ *                 an unparseable one restores it (and logs a
+ *                 warning). Safe to pass uninitialized.
+ *
+ * \note The \c 0 written to \p *memcap on parse failure is a
+ *       sentinel, not a valid limit; callers should treat it as
+ *       "no default available" and fall back to their own value.
+ */
 void DatasetGetDefaultMemcap(uint64_t *memcap, uint32_t *hashsize);
+
+/**
+ * \brief Parse a textual IP address into Suricata's internal IPv6
+ *        storage form.
+ *
+ * Accepts either an IPv4 dotted-quad or an IPv6 textual address;
+ * the family is inferred from the presence of a \c ':' in \p line.
+ * The result is written to \p in6 in the layout the IPv4 and IPv6
+ * dataset workers expect: for an IPv4 input (or for an IPv6 input
+ * in \c ::ffff:a.b.c.d form) the four IPv4 bytes occupy the low
+ * positions of \p in6 with the remainder zeroed. This is \b not a
+ * standard IPv4-mapped IPv6 address: it is Suricata's internal
+ * representation, and matches what \c SCDatasetAdd's IPv4 and
+ * permissive-IPv6 paths store.
+ *
+ * \param set  Dataset being loaded. Consulted only to name the set
+ *             in the fatal-error message on parse failure; the
+ *             function does not read or modify its contents and
+ *             does not validate that \c set->type is an IP type.
+ * \param line NUL-terminated textual address.
+ * \param in6  Out. Populated on success; contents undefined on
+ *             failure.
+ *
+ * \retval  0 parse succeeded.
+ * \retval -1 parse failed. Only observable outside init: during
+ *            init, the underlying \c FatalErrorOnInit aborts the
+ *            process and this function does not return to the
+ *            caller.
+ */
 int DatasetParseIpv6String(Dataset *set, const char *line, struct in6_addr *in6);
 
+
+/** \name Serialized-form membership operations
+ * \brief Add, look up or remove a value given in its textual
+ *        ("serialized") form.
+ *
+ * String-input counterparts to \c SCDatasetAdd, \c DatasetLookup and
+ * \c DatasetRemove. Each parses \p string according to \c set->type
+ * and dispatches to the corresponding per-type worker. Callers that
+ * already hold the value in native binary form should prefer the
+ * binary variants and skip the parse step.
+ *
+ * Shared parameters:
+ *   \param set    Target dataset. Must be a fully initialized set
+ *                 as returned by \c DatasetGet().
+ *   \param string NUL-terminated textual value. Must be non-empty
+ *                 and, for the string type, no longer than
+ *                 \c UINT16_MAX bytes; both limits are enforced
+ *                 before parsing and reported as \c -1.
+ *
+ * Parse contract per type:
+ *   - \c DATASET_TYPE_STRING  strict base64.
+ *   - \c DATASET_TYPE_MD5     exactly 32 hex characters.
+ *   - \c DATASET_TYPE_SHA256  exactly 64 hex characters.
+ *   - \c DATASET_TYPE_IPV4    dotted-quad, via \c inet_pton.
+ *   - \c DATASET_TYPE_IPV6    textual IPv6 \b or IPv4 dotted-quad,
+ *                             via \c DatasetParseIpv6String. An
+ *                             IPv4 spelling is accepted even for an
+ *                             IPv6 set and is stored in Suricata's
+ *                             4-byte-in-low-position layout.
+ *
+ * Shared return code semantics:
+ *   \c -2 always means the parse failed against the set's type.
+ *   \c -1 always includes API misuse (\c NULL set, empty or too-long
+ *   string, unknown \c set->type); individual functions document any
+ *   additional \c -1 cases below. A parse of a valid input never
+ *   triggers a length-mismatch \c -2 from the underlying worker,
+ *   the parse layer only ever hands the worker a correctly-sized
+ *   buffer.
+ *
+ * These functions do not touch the global set list; per-set hash
+ * locking is handled internally.
+ *
+ * \note During init, a parse failure on an IPv6 (or IPv4-via-IPv6)
+ *       input aborts the process rather than returning \c -2 ,
+ *       inherited from \c DatasetParseIpv6String's use of
+ *       \c FatalErrorOnInit.
+ *
+ * \sa SCDatasetAdd, DatasetLookup, DatasetRemove,
+ *     DatasetParseIpv6String
+ *
+ * @{
+ */
+
+ /**
+ * \brief Parse \p string and insert the resulting value into the set.
+ *
+ * \retval  1 value inserted as a new entry.
+ * \retval  0 value already present; no duplicate stored.
+ * \retval -1 API error (see group intro), or the underlying hash
+ *            layer failed to insert.
+ * \retval -2 \p string could not be parsed as \c set->type.
+ */
 int DatasetAddSerialized(Dataset *set, const char *string);
+
+/**
+ * \brief Parse \p string and remove the resulting value from the set.
+ *
+ * \retval  1 value found and removed.
+ * \retval  0 value found but currently busy; left in place. May be
+ *            retried.
+ * \retval -1 API error (see group intro) \b or value not found;
+ *            these two conditions are not distinguishable from the
+ *            return code. Matches \c DatasetRemove.
+ * \retval -2 \p string could not be parsed as \c set->type.
+ */
+
 int DatasetRemoveSerialized(Dataset *set, const char *string);
+
+/**
+ * \brief Parse \p string and test whether the value is present.
+ *
+ * \retval  1 value found.
+ * \retval  0 value not found. Normal negative result, not an error.
+ * \retval -1 API error (see group intro).
+ * \retval -2 \p string could not be parsed as \c set->type.
+ */
 int DatasetLookupSerialized(Dataset *set, const char *string);
+
+/** @} */
 
 #endif // SURICATA_BINDGEN_H
 

--- a/src/decode-teredo.h
+++ b/src/decode-teredo.h
@@ -15,12 +15,65 @@
  * 02110-1301, USA.
  */
 
+/**
+ * \file
+ *
+ * \author Eric Leblond <eric@regit.org>
+ *
+ * Decode Teredo Tunneling protocol.
+ *
+ * This implementation is based upon RFC 4380: http://www.ietf.org/rfc/rfc4380.txt
+ */
+
 #ifndef SURICATA_DECODE_TEREDO_H
 #define SURICATA_DECODE_TEREDO_H
 
+/**
+ * \brief Attempt to decode a Teredo-tunneled IPv6 packet from a UDP payload.
+ *
+ * On success, an inner IPv6 tunnel packet is queued on the thread's decode
+ * queue for further processing. On failure, the buffer is left untouched and
+ * the caller should treat the datagram as regular UDP.
+ *
+ * Has no effect (returns failure) when Teredo decoding is disabled in the
+ * configuration.
+ *
+ * \param tv  Current thread variables.
+ * \param dtv Per-thread decoder state.
+ * \param p   Outer packet carrying the UDP datagram; becomes the parent of
+ *            the tunnel packet.
+ * \param pkt Pointer to the UDP payload to inspect.
+ * \param len Length in bytes of \p pkt.
+ *
+ * \retval TM_ECODE_OK     A Teredo packet was recognized and queued.
+ * \retval TM_ECODE_FAILED Not a Teredo packet, decoding disabled, or the
+ *                         tunnel packet could not be created.
+ */
 int DecodeTeredo(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                  const uint8_t *pkt, uint16_t len);
+
+/**
+ * \brief Load Teredo decoder settings from the Suricata configuration.
+ *
+ * Reads \c decoder.teredo.enabled and \c decoder.teredo.ports from the
+ * running YAML configuration. Must be called once during engine startup,
+ * before packet processing begins.
+ */
 void DecodeTeredoConfig(void);
+
+/**
+ * \brief Check whether Teredo decoding should be attempted for a UDP flow.
+ *
+ * Intended as a fast gate for the UDP decoder: only call DecodeTeredo()
+ * when this returns true. The answer depends on the configuration loaded
+ * by DecodeTeredoConfig() (global enable flag and configured port list).
+ *
+ * \param sp UDP source port.
+ * \param dp UDP destination port.
+ *
+ * \retval true  Teredo decoding is enabled and at least one port is eligible.
+ * \retval false Teredo decoding is disabled, or neither port is eligible.
+ */
 bool DecodeTeredoEnabledForPort(const uint16_t sp, const uint16_t dp);
 
-#endif
+#endif /* SURICATA_DECODE_TEREDO_H */

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -15,6 +15,19 @@
  * 02110-1301, USA.
  */
 
+/**
+ * \file
+ *
+ * \author Victor Julien <victor@inliniac.net>
+ *
+ * Hash table for DefragTracker objects: lookup, allocation,
+ * memcap accounting, and eviction under pressure.
+ *
+ * Locking order is always row-lock (DRLOCK) then tracker mutex.
+ * use_cnt is an atomic refcount that keeps a tracker alive across
+ * lock drops; the pruner refuses to evict trackers with use_cnt > 0.
+ */
+
 #include "suricata-common.h"
 #include "conf.h"
 #include "defrag-hash.h"
@@ -27,23 +40,44 @@
 #include "util-hash-lookup3.h"
 #include "util-validate.h"
 
-/** defrag tracker hash table */
+/** Bucket array for the tracker hash. Allocated in DefragInitConfig,
+ *  freed in DefragHashShutdown. Sized by defrag.hash-size. */
 DefragTrackerHashRow *defragtracker_hash;
+
+/** Process-wide defrag hash config: memcap (atomic), hash size,
+ *  prealloc count, per-run random seed, and exception policy. */
 DefragConfig defrag_config;
+
+/** Total bytes charged against defrag.memcap: hash buckets +
+ *  every live and spare DefragTracker. Atomic so the fast path
+ *  can check it without taking a lock. */
 SC_ATOMIC_DECLARE(uint64_t,defrag_memuse);
+
+/** Count of trackers currently in service (handed out to a
+ *  bucket, not sitting in the spare queue). Bumped by
+ *  DefragTrackerGetNew, dropped by DefragTrackerMoveToSpare. */
 SC_ATOMIC_DECLARE(unsigned int,defragtracker_counter);
+
+/** Rolling cursor into the hash used by
+ *  DefragTrackerGetUsedDefragTracker so successive eviction sweeps
+ *  don't repeatedly hammer the low-index buckets. */
 SC_ATOMIC_DECLARE(unsigned int,defragtracker_prune_idx);
 
 static DefragTracker *DefragTrackerGetUsedDefragTracker(
         ThreadVars *tv, const DecodeThreadVars *dtv);
 
-/** queue with spare tracker */
+/** Spare/free stack of DefragTrackers. LIFO so the most recently
+ *  freed tracker (still likely to be cache-hot) is handed out first.
+ *  Filled by defrag.prealloc at startup and by runtime recycling. */
 static DefragTrackerStack defragtracker_spare_q;
 
 /**
- *  \brief Update memcap value
+ * \brief Raise the memcap at runtime (atomic).
  *
- *  \param size new memcap value
+ * Refuses to lower the cap below current memuse; that would leave
+ * every subsequent allocation permanently failing the memcap check.
+ *
+ * \retval 1 updated, 0 rejected (size below current usage)
  */
 int DefragTrackerSetMemcap(uint64_t size)
 {
@@ -55,39 +89,54 @@ int DefragTrackerSetMemcap(uint64_t size)
     return 0;
 }
 
-/**
- *  \brief Return memcap value
- *
- *  \retval memcap value
- */
+/** \brief Atomic read of the current memcap. */
 uint64_t DefragTrackerGetMemcap(void)
 {
     uint64_t memcapcopy = SC_ATOMIC_GET(defrag_config.memcap);
     return memcapcopy;
 }
 
-/**
- *  \brief Return memuse value
- *
- *  \retval memuse value
- */
+/** \brief Atomic read of the current memuse. */
 uint64_t DefragTrackerGetMemuse(void)
 {
     uint64_t memusecopy = (uint64_t)SC_ATOMIC_GET(defrag_memuse);
     return memusecopy;
 }
 
+/**
+ * \brief Report the configured exception policy for memcap hits.
+ */
 enum ExceptionPolicy DefragGetMemcapExceptionPolicy(void)
 {
     return defrag_config.memcap_policy;
 }
 
+/**
+ * \brief Push a tracker back onto the spare stack for reuse.
+ *
+ * Struct and its memcap charge stay allocated; only the
+ * in-service counter is decremented.
+ */
 void DefragTrackerMoveToSpare(DefragTracker *h)
 {
     DefragTrackerEnqueue(&defragtracker_spare_q, h);
     (void) SC_ATOMIC_SUB(defragtracker_counter, 1);
 }
 
+/**
+ * \internal
+ * \brief Allocate and initialise a bare DefragTracker.
+ *
+ * Charges memcap BEFORE calling SCCalloc so a racing
+ * allocator can't slip in and push us over budget. On calloc
+ * failure the charge is rolled back.
+ *
+ * The tracker is returned unlocked with use_cnt initialised to 0.
+ * Callers (DefragTrackerGetNew) lock it before handing it out.
+ *
+ * \retval dt   new tracker
+ * \retval NULL memcap exhausted or calloc failed
+ */
 static DefragTracker *DefragTrackerAlloc(void)
 {
     if (!(DEFRAG_CHECK_MEMCAP(sizeof(DefragTracker)))) {
@@ -106,6 +155,14 @@ static DefragTracker *DefragTrackerAlloc(void)
     return dt;
 }
 
+/**
+ * \internal
+ * \brief Fully destroy a DefragTracker.
+ *
+ * Releases any attached fragments, destroys the mutex, frees
+ * the struct, and refunds the memcap charge. Normal runtime
+ * recycling goes through the spare stack instead.
+ */
 static void DefragTrackerFree(DefragTracker *dt)
 {
     if (dt != NULL) {
@@ -117,14 +174,29 @@ static void DefragTrackerFree(DefragTracker *dt)
     }
 }
 
+/* Atomic refcount helpers. The count is bumped whenever a caller
+ * takes a pointer to a tracker (lookup returns) and dropped when
+ * they're done (Release). The pruner refuses to evict trackers
+ * with use_cnt > 0, so this refcount is what prevents another
+ * thread from stealing a tracker mid-use even after the tracker
+ * lock has been dropped. */
 #define DefragTrackerIncrUsecnt(dt) \
     SC_ATOMIC_ADD((dt)->use_cnt, 1)
 #define DefragTrackerDecrUsecnt(dt) \
     SC_ATOMIC_SUB((dt)->use_cnt, 1)
 
+/**
+ * \internal
+ * \brief Fill a newly acquired tracker from its first packet.
+ *
+ * Copies both addresses (both directions: src<->dst comparison at
+ * lookup time handles either order), captures IP id, protocol, and
+ * the VLAN stack, and looks up the per-destination reassembly
+ * policy and host timeout. Also bumps use_cnt for the caller
+ * that requested the tracker.
+ */
 static void DefragTrackerInit(DefragTracker *dt, Packet *p)
 {
-    /* copy address */
     COPY_ADDRESS(&p->src, &dt->src_addr);
     COPY_ADDRESS(&p->dst, &dt->dst_addr);
 
@@ -147,12 +219,25 @@ static void DefragTrackerInit(DefragTracker *dt, Packet *p)
     (void) DefragTrackerIncrUsecnt(dt);
 }
 
+
+ /**
+ * \brief Drop the caller's reference and unlock. Decrement must
+ *        happen while the tracker is still valid.
+ *
+ * The atomic decrement must happen while the tracker is
+ * still valid (i.e. hasn't been freed by a pruner racing on the
+ * bucket lock).
+ */
 void DefragTrackerRelease(DefragTracker *t)
 {
     (void) DefragTrackerDecrUsecnt(t);
     SCMutexUnlock(&t->lock);
 }
 
+/**
+ * \brief Detach every Frag from a tracker; the tracker itself
+ *        stays valid.
+ */
 void DefragTrackerClearMemory(DefragTracker *dt)
 {
     DefragTrackerFreeFrags(dt);
@@ -162,8 +247,33 @@ void DefragTrackerClearMemory(DefragTracker *dt)
 #define DEFRAG_DEFAULT_MEMCAP 16777216
 #define DEFRAG_DEFAULT_PREALLOC 1000
 
-/** \brief initialize the configuration
- *  \warning Not thread safe */
+/**
+ * \brief Build the hash table, apply yaml config, optionally
+ *        prealloc trackers.
+ *
+ * Fails fatally if the configured hash size alone would exceed
+ * memcap, better than failing every allocation forever.
+ * Called once from DefragInit() (in defrag.c) during engine
+ * start-up, before any packets are processed.
+ *
+ * Sequence:
+ *   1. Zero the config struct; initialise the atomics; init the
+ *      spare-stack lock structure.
+ *   2. Seed hash_rand from the process RNG so bucket assignment
+ *      isn't predictable across runs.
+ *   3. Apply defaults, then override from suricata.yaml.
+ *   4. Verify hash_size * sizeof(DefragTrackerHashRow) fits in
+ *      memcap; refusing to start if not.
+ *   5. Allocate the bucket array, init each row lock, charge the
+ *      allocation against memuse.
+ *   6. If defrag.prealloc is true, DefragTrackerAlloc() up to
+ *      `prealloc` trackers and push them onto the spare stack.
+ *      Preallocation faults early on RAM shortage rather than
+ *      failing under traffic.
+ *
+ * \warning Not thread-safe. Only ever called on the main thread
+ *          before workers are spawned, and once at test setup.
+ */
 void DefragInitConfig(bool quiet)
 {
     SCLogDebug("initializing defrag engine...");
@@ -250,6 +360,7 @@ void DefragInitConfig(bool quiet)
                   (uintmax_t)sizeof(DefragTrackerHashRow));
     }
 
+    /* Prealloc surfaces RAM shortage now rather than under traffic. */
     if ((SCConfGetNonNull("defrag.prealloc", &conf_val)) == 1) {
         if (SCConfValIsTrue(conf_val)) {
             /* pre allocate defrag trackers */
@@ -285,8 +396,18 @@ void DefragInitConfig(bool quiet)
     }
 }
 
-/** \brief shutdown the flow engine
- *  \warning Not thread safe */
+ /**
+ * \brief Tear down everything DefragInitConfig set up.
+ *
+ * Drains the spare stack, then walks every bucket freeing any
+ * tracker still linked in, then frees the bucket array and refunds
+ * the memcap charge. Any tracker whose use_cnt is still non-zero
+ * at this point is a bug, nothing should hold a tracker
+ * reference after workers have joined.
+ *
+ * \warning Not thread-safe. Only called during engine shutdown
+ *          after all worker threads have exited.
+ */
 void DefragHashShutdown(void)
 {
     DefragTracker *dt;
@@ -317,15 +438,20 @@ void DefragHashShutdown(void)
     DefragTrackerStackDestroy(&defragtracker_spare_q);
 }
 
-/** \brief compare two raw ipv6 addrs
+/**
+ * \internal
+ * \brief Byte-wise "greater than" over two 128-bit raw IPv6
+ *        addresses viewed as four uint32_t words.
  *
- *  \note we don't care about the real ipv6 ip's, this is just
- *        to consistently fill the DefragHashKey6 struct, without all
- *        the SCNtohl calls.
+ * Purpose is strictly to give DefragHashGetKey a stable ordering so
+ * (src, dst) and (dst, src) hash to the same bucket. The comparison
+ * is done in the raw wire order without SCNtohl, endianness is
+ * irrelevant as long as the ordering is deterministic.
  *
- *  \warning do not use elsewhere unless you know what you're doing.
- *           detect-engine-address-ipv6.c's AddressIPv6GtU32 is likely
- *           what you are looking for.
+ * \warning Do NOT use this for real IPv6 address comparison
+ *          elsewhere in the codebase. detect-engine-address-ipv6.c
+ *          has proper byte-order-aware helpers for that. This
+ *          function exists only for hash-key normalisation.
  */
 static inline int DefragHashRawAddressIPv6GtU32(const uint32_t *a, const uint32_t *b)
 {
@@ -339,6 +465,14 @@ static inline int DefragHashRawAddressIPv6GtU32(const uint32_t *a, const uint32_
     return 0;
 }
 
+/* Packed key structs fed into hashword(). The union with a flat
+ * uint32_t array lets Jenkins lookup3 consume the key as a word
+ * stream while the named fields document what each word means.
+ *
+ * The `pad[1]` slot forces the u32 count to a round number and
+ * makes it explicit that the struct is zeroed on init (memset via
+ * designated initialiser), otherwise padding bytes could leak
+ * uninitialised bits into the hash. */
 typedef struct DefragHashKey4_ {
     union {
         struct {
@@ -363,14 +497,25 @@ typedef struct DefragHashKey6_ {
     };
 } DefragHashKey6;
 
-/* calculate the hash key for this packet
+/**
+ * \internal
+ * \brief Compute the bucket index for a fragment.
  *
- * we're using:
- *  hash_rand -- set at init time
- *  source address
- *  destination address
- *  id
- *  vlan_id
+ * Key material:
+ *   - hash_rand    (per-run seed, defeats collision attacks)
+ *   - source IP    ┐ sorted so both directions of a datagram
+ *   - dest IP      ┘ hash to the same bucket
+ *   - IP id        (16-bit v4, 32-bit v6 frag header ident)
+ *   - VLAN stack   (up to VLAN_MAX_LAYERS entries)
+ *
+ * Protocol is intentionally NOT hashed but IS compared at bucket
+ * walk time (see CMP_DEFRAGTRACKER), this is a deliberate tradeoff
+ * favouring bucket-lookup speed over discrimination, since IP id
+ * collisions across protocols are rare enough that walking the
+ * short chain is cheaper than paying for extra hashing.
+ *
+ * Non-IPv4/IPv6 packets return key 0. They should never reach here
+ * because Defrag() filters them at the entry point.
  */
 static inline uint32_t DefragHashGetKey(Packet *p)
 {
@@ -425,8 +570,7 @@ static inline uint32_t DefragHashGetKey(Packet *p)
     return key;
 }
 
-/* Since two or more trackers can have the same hash key, we need to compare
- * the tracker with the current tracker key. */
+/* Full tuple match; addresses may be src<->dst swapped. */
 #define CMP_DEFRAGTRACKER(d1, d2, id)                                                              \
     (((CMP_ADDR(&(d1)->src_addr, &(d2)->src) && CMP_ADDR(&(d1)->dst_addr, &(d2)->dst)) ||          \
              (CMP_ADDR(&(d1)->src_addr, &(d2)->dst) && CMP_ADDR(&(d1)->dst_addr, &(d2)->src))) &&  \
@@ -434,6 +578,14 @@ static inline uint32_t DefragHashGetKey(Packet *p)
             (d1)->vlan_id[0] == (d2)->vlan_id[0] && (d1)->vlan_id[1] == (d2)->vlan_id[1] &&        \
             (d1)->vlan_id[2] == (d2)->vlan_id[2])
 
+/**
+ * \internal
+ * \brief Address-family gate + full tuple comparison.
+ *
+ * Cheap AF check first, a v4 packet cannot match a v6 tracker no
+ * matter how the id and VLANs line up; then delegate to
+ * CMP_DEFRAGTRACKER for the tuple.
+ */
 static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
 {
     uint32_t id;
@@ -451,6 +603,14 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
     return CMP_DEFRAGTRACKER(t, p, id);
 }
 
+/**
+ * \internal
+ * \brief Bump the per-policy memcap-hit counter for the current
+ *        exception policy.
+ *
+ * The counter ids are cached per thread (dtv->counter_defrag_memcap_eps)
+ * so this hot-path helper stays branchless past the id lookup.
+ */
 static void DefragExceptionPolicyStatsIncr(
         ThreadVars *tv, DecodeThreadVars *dtv, enum ExceptionPolicy policy)
 {
@@ -461,12 +621,25 @@ static void DefragExceptionPolicyStatsIncr(
 }
 
 /**
- *  \brief Get a new defrag tracker
+ * \internal
+ * \brief Obtain a locked tracker for a packet that had no existing
+ *        entry in its bucket.
  *
- *  Get a new defrag tracker. We're checking memcap first and will try to make room
- *  if the memcap is reached.
+ * Three-tier acquisition, tried in order of cost:
+ *   1. Pop from the spare stack. Cheapest and common; the tracker already
+ *      exists and its memcap charge is already paid.
+ *   2. Spare stack empty AND memcap allows another allocation,
+ *      DefragTrackerAlloc a new one. Grows the working set.
+ *   3. Spare stack empty AND memcap is exhausted,
+ *      DefragTrackerGetUsedDefragTracker to steal an idle one.
+ *      This walks the hash and is the slowest path.
  *
- *  \retval dt *LOCKED* tracker on success, NULL on error.
+ * If all three fail, apply the configured exception policy to the
+ * packet and bump the per-policy stats counter. NULL is returned to
+ * the caller.
+ *
+ * \retval dt   LOCKED tracker
+ * \retval NULL memcap and eviction both failed
  */
 static DefragTracker *DefragTrackerGetNew(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
@@ -516,13 +689,42 @@ static DefragTracker *DefragTrackerGetNew(ThreadVars *tv, DecodeThreadVars *dtv,
     return dt;
 }
 
-/* DefragGetTrackerFromHash
+/**
+ * \brief Look up (or create) the tracker for a packet.
  *
- * Hash retrieval function for trackers. Looks up the hash bucket containing the
- * tracker pointer. Then compares the packet with the found tracker to see if it is
- * the tracker we need. If it isn't, walk the list until the right tracker is found.
+ * This is the main entry point called by Defrag() in defrag.c.
  *
- * returns a *LOCKED* tracker or NULL
+ * Sequence:
+ *   1. Hash the packet to a bucket, lock the row.
+ *   2. Empty bucket, call DefragTrackerGetNew, splice it in as
+ *      the head, initialise, drop the row lock, return the
+ *      (locked) tracker.
+ *   3. Non-empty bucket, walk the hnext chain. For each candidate:
+ *        a. Lock the tracker.
+ *        b. If it has timed out (per DefragTrackerTimedOut against
+ *           the packet timestamp): unlink it, clear its frags,
+ *           push it back to the spare stack, bump the timeout
+ *           counter, and continue walking. Timeout-on-lookup is
+ *           opportunistic garbage collection; the flow-manager
+ *           thread also sweeps for timeouts, but reaping them
+ *           inline saves a full sweep pass on hot buckets.
+ *        c. If it is not marked `remove` AND its tuple matches:
+ *           bump use_cnt, drop the row lock, return the (still
+ *           locked) tracker. Note the tracker stays locked while
+ *           we release the row; the caller will unlock it via
+ *           DefragTrackerRelease.
+ *        d. Otherwise unlock the tracker and advance.
+ *   4. End of chain reached, allocate a new tracker via
+ *      DefragTrackerGetNew, splice at the HEAD (LIFO - new
+ *      trackers are more likely to see more fragments soon),
+ *      initialise, drop the row lock, return.
+ *
+ * Locking order is always row-lock outer, tracker-lock inner. The
+ * `goto tracker_removed` construct keeps `prev_dt` correct when
+ * a timed-out entry has been spliced out mid-walk.
+ *
+ * \retval dt   LOCKED tracker; caller MUST DefragTrackerRelease
+ * \retval NULL memcap exhausted and no candidate could be evicted
  */
 DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
@@ -604,7 +806,6 @@ DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, P
             DRLOCK_UNLOCK(hb);
             return dt;
         }
-
         dt = next_dt;
     } while (dt != NULL);
 
@@ -613,11 +814,19 @@ DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, P
     return NULL;
 }
 
-/** \brief look up a tracker in the hash
+/**
+ * \brief Read-only lookup: return the existing tracker for a packet,
+ *        or NULL if there isn't one.
  *
- *  \param a address to look up
+ * Unlike DefragGetTrackerFromHash, this never allocates and never
+ * evicts. Used by unit tests and by paths that want to inspect
+ * tracker state without registering interest in creating one.
  *
- *  \retval h *LOCKED* tracker or NULL
+ * Does not run the timeout-on-lookup logic, a read-only caller
+ * shouldn't have side effects on the hash.
+ *
+ * \retval dt   LOCKED tracker
+ * \retval NULL no matching tracker in the bucket
  */
 DefragTracker *DefragLookupTrackerFromHash (Packet *p)
 {
@@ -659,16 +868,41 @@ DefragTracker *DefragLookupTrackerFromHash (Packet *p)
     return NULL;
 }
 
-/** \internal
- *  \brief Get a tracker from the hash directly.
+/**
+ * \internal
+ * \brief Find and detach an idle tracker so its slot can be reused.
  *
- *  Called in conditions where the spare queue is empty and memcap is reached.
+ * Called by DefragTrackerGetNew when the spare stack is empty and
+ * memcap is exhausted. This is the pressure-relief valve of the
+ * whole engine.
  *
- *  Walks the hash until a tracker can be freed. "defragtracker_prune_idx" atomic int makes
- *  sure we don't start at the top each time since that would clear the top of
- *  the hash leading to longer and longer search times under high pressure (observed).
+ * Sweep strategy:
+ *   - Start from a rotating cursor (defragtracker_prune_idx),
+ *     wrapping on hash_size. The rotation is critical because always
+ *     starting at 0 would repeatedly evict the same top-of-table
+ *     entries, causing longer and longer search times under high pressure
+ *     (observed).
+ *   - For each bucket:
+ *       DRLOCK_TRYLOCK: skip contended buckets rather than block.
+ *       Empty head: skip.
+ *       SCMutexTrylock on the first tracker: skip on contention.
+ *       use_cnt > 0: in-flight, must not steal so skip.
+ *       Otherwise: unlink from the bucket, drop the row lock,
+ *       clear the tracker's frags, unlock it, and return it.
+ *   - Distinguish "hard reuse" (tracker was live, we're stealing
+ *     it) from "soft reuse" (tracker was already marked `remove`
+ *     but hadn't been reaped yet). Sustained hard reuse is a
+ *     signal to raise memcap or prealloc.
+ *   - Advance defragtracker_prune_idx by however many buckets
+ *     the sweep consumed so the next call starts where this one
+ *     left off.
  *
- *  \retval dt tracker or NULL
+ * All acquisitions are trylocks precisely because this runs on the
+ * packet-processing hot path; blocking here would head-of-line-block
+ * every worker.
+ *
+ * \retval dt   unlocked, cleared tracker ready to be re-initialised
+ * \retval NULL a full sweep found nothing evictable
  */
 static DefragTracker *DefragTrackerGetUsedDefragTracker(ThreadVars *tv, const DecodeThreadVars *dtv)
 {

--- a/src/detect-base64-data.c
+++ b/src/detect-base64-data.c
@@ -15,6 +15,19 @@
  * 02110-1301, USA.
  */
 
+/**
+ * \file
+ *
+ * \author Jason Ish <jason.ish@oisf.net>
+ *
+ * Implementation of the "base64_data" rule keyword.
+ *
+ * The keyword itself carries no options; it is a sticky buffer
+ * switch. It redirects subsequent content matches in the rule to
+ * DETECT_SM_LIST_BASE64_DATA, so they inspect the decoded output
+ * produced by a preceding "base64_decode".
+ */
+
 #include "suricata-common.h"
 #include "detect.h"
 #include "detect-engine.h"
@@ -45,6 +58,12 @@ void DetectBase64DataRegister(void)
     sigmatch_table[DETECT_BASE64_DATA].flags |= SIGMATCH_NOOPT;
 }
 
+/**
+ * \brief Switch the current sig-match list to DETECT_SM_LIST_BASE64_DATA.
+ *
+ * Rejects rules that use "base64_data" without a preceding
+ * "base64_decode": there would be no decoded buffer to inspect.
+ */
 static int DetectBase64DataSetup(DetectEngineCtx *de_ctx, Signature *s,
     const char *str)
 {
@@ -65,6 +84,7 @@ static int DetectBase64DataSetup(DetectEngineCtx *de_ctx, Signature *s,
 
 static int g_file_data_buffer_id = 0;
 
+/** \test base64_data after base64_decode switches the active list. */
 static int DetectBase64DataSetupTest01(void)
 {
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
@@ -85,10 +105,7 @@ static int DetectBase64DataSetupTest01(void)
     PASS;
 }
 
-/**
- * \test Test that the list can be changed to post-detection lists
- *     after the base64 keyword.
- */
+/** \test post-detection keywords (tag) may follow base64_data. */
 static int DetectBase64DataSetupTest04(void)
 {
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();

--- a/src/detect-base64-data.h
+++ b/src/detect-base64-data.h
@@ -15,9 +15,18 @@
  * 02110-1301, USA.
  */
 
+/**
+ * \file
+ *
+ * \author Jason Ish <jason.ish@oisf.net>
+ *
+ * Public interface for the "base64_data" rule keyword.
+ */
+
 #ifndef SURICATA_DETECT_BASE64_DATA_H
 #define SURICATA_DETECT_BASE64_DATA_H
 
+/** \brief Register the "base64_data" keyword with the detect engine. */
 void DetectBase64DataRegister(void);
 
 #endif /* SURICATA_DETECT_BASE64_DATA_H */

--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -15,6 +15,23 @@
  * 02110-1301, USA.
  */
 
+/**
+ * \file
+ *
+ * Implementation of the "base64_decode" rule keyword.
+ *
+ * Syntax:  base64_decode[: [bytes N,] [offset N,] [relative]]
+ *
+ * Setup time picks the sig-match list to attach to (either the
+ * explicitly selected sticky buffer, or the list of the nearest
+ * preceding payload keyword, defaulting to pmatch) and grows
+ * de_ctx->base64_decode_max_len so the thread-ctx decode buffer
+ * is sized to fit the largest request in the ruleset.
+ *
+ * Match time decodes up to `bytes` from payload+offset (optionally
+ * relative to the previous match) into det_ctx->base64_decoded.
+ */
+
 #include "suricata-common.h"
 #include "detect.h"
 #include "detect-parse.h"
@@ -24,7 +41,7 @@
 #include "detect-engine-build.h"
 #include "rust.h"
 
-/* Arbitrary maximum buffer size for decoded base64 data. */
+/** Cap on bytes decoded per match; also the default when "bytes" is omitted. */
 #define BASE64_DECODE_MAX 65535
 
 typedef struct DetectBase64Decode_ {
@@ -110,6 +127,13 @@ int DetectBase64DecodeDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s
     return det_ctx->base64_decoded_len > 0;
 }
 
+/**
+ * \brief Parse the keyword's argument string into (bytes, offset, relative).
+ *
+ * All three are optional and may appear in any order per decode_pattern.
+ * A missing option leaves its out-parameter at 0; unrecognised trailing
+ * tokens fail the parse.
+ */
 static int DetectBase64DecodeParse(
         const char *str, uint16_t *bytes, uint32_t *offset, uint8_t *relative)
 {
@@ -182,6 +206,17 @@ error:
     return retval;
 }
 
+/**
+ * \brief Attach a base64_decode match to the signature.
+ *
+ * Target list selection: an active sticky buffer wins; otherwise
+ * anchor to the list of the nearest preceding payload keyword
+ * (content, pcre, byte_test/jump/extract, isdataat); otherwise
+ * default to pmatch.
+ *
+ * Also raises de_ctx->base64_decode_max_len so the per-thread
+ * decode buffer, allocated later, is large enough for this rule.
+ */
 static int DetectBase64DecodeSetup(DetectEngineCtx *de_ctx, Signature *s,
     const char *str)
 {
@@ -259,6 +294,7 @@ static void DetectBase64DecodeFree(DetectEngineCtx *de_ctx, void *ptr)
 
 static int g_http_header_buffer_id = 0;
 
+/** \test Parser accepts every valid combination and rejects typos. */
 static int DetectBase64TestDecodeParse(void)
 {
     int retval = 0;
@@ -339,9 +375,7 @@ end:
     return retval;
 }
 
-/**
- * Test keyword setup on basic content.
- */
+/** \test Setup attaches to pmatch when no sticky buffer is active. */
 static int DetectBase64DecodeTestSetup(void)
 {
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
@@ -357,6 +391,7 @@ static int DetectBase64DecodeTestSetup(void)
     PASS;
 }
 
+/** \test End-to-end decode of a full payload with no options. */
 static int DetectBase64DecodeTestDecode(void)
 {
     ThreadVars tv;
@@ -412,6 +447,7 @@ end:
     return retval;
 }
 
+/** \test "offset N" skips leading bytes before decoding. */
 static int DetectBase64DecodeTestDecodeWithOffset(void)
 {
     ThreadVars tv;
@@ -474,6 +510,7 @@ end:
     return retval;
 }
 
+/** \test Offset past end of payload is a no-op, not an error. */
 static int DetectBase64DecodeTestDecodeLargeOffset(void)
 {
     ThreadVars tv;
@@ -530,6 +567,7 @@ end:
     return retval;
 }
 
+/** \test "relative" starts decoding after the previous match. */
 static int DetectBase64DecodeTestDecodeRelative(void)
 {
     ThreadVars tv;

--- a/src/detect-base64-decode.h
+++ b/src/detect-base64-decode.h
@@ -15,10 +15,33 @@
  * 02110-1301, USA.
  */
 
+/**
+ * \file
+ *
+ * \author Jason Ish <jason.ish@oisf.net>
+ *
+ * Public interface for the "base64_decode" rule keyword.
+ *
+ * Decodes a slice of the inspection buffer as base64 into
+ * det_ctx->base64_decoded, sized by de_ctx->base64_decode_max_len.
+ * A following "base64_data" keyword redirects subsequent content
+ * matches onto that decoded buffer.
+ */
+
 #ifndef SURICATA_DETECT_BASE64_DECODE_H
 #define SURICATA_DETECT_BASE64_DECODE_H
 
+/** \brief Register the "base64_decode" keyword with the detect engine. */
 void DetectBase64DecodeRegister(void);
+
+/**
+ * \brief Run the decode step at match time.
+ *
+ * Honours the keyword's bytes/offset/relative options; on success
+ * populates det_ctx->base64_decoded and base64_decoded_len.
+ *
+ * \retval 1 if any bytes were decoded, 0 otherwise
+ */
 int DetectBase64DecodeDoMatch(DetectEngineThreadCtx *, const Signature *,
     const SigMatchData *, const uint8_t *, uint32_t);
 

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -15,10 +15,27 @@
  * 02110-1301, USA.
  */
 
+/**
+ * \file
+ *
+ * DNP3 rule keywords.
+ *
+ * Four keywords, all scoped to ALPROTO_DNP3 and matched per
+ * transaction:
+ *   dnp3_func  application function code (u8 match)
+ *   dnp3_ind   response internal indicator flags (u16 bitfield)
+ *   dnp3_obj   presence of an (group, variation) object pair
+ *   dnp3.data  sticky buffer over the reassembled app-layer buffer
+ *
+ * dnp3_func/ind/obj live on their own inspection lists; dnp3.data
+ * registers full inspect + MPM engines for both directions and
+ * exposes the transaction's reassembled buffer via GetDNP3Data.
+ * Direction filtering (request vs response) is done at match time
+ * against DNP3Transaction::is_request.
+ */
+
 #include "suricata-common.h"
-
 #include "stream.h"
-
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-dnp3.h"
@@ -36,11 +53,8 @@ static int g_dnp3_match_buffer_id = 0;
 static int g_dnp3_data_buffer_id = 0;
 static int g_dnp3_ind_buffer_id = 0;
 
-/**
- * The detection struct.
- */
+/** Context for the dnp3_obj keyword: the (group, variation) pair to match. */
 typedef struct DetectDNP3_ {
-    /* Object info for object detection. */
     uint8_t obj_group;
     uint8_t obj_variation;
 } DetectDNP3;
@@ -50,6 +64,14 @@ static void DetectDNP3FuncRegisterTests(void);
 static void DetectDNP3ObjRegisterTests(void);
 #endif
 
+/**
+ * \brief Inspection-buffer accessor for dnp3.data.
+ *
+ * Serves the transaction's reassembled application buffer, but only
+ * in the matching direction; a TOSERVER inspection against a
+ * response transaction (or vice versa) returns NULL so the wrong
+ * side's payload never leaks into a match.
+ */
 static InspectionBuffer *GetDNP3Data(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t flow_flags,
@@ -140,13 +162,11 @@ error:
 }
 
 /**
- * \brief Parse the value of string of the dnp3_obj keyword.
+ * \brief Parse a "group,variation" pair for dnp3_obj.
  *
- * \param str the input string
- * \param gout pointer to variable to store the parsed group integer
- * \param vout pointer to variable to store the parsed variation integer
+ * Both fields are u8 in decimal; anything else fails the parse.
  *
- * \retval 1 if parsing successful otherwise 0.
+ * \retval 1 on success, 0 on any parse error
  */
 static int DetectDNP3ObjParse(const char *str, uint8_t *group, uint8_t *var)
 {
@@ -215,6 +235,12 @@ static void DetectDNP3Free(DetectEngineCtx *de_ctx, void *ptr)
     SCReturn;
 }
 
+/**
+ * \brief Match the transaction's function code, gated on direction.
+ *
+ * Requests carry the function code toserver; responses toclient.
+ * Mismatched direction is a non-match, not an error.
+ */
 static int DetectDNP3FuncMatch(DetectEngineThreadCtx *det_ctx,
     Flow *f, uint8_t flags, void *state, void *txv, const Signature *s,
     const SigMatchCtx *ctx)
@@ -231,6 +257,12 @@ static int DetectDNP3FuncMatch(DetectEngineThreadCtx *det_ctx,
     return 0;
 }
 
+/**
+ * \brief Match if the transaction carries an object with the configured
+ *        (group, variation).
+ *
+ * Linear scan over tx->objects: DNP3 object lists are typically short.
+ */
 static int DetectDNP3ObjMatch(DetectEngineThreadCtx *det_ctx,
     Flow *f, uint8_t flags, void *state, void *txv, const Signature *s,
     const SigMatchCtx *ctx)
@@ -258,6 +290,12 @@ static int DetectDNP3ObjMatch(DetectEngineThreadCtx *det_ctx,
     return 0;
 }
 
+/**
+ * \brief Match against the packed IIN1|IIN2 word from the response header.
+ *
+ * IIN1 is the high byte, IIN2 the low; the DetectU16 comparator does
+ * the bitfield/range work.
+ */
 static int DetectDNP3IndMatch(DetectEngineThreadCtx *det_ctx,
     Flow *f, uint8_t flags, void *state, void *txv, const Signature *s,
     const SigMatchCtx *ctx)
@@ -302,6 +340,7 @@ static void DetectDNP3IndRegister(void)
     sigmatch_table[DETECT_DNP3IND].Setup = DetectDNP3IndSetup;
     sigmatch_table[DETECT_DNP3IND].Free = DetectDNP3IndFree;
     sigmatch_table[DETECT_DNP3IND].flags = SIGMATCH_INFO_UINT16 | SIGMATCH_INFO_BITFLAGS_UINT;
+
     SCReturn;
 }
 
@@ -335,6 +374,13 @@ static int DetectDNP3DataSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     SCReturnInt(0);
 }
 
+/**
+ * \brief Register the dnp3.data sticky buffer.
+ *
+ * Inspect + MPM engines are registered for both directions against
+ * the same GetDNP3Data accessor; direction filtering happens inside
+ * the accessor.
+ */
 static void DetectDNP3DataRegister(void)
 {
     SCEnter();
@@ -361,6 +407,7 @@ static void DetectDNP3DataRegister(void)
     SCReturn;
 }
 
+/** \brief Register all four DNP3 keywords and their inspection engines. */
 void DetectDNP3Register(void)
 {
     DetectDNP3DataRegister();
@@ -369,7 +416,7 @@ void DetectDNP3Register(void)
     DetectDNP3IndRegister();
     DetectDNP3ObjRegister();
 
-    /* Register the list of func, ind and obj. */
+    /* Shared "dnp3" list carries func + obj matches for both directions. */
     DetectAppLayerInspectEngineRegister(
             "dnp3", ALPROTO_DNP3, SIG_FLAG_TOSERVER, 0, DetectEngineInspectGenericList, NULL);
     DetectAppLayerInspectEngineRegister(
@@ -377,6 +424,7 @@ void DetectDNP3Register(void)
 
     g_dnp3_match_buffer_id = DetectBufferTypeRegister("dnp3");
 
+    /* dnp3_ind is response-only. */
     DetectAppLayerInspectEngineRegister(
             "dnp3_ind", ALPROTO_DNP3, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectGenericList, NULL);
     g_dnp3_ind_buffer_id = DetectBufferTypeRegister("dnp3_ind");
@@ -390,6 +438,7 @@ void DetectDNP3Register(void)
 #include "flow-util.h"
 #include "stream-tcp.h"
 
+/** \test dnp3_func:2 parses and lands on the dnp3 match list. */
 static int DetectDNP3FuncTest01(void)
 {
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
@@ -411,6 +460,7 @@ static int DetectDNP3FuncTest01(void)
     PASS;
 }
 
+/** \test dnp3_obj:99,99 stores group and variation on the sig-match ctx. */
 static int DetectDNP3ObjSetupTest(void)
 {
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
@@ -433,6 +483,7 @@ static int DetectDNP3ObjSetupTest(void)
     PASS;
 }
 
+/** \test dnp3_obj parser: valid u8 range, rejects overflow and non-numeric. */
 static int DetectDNP3ObjParseTest(void)
 {
     uint8_t group, var;
@@ -461,4 +512,5 @@ static void DetectDNP3ObjRegisterTests(void)
     UtRegisterTest("DetectDNP3ObjParseTest", DetectDNP3ObjParseTest);
     UtRegisterTest("DetectDNP3ObjSetupTest", DetectDNP3ObjSetupTest);
 }
+
 #endif


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8899

Describe changes:
- Add code documentation to the C files listed in ticket 8899: defrag-hash.c,
  detect-base64-data.{c,h}, detect-base64-decode.{c,h}, detect-dnp3.c, and
  the remaining headers from the ticket.
- Comments only; no functional changes, no new tests.
- Two files from the ticket list are intentionally not touched:
  * detect-dce-iface.h: the DCERPC detection module was rewritten in Rust
    (see rust/src/dcerpc/) and this header no longer exists in the tree.
  * build-info.h: generated at build time and excluded via .gitignore;

### Provide values to any of the below to override the defaults.
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=