### PR TITLE
eve/netflow: account for capture bypassed packets and bytes

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4825,6 +4825,19 @@
                         ]
                     }
                 },
+                "bypassed": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "description": "Packets and bytes counted by the capture bypass method",
+                    "properties": {
+                        "bytes": {
+                            "type": "integer"
+                        },
+                        "pkts": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "bytes": {
                     "type": "integer",
                     "description": "Total number of bytes transferred to server/client",

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -29,6 +29,8 @@
 #include "pkt-var.h"
 #include "conf.h"
 
+#include "flow.h"
+#include "flow-storage.h"
 #include "threads.h"
 #include "threadvars.h"
 #include "tm-threads.h"
@@ -187,9 +189,19 @@ static void NetFlowLogEveToServer(SCJsonBuilder *js, Flow *f)
     SCJbSetString(js, "app_proto", AppProtoToString(f->alproto_ts ? f->alproto_ts : f->alproto));
 
     SCJbOpenObject(js, "netflow");
+    FlowBypassInfo *fc = SCFlowGetStorageById(f, GetFlowBypassInfoID());
+    if (fc) {
+        SCJbSetUint(js, "pkts", f->todstpktcnt + fc->todstpktcnt);
+        SCJbSetUint(js, "bytes", f->todstbytecnt + fc->todstbytecnt);
 
-    SCJbSetUint(js, "pkts", f->todstpktcnt);
-    SCJbSetUint(js, "bytes", f->todstbytecnt);
+        SCJbOpenObject(js, "bypassed");
+        SCJbSetUint(js, "pkts", fc->todstpktcnt);
+        SCJbSetUint(js, "bytes", fc->todstbytecnt);
+        SCJbClose(js);
+    } else {
+        SCJbSetUint(js, "pkts", f->todstpktcnt);
+        SCJbSetUint(js, "bytes", f->todstbytecnt);
+    }
 
     char timebuf1[64], timebuf2[64];
 
@@ -237,9 +249,19 @@ static void NetFlowLogEveToClient(SCJsonBuilder *js, Flow *f)
     SCJbSetString(js, "app_proto", AppProtoToString(f->alproto_tc ? f->alproto_tc : f->alproto));
 
     SCJbOpenObject(js, "netflow");
+    FlowBypassInfo *fc = SCFlowGetStorageById(f, GetFlowBypassInfoID());
+    if (fc) {
+        SCJbSetUint(js, "pkts", f->tosrcpktcnt + fc->tosrcpktcnt);
+        SCJbSetUint(js, "bytes", f->tosrcbytecnt + fc->tosrcbytecnt);
 
-    SCJbSetUint(js, "pkts", f->tosrcpktcnt);
-    SCJbSetUint(js, "bytes", f->tosrcbytecnt);
+        SCJbOpenObject(js, "bypassed");
+        SCJbSetUint(js, "pkts", fc->tosrcpktcnt);
+        SCJbSetUint(js, "bytes", fc->tosrcbytecnt);
+        SCJbClose(js);
+    } else {
+        SCJbSetUint(js, "pkts", f->tosrcpktcnt);
+        SCJbSetUint(js, "bytes", f->tosrcbytecnt);
+    }
 
     char timebuf1[64], timebuf2[64];
 


### PR DESCRIPTION
When a flow is bypassed by the capture method, the packets and bytes counted by the bypass are stored in the flow's FlowBypassInfo storage and not in the Flow counters. The netflow logger only read the Flow counters, so netflow.pkts and netflow.bytes only reported what Suricata saw before the bypass was installed, which disagreed with the flow event logged for the same flow.

Add the bypassed counters to the reported values and expose the bypassed part alone in a netflow.bypassed object, mirroring what the flow event already does in flow.bypassed.

Ticket: #8918

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8918



### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=

