### PR TITLE
util-ioctl: add missing socket() error logging (v2)

### DIFF
--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -88,6 +88,7 @@ int GetIfaceMTU(const char *dev)
     (void)strlcpy(ifr.ifr_name, dev, sizeof(ifr.ifr_name));
     fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd == -1) {
+        SCLogError("%s: failed to open socket for ioctl: %s", dev, strerror(errno));
         return -1;
     }
 
@@ -153,6 +154,7 @@ int GetIfaceFlags(const char *ifname)
 
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0) {
+        SCLogError("%s: failed to open socket for ioctl: %s", ifname, strerror(errno));
         return -1;
     }
 
@@ -188,6 +190,7 @@ int SetIfaceFlags(const char *ifname, int flags)
 
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0) {
+        SCLogError("%s: failed to open socket for ioctl: %s", ifname, strerror(errno));
         return -1;
     }
 
@@ -218,6 +221,7 @@ int GetIfaceCaps(const char *ifname)
 
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0) {
+        SCLogError("%s: failed to open socket for ioctl: %s", ifname, strerror(errno));
         return -1;
     }
 
@@ -241,6 +245,7 @@ int SetIfaceCaps(const char *ifname, int caps)
 
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0) {
+        SCLogError("%s: failed to open socket for ioctl: %s", ifname, strerror(errno));
         return -1;
     }
 
@@ -269,6 +274,7 @@ static int GetEthtoolValue(const char *dev, int cmd, uint32_t *value)
 
     fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd == -1) {
+        SCLogError("%s: failed to open socket for ioctl: %s", dev, strerror(errno));
         return -1;
     }
     (void)strlcpy(ifr.ifr_name, dev, sizeof(ifr.ifr_name));
@@ -294,6 +300,7 @@ static int SetEthtoolValue(const char *dev, int cmd, uint32_t value)
 
     fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd == -1) {
+        SCLogError("%s: failed to open socket for ioctl: %s", dev, strerror(errno));
         return -1;
     }
     (void)strlcpy(ifr.ifr_name, dev, sizeof(ifr.ifr_name));
@@ -720,7 +727,7 @@ int GetIfaceRSSQueuesNum(const char *dev)
     (void)strlcpy(ifr.ifr_name, dev, sizeof(ifr.ifr_name));
     fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd == -1) {
-        SCLogWarning("%s: failed to open socket for ioctl: %s", dev, strerror(errno));
+        SCLogError("%s: failed to open socket for ioctl: %s", dev, strerror(errno));
         return -1;
     }
 


### PR DESCRIPTION
Supersedes #15934.

The functions in `util-ioctl.c` use an `AF_INET` datagram socket to
perform interface ioctl operations. Most of them returned silently when
socket creation failed, while `GetIfaceRSSQueuesNum()` logged only a
warning.

Report socket creation failures as errors in all of these functions.
Such failures can indicate a system-level problem, such as file
descriptor exhaustion, and otherwise make startup and interface
reconfiguration failures difficult to diagnose.

Changes since #15934:

- Use `SCLogError()` consistently for every ioctl socket creation failure.
- Change the existing warning in `GetIfaceRSSQueuesNum()` to an error.
- Keep the existing log levels for subsequent `ioctl()` failures unchanged.