### PR TITLE
detect/dcerpc: match zero-flag version 0 binds - v1

### DIFF
--- a/doc/userguide/rules/dcerpc-keywords.rst
+++ b/doc/userguide/rules/dcerpc-keywords.rst
@@ -9,9 +9,15 @@ of DCERPC packets over UDP, TCP and SMB.
 dcerpc.iface
 ------------
 
-Match on the value of the interface UUID in a DCERPC header. If `any_frag` option
-is given, the match shall be done on all fragments. If it's not, the match shall
-only happen on the first fragment.
+Match on an interface UUID negotiated by BIND and BIND_ACK. For native
+connection-oriented DCERPC, matching occurs on later REQUEST and RESPONSE PDUs
+using the interface context ID.
+
+The optional ``any_frag`` argument controls which BIND fragments are considered.
+Without it, the BIND must set ``PFC_FIRST_FRAG``; a minor-version-0 BIND with
+``pfc_flags`` set to ``0`` is also treated as the first fragment. With
+``any_frag``, all BIND fragments are considered. The option has no effect for
+DCERPC over SMB.
 
 The format of the keyword::
 

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -539,9 +539,11 @@ impl DCERPCState {
                 uuidentry.version = ctxitem.version;
                 uuidentry.versionminor = ctxitem.versionminor;
                 let pfcflags = hdr.pfc_flags;
-                // Store the first frag flag in the uuid as pfc_flags will
-                // be overwritten by new packets
-                if pfcflags & PFC_FIRST_FRAG > 0 {
+                // Store whether this is the first fragment, as pfc_flags will
+                // be overwritten by new packets. Minor version 0 runtimes assume
+                // BIND PDUs are not fragmented, so treat a BIND with no flags as
+                // its first fragment.
+                if pfcflags & PFC_FIRST_FRAG > 0 || (hdr.rpc_vers_minor == 0 && pfcflags == 0) {
                     uuidentry.flags |= DCERPC_UUID_ENTRY_FLAG_FF;
                 }
                 for uuid in self.interface_uuids.iter_mut() {


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8578
Ticket: https://redmine.openinfosecfoundation.org/issues/8577

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3297

The DCE/RPC specification states that minor-version-0 runtimes assume
BIND PDUs are not fragmented. Treat a BIND with no PFC flags as eligible
for default dcerpc.iface matching instead of requiring any_frag.

Limit this compatibility behavior to minor version 0 so fragmented
minor-version-1 BIND handling is unchanged.

Specification:
https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm#tagcjh_17_06_02

AI dug up the detail about minor version 0, however, the spec above appears to
support that. Would like further confirmation as I'm not that familiar with
DCERPC.
