### PR TITLE
doc: update Rust installation instructions v2

### DIFF
--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -135,15 +135,7 @@ Rust support
   Rust packages can be found in package managers but some distributions
   don't provide Rust or provide outdated Rust packages.
   In case of insufficient version you can install Rust directly
-  from the Rust project itself::
-
-    1) Install Rust https://www.rust-lang.org/en-US/install.html
-    2) Install cbindgen - if the cbindgen is not found in the repository
-       or the cbindgen version is lower than required, it can be
-       alternatively installed as: cargo install --force cbindgen
-    3) Make sure the cargo path is within your PATH environment
-       echo 'export PATH="~/.cargo/bin:${PATH}"' >> ~/.bashrc
-       export PATH="~/.cargo/bin:${PATH}"
+  from the Rust project itself at https://rust-lang.org/tools/install/.
 
 Auto-Setup
 ^^^^^^^^^^


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata/pull/14948

Rust website has changed the location of the installer. Additionally their installer now includes automatic append to .bashrc to source the correct path to Rust binaries.

Cbindgen as an instruction is also removed as it is not needed when building from the downloaded and packaged Suricata.

Ticket: https://redmine.openinfosecfoundation.org/issues/8344

