### PR TITLE
dhcp: remove unused import in test

### DIFF
--- a/rust/src/dhcp/parser.rs
+++ b/rust/src/dhcp/parser.rs
@@ -272,7 +272,6 @@ pub fn parse_dhcp(input: &[u8]) -> IResult<&[u8], DHCPMessage> {
 
 #[cfg(test)]
 mod tests {
-    use crate::dhcp::dhcp::*;
     use crate::dhcp::parser::*;
 
     #[test]


### PR DESCRIPTION
To address clippy warning.
