### PR TITLE
flow/bypass: report last packet time as flow end time

### DIFF
--- a/ebpf/bypass_filter.c
+++ b/ebpf/bypass_filter.c
@@ -60,6 +60,7 @@ struct flowv6_keys {
 struct pair {
     __u64 packets;
     __u64 bytes;
+    __u64 time;
 };
 
 struct {
@@ -143,6 +144,7 @@ static __always_inline int ipv4_filter(struct __sk_buff *skb, __u16 vlan0, __u16
 #endif
         value->packets++;
         value->bytes += skb->len;
+        value->time = bpf_ktime_get_ns();
         return 0;
     }
     return -1;
@@ -205,6 +207,7 @@ static __always_inline int ipv6_filter(struct __sk_buff *skb, __u16 vlan0, __u16
         //bpf_trace_printk(fmt, sizeof(fmt), tuple.port16[0], tuple.port16[1]);
         value->packets++;
         value->bytes += skb->len;
+        value->time = bpf_ktime_get_ns();
         return 0;
     }
     return -1;

--- a/ebpf/xdp_filter.c
+++ b/ebpf/xdp_filter.c
@@ -93,6 +93,7 @@ struct flowv6_keys {
 struct pair {
     __u64 packets;
     __u64 bytes;
+    __u64 time;
 };
 
 struct {
@@ -305,6 +306,7 @@ static int __always_inline filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_
         __sync_fetch_and_add(&value->packets, 1);
         __sync_fetch_and_add(&value->bytes, data_end - data);
 #endif
+        value->time = bpf_ktime_get_ns();
 
 #if GOT_TX_PEER
         iface_peer = bpf_map_lookup_elem(&tx_peer_int, &key0);
@@ -436,6 +438,7 @@ static int __always_inline filter_ipv6(struct xdp_md *ctx, void *data, __u64 nh_
         __sync_fetch_and_add(&value->packets, 1);
         __sync_fetch_and_add(&value->bytes, data_end - data);
 #endif
+        value->time = bpf_ktime_get_ns();
 
 #if GOT_TX_PEER
         iface_peer = bpf_map_lookup_elem(&tx_peer_int, &key0);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -226,13 +226,12 @@ static bool FlowManagerFlowTimeout(Flow *f, SCTime_t ts, uint32_t *next_ts, cons
  *  \brief check timeout of captured bypassed flow by querying capture method
  *
  *  \param f Flow
- *  \param ts timestamp
  *  \param counters Flow timeout counters
  *
  *  \retval false not timeout
  *  \retval true timeout (or not capture bypassed)
  */
-static inline bool FlowBypassedTimeout(Flow *f, SCTime_t ts, FlowTimeoutCounters *counters)
+static inline bool FlowBypassedTimeout(Flow *f, FlowTimeoutCounters *counters)
 {
     if (f->flow_state != FLOW_STATE_CAPTURE_BYPASSED) {
         return true;
@@ -246,7 +245,7 @@ static inline bool FlowBypassedTimeout(Flow *f, SCTime_t ts, FlowTimeoutCounters
         uint64_t bytes_tosrc = fc->tosrcbytecnt;
         uint64_t pkts_todst = fc->todstpktcnt;
         uint64_t bytes_todst = fc->todstbytecnt;
-        bool update = fc->BypassUpdate(f, fc->bypass_data, SCTIME_SECS(ts));
+        bool update = fc->BypassUpdate(f, fc->bypass_data);
         if (update) {
             SCLogDebug("Updated flow: %" PRIu64 "", FlowGetId(f));
             pkts_tosrc = fc->tosrcpktcnt - pkts_tosrc;
@@ -371,7 +370,7 @@ static void FlowManagerHashRowTimeout(FlowManagerTimeoutThread *td, Flow *f, SCT
 #ifdef CAPTURE_OFFLOAD
         /* never prune a flow that is used by a packet we
          * are currently processing in one of the threads */
-        if (!FlowBypassedTimeout(f, ts, counters)) {
+        if (!FlowBypassedTimeout(f, counters)) {
             FLOWLOCK_UNLOCK(f);
             prev_f = f;
             f = f->next;

--- a/src/flow.h
+++ b/src/flow.h
@@ -528,13 +528,15 @@ typedef struct FlowProtoFreeFunc_ {
 } FlowProtoFreeFunc;
 
 typedef struct FlowBypassInfo_ {
-    bool (* BypassUpdate)(Flow *f, void *data, time_t tsec);
+    bool (*BypassUpdate)(Flow *f, void *data);
     void (* BypassFree)(void *data);
     void *bypass_data;
     uint64_t tosrcpktcnt;
     uint64_t tosrcbytecnt;
     uint64_t todstpktcnt;
     uint64_t todstbytecnt;
+    /** time of the last packet seen by the capture bypass method */
+    SCTime_t lastpktts;
 } FlowBypassInfo;
 
 #include "flow-queue.h"

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -202,6 +202,7 @@ void EveAddAppProto(Flow *f, SCJsonBuilder *js)
 
 void EveAddFlow(Flow *f, SCJsonBuilder *js)
 {
+    SCTime_t lastts = f->lastts;
     FlowBypassInfo *fc = SCFlowGetStorageById(f, GetFlowBypassInfoID());
     if (fc) {
         SCJbSetUint(js, "pkts_toserver", f->todstpktcnt + fc->todstpktcnt);
@@ -215,6 +216,10 @@ void EveAddFlow(Flow *f, SCJsonBuilder *js)
         SCJbSetUint(js, "bytes_toserver", fc->todstbytecnt);
         SCJbSetUint(js, "bytes_toclient", fc->tosrcbytecnt);
         SCJbClose(js);
+
+        if (SCTIME_SECS(fc->lastpktts)) {
+            lastts = fc->lastpktts;
+        }
     } else {
         SCJbSetUint(js, "pkts_toserver", f->todstpktcnt);
         SCJbSetUint(js, "pkts_toclient", f->tosrcpktcnt);
@@ -222,9 +227,12 @@ void EveAddFlow(Flow *f, SCJsonBuilder *js)
         SCJbSetUint(js, "bytes_toclient", f->tosrcbytecnt);
     }
 
-    char timebuf1[64];
+    char timebuf1[64], timebuf2[64];
     CreateIsoTimeString(f->startts, timebuf1, sizeof(timebuf1));
+    CreateIsoTimeString(lastts, timebuf2, sizeof(timebuf2));
     SCJbSetString(js, "start", timebuf1);
+    SCJbSetString(js, "end", timebuf2);
+    SCJbSetUint(js, "age", SCTIME_SECS(lastts) - SCTIME_SECS(f->startts));
 }
 
 static void EveExceptionPolicyLog(SCJsonBuilder *js, uint16_t flag)
@@ -292,13 +300,6 @@ static void EveFlowLogJSON(OutputJsonThreadCtx *aft, SCJsonBuilder *jb, Flow *f)
     EveAddAppProto(f, jb);
     SCJbOpenObject(jb, "flow");
     EveAddFlow(f, jb);
-
-    char timebuf2[64];
-    CreateIsoTimeString(f->lastts, timebuf2, sizeof(timebuf2));
-    SCJbSetString(jb, "end", timebuf2);
-
-    uint64_t age = (SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts));
-    SCJbSetUint(jb, "age", age);
 
     if (f->flow_end_flags & FLOW_END_FLAG_EMERGENCY)
         JB_SET_TRUE(jb, "emergency");

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -193,13 +193,15 @@ static void NetFlowLogEveToServer(SCJsonBuilder *js, Flow *f)
 
     char timebuf1[64], timebuf2[64];
 
+    const SCTime_t lastts = (fc && SCTIME_SECS(fc->lastpktts)) ? fc->lastpktts : f->lastts;
+
     CreateIsoTimeString(f->startts, timebuf1, sizeof(timebuf1));
-    CreateIsoTimeString(f->lastts, timebuf2, sizeof(timebuf2));
+    CreateIsoTimeString(lastts, timebuf2, sizeof(timebuf2));
 
     SCJbSetString(js, "start", timebuf1);
     SCJbSetString(js, "end", timebuf2);
 
-    uint64_t age = (SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts));
+    uint64_t age = (SCTIME_SECS(lastts) - SCTIME_SECS(f->startts));
     SCJbSetUint(js, "age", age);
 
     SCJbSetUint(js, "min_ttl", f->min_ttl_toserver);
@@ -243,13 +245,15 @@ static void NetFlowLogEveToClient(SCJsonBuilder *js, Flow *f)
 
     char timebuf1[64], timebuf2[64];
 
+    const SCTime_t lastts = (fc && SCTIME_SECS(fc->lastpktts)) ? fc->lastpktts : f->lastts;
+
     CreateIsoTimeString(f->startts, timebuf1, sizeof(timebuf1));
-    CreateIsoTimeString(f->lastts, timebuf2, sizeof(timebuf2));
+    CreateIsoTimeString(lastts, timebuf2, sizeof(timebuf2));
 
     SCJbSetString(js, "start", timebuf1);
     SCJbSetString(js, "end", timebuf2);
 
-    uint64_t age = (SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts));
+    uint64_t age = (SCTIME_SECS(lastts) - SCTIME_SECS(f->startts));
     SCJbSetUint(js, "age", age);
 
     /* To client is zero if we did not see any packet */

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2182,6 +2182,7 @@ static int AFPInsertHalfFlow(int mapd, void *key, unsigned int nr_cpus)
     for (i = 0; i < nr_cpus; i++) {
         BPF_PERCPU(value, i).packets = 0;
         BPF_PERCPU(value, i).bytes = 0;
+        BPF_PERCPU(value, i).time = 0;
     }
     if (bpf_map_update_elem(mapd, key, value, BPF_NOEXIST) != 0) {
         switch (errno) {

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -603,6 +603,41 @@ void EBPFBypassFree(void *data)
 }
 
 /**
+ * Store the time of the last packet of a half flow in the bypass info.
+ *
+ * The eBPF programs stamp the entries with bpf_ktime_get_ns() which is a
+ * monotonic clock, so get the age of the stamp and remove it from the current
+ * wall clock time.
+ */
+static void EBPFSetLastPktTs(FlowBypassInfo *fc, uint64_t last_pkt_mono_ns)
+{
+    struct timespec now_monotonic_clock;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now_monotonic_clock) != 0)
+        return;
+
+    /* SCTime_t is a microsecond precision timestamp, the eBPF one a nanosecond one */
+    uint64_t last_pkt_mono_us = last_pkt_mono_ns / 1000;
+
+    /* age of the stamp, both times are on the monotonic clock */
+    SCTime_t now_monotonic = SCTIME_FROM_TIMESPEC(&now_monotonic_clock);
+    uint64_t now_monotonic_us =
+            SCTIME_SECS(now_monotonic) * 1000000ULL + SCTIME_USECS(now_monotonic);
+    /* num us before now when pkt was last seen */
+    uint64_t age_pkt_us = now_monotonic_us - last_pkt_mono_us;
+
+    /* remove the age of the stamp from the current wall clock time */
+    SCTime_t now_wall_clock = TimeGet();
+    uint64_t last_pkt_us =
+            SCTIME_SECS(now_wall_clock) * 1000000ULL + SCTIME_USECS(now_wall_clock) - age_pkt_us;
+
+    SCTime_t last_pkt_ts = { .secs = last_pkt_us / 1000000, .usecs = last_pkt_us % 1000000 };
+    if (SCTIME_CMP_GT(last_pkt_ts, fc->lastpktts)) {
+        fc->lastpktts = last_pkt_ts;
+    }
+}
+
+/**
  *
  * Compare eBPF half flow to Flow
  *
@@ -616,6 +651,7 @@ static bool EBPFBypassCheckHalfFlow(Flow *f, FlowBypassInfo *fc,
     int i;
     uint64_t pkts_cnt = 0;
     uint64_t bytes_cnt = 0;
+    uint64_t last_pkt_ns = 0;
     /* We use a per CPU structure so we will get a array of values. But if nr_cpus
      * is 1 then we have a global hash. */
     BPF_DECLARE_PERCPU(struct pair, values_array, eb->cpus_count);
@@ -632,17 +668,23 @@ static bool EBPFBypassCheckHalfFlow(Flow *f, FlowBypassInfo *fc,
                 BPF_PERCPU(values_array, i).bytes);
         pkts_cnt += BPF_PERCPU(values_array, i).packets;
         bytes_cnt += BPF_PERCPU(values_array, i).bytes;
+        // Keeping info on CPU who last seen pkt
+        if (BPF_PERCPU(values_array, i).time > last_pkt_ns) {
+            last_pkt_ns = BPF_PERCPU(values_array, i).time;
+        }
     }
     if (index == 0) {
         if (pkts_cnt != fc->todstpktcnt) {
             fc->todstpktcnt = pkts_cnt;
             fc->todstbytecnt = bytes_cnt;
+            EBPFSetLastPktTs(fc, last_pkt_ns);
             return true;
         }
     } else {
         if (pkts_cnt != fc->tosrcpktcnt) {
             fc->tosrcpktcnt = pkts_cnt;
             fc->tosrcbytecnt = bytes_cnt;
+            EBPFSetLastPktTs(fc, last_pkt_ns);
             return true;
         }
     }
@@ -655,7 +697,7 @@ static bool EBPFBypassCheckHalfFlow(Flow *f, FlowBypassInfo *fc,
  * Update lastts in the flow and do accounting
  *
  * */
-bool EBPFBypassUpdate(Flow *f, void *data, time_t tsec)
+bool EBPFBypassUpdate(Flow *f, void *data)
 {
     EBPFBypassData *eb = (EBPFBypassData *)data;
     if (eb == NULL) {
@@ -674,7 +716,8 @@ bool EBPFBypassUpdate(Flow *f, void *data, time_t tsec)
         EBPFDeleteKey(eb->mapfd, eb->key[1]);
         SCLogDebug("Done delete entry: %u", FLOW_IS_IPV6(f));
     } else {
-        f->lastts = SCTIME_FROM_SECS(tsec);
+        /* Recuperate added info in flow bypass that comes from ebpf map from latest activity */
+        f->lastts = fc->lastpktts;
         return true;
     }
     return false;

--- a/src/util-ebpf.h
+++ b/src/util-ebpf.h
@@ -62,6 +62,7 @@ struct flowv6_keys {
 struct pair {
     uint64_t packets;
     uint64_t bytes;
+    uint64_t time;
 };
 
 typedef struct EBPFBypassData_ {
@@ -89,7 +90,7 @@ void EBPFBuildCPUSet(SCConfNode *node, char *iface);
 int EBPFSetPeerIface(const char *iface, const char *out_iface);
 
 int EBPFUpdateFlow(Flow *f, Packet *p, void *data);
-bool EBPFBypassUpdate(Flow *f, void *data, time_t tsec);
+bool EBPFBypassUpdate(Flow *f, void *data);
 void EBPFBypassFree(void *data);
 
 void EBPFDeleteKey(int fd, void *key);


### PR DESCRIPTION
EBPFBypassUpdate() set the flow's lastts from the timestamp of the flow manager pass that noticed a counter change, not from the time of the last packet, which was not available: the eBPF bypass map only carried packet and byte counters.

Stamp every counted packet with bpf_ktime_get_ns() in a new field of struct pair, in both the bypass_filter and xdp_filter programs, and take the most recent stamp over the per CPU values when reading the map.

Ticket: #8919

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8919


### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
