### PR TITLE
Backport 8.0.x: fw: adjust policy schema to the new format v1

### DIFF
--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -327,28 +327,32 @@ of :ref:`engine analysis<config:engine-analysis>`.
 Default policies
 ================
 
-Each hook has a default policy. By default ``packet:filter`` enforces a ``drop:packet`` policy and the
-``app:filter`` hooks applies ``drop:flow``.
+Each hook has a default policy. By default ``packet.filter`` enforces a ``drop:packet`` policy and the
+``app`` hooks apply ``drop:flow``.
 
-The policies can be configured in ``firewall`` block in the config.
+The policies can be configured in ``firewall`` block in the config. Packet hooks
+live under ``packet`` and app-layer hooks under ``app``, keyed by protocol.
 
-Example for ``packet:filter``, to use reject instead of drop::
+Example for ``packet.filter``, to use reject instead of drop::
 
     firewall:
       policies:
-        packet-filter: [ "reject:packet" ]
+        packet:
+          filter: [ "reject:packet" ]
 
 
 Example for DNS::
 
     firewall:
       policies:
-        dns:
-          request-started: ["accept:hook"]
+        app:
+          dns:
+            request-started: ["accept:hook"]
 
-          # Drop and alert on all DNS requests that are not allowed in
-          # firewall.rules.
-          request-complete: ["drop:flow", "alert"]
+            # Drop and alert on all DNS requests that are not allowed in
+            # firewall.rules.
+            request-complete: ["drop:flow", "alert"]
 
-          # Accept all responses.
-          response-started: ["accept:tx"]
+            # Accept all responses.
+            response-started: ["accept:tx"]
+

--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -62,7 +62,7 @@ Application layer tables
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 If applayer is available, rules from the following tables apply. The tables for the
-application layer are per app layer protocol and per protocol state. e.g. ``http:request_line``.
+application layer are per app layer protocol and per protocol state. e.g. ``http1:request_line``.
 
 
 .. table::

--- a/doc/userguide/firewall/firewall-example.rst
+++ b/doc/userguide/firewall/firewall-example.rst
@@ -62,35 +62,36 @@ HTTP example with partially using default policies
 
     firewall:
       policies:
-        http1:
-          request-started:
-            - "accept:hook"
-          request-line:
-            - "drop:flow"
-            - "alert"
-          request-headers:
-            - "drop:flow"
-            - "alert"
-          request-body:
-            - "accept:hook"
-          request-trailer:
-            - "accept:hook"
-          request-complete:
-            - "accept:hook"
+        app:
+          http1:
+            request-started:
+              - "accept:hook"
+            request-line:
+              - "drop:flow"
+              - "alert"
+            request-headers:
+              - "drop:flow"
+              - "alert"
+            request-body:
+              - "accept:hook"
+            request-trailer:
+              - "accept:hook"
+            request-complete:
+              - "accept:hook"
 
-          response-started:
-            - "accept:hook"
-          response-line:
-            - "drop:flow"
-            - "alert"
-          response-headers:
-            - "accept:hook"
-          response-body:
-            - "accept:hook"
-          response-trailer:
-            - "accept:hook"
-          response-complete:
-            - "accept:hook"
+            response-started:
+              - "accept:hook"
+            response-line:
+              - "drop:flow"
+              - "alert"
+            response-headers:
+              - "accept:hook"
+            response-body:
+              - "accept:hook"
+            response-trailer:
+              - "accept:hook"
+            response-complete:
+              - "accept:hook"
 
 
 ::

--- a/doc/userguide/firewall/firewall-example.rst
+++ b/doc/userguide/firewall/firewall-example.rst
@@ -62,7 +62,7 @@ HTTP example with partially using default policies
 
     firewall:
       policies:
