### PR TITLE
scripts: fix check doc rules - v1

### DIFF
--- a/scripts/check-doc-rules.py
+++ b/scripts/check-doc-rules.py
@@ -119,24 +119,38 @@ def check_rule_with_suricata(
         shutil.copytree(data_dir, tmpdir, dirs_exist_ok=True)
         rule_file.write_text(rule + "\n", encoding="utf-8")
 
-        cmd = [
-            str(suricata_bin),
-            "-T",
-            "-c", str(suricata_yaml),
-            "--data-dir="+tmpdir,
-            "-S", str(rule_file),
-            '--strict-rule-keywords=all',
-            "-l", tmpdir,
-        ]
-        proc = subprocess.run(
-            cmd,
-            check=False,
-            capture_output=True,
-            text=True,
+        load_modes = (
+            ("detection", ["-S", str(rule_file)]),
+            ("firewall", ["--firewall-rules-exclusive=" + str(rule_file)]),
         )
 
-        combined = proc.stderr.strip()
-        return proc.returncode == 0, combined
+        """ Check against both Threat Detection and Firewall rule parsers before failing the example rules"""
+        failures: List[str] = []
+        for label, load_args in load_modes:
+            cmd = [
+                str(suricata_bin),
+                "-T",
+                "-c", str(suricata_yaml),
+                "--data-dir="+tmpdir,
+                *load_args,
+                '--strict-rule-keywords=all',
+                "-l", tmpdir,
+            ]
+            proc = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            if proc.returncode == 0:
+                return True, ""
+
+            failures.append(
+                f"--- rejected as {label} rule ---\n{proc.stderr.strip()}"
+                )
+
+        return False, "\n\n".join(failures)
 
 
 def main() -> int:

--- a/scripts/check-doc-rules.py
+++ b/scripts/check-doc-rules.py
@@ -90,17 +90,18 @@ def iter_rst_files(path: Path) -> Iterable[Path]:
 
 
 def resolve_suricata_bin(repo_root: Path, configured: Optional[str]) -> Path:
+    candidates = [repo_root / "src" / "suricata", repo_root / "suricata"]
+    """First check for local repo, as there may be patches to test"""
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
     if configured:
         return Path(configured)
 
     in_path = shutil.which("suricata")
     if in_path:
         return Path(in_path)
-
-    candidates = [repo_root / "src" / "suricata", repo_root / "suricata"]
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
 
     raise SystemExit(
         "Unable to find Suricata binary. Use --suricata-bin to provide it."


### PR DESCRIPTION
https://github.com/OISF/suricata/pull/15996 is failing in CI docs check because the check-doc-rules script didn't check rule examples against firewall rule parser.

Fix that, and first check for suricata binary in the local tree before defaulting to usr path, since there are chances that the local repo will have important changes, when testing docs.