-        http:
+        http1:
           request-started:
             - "accept:hook"
           request-line:

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -49,7 +49,11 @@ pub enum AppProtoEnum {
 }
 pub type AppProto = u16;
 extern "C" {
-    #[doc = " \\brief Maps the ALPROTO_*, to its string equivalent.\n\n \\param alproto App layer protocol id.\n\n \\retval String equivalent for the alproto."]
+    #[doc = " \\brief Maps the ALPROTO_*, to its registered string equivalent.\n \\param alproto App layer protocol id.\n \\retval String equivalent for the alproto."]
+    pub fn AppProtoToStringRaw(alproto: AppProto) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    #[doc = " \\brief Maps the ALPROTO_*, to its normalized string equivalent.\n\n \\param alproto App layer protocol id.\n\n \\retval String equivalent for the alproto."]
     pub fn AppProtoToString(alproto: AppProto) -> *const ::std::os::raw::c_char;
 }
 extern "C" {

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -38,6 +38,16 @@ typedef struct AppProtoStringTuple {
 
 AppProtoStringTuple *g_alproto_strings = NULL;
 
+const char *AppProtoToStringRaw(AppProto alproto)
+{
+    const char *proto_name = NULL;
+    if (alproto < g_alproto_max) {
+        DEBUG_VALIDATE_BUG_ON(g_alproto_strings[alproto].alproto != alproto);
+        proto_name = g_alproto_strings[alproto].str;
+    }
+    return proto_name;
+}
+
 const char *AppProtoToString(AppProto alproto)
 {
     const char *proto_name = NULL;

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -159,7 +159,14 @@ static inline AppProto AppProtoCommon(AppProto sigproto, AppProto alproto)
 }
 
 /**
- * \brief Maps the ALPROTO_*, to its string equivalent.
+ * \brief Maps the ALPROTO_*, to its registered string equivalent.
+ * \param alproto App layer protocol id.
+ * \retval String equivalent for the alproto.
+ */
+const char *AppProtoToStringRaw(AppProto alproto);
+
+/**
+ * \brief Maps the ALPROTO_*, to its normalized string equivalent.
  *
  * \param alproto App layer protocol id.
  *

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -841,13 +841,11 @@ const char *DetectEngineAppHookToName(
 /** \brief get the sm_list for a app hook */
 int DetectEngineAppHookToSmlist(const AppProto p, const uint8_t state, const int direction)
 {
-    const char *app_proto = AppProtoToString(p);
+    const char *app_proto = AppProtoToStringRaw(p);
     if (app_proto == NULL) {
         SCLogError("unknown app_proto %u", p);
         return -1;
     }
-    if (strcmp(app_proto, "http") == 0)
-        app_proto = "http1";
 
     const char *name =
             DetectEngineAppHookToName(p, state, direction & (STREAM_TOSERVER | STREAM_TOCLIENT));

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3929,7 +3929,7 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
             nname[i] = '-';
     }
 
-    const char *app_name = AppProtoToString(app_proto);
+    const char *app_name = AppProtoToStringRaw(app_proto);
     int r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s", prefix, app_name, nname);
     SCFree(nname);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1152,9 +1152,7 @@ static bool IsBuiltIn(const char *n)
 void DetectRegisterAppLayerHookLists(void)
 {
     for (AppProto a = ALPROTO_FAILED + 1; a < g_alproto_max; a++) {
-        const char *alproto_name = AppProtoToString(a);
-        if (strcmp(alproto_name, "http") == 0)
-            alproto_name = "http1";
+        const char *alproto_name = AppProtoToStringRaw(a);
         SCLogDebug("alproto %u/%s", a, alproto_name);
 
         const int max_progress_ts =

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3930,7 +3930,7 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
     }
 
     const char *app_name = AppProtoToStringRaw(app_proto);
-    int r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s", prefix, app_name, nname);
+    int r = snprintf(policy_name, sizeof(policy_name), "%s.app.%s.%s", prefix, app_name, nname);
     SCFree(nname);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
         FatalError("internal error: failed to assemble firewall policy config string");
@@ -3956,7 +3956,7 @@ static int DoParseAppPolicy(const char *prefix, const AppProto app_proto, const 
         }
         if (hookname == NULL)
             return 0;
-        r = snprintf(policy_name, sizeof(policy_name), "%s.%s.%s", prefix, app_name, hookname);
+        r = snprintf(policy_name, sizeof(policy_name), "%s.app.%s.%s", prefix, app_name, hookname);
         if (r < 0 || (size_t)r >= sizeof(policy_name)) {
             FatalError("internal error: failed to assemble firewall policy config string");
         }
@@ -4029,7 +4029,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
     if (app_fw_policies == NULL)
         return -1;
 
-    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-filter", prefix);
+    r = snprintf(policy_name, sizeof(policy_name), "%s.packet.filter", prefix);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
         FatalError("internal error: failed to assemble firewall policy config string");
     }
@@ -4042,7 +4042,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
                     DETECT_FIREWALL_POLICY_PACKET_FILTER) < 0)
             return -1;
 
-    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-flow", prefix);
+    r = snprintf(policy_name, sizeof(policy_name), "%s.packet.pre-flow", prefix);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
         FatalError("internal error: failed to assemble firewall policy config string");
     }
@@ -4054,7 +4054,7 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
                     DETECT_FIREWALL_POLICY_PRE_FLOW) < 0)
             return -1;
 
-    r = snprintf(policy_name, sizeof(policy_name), "%s.packet-pre-stream", prefix);
+    r = snprintf(policy_name, sizeof(policy_name), "%s.packet.pre-stream", prefix);
     if (r < 0 || (size_t)r >= sizeof(policy_name)) {
         FatalError("internal error: failed to assemble firewall policy config string");
     }

--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -83,9 +83,7 @@ int ListAppLayerHooks(const char *conf_filename)
         if (alprotos[a] != 1)
             continue;
 
-        const char *alproto_name = AppProtoToString(a);
-        if (strcmp(alproto_name, "http") == 0)
-            alproto_name = "http1";
+        const char *alproto_name = AppProtoToStringRaw(a);
         SCLogDebug("alproto %u/%s", a, alproto_name);
 
         const int max_progress_ts =
@@ -133,9 +131,7 @@ int ListAppLayerFrames(const char *conf_filename)
         if (alprotos[a] != 1)
             continue;
 
-        const char *alproto_name = AppProtoToString(a);
-        if (strcmp(alproto_name, "http") == 0)
-            alproto_name = "http1";
+        const char *alproto_name = AppProtoToStringRaw(a);
         SCLogDebug("alproto %u/%s", a, alproto_name);
 
         bool tcp_stream_once = false;


### PR DESCRIPTION
Backport of https://github.com/OISF/suricata/pull/16021 which will be a prerequisite for full integration of the [Redmine ticket 8770](https://redmine.openinfosecfoundation.org/issues/8770)

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8770

Describe changes:
v1:
- initial backport, didn't change much except I leaved out sub-state policy querying as that is not part of Suricata 8.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3291
