### PR TITLE
dpdk: add initial unittests for DPDK codebase v13.3

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -954,6 +954,7 @@ jobs:
                 ccache \
                 clang \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -979,6 +980,7 @@ jobs:
                 lz4-devel \
                 make \
                 parallel \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python \
@@ -998,7 +1000,7 @@ jobs:
       - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow" ./configure --disable-shared
       - run: make check
       - run: make distclean
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-qa-simulation --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-qa-simulation --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         env:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -469,7 +469,7 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
         SCReturnInt(-EINVAL);
     }
 
-    if (iconf->threads <= 0) {
+    if (iconf->threads == 0) {
         SCLogError("%s: positive number of threads required", iconf->iface);
         SCReturnInt(-ERANGE);
     }

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -389,32 +389,32 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
     }
 
     bool wtaf_periface = true;
-    ThreadsAffinityType *wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", iconf->iface);
+    ThreadsAffinityType *wtaf = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", iconf->iface);
     if (wtaf == NULL) {
         wtaf_periface = false;
-        wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", NULL); // mandatory
+        wtaf = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", NULL); // mandatory
         if (wtaf == NULL) {
             SCLogError("Specify worker-cpu-set list in the threading section");
             SCReturnInt(-EINVAL);
         }
     }
-    ThreadsAffinityType *mtaf = GetAffinityTypeForNameAndIface("management-cpu-set", NULL);
+    ThreadsAffinityType *mtaf = AffinityTypeGetByIfaceOrCpuset("management-cpu-set", NULL);
     if (mtaf == NULL) {
         SCLogError("Specify management-cpu-set list in the threading section");
         SCReturnInt(-EINVAL);
     }
-    uint16_t sched_cpus = UtilAffinityGetAffinedCPUNum(wtaf);
+    uint16_t sched_cpus = AffinityGetAffinedCPUNum(wtaf);
     if (sched_cpus == UtilCpuGetNumProcessorsOnline()) {
         SCLogWarning(
                 "\"all\" specified in worker CPU cores affinity, excluding management threads");
-        UtilAffinityCpusExclude(wtaf, mtaf);
-        sched_cpus = UtilAffinityGetAffinedCPUNum(wtaf);
+        AffinityCpusSubtract(wtaf, mtaf);
+        sched_cpus = AffinityGetAffinedCPUNum(wtaf);
     }
 
     if (sched_cpus == 0) {
         SCLogError("No worker CPU cores with configured affinity were configured");
         SCReturnInt(-EINVAL);
-    } else if (UtilAffinityCpusOverlap(wtaf, mtaf) != 0) {
+    } else if (AffinityCpusOverlap(wtaf, mtaf)) {
         SCLogWarning("Worker threads should not overlap with management threads in the CPU core "
                      "affinity configuration");
     }
@@ -1080,10 +1080,10 @@ static bool ConfigThreadsGenericIsValid(uint16_t iface_threads, ThreadsAffinityT
         SCLogError("Specify worker-cpu-set list in the threading section");
         return false;
     }
-    if (total_cpus > UtilAffinityGetAffinedCPUNum(wtaf)) {
+    if (total_cpus > AffinityGetAffinedCPUNum(wtaf)) {
         SCLogError("Interfaces requested more cores than configured in the worker-cpu-set "
                    "threading section (requested %d configured %d",
-                total_cpus, UtilAffinityGetAffinedCPUNum(wtaf));
+                total_cpus, AffinityGetAffinedCPUNum(wtaf));
         return false;
     }
 
@@ -1092,10 +1092,10 @@ static bool ConfigThreadsGenericIsValid(uint16_t iface_threads, ThreadsAffinityT
 
 static bool ConfigThreadsInterfaceIsValid(uint16_t iface_threads, ThreadsAffinityType *itaf)
 {
-    if (iface_threads > UtilAffinityGetAffinedCPUNum(itaf)) {
+    if (iface_threads > AffinityGetAffinedCPUNum(itaf)) {
         SCLogError("Interface requested more cores than configured in the interface-specific "
                    "threading section (requested %d configured %d",
-                iface_threads, UtilAffinityGetAffinedCPUNum(itaf));
+                iface_threads, AffinityGetAffinedCPUNum(itaf));
         return false;
     }
 
@@ -1104,8 +1104,8 @@ static bool ConfigThreadsInterfaceIsValid(uint16_t iface_threads, ThreadsAffinit
 
 static bool ConfigIsThreadingValid(uint16_t iface_threads, const char *iface)
 {
-    ThreadsAffinityType *itaf = GetAffinityTypeForNameAndIface("worker-cpu-set", iface);
-    ThreadsAffinityType *wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", NULL);
+    ThreadsAffinityType *itaf = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", iface);
+    ThreadsAffinityType *wtaf = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", NULL);
     if (itaf && !ConfigThreadsInterfaceIsValid(iface_threads, itaf)) {
         return false;
     } else if (itaf == NULL && !ConfigThreadsGenericIsValid(iface_threads, wtaf)) {

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -379,10 +379,47 @@ static void ConfigSetIface(DPDKIfaceConfig *iconf, const char *entry_str)
     SCReturn;
 }
 
+static int32_t remaining_auto_cpus = -1; // -1 means not initialized
+
+/**
+ * \brief Initialize the number of remaining auto-assigned threads.
+ * \retval 0 on success, -EINVAL on invalid input
+ */
+static int AutoRemainingThreadsInit(uint16_t sched_cpus, uint16_t live_dev_count)
+{
+    if (remaining_auto_cpus != -1) {
+        return 0;
+    }
+
+    if (sched_cpus == 0) {
+        SCLogError("No worker CPU cores with affinity were configured");
+        return -EINVAL;
+    }
+    if (live_dev_count == 0) {
+        SCLogError("No devices configured");
+        return -EINVAL;
+    }
+    remaining_auto_cpus = sched_cpus % live_dev_count;
+    return 0;
+}
+
+/**
+ * \brief Decrease the number of remaining auto-assigned threads by one
+ * \retval true if a leftover thread was consumed, false otherwise
+ */
+static bool AutoRemainingThreadsUsedOne(void)
+{
+    if (remaining_auto_cpus <= 0) {
+        return false;
+    }
+
+    remaining_auto_cpus--;
+    return true;
+}
+
 static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
 {
     SCEnter();
-    static uint16_t remaining_auto_cpus = UINT16_MAX; // uninitialized
     if (!threading_set_cpu_affinity) {
         SCLogError("DPDK runmode requires configured thread affinity");
         SCReturnInt(-EINVAL);
@@ -448,16 +485,11 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
             SCReturnInt(-ERANGE);
         }
 
-        if (remaining_auto_cpus == UINT16_MAX) {
-            // first time auto-assignment
-            remaining_auto_cpus = sched_cpus % live_dev_count;
-            if (remaining_auto_cpus > 0) {
-                iconf->threads++;
-                remaining_auto_cpus--;
-            }
-        } else if (remaining_auto_cpus > 0) {
+        int init_ret = AutoRemainingThreadsInit(sched_cpus, live_dev_count);
+        if (init_ret < 0)
+            SCReturnInt(init_ret);
+        if (AutoRemainingThreadsUsedOne()) {
             iconf->threads++;
-            remaining_auto_cpus--;
         }
         SCLogConfig("%s: auto-assigned %u threads", iconf->iface, iconf->threads);
         SCReturnInt(0);

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -51,6 +51,7 @@
 #include "util-conf.h"
 #include "suricata.h"
 #include "util-affinity.h"
+#include "conf-yaml-loader.h"
 
 #ifdef HAVE_DPDK
 
@@ -2037,6 +2038,464 @@ int RunModeIdsDpdkWorkers(void)
 #endif /* HAVE_DPDK */
     SCReturnInt(0);
 }
+
+#if defined(HAVE_DPDK) && defined(UNITTESTS)
+
+/**
+ * \brief Reset the remaining auto-assigned threads count so next call of
+ * AutoRemainingThreadsInit() will recalculate the number of remaining
+ * auto-assigned threads.
+ */
+static void AutoRemainingThreadsReset(void)
+{
+    remaining_auto_cpus = -1;
+}
+
+static bool saved_threading_set_cpu_affinity;
+
+static void DPDKRunmodeSetThreadsDeinit(void)
+{
+    threading_set_cpu_affinity = saved_threading_set_cpu_affinity;
+    LiveDeviceListClean();
+    SCConfDeInit();
+    SCConfRestoreContextBackup();
+}
+
+/**
+ * \brief Initialize DPDK runmode test: backup config, load YAML, load affinity,
+ * build device list, and initialize auto-remaining threads.
+ * On error, cleans up before returning.
+ * \retval 0 on success, negative errno on error
+ */
+static int DPDKRunmodeSetThreadsInit(const char *input, size_t input_len)
+{
+    saved_threading_set_cpu_affinity = threading_set_cpu_affinity;
+    SCConfCreateContextBackup();
+    SCConfInit();
+    AffinityReset();
+    LiveDeviceListClean();
+    AutoRemainingThreadsReset();
+    int ret = SCConfYamlLoadString(input, input_len);
+    if (ret != 0) {
+        DPDKRunmodeSetThreadsDeinit();
+        return -EINVAL;
+    }
+
+    int affinity = 0;
+    if (SCConfGetBool("threading.set-cpu-affinity", &affinity) == 1) {
+        threading_set_cpu_affinity = (affinity == 1);
+    }
+
+    if (threading_set_cpu_affinity) {
+        ret = AffinityLoadFromConfig();
+        if (ret < 0) {
+            DPDKRunmodeSetThreadsDeinit();
+            return ret;
+        }
+    }
+
+    LiveBuildDeviceListCustom("unittest-ifaces", "iface");
+    LiveDeviceFinalize();
+    return 0;
+}
+
+/**
+ * \brief Management CPU set excludes all available CPUs from the Worker CPU set
+ */
+static int DPDKRunmodeSetThreads01(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+  - iface: test_dev\n\
+threading:\n\
+  set-cpu-affinity: yes\n\
+  cpu-affinity:\n\
+    management-cpu-set:\n\
+      cpu: [ \"all\" ] \n\
+    worker-cpu-set:\n\
+      cpu: [ \"all\" ]\n\
+";
+
+    int ret = DPDKRunmodeSetThreadsInit(input, strlen(input));
+    if (ret == -ERANGE)
+        SKIP("not enough cpus in the system");
+    FAIL_IF(ret < 0);
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "1");
+    FAIL_IF_NOT(r == -EINVAL);
+
+    DPDKRunmodeSetThreadsDeinit();
+
+    PASS;
+}
+
+/**
+ * \brief Worker "all" minus management CPU 0 yields remaining online CPUs
+ */
+static int DPDKRunmodeSetThreads02(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+  - iface: test_dev\n\
+threading:\n\
+  set-cpu-affinity: yes\n\
+  cpu-affinity:\n\
+    management-cpu-set:\n\
+      cpu: [ 0 ] \n\
+    worker-cpu-set:\n\
+      cpu: [ \"all\" ]\n\
+";
+
+    int ret = DPDKRunmodeSetThreadsInit(input, strlen(input));
+    if (ret == -ERANGE)
+        SKIP("not enough cpus in the system");
+    FAIL_IF(ret < 0);
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "auto");
+    FAIL_IF_NOT(iconf.threads == UtilCpuGetNumProcessorsOnline() - 1);
+    FAIL_IF_NOT(r == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Management/Worker CPU set exclusion leaves 2 CPUs available
+ */
+static int DPDKRunmodeSetThreads03(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+  - iface: test_dev\n\
+threading:\n\
+  set-cpu-affinity: yes\n\
+  cpu-affinity:\n\
+    management-cpu-set:\n\
+      cpu: [ 0 ] \n\
+    worker-cpu-set:\n\
+      cpu: [ \"1-2\" ]\n\
+";
+
+    int ret = DPDKRunmodeSetThreadsInit(input, strlen(input));
+    if (ret == -ERANGE)
+        SKIP("not enough cpus in the system");
+    FAIL_IF(ret < 0);
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "auto");
+    FAIL_IF_NOT(iconf.threads == 2);
+    FAIL_IF_NOT(r == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Auto assignment of 1 CPU per interface
+ */
+static int DPDKRunmodeSetThreads04(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+  - iface: test_dev1\n\
+  - iface: test_dev2\n\
+threading:\n\
+  set-cpu-affinity: yes\n\
+  cpu-affinity:\n\
+    management-cpu-set:\n\
+      cpu: [ 0 ] \n\
+    worker-cpu-set:\n\
+      cpu: [ \"1-2\" ]\n\
+";
+
+    int ret = DPDKRunmodeSetThreadsInit(input, strlen(input));
+    if (ret == -ERANGE)
+        SKIP("not enough cpus in the system");
+    FAIL_IF(ret < 0);
+
+    DPDKIfaceConfig iconf1 = { 0 };
+    int r1 = ConfigSetThreads(&iconf1, "auto");
+    DPDKIfaceConfig iconf2 = { 0 };
+    int r2 = ConfigSetThreads(&iconf2, "auto");
+    FAIL_IF_NOT(iconf1.threads == 1);
+    FAIL_IF_NOT(r1 == 0);
+    FAIL_IF_NOT(iconf2.threads == 1);
+    FAIL_IF_NOT(r2 == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Auto assignment test with 2 CPUs available for the first interface
+ */
+static int DPDKRunmodeSetThreads05(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+  - iface: test_dev1\n\
+  - iface: test_dev2\n\
+threading:\n\
+  set-cpu-affinity: yes\n\
+  cpu-affinity:\n\
+    management-cpu-set:\n\
+      cpu: [ 0 ] \n\
+    worker-cpu-set:\n\
+      cpu: [ \"1-3\" ]\n\
+";
+
+    int ret = DPDKRunmodeSetThreadsInit(input, strlen(input));
+    if (ret == -ERANGE)
+        SKIP("not enough cpus in the system");
+    FAIL_IF(ret < 0);
+
+    DPDKIfaceConfig iconf1 = { 0 }; // test_dev1
+    int r1 = ConfigSetThreads(&iconf1, "auto");
+    DPDKIfaceConfig iconf2 = { 0 }; // test_dev2
+    int r2 = ConfigSetThreads(&iconf2, "auto");
+    FAIL_IF_NOT(iconf1.threads == 2);
+    FAIL_IF_NOT(r1 == 0);
+    FAIL_IF_NOT(iconf2.threads == 1);
+    FAIL_IF_NOT(r2 == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Sanity test for the ConfigSetThreads function
+ */
+static int DPDKRunmodeSetThreads06(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+  - iface: test_dev\n\
+threading:\n\
+  set-cpu-affinity: yes\n\
+  cpu-affinity:\n\
+    management-cpu-set:\n\
+      cpu: [ 0 ] \n\
+    worker-cpu-set:\n\
+      cpu: [ \"1-2\" ]\n\
+";
+    int ret = DPDKRunmodeSetThreadsInit(input, strlen(input));
+    if (ret == -ERANGE)
+        SKIP("not enough cpus in the system");
+    FAIL_IF(ret < 0);
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "-2");
+    FAIL_IF_NOT(r == -EINVAL);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "0");
+    FAIL_IF_NOT(r == -ERANGE);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "abc");
+    FAIL_IF_NOT(r == -EINVAL);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "99999999999999");
+    FAIL_IF(r == 0);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "1");
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.threads == 1);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "2");
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.threads == 2);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Test auto assignment of threads to ifaces based on both generic and
+ * per-interface CPU affinity config
+ */
+static int DPDKRunmodeSetThreads07(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+  - iface: test_dev1\n\
+  - iface: test_dev2\n\
+  - iface: test_dev3\n\
+threading:\n\
+  set-cpu-affinity: yes\n\
+  cpu-affinity:\n\
+    management-cpu-set:\n\
+      cpu: [ 0 ] \n\
+    worker-cpu-set:\n\
+      cpu: [ \"2-3\" ]\n\
+      interface-specific-cpu-set:\n\
+        - interface: \"test_dev1\"\n\
+          cpu: [ 1 ]\n\
+";
+
+    int ret = DPDKRunmodeSetThreadsInit(input, strlen(input));
+    if (ret == -ERANGE)
+        SKIP("not enough cpus in the system");
+    FAIL_IF(ret < 0);
+
+    DPDKIfaceConfig iconf1 = { .iface = "test_dev1" };
+    int r1 = ConfigSetThreads(&iconf1, "auto");
+    DPDKIfaceConfig iconf2 = { .iface = "test_dev2" };
+    int r2 = ConfigSetThreads(&iconf2, "auto");
+    DPDKIfaceConfig iconf3 = { .iface = "test_dev3" };
+    int r3 = ConfigSetThreads(&iconf3, "auto");
+    FAIL_IF_NOT(iconf1.threads == 1);
+    FAIL_IF_NOT(r1 == 0);
+    FAIL_IF_NOT(iconf2.threads == 1);
+    FAIL_IF_NOT(r2 == 0);
+    FAIL_IF_NOT(iconf3.threads == 1);
+    FAIL_IF_NOT(r3 == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+/**
+ * \brief Auto assignment with more interfaces than CPUs
+ */
+static int DPDKRunmodeSetThreads08(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+  - iface: test_dev1\n\
+  - iface: test_dev2\n\
+  - iface: test_dev3\n\
+threading:\n\
+  set-cpu-affinity: yes\n\
+  cpu-affinity:\n\
+    management-cpu-set:\n\
+      cpu: [ 0 ] \n\
+    worker-cpu-set:\n\
+      cpu: [ \"1-2\" ]\n\
+";
+
+    int ret = DPDKRunmodeSetThreadsInit(input, strlen(input));
+    if (ret == -ERANGE)
+        SKIP("not enough cpus in the system");
+    FAIL_IF(ret < 0);
+
+    DPDKIfaceConfig iconf1 = { 0 };
+    int r1 = ConfigSetThreads(&iconf1, "auto");
+    FAIL_IF_NOT(r1 == -ERANGE);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize01(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    const char *entry_str;
+
+    entry_str = NULL;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    entry_str = "";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    entry_str = "-1";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    entry_str = "999999999999999999";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -EINVAL);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize02(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "auto");
+    iconf.queue_mempool_size = 1023;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.mempool_cache_size_auto);
+    iconf.mempool_cache_size = MempoolCacheSizeCalculate(iconf.queue_mempool_size);
+    FAIL_IF(iconf.mempool_cache_size >= RTE_MEMPOOL_CACHE_MAX_SIZE);
+    FAIL_IF(iconf.mempool_cache_size >= iconf.queue_mempool_size / 1.5);
+    FAIL_IF_NOT(iconf.queue_mempool_size % iconf.mempool_cache_size == 0);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize03(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "%d", 1);
+    iconf.queue_mempool_size = 1023;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == 0);
+    FAIL_IF_NOT(iconf.mempool_cache_size == 1);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize04(void)
+{
+    DPDKIfaceConfig iconf = { 0 };
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "%d", RTE_MEMPOOL_CACHE_MAX_SIZE + 1);
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF_NOT(r == -ERANGE);
+
+    PASS;
+}
+
+/**
+ * \brief Register DPDK runmode unit tests for threads and mempool cache size.
+ */
+void RunmodeDpdkRegisterTests(void)
+{
+
+    UtRegisterTest("DPDKRunmodeSetThreads01", DPDKRunmodeSetThreads01);
+    UtRegisterTest("DPDKRunmodeSetThreads02", DPDKRunmodeSetThreads02);
+    UtRegisterTest("DPDKRunmodeSetThreads03", DPDKRunmodeSetThreads03);
+    UtRegisterTest("DPDKRunmodeSetThreads04", DPDKRunmodeSetThreads04);
+    UtRegisterTest("DPDKRunmodeSetThreads05", DPDKRunmodeSetThreads05);
+    UtRegisterTest("DPDKRunmodeSetThreads06", DPDKRunmodeSetThreads06);
+    UtRegisterTest("DPDKRunmodeSetThreads07", DPDKRunmodeSetThreads07);
+    UtRegisterTest("DPDKRunmodeSetThreads08", DPDKRunmodeSetThreads08);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize01", DPDKRunmodeSetMempoolCacheSize01);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize02", DPDKRunmodeSetMempoolCacheSize02);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize03", DPDKRunmodeSetMempoolCacheSize03);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize04", DPDKRunmodeSetMempoolCacheSize04);
+}
+#endif /* UNITTESTS and HAVE_DPDK */
 
 /**
  * @}

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -46,4 +46,8 @@ int RunModeIdsDpdkWorkers(void);
 void RunModeDpdkRegister(void);
 const char *RunModeDpdkGetDefaultMode(void);
 
+#if defined(HAVE_DPDK) && defined(UNITTESTS)
+void RunmodeDpdkRegisterTests(void);
+#endif /* HAVE_DPDK and UNITTESTS */
+
 #endif /* SURICATA_RUNMODE_DPDK_H */

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -203,7 +203,7 @@ static void RegisterUnittests(void)
     SCLogRegisterTests();
     MagicRegisterTests();
     UtilMiscRegisterTests();
-    ThreadingAffinityRegisterTests();
+    AffinityRegisterTests();
     DetectAddressTests();
     DetectProtoTests();
     DetectPortTests();

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -128,6 +128,8 @@
 #include "source-windivert.h"
 #endif
 
+#include "runmode-dpdk.h"
+
 #endif /* UNITTESTS */
 
 void TmqhSetup (void);
@@ -226,6 +228,9 @@ static void RegisterUnittests(void)
     UtilCIDRTests();
     OutputJsonStatsRegisterTests();
     CoredumpConfigRegisterTests();
+#ifdef HAVE_DPDK
+    RunmodeDpdkRegisterTests();
+#endif
 }
 #endif
 

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -970,7 +970,7 @@ void RunModeInitializeThreadSettings(void)
 
     /* try to get custom cpu mask value if needed */
     if (threading_set_cpu_affinity) {
-        AffinitySetupLoadFromConfig();
+        AffinityLoadFromConfig();
     }
     if ((SCConfGetFloat("threading.detect-thread-ratio", &threading_detect_ratio)) != 1) {
         if (SCConfGetNode("threading.detect-thread-ratio") != NULL)

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -970,7 +970,12 @@ void RunModeInitializeThreadSettings(void)
 
     /* try to get custom cpu mask value if needed */
     if (threading_set_cpu_affinity) {
-        AffinityLoadFromConfig();
+        int ret = AffinityLoadFromConfig();
+        if (ret < 0) {
+            FatalError("CPU affinity configuration failed (%s). "
+                       "Please check your threading.cpu-affinity configuration.",
+                    strerror(-ret));
+        }
     }
     if ((SCConfGetFloat("threading.detect-thread-ratio", &threading_detect_ratio)) != 1) {
         if (SCConfGetNode("threading.detect-thread-ratio") != NULL)

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -877,15 +877,15 @@ TmEcode TmThreadSetupOptions(ThreadVars *tv)
     if (tv->thread_setup_flags & THREAD_SET_AFFTYPE) {
         ThreadsAffinityType *taf = &thread_affinity[tv->cpu_affinity];
         bool use_iface_affinity = RunmodeIsAutofp() && tv->cpu_affinity == RECEIVE_CPU_SET &&
-                                  FindAffinityByInterface(taf, tv->iface_name) != NULL;
+                                  AffinityTypeGetChildTypeByIface(taf, tv->iface_name) != NULL;
         use_iface_affinity |= RunmodeIsWorkers() && tv->cpu_affinity == WORKER_CPU_SET &&
-                              FindAffinityByInterface(taf, tv->iface_name) != NULL;
+                              AffinityTypeGetChildTypeByIface(taf, tv->iface_name) != NULL;
 
         if (use_iface_affinity) {
-            taf = FindAffinityByInterface(taf, tv->iface_name);
+            taf = AffinityTypeGetChildTypeByIface(taf, tv->iface_name);
         }
 
-        if (UtilAffinityGetAffinedCPUNum(taf) == 0) {
+        if (AffinityGetAffinedCPUNum(taf) == 0) {
             if (!taf->nocpu_warned) {
                 SCLogWarning("No CPU affinity set for %s", AffinityGetYamlPath(taf));
                 taf->nocpu_warned = true;

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -1289,7 +1289,7 @@ static int ThreadingAffinityTest04(void)
                          "threading:\n"
                          "  cpu-affinity:\n"
                          "    worker-cpu-set:\n"
-                         "      cpu: [ 1, 3, 5 ]\n";
+                         "      cpu: [ 0, 1, 3 ]\n";
 
     int ret = AffinityTestInit(config);
     if (ret == -ERANGE) {
@@ -1298,12 +1298,10 @@ static int ThreadingAffinityTest04(void)
     FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
+    FAIL_IF_NOT(CPU_ISSET(0, &worker_taf->cpu_set));
     FAIL_IF_NOT(CPU_ISSET(1, &worker_taf->cpu_set));
     FAIL_IF_NOT(CPU_ISSET(3, &worker_taf->cpu_set));
-    FAIL_IF_NOT(CPU_ISSET(5, &worker_taf->cpu_set));
-    FAIL_IF(CPU_ISSET(0, &worker_taf->cpu_set));
     FAIL_IF(CPU_ISSET(2, &worker_taf->cpu_set));
-    FAIL_IF(CPU_ISSET(4, &worker_taf->cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == 3);
 
     SCConfDeInit();
@@ -1478,7 +1476,7 @@ static int ThreadingAffinityTest10(void)
                          "        - interface: \"eth0\"\n"
                          "          cpu: [ 1, 2 ]\n"
                          "        - interface: \"eth1\"\n"
-                         "          cpu: [ 3, 4 ]\n";
+                         "          cpu: [ 3 ]\n";
 
     int ret = AffinityTestInit(config);
     if (ret == -ERANGE) {
@@ -1499,8 +1497,7 @@ static int ThreadingAffinityTest10(void)
                 eth0_found = true;
             }
         } else if (strcmp(iface_taf->name, "eth1") == 0) {
-            if (CPU_ISSET(3, &iface_taf->cpu_set) && CPU_ISSET(4, &iface_taf->cpu_set) &&
-                    CPU_COUNT(&iface_taf->cpu_set) == 2) {
+            if (CPU_ISSET(3, &iface_taf->cpu_set) && CPU_COUNT(&iface_taf->cpu_set) == 1) {
                 eth1_found = true;
             }
         }
@@ -1569,12 +1566,12 @@ static int ThreadingAffinityTest12(void)
                          "      cpu: [ 2, 3 ]\n"
                          "      interface-specific-cpu-set:\n"
                          "        - interface: \"eth0\"\n"
-                         "          cpu: [ \"5-7\" ]\n"
+                         "          cpu: [ \"1-3\" ]\n"
                          "          prio:\n"
                          "            high: [ \"all\" ]\n"
                          "            default: \"high\"\n"
                          "    verdict-cpu-set:\n"
-                         "      cpu: [ 4 ]\n";
+                         "      cpu: [ 1 ]\n";
 
     int ret = AffinityTestInit(config);
     if (ret == -ERANGE) {
@@ -1586,19 +1583,20 @@ static int ThreadingAffinityTest12(void)
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[MANAGEMENT_CPU_SET].cpu_set) == 1);
     FAIL_IF_NOT(CPU_ISSET(1, &thread_affinity[RECEIVE_CPU_SET].cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[RECEIVE_CPU_SET].cpu_set) == 1);
-    FAIL_IF_NOT(CPU_ISSET(4, &thread_affinity[VERDICT_CPU_SET].cpu_set));
+    FAIL_IF_NOT(CPU_ISSET(1, &thread_affinity[VERDICT_CPU_SET].cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[VERDICT_CPU_SET].cpu_set) == 1);
     FAIL_IF_NOT(CPU_ISSET(2, &thread_affinity[WORKER_CPU_SET].cpu_set));
     FAIL_IF_NOT(CPU_ISSET(3, &thread_affinity[WORKER_CPU_SET].cpu_set));
+    FAIL_IF_NOT(CPU_COUNT(&thread_affinity[WORKER_CPU_SET].cpu_set) == 2);
 
     FAIL_IF_NOT(thread_affinity[WORKER_CPU_SET].nb_children == 1);
     ThreadsAffinityType *iface_taf = thread_affinity[WORKER_CPU_SET].children[0];
     FAIL_IF_NOT(strcmp(iface_taf->name, "eth0") == 0);
-    FAIL_IF_NOT(CPU_ISSET(1, &iface_taf->hiprio_cpu));
-    FAIL_IF_NOT(CPU_ISSET(2, &iface_taf->hiprio_cpu));
-    FAIL_IF_NOT(CPU_ISSET(3, &iface_taf->hiprio_cpu));
+    FAIL_IF_NOT(CPU_ISSET(1, &iface_taf->cpu_set));
+    FAIL_IF_NOT(CPU_ISSET(2, &iface_taf->cpu_set));
+    FAIL_IF_NOT(CPU_ISSET(3, &iface_taf->cpu_set));
+    FAIL_IF_NOT(CPU_COUNT(&iface_taf->cpu_set) == 3);
     FAIL_IF_NOT(iface_taf->prio == PRIO_HIGH);
-    FAIL_IF_NOT(CPU_COUNT(&thread_affinity[WORKER_CPU_SET].cpu_set) == 2);
 
     SCConfDeInit();
     SCConfRestoreContextBackup();

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -110,7 +110,7 @@ static ThreadsAffinityType *AllocAndInitAffinityType(
     return new_affinity;
 }
 
-ThreadsAffinityType *FindAffinityByInterface(
+ThreadsAffinityType *AffinityTypeGetChildTypeByIface(
         ThreadsAffinityType *parent, const char *interface_name)
 {
     if (parent == NULL || interface_name == NULL || parent->nb_children == 0 ||
@@ -129,34 +129,36 @@ ThreadsAffinityType *FindAffinityByInterface(
 
 /**
  * \brief Find affinity by name (*-cpu-set name) and an interface name.
- * \param name the name of the affinity (e.g. worker-cpu-set, receive-cpu-set).
- * The name is required and cannot be NULL.
+ * \param affinity_set_name the name of the affinity (e.g. worker-cpu-set, receive-cpu-set).
+ * The affinity_set_name is required and cannot be NULL.
  * \param interface_name the name of the interface.
- * If NULL, the affinity is looked up by name only.
+ * If NULL, the affinity is looked up by affinity_set_name only.
  *  \retval a pointer to the affinity or NULL if not found
  */
-ThreadsAffinityType *GetAffinityTypeForNameAndIface(const char *name, const char *interface_name)
+ThreadsAffinityType *AffinityTypeGetByIfaceOrCpuset(
+        const char *affinity_set_name, const char *interface_name)
 {
-    if (name == NULL || *name == '\0') {
+    if (affinity_set_name == NULL || *affinity_set_name == '\0') {
         return NULL;
     }
 
     ThreadsAffinityType *parent_affinity = NULL;
     for (int i = 0; i < MAX_CPU_SET; i++) {
-        if (thread_affinity[i].name != NULL && strcmp(thread_affinity[i].name, name) == 0) {
+        if (thread_affinity[i].name != NULL &&
+                strcmp(thread_affinity[i].name, affinity_set_name) == 0) {
             parent_affinity = &thread_affinity[i];
             break;
         }
     }
 
     if (parent_affinity == NULL) {
-        SCLogError("CPU affinity with name \"%s\" not found", name);
+        SCLogError("CPU affinity with name \"%s\" not found", affinity_set_name);
         return NULL;
     }
 
     if (interface_name != NULL) {
         ThreadsAffinityType *child_affinity =
-                FindAffinityByInterface(parent_affinity, interface_name);
+                AffinityTypeGetChildTypeByIface(parent_affinity, interface_name);
         // found or not found, it is returned
         return child_affinity;
     }
@@ -168,39 +170,39 @@ ThreadsAffinityType *GetAffinityTypeForNameAndIface(const char *name, const char
  * \brief Finds affinity by its name and interface name.
  * Interfaces are children of cpu-set names. If the queried interface is not
  * found, then it is allocated, initialized and assigned to the queried cpu-set.
- * \param name the name of the affinity (e.g. worker-cpu-set, receive-cpu-set).
- * The name is required and cannot be NULL.
+ * \param affinity_set_name the name of the affinity (e.g. worker-cpu-set, receive-cpu-set).
+ * The affinity_set_name is required and cannot be NULL.
  * \param interface_name the name of the interface.
- * If NULL, the affinity is looked up by name only.
+ * If NULL, the affinity is looked up by affinity_set_name only.
  * \retval a pointer to the affinity or NULL if not found
  */
-ThreadsAffinityType *GetOrAllocAffinityTypeForIfaceOfName(
-        const char *name, const char *interface_name)
+ThreadsAffinityType *AffinityTypeGetOrCreateByIfaceOrCpuset(
+        const char *affinity_set_name, const char *interface_name)
 {
     int i;
     ThreadsAffinityType *parent_affinity = NULL;
 
     for (i = 0; i < MAX_CPU_SET; i++) {
-        if (strcmp(thread_affinity[i].name, name) == 0) {
+        if (strcmp(thread_affinity[i].name, affinity_set_name) == 0) {
             parent_affinity = &thread_affinity[i];
             break;
         }
     }
 
     if (parent_affinity == NULL) {
-        SCLogError("CPU affinity with name \"%s\" not found", name);
+        SCLogError("CPU affinity with name \"%s\" not found", affinity_set_name);
         return NULL;
     }
 
     if (interface_name != NULL) {
         ThreadsAffinityType *child_affinity =
-                FindAffinityByInterface(parent_affinity, interface_name);
+                AffinityTypeGetChildTypeByIface(parent_affinity, interface_name);
         if (child_affinity != NULL) {
             return child_affinity;
         }
 
         // If not found, allocate and initialize a new child affinity
-        return AllocAndInitAffinityType(name, interface_name, parent_affinity);
+        return AllocAndInitAffinityType(affinity_set_name, interface_name, parent_affinity);
     }
 
     return parent_affinity;
@@ -224,7 +226,7 @@ static void AffinitySetupInit(void)
     }
 }
 
-int BuildCpusetWithCallback(
+int AffinityBuildCpusetWithCallback(
         const char *name, SCConfNode *node, void (*Callback)(int i, void *data), void *data)
 {
     SCConfNode *lnode;
@@ -283,7 +285,7 @@ static void AffinityCallback(int i, void *data)
 
 static int BuildCpuset(const char *name, SCConfNode *node, cpu_set_t *cpu)
 {
-    return BuildCpusetWithCallback(name, node, AffinityCallback, (void *)cpu);
+    return AffinityBuildCpusetWithCallback(name, node, AffinityCallback, (void *)cpu);
 }
 
 /**
@@ -503,7 +505,7 @@ static int SetupSingleIfaceAffinity(ThreadsAffinityType *taf, SCConfNode *iface_
     }
 
     ThreadsAffinityType *iface_taf =
-            GetOrAllocAffinityTypeForIfaceOfName(taf->name, interface_name);
+            AffinityTypeGetOrCreateByIfaceOrCpuset(taf->name, interface_name);
     if (iface_taf == NULL) {
         SCLogError("Failed to allocate CPU affinity type for interface: %s", interface_name);
         return -1;
@@ -585,7 +587,7 @@ static bool AffinityConfigIsLegacy(void)
 /**
  * \brief Extract CPU affinity configuration from current config file
  */
-void AffinitySetupLoadFromConfig(void)
+void AffinityLoadFromConfig(void)
 {
 #if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
     if (thread_affinity_init_done == 0) {
@@ -609,7 +611,7 @@ void AffinitySetupLoadFromConfig(void)
             continue;
         }
 
-        ThreadsAffinityType *taf = GetOrAllocAffinityTypeForIfaceOfName(setname, NULL);
+        ThreadsAffinityType *taf = AffinityTypeGetOrCreateByIfaceOrCpuset(setname, NULL);
         if (taf == NULL) {
             SCLogError("Failed to allocate CPU affinity type: %s", setname);
             continue;
@@ -1040,12 +1042,12 @@ uint16_t AffinityGetNextCPU(ThreadVars *tv, ThreadsAffinityType *taf)
  * \brief Return the total number of CPUs in a given affinity
  * \retval the number of affined CPUs
  */
-uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf)
+uint16_t AffinityGetAffinedCPUNum(ThreadsAffinityType *taf)
 {
     uint16_t ncpu = 0;
 #if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
     SCMutexLock(&taf->taf_mutex);
-    for (int i = UtilCpuGetNumProcessorsOnline(); i >= 0; i--)
+    for (int i = UtilCpuGetNumProcessorsOnline() - 1; i >= 0; i--)
         if (CPU_ISSET(i, &taf->cpu_set)) {
             ncpu++;
         }
@@ -1057,14 +1059,10 @@ uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf)
 #ifdef HAVE_DPDK
 /**
  * Find if CPU sets overlap
- * \return 1 if CPUs overlap, 0 otherwise
+ * \retval true if CPUs overlap, false otherwise
  */
-uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2)
+bool AffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2)
 {
-    ThreadsAffinityType tmptaf;
-    CPU_ZERO(&tmptaf);
-    SCMutexInit(&tmptaf.taf_mutex, NULL);
-
     cpu_set_t tmpcset;
 
     SCMutexLock(&taf1->taf_mutex);
@@ -1073,7 +1071,7 @@ uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType 
     SCMutexUnlock(&taf2->taf_mutex);
     SCMutexUnlock(&taf1->taf_mutex);
 
-    for (int i = UtilCpuGetNumProcessorsOnline(); i >= 0; i--)
+    for (int i = UtilCpuGetNumProcessorsOnline() - 1; i >= 0; i--)
         if (CPU_ISSET(i, &tmpcset)) {
             return 1;
         }
@@ -1086,7 +1084,7 @@ uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType 
  * \param mod_taf - CPU set to be modified
  * \param static_taf - static CPU set to be used only for evaluation
  */
-void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf)
+void AffinityCpusSubtract(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf)
 {
     SCMutexLock(&mod_taf->taf_mutex);
     SCMutexLock(&static_taf->taf_mutex);
@@ -1109,7 +1107,7 @@ void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *
  * \brief Helper function to reset affinity state for unit tests
  * This properly clears CPU sets without destroying initialized mutexes
  */
-static void ResetAffinityForTest(void)
+void AffinityReset(void)
 {
     thread_affinity_init_done = 0;
     for (int i = 0; i < MAX_CPU_SET; i++) {
@@ -1162,7 +1160,7 @@ static int ThreadingAffinityTest01(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1174,7 +1172,7 @@ static int ThreadingAffinityTest01(void)
 
     SCConfYamlLoadString(config, strlen(config));
 
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
     FAIL_IF_NOT(AffinityConfigIsLegacy() == false);
 
     ThreadsAffinityType *mgmt_taf = &thread_affinity[MANAGEMENT_CPU_SET];
@@ -1199,7 +1197,7 @@ static int ThreadingAffinityTest02(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1209,7 +1207,7 @@ static int ThreadingAffinityTest02(void)
                          "        cpu: [ 1, 2 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
     FAIL_IF_NOT(AffinityConfigIsLegacy() == true);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
@@ -1229,7 +1227,7 @@ static int ThreadingAffinityTest03(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1239,7 +1237,7 @@ static int ThreadingAffinityTest03(void)
                          "      cpu: [ \"0-3\" ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_ISSET(0, &worker_taf->cpu_set));
@@ -1260,7 +1258,7 @@ static int ThreadingAffinityTest04(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1270,7 +1268,7 @@ static int ThreadingAffinityTest04(void)
                          "      cpu: [ 1, 3, 5 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_ISSET(1, &worker_taf->cpu_set));
@@ -1293,7 +1291,7 @@ static int ThreadingAffinityTest05(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1303,7 +1301,7 @@ static int ThreadingAffinityTest05(void)
                          "      cpu: [ \"all\" ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == UtilCpuGetNumProcessorsOnline());
@@ -1320,7 +1318,7 @@ static int ThreadingAffinityTest06(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1335,7 +1333,7 @@ static int ThreadingAffinityTest06(void)
                          "        default: \"medium\"\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_ISSET(0, &worker_taf->lowprio_cpu));
@@ -1356,7 +1354,7 @@ static int ThreadingAffinityTest07(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1367,7 +1365,7 @@ static int ThreadingAffinityTest07(void)
                          "      mode: \"exclusive\"\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->mode_flag == EXCLUSIVE_AFFINITY);
@@ -1384,7 +1382,7 @@ static int ThreadingAffinityTest08(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1395,7 +1393,7 @@ static int ThreadingAffinityTest08(void)
                          "      threads: 4\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_threads == 4);
@@ -1412,7 +1410,7 @@ static int ThreadingAffinityTest09(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1426,7 +1424,7 @@ static int ThreadingAffinityTest09(void)
                          "          mode: \"exclusive\"\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 1);
@@ -1450,7 +1448,7 @@ static int ThreadingAffinityTest10(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1465,7 +1463,7 @@ static int ThreadingAffinityTest10(void)
                          "          cpu: [ 3, 4 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *receive_taf = &thread_affinity[RECEIVE_CPU_SET];
     FAIL_IF_NOT(receive_taf->nb_children == 2);
@@ -1501,7 +1499,7 @@ static int ThreadingAffinityTest11(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1517,7 +1515,7 @@ static int ThreadingAffinityTest11(void)
                          "            default: \"high\"\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 1);
@@ -1541,7 +1539,7 @@ static int ThreadingAffinityTest12(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1563,7 +1561,7 @@ static int ThreadingAffinityTest12(void)
                          "      cpu: [ 4 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     FAIL_IF_NOT(CPU_ISSET(0, &thread_affinity[MANAGEMENT_CPU_SET].cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[MANAGEMENT_CPU_SET].cpu_set) == 1);
@@ -1595,7 +1593,7 @@ static int ThreadingAffinityTest13(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1605,7 +1603,7 @@ static int ThreadingAffinityTest13(void)
                          "      cpu: [ \"invalid-cpu\" ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == 0);
@@ -1622,7 +1620,7 @@ static int ThreadingAffinityTest14(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1630,7 +1628,7 @@ static int ThreadingAffinityTest14(void)
                          "  cpu-affinity:\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     FAIL_IF_NOT(
             CPU_COUNT(&thread_affinity[WORKER_CPU_SET].cpu_set) == UtilCpuGetNumProcessorsOnline());
@@ -1648,7 +1646,7 @@ static int ThreadingAffinityTest15(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1658,7 +1656,7 @@ static int ThreadingAffinityTest15(void)
                          "        cpu: [ \"3-1\" ]\n"; // Invalid reverse range
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[MANAGEMENT_CPU_SET].cpu_set) == 0);
 
@@ -1675,7 +1673,7 @@ static int ThreadingAffinityTest16(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1686,7 +1684,7 @@ static int ThreadingAffinityTest16(void)
                          "          default: invalid_priority\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1701,7 +1699,7 @@ static int ThreadingAffinityTest17(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1711,7 +1709,7 @@ static int ThreadingAffinityTest17(void)
                          "        mode: invalid_mode\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1726,7 +1724,7 @@ static int ThreadingAffinityTest18(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1736,7 +1734,7 @@ static int ThreadingAffinityTest18(void)
                          "        threads: 0\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1751,7 +1749,7 @@ static int ThreadingAffinityTest19(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1761,7 +1759,7 @@ static int ThreadingAffinityTest19(void)
                          "        cpu: [ -1 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1776,7 +1774,7 @@ static int ThreadingAffinityTest20(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1786,7 +1784,7 @@ static int ThreadingAffinityTest20(void)
                          "        threads: invalid_number\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1801,7 +1799,7 @@ static int ThreadingAffinityTest21(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1811,7 +1809,7 @@ static int ThreadingAffinityTest21(void)
                          "        cpu: [ 0-99999 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
@@ -1826,7 +1824,7 @@ static int ThreadingAffinityTest22(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1841,7 +1839,7 @@ static int ThreadingAffinityTest22(void)
                          "              cpu: [ 2 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 1);
@@ -1856,14 +1854,14 @@ static int ThreadingAffinityTest22(void)
 }
 
 /**
- * \brief Test GetAffinityTypeForNameAndIface with NULL and empty string parameters
+ * \brief Test AffinityTypeGetByIfaceOrCpuset with NULL and empty string parameters
  * Comprehensive NULL parameter testing
  */
 static int ThreadingAffinityTest23(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1873,19 +1871,19 @@ static int ThreadingAffinityTest23(void)
                          "      cpu: [ 1, 2, 3 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
-    ThreadsAffinityType *result = GetAffinityTypeForNameAndIface(NULL, "eth0");
+    ThreadsAffinityType *result = AffinityTypeGetByIfaceOrCpuset(NULL, "eth0");
     FAIL_IF_NOT(result == NULL);
 
-    result = GetAffinityTypeForNameAndIface("", "eth0");
+    result = AffinityTypeGetByIfaceOrCpuset("", "eth0");
     FAIL_IF_NOT(result == NULL);
 
-    result = GetAffinityTypeForNameAndIface("worker-cpu-set", NULL);
+    result = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", NULL);
     FAIL_IF(result == NULL);
     FAIL_IF_NOT(strcmp(result->name, "worker-cpu-set") == 0);
 
-    result = GetAffinityTypeForNameAndIface("worker-cpu-set", "");
+    result = AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", "");
     FAIL_IF_NOT(result == NULL); // Returns NULL as no child with an empty name exists
 
     SCConfDeInit();
@@ -1901,7 +1899,7 @@ static int ThreadingAffinityTest24(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1915,7 +1913,7 @@ static int ThreadingAffinityTest24(void)
                          "            cpu: [ 2 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 0);
@@ -1931,23 +1929,27 @@ static int ThreadingAffinityTest24(void)
  */
 static int ThreadingAffinityTest25(void)
 {
-    ResetAffinityForTest();
+    AffinityReset();
 
-    ThreadsAffinityType *parent = GetOrAllocAffinityTypeForIfaceOfName("worker-cpu-set", NULL);
+    ThreadsAffinityType *parent = AffinityTypeGetOrCreateByIfaceOrCpuset("worker-cpu-set", NULL);
     FAIL_IF(parent == NULL);
 
-    ThreadsAffinityType *child1 = GetOrAllocAffinityTypeForIfaceOfName("worker-cpu-set", "iface1");
-    ThreadsAffinityType *child2 = GetOrAllocAffinityTypeForIfaceOfName("worker-cpu-set", "iface2");
-    ThreadsAffinityType *child3 = GetOrAllocAffinityTypeForIfaceOfName("worker-cpu-set", "iface3");
-    ThreadsAffinityType *child4 = GetOrAllocAffinityTypeForIfaceOfName("worker-cpu-set", "iface4");
+    ThreadsAffinityType *child1 =
+            AffinityTypeGetOrCreateByIfaceOrCpuset("worker-cpu-set", "iface1");
+    ThreadsAffinityType *child2 =
+            AffinityTypeGetOrCreateByIfaceOrCpuset("worker-cpu-set", "iface2");
+    ThreadsAffinityType *child3 =
+            AffinityTypeGetOrCreateByIfaceOrCpuset("worker-cpu-set", "iface3");
+    ThreadsAffinityType *child4 =
+            AffinityTypeGetOrCreateByIfaceOrCpuset("worker-cpu-set", "iface4");
 
     FAIL_IF_NOT(child1 && child2 && child3 && child4);
     FAIL_IF_NOT(parent->nb_children == 4);
 
-    ThreadsAffinityType *found = FindAffinityByInterface(parent, "iface2");
+    ThreadsAffinityType *found = AffinityTypeGetChildTypeByIface(parent, "iface2");
     FAIL_IF_NOT(found == child2);
 
-    found = GetOrAllocAffinityTypeForIfaceOfName("worker-cpu-set", "iface2");
+    found = AffinityTypeGetOrCreateByIfaceOrCpuset("worker-cpu-set", "iface2");
     FAIL_IF_NOT(found == child2);
 
     PASS;
@@ -1959,7 +1961,7 @@ static int ThreadingAffinityTest25(void)
  */
 static int ThreadingAffinityTest26(void)
 {
-    ResetAffinityForTest();
+    AffinityReset();
 
     ThreadsAffinityType test_taf;
     memset(&test_taf, 0, sizeof(test_taf));
@@ -1986,7 +1988,7 @@ static int ThreadingAffinityTest27(void)
 {
     SCConfCreateContextBackup();
     SCConfInit();
-    ResetAffinityForTest();
+    AffinityReset();
 
     const char *config = "%YAML 1.1\n"
                          "---\n"
@@ -1998,7 +2000,7 @@ static int ThreadingAffinityTest27(void)
                          "        cpu: [ 1, 2 ]\n";
 
     SCConfYamlLoadString(config, strlen(config));
-    AffinitySetupLoadFromConfig();
+    AffinityLoadFromConfig();
 
     ThreadsAffinityType *mgmt_taf = &thread_affinity[MANAGEMENT_CPU_SET];
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
@@ -2017,7 +2019,7 @@ static int ThreadingAffinityTest27(void)
 /**
  * \brief Register all threading affinity unit tests
  */
-void ThreadingAffinityRegisterTests(void)
+void AffinityRegisterTests(void)
 {
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__)
     UtRegisterTest("ThreadingAffinityTest01", ThreadingAffinityTest01);

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -246,29 +246,32 @@ int AffinityBuildCpusetWithCallback(
         } else if ((sep = strchr(lnode->val, '-')) != NULL) {
             if (StringParseUint32(&a, 10, sep - lnode->val, lnode->val) <= 0) {
                 SCLogError("%s: invalid cpu range (start invalid): \"%s\"", name, lnode->val);
-                return -1;
+                return -EINVAL;
             }
             if (StringParseUint32(&b, 10, strlen(sep) - 1, sep + 1) <= 0) {
                 SCLogError("%s: invalid cpu range (end invalid): \"%s\"", name, lnode->val);
-                return -1;
+                return -EINVAL;
             }
             if (a > b) {
                 SCLogError("%s: invalid cpu range (bad order): \"%s\"", name, lnode->val);
-                return -1;
-            }
-            if (b > max) {
-                SCLogError("%s: upper bound (%d) of cpu set is too high, only %d cpu(s)", name, b,
-                        max + 1);
-                return -1;
+                return -EINVAL;
             }
         } else {
             if (StringParseUint32(&a, 10, strlen(lnode->val), lnode->val) <= 0) {
                 SCLogError("%s: invalid cpu range (not an integer): \"%s\"", name, lnode->val);
-                return -1;
+                return -EINVAL;
             }
             b = a;
         }
-        for (i = a; i<= b; i++) {
+        if (a > max) {
+            SCLogError("%s: CPU %" PRIu32 " exceeds available range (0-%" PRIu32 ")", name, a, max);
+            return -ERANGE;
+        }
+        if (b > max) {
+            SCLogError("%s: CPU %" PRIu32 " exceeds available range (0-%" PRIu32 ")", name, b, max);
+            return -ERANGE;
+        }
+        for (i = a; i <= b; i++) {
             Callback(i, data);
         }
         if (stop) {
@@ -303,34 +306,32 @@ static const char *GetAffinitySetName(const char *val)
 
 /**
  * \brief Set up CPU sets for the given affinity type.
+ * \retval 0 on success, -EINVAL on parse error, -ERANGE on HW incompatibility
  */
-static void SetupCpuSets(ThreadsAffinityType *taf, SCConfNode *affinity, const char *setname)
+static int SetupCpuSets(ThreadsAffinityType *taf, SCConfNode *affinity, const char *setname)
 {
     CPU_ZERO(&taf->cpu_set);
     SCConfNode *cpu_node = SCConfNodeLookupChild(affinity, "cpu");
-    if (cpu_node != NULL) {
-        if (BuildCpuset(setname, cpu_node, &taf->cpu_set) < 0) {
-            SCLogWarning("Failed to parse CPU set for %s", setname);
-        }
-    } else {
+    if (cpu_node == NULL) {
         SCLogWarning("Unable to find 'cpu' node for set %s", setname);
+        return 0;
     }
+    return BuildCpuset(setname, cpu_node, &taf->cpu_set);
 }
 
 /**
  * \brief Build a priority CPU set for the given priority level.
+ * \retval 0 on success, -EINVAL on parse error, -ERANGE on HW incompatibility
  */
-static void BuildPriorityCpuset(ThreadsAffinityType *taf, SCConfNode *prio_node,
+static int BuildPriorityCpuset(ThreadsAffinityType *taf, SCConfNode *prio_node,
         const char *priority, cpu_set_t *cpuset, const char *setname)
 {
     SCConfNode *node = SCConfNodeLookupChild(prio_node, priority);
-    if (node != NULL) {
-        if (BuildCpuset(setname, node, cpuset) < 0) {
-            SCLogWarning("Failed to parse %s priority CPU set for %s", priority, setname);
-        }
-    } else {
+    if (node == NULL) {
         SCLogDebug("Unable to find '%s' priority for set %s", priority, setname);
+        return 0;
     }
+    return BuildCpuset(setname, node, cpuset);
 }
 
 /**
@@ -353,7 +354,7 @@ static int SetupDefaultPriority(
         taf->prio = PRIO_HIGH;
     } else {
         SCLogError("Unknown default CPU affinity priority: %s", default_node->val);
-        return -1;
+        return -EINVAL;
     }
 
     SCLogConfig("Using default priority '%s' for set %s", default_node->val, setname);
@@ -375,9 +376,18 @@ static int SetupAffinityPriority(
         return 0;
     }
 
-    BuildPriorityCpuset(taf, prio_node, "low", &taf->lowprio_cpu, setname);
-    BuildPriorityCpuset(taf, prio_node, "medium", &taf->medprio_cpu, setname);
-    BuildPriorityCpuset(taf, prio_node, "high", &taf->hiprio_cpu, setname);
+    int ret = BuildPriorityCpuset(taf, prio_node, "low", &taf->lowprio_cpu, setname);
+    if (ret < 0) {
+        return ret;
+    }
+    ret = BuildPriorityCpuset(taf, prio_node, "medium", &taf->medprio_cpu, setname);
+    if (ret < 0) {
+        return ret;
+    }
+    ret = BuildPriorityCpuset(taf, prio_node, "high", &taf->hiprio_cpu, setname);
+    if (ret < 0) {
+        return ret;
+    }
     return SetupDefaultPriority(taf, prio_node, setname);
 }
 
@@ -398,7 +408,7 @@ static int SetupAffinityMode(ThreadsAffinityType *taf, SCConfNode *affinity)
         taf->mode_flag = BALANCED_AFFINITY;
     } else {
         SCLogError("Unknown CPU affinity mode: %s", mode_node->val);
-        return -1;
+        return -EINVAL;
     }
     return 0;
 }
@@ -416,7 +426,7 @@ static int SetupAffinityThreads(ThreadsAffinityType *taf, SCConfNode *affinity)
 
     if (StringParseUint32(&taf->nb_threads, 10, 0, threads_node->val) < 0 || taf->nb_threads == 0) {
         SCLogError("Invalid thread count: %s", threads_node->val);
-        return -1;
+        return -EINVAL;
     }
     return 0;
 }
@@ -484,14 +494,10 @@ static bool IsReceiveCpuSet(const char *setname)
 
 /**
  * \brief Set up affinity configuration for a single interface.
- */
-/**
- * \brief Set up affinity configuration for a single interface.
- * \retval 0 on success, -1 on error
+ * \retval 0 on success, negative errno on error
  */
 static int SetupSingleIfaceAffinity(ThreadsAffinityType *taf, SCConfNode *iface_node)
 {
-    // offload to Setup function
     SCConfNode *child_node;
     const char *interface_name = NULL;
     TAILQ_FOREACH (child_node, &iface_node->head, next) {
@@ -508,25 +514,31 @@ static int SetupSingleIfaceAffinity(ThreadsAffinityType *taf, SCConfNode *iface_
             AffinityTypeGetOrCreateByIfaceOrCpuset(taf->name, interface_name);
     if (iface_taf == NULL) {
         SCLogError("Failed to allocate CPU affinity type for interface: %s", interface_name);
-        return -1;
+        return -EINVAL;
     }
 
-    SetupCpuSets(iface_taf, iface_node, interface_name);
-    if (SetupAffinityPriority(iface_taf, iface_node, interface_name) < 0) {
-        return -1;
+    int ret = SetupCpuSets(iface_taf, iface_node, interface_name);
+    if (ret < 0) {
+        return ret;
     }
-    if (SetupAffinityMode(iface_taf, iface_node) < 0) {
-        return -1;
+    ret = SetupAffinityPriority(iface_taf, iface_node, interface_name);
+    if (ret < 0) {
+        return ret;
     }
-    if (SetupAffinityThreads(iface_taf, iface_node) < 0) {
-        return -1;
+    ret = SetupAffinityMode(iface_taf, iface_node);
+    if (ret < 0) {
+        return ret;
+    }
+    ret = SetupAffinityThreads(iface_taf, iface_node);
+    if (ret < 0) {
+        return ret;
     }
     return 0;
 }
 
 /**
  * \brief Set up per-interface affinity configurations.
- * \retval 0 on success, -1 on error
+ * \retval 0 on success, negative errno on error
  */
 static int SetupPerIfaceAffinity(ThreadsAffinityType *taf, SCConfNode *affinity)
 {
@@ -539,8 +551,9 @@ static int SetupPerIfaceAffinity(ThreadsAffinityType *taf, SCConfNode *affinity)
     SCConfNode *iface_node;
     TAILQ_FOREACH (iface_node, &per_iface_node->head, next) {
         if (strcmp(iface_node->val, "interface") == 0) {
-            if (SetupSingleIfaceAffinity(taf, iface_node) < 0) {
-                return -1;
+            int ret = SetupSingleIfaceAffinity(taf, iface_node);
+            if (ret < 0) {
+                return ret;
             }
         } else {
             SCLogWarning("Unknown node in %s: %s", if_af, iface_node->name);
@@ -586,8 +599,9 @@ static bool AffinityConfigIsLegacy(void)
 
 /**
  * \brief Extract CPU affinity configuration from current config file
+ * \retval 0 on success, -EINVAL on config error, -ERANGE on HW incompatibility
  */
-void AffinityLoadFromConfig(void)
+int AffinityLoadFromConfig(void)
 {
 #if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
     if (thread_affinity_init_done == 0) {
@@ -600,7 +614,7 @@ void AffinityLoadFromConfig(void)
     SCConfNode *root = SCConfGetNode(AffinityGetYamlPath(NULL));
     if (root == NULL) {
         SCLogInfo("Cannot find %s node in config", AffinityGetYamlPath(NULL));
-        return;
+        return 0;
     }
 
     SCConfNode *affinity;
@@ -614,35 +628,33 @@ void AffinityLoadFromConfig(void)
         ThreadsAffinityType *taf = AffinityTypeGetOrCreateByIfaceOrCpuset(setname, NULL);
         if (taf == NULL) {
             SCLogError("Failed to allocate CPU affinity type: %s", setname);
-            continue;
+            return -EINVAL;
         }
 
         SCLogConfig("Found CPU affinity definition for \"%s\"", setname);
 
         SCConfNode *aff_query_node = AffinityConfigIsLegacy() ? affinity->head.tqh_first : affinity;
-        SetupCpuSets(taf, aff_query_node, setname);
-        if (SetupAffinityPriority(taf, aff_query_node, setname) < 0) {
-            SCLogError("Failed to setup priority for CPU affinity type: %s", setname);
-            continue;
-        }
-        if (SetupAffinityMode(taf, aff_query_node) < 0) {
-            SCLogError("Failed to setup mode for CPU affinity type: %s", setname);
-            continue;
-        }
-        if (SetupAffinityThreads(taf, aff_query_node) < 0) {
-            SCLogError("Failed to setup threads for CPU affinity type: %s", setname);
-            continue;
-        }
+        int ret = SetupCpuSets(taf, aff_query_node, setname);
+        if (ret < 0)
+            return ret;
+        ret = SetupAffinityPriority(taf, aff_query_node, setname);
+        if (ret < 0)
+            return ret;
+        ret = SetupAffinityMode(taf, aff_query_node);
+        if (ret < 0)
+            return ret;
+        ret = SetupAffinityThreads(taf, aff_query_node);
+        if (ret < 0)
+            return ret;
 
         if (!AffinityConfigIsLegacy() && (IsWorkerCpuSet(setname) || IsReceiveCpuSet(setname))) {
-            if (SetupPerIfaceAffinity(taf, affinity) < 0) {
-                SCLogError("Failed to setup per-interface affinity for CPU affinity type: %s",
-                        setname);
-                continue;
-            }
+            ret = SetupPerIfaceAffinity(taf, affinity);
+            if (ret < 0)
+                return ret;
         }
     }
 #endif /* OS_WIN32 and __OpenBSD__ */
+    return 0;
 }
 
 #if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined __sun
@@ -1154,13 +1166,29 @@ void AffinityReset(void)
 }
 
 /**
- * \brief Test basic CPU affinity parsing in new format
+ * \brief Initialize affinity test: backup config, load YAML, load affinity.
+ * On error, cleans up config context before returning.
+ * \retval 0 on success, negative errno on error
  */
-static int ThreadingAffinityTest01(void)
+static int AffinityTestInit(const char *config)
 {
     SCConfCreateContextBackup();
     SCConfInit();
     AffinityReset();
+    SCConfYamlLoadString(config, strlen(config));
+    int ret = AffinityLoadFromConfig();
+    if (ret < 0) {
+        SCConfDeInit();
+        SCConfRestoreContextBackup();
+    }
+    return ret;
+}
+
+/**
+ * \brief Test basic CPU affinity parsing in new format
+ */
+static int ThreadingAffinityTest01(void)
+{
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1170,9 +1198,11 @@ static int ThreadingAffinityTest01(void)
                          "    worker-cpu-set:\n"
                          "      cpu: [ 1, 2, 3 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
     FAIL_IF_NOT(AffinityConfigIsLegacy() == false);
 
     ThreadsAffinityType *mgmt_taf = &thread_affinity[MANAGEMENT_CPU_SET];
@@ -1195,10 +1225,6 @@ static int ThreadingAffinityTest01(void)
  */
 static int ThreadingAffinityTest02(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1206,8 +1232,11 @@ static int ThreadingAffinityTest02(void)
                          "    - worker-cpu-set:\n"
                          "        cpu: [ 1, 2 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
     FAIL_IF_NOT(AffinityConfigIsLegacy() == true);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
@@ -1225,10 +1254,6 @@ static int ThreadingAffinityTest02(void)
  */
 static int ThreadingAffinityTest03(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1236,8 +1261,11 @@ static int ThreadingAffinityTest03(void)
                          "    worker-cpu-set:\n"
                          "      cpu: [ \"0-3\" ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_ISSET(0, &worker_taf->cpu_set));
@@ -1256,10 +1284,6 @@ static int ThreadingAffinityTest03(void)
  */
 static int ThreadingAffinityTest04(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1267,8 +1291,11 @@ static int ThreadingAffinityTest04(void)
                          "    worker-cpu-set:\n"
                          "      cpu: [ 1, 3, 5 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_ISSET(1, &worker_taf->cpu_set));
@@ -1289,10 +1316,6 @@ static int ThreadingAffinityTest04(void)
  */
 static int ThreadingAffinityTest05(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1300,8 +1323,11 @@ static int ThreadingAffinityTest05(void)
                          "    worker-cpu-set:\n"
                          "      cpu: [ \"all\" ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == UtilCpuGetNumProcessorsOnline());
@@ -1316,10 +1342,6 @@ static int ThreadingAffinityTest05(void)
  */
 static int ThreadingAffinityTest06(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1332,8 +1354,11 @@ static int ThreadingAffinityTest06(void)
                          "        high: [ 3 ]\n"
                          "        default: \"medium\"\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(CPU_ISSET(0, &worker_taf->lowprio_cpu));
@@ -1352,10 +1377,6 @@ static int ThreadingAffinityTest06(void)
  */
 static int ThreadingAffinityTest07(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1364,8 +1385,11 @@ static int ThreadingAffinityTest07(void)
                          "      cpu: [ 0, 1 ]\n"
                          "      mode: \"exclusive\"\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->mode_flag == EXCLUSIVE_AFFINITY);
@@ -1380,10 +1404,6 @@ static int ThreadingAffinityTest07(void)
  */
 static int ThreadingAffinityTest08(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1392,8 +1412,11 @@ static int ThreadingAffinityTest08(void)
                          "      cpu: [ 0, 1, 2 ]\n"
                          "      threads: 4\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_threads == 4);
@@ -1408,10 +1431,6 @@ static int ThreadingAffinityTest08(void)
  */
 static int ThreadingAffinityTest09(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1423,8 +1442,11 @@ static int ThreadingAffinityTest09(void)
                          "          cpu: [ 2, 3 ]\n"
                          "          mode: \"exclusive\"\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 1);
@@ -1446,10 +1468,6 @@ static int ThreadingAffinityTest09(void)
  */
 static int ThreadingAffinityTest10(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1462,8 +1480,11 @@ static int ThreadingAffinityTest10(void)
                          "        - interface: \"eth1\"\n"
                          "          cpu: [ 3, 4 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *receive_taf = &thread_affinity[RECEIVE_CPU_SET];
     FAIL_IF_NOT(receive_taf->nb_children == 2);
@@ -1497,10 +1518,6 @@ static int ThreadingAffinityTest10(void)
  */
 static int ThreadingAffinityTest11(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1514,8 +1531,11 @@ static int ThreadingAffinityTest11(void)
                          "            high: [ \"all\" ]\n"
                          "            default: \"high\"\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 1);
@@ -1537,10 +1557,6 @@ static int ThreadingAffinityTest11(void)
  */
 static int ThreadingAffinityTest12(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1560,8 +1576,11 @@ static int ThreadingAffinityTest12(void)
                          "    verdict-cpu-set:\n"
                          "      cpu: [ 4 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     FAIL_IF_NOT(CPU_ISSET(0, &thread_affinity[MANAGEMENT_CPU_SET].cpu_set));
     FAIL_IF_NOT(CPU_COUNT(&thread_affinity[MANAGEMENT_CPU_SET].cpu_set) == 1);
@@ -1591,10 +1610,6 @@ static int ThreadingAffinityTest12(void)
  */
 static int ThreadingAffinityTest13(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1602,14 +1617,9 @@ static int ThreadingAffinityTest13(void)
                          "    worker-cpu-set:\n"
                          "      cpu: [ \"invalid-cpu\" ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    FAIL_IF_NOT(ret == -EINVAL);
 
-    ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
-    FAIL_IF_NOT(CPU_COUNT(&worker_taf->cpu_set) == 0);
-
-    SCConfDeInit();
-    SCConfRestoreContextBackup();
     PASS;
 }
 
@@ -1618,17 +1628,16 @@ static int ThreadingAffinityTest13(void)
  */
 static int ThreadingAffinityTest14(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
                          "  cpu-affinity:\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     FAIL_IF_NOT(
             CPU_COUNT(&thread_affinity[WORKER_CPU_SET].cpu_set) == UtilCpuGetNumProcessorsOnline());
@@ -1644,24 +1653,16 @@ static int ThreadingAffinityTest14(void)
  */
 static int ThreadingAffinityTest15(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
                          "  cpu-affinity:\n"
                          "    - management-cpu-set:\n"
-                         "        cpu: [ \"3-1\" ]\n"; // Invalid reverse range
+                         "        cpu: [ \"3-1\" ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    FAIL_IF_NOT(ret == -EINVAL);
 
-    FAIL_IF_NOT(CPU_COUNT(&thread_affinity[MANAGEMENT_CPU_SET].cpu_set) == 0);
-
-    SCConfDeInit();
-    SCConfRestoreContextBackup();
     PASS;
 }
 
@@ -1671,10 +1672,6 @@ static int ThreadingAffinityTest15(void)
  */
 static int ThreadingAffinityTest16(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1683,11 +1680,9 @@ static int ThreadingAffinityTest16(void)
                          "        prio:\n"
                          "          default: invalid_priority\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    FAIL_IF_NOT(ret == -EINVAL);
 
-    SCConfDeInit();
-    SCConfRestoreContextBackup();
     PASS;
 }
 
@@ -1697,10 +1692,6 @@ static int ThreadingAffinityTest16(void)
  */
 static int ThreadingAffinityTest17(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1708,11 +1699,9 @@ static int ThreadingAffinityTest17(void)
                          "    - management-cpu-set:\n"
                          "        mode: invalid_mode\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    FAIL_IF_NOT(ret == -EINVAL);
 
-    SCConfDeInit();
-    SCConfRestoreContextBackup();
     PASS;
 }
 
@@ -1722,10 +1711,6 @@ static int ThreadingAffinityTest17(void)
  */
 static int ThreadingAffinityTest18(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1733,11 +1718,9 @@ static int ThreadingAffinityTest18(void)
                          "    - management-cpu-set:\n"
                          "        threads: 0\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    FAIL_IF_NOT(ret == -EINVAL);
 
-    SCConfDeInit();
-    SCConfRestoreContextBackup();
     PASS;
 }
 
@@ -1747,10 +1730,6 @@ static int ThreadingAffinityTest18(void)
  */
 static int ThreadingAffinityTest19(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1758,11 +1737,9 @@ static int ThreadingAffinityTest19(void)
                          "    - management-cpu-set:\n"
                          "        cpu: [ -1 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    FAIL_IF_NOT(ret == -EINVAL);
 
-    SCConfDeInit();
-    SCConfRestoreContextBackup();
     PASS;
 }
 
@@ -1772,10 +1749,6 @@ static int ThreadingAffinityTest19(void)
  */
 static int ThreadingAffinityTest20(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1783,11 +1756,9 @@ static int ThreadingAffinityTest20(void)
                          "    - management-cpu-set:\n"
                          "        threads: invalid_number\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    FAIL_IF_NOT(ret == -EINVAL);
 
-    SCConfDeInit();
-    SCConfRestoreContextBackup();
     PASS;
 }
 
@@ -1797,10 +1768,6 @@ static int ThreadingAffinityTest20(void)
  */
 static int ThreadingAffinityTest21(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1808,11 +1775,9 @@ static int ThreadingAffinityTest21(void)
                          "    - management-cpu-set:\n"
                          "        cpu: [ 0-99999 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    FAIL_IF_NOT(ret == -ERANGE);
 
-    SCConfDeInit();
-    SCConfRestoreContextBackup();
     PASS;
 }
 
@@ -1822,10 +1787,6 @@ static int ThreadingAffinityTest21(void)
  */
 static int ThreadingAffinityTest22(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1838,8 +1799,11 @@ static int ThreadingAffinityTest22(void)
                          "            - interface: eth1\n"
                          "              cpu: [ 2 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 1);
@@ -1859,10 +1823,6 @@ static int ThreadingAffinityTest22(void)
  */
 static int ThreadingAffinityTest23(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1870,8 +1830,11 @@ static int ThreadingAffinityTest23(void)
                          "    worker-cpu-set:\n"
                          "      cpu: [ 1, 2, 3 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *result = AffinityTypeGetByIfaceOrCpuset(NULL, "eth0");
     FAIL_IF_NOT(result == NULL);
@@ -1897,10 +1860,6 @@ static int ThreadingAffinityTest23(void)
  */
 static int ThreadingAffinityTest24(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1912,8 +1871,11 @@ static int ThreadingAffinityTest24(void)
                          "          - interface_name: eth0\n" // Wrong field name
                          "            cpu: [ 2 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
     FAIL_IF_NOT(worker_taf->nb_children == 0);
@@ -1986,10 +1948,6 @@ static int ThreadingAffinityTest26(void)
  */
 static int ThreadingAffinityTest27(void)
 {
-    SCConfCreateContextBackup();
-    SCConfInit();
-    AffinityReset();
-
     const char *config = "%YAML 1.1\n"
                          "---\n"
                          "threading:\n"
@@ -1999,8 +1957,11 @@ static int ThreadingAffinityTest27(void)
                          "    - worker-cpu-set:\n" // Deprecated format
                          "        cpu: [ 1, 2 ]\n";
 
-    SCConfYamlLoadString(config, strlen(config));
-    AffinityLoadFromConfig();
+    int ret = AffinityTestInit(config);
+    if (ret == -ERANGE) {
+        SKIP("not enough cpus in the system");
+    }
+    FAIL_IF(ret < 0);
 
     ThreadsAffinityType *mgmt_taf = &thread_affinity[MANAGEMENT_CPU_SET];
     ThreadsAffinityType *worker_taf = &thread_affinity[WORKER_CPU_SET];
@@ -2011,6 +1972,42 @@ static int ThreadingAffinityTest27(void)
 
     SCConfDeInit();
     SCConfRestoreContextBackup();
+    PASS;
+}
+
+/**
+ * \brief Single CPU value exceeding online CPUs should fail parsing
+ */
+static int ThreadingAffinityTest28(void)
+{
+    const char *config = "%YAML 1.1\n"
+                         "---\n"
+                         "threading:\n"
+                         "  cpu-affinity:\n"
+                         "    worker-cpu-set:\n"
+                         "      cpu: [ 99999 ]\n";
+
+    int ret = AffinityTestInit(config);
+    FAIL_IF_NOT(ret == -ERANGE);
+
+    PASS;
+}
+
+/**
+ * \brief CPU range with both bounds exceeding online CPUs should fail parsing
+ */
+static int ThreadingAffinityTest29(void)
+{
+    const char *config = "%YAML 1.1\n"
+                         "---\n"
+                         "threading:\n"
+                         "  cpu-affinity:\n"
+                         "    worker-cpu-set:\n"
+                         "      cpu: [ \"99998-99999\" ]\n";
+
+    int ret = AffinityTestInit(config);
+    FAIL_IF_NOT(ret == -ERANGE);
+
     PASS;
 }
 
@@ -2049,6 +2046,8 @@ void AffinityRegisterTests(void)
     UtRegisterTest("ThreadingAffinityTest25", ThreadingAffinityTest25);
     UtRegisterTest("ThreadingAffinityTest26", ThreadingAffinityTest26);
     UtRegisterTest("ThreadingAffinityTest27", ThreadingAffinityTest27);
+    UtRegisterTest("ThreadingAffinityTest28", ThreadingAffinityTest28);
+    UtRegisterTest("ThreadingAffinityTest29", ThreadingAffinityTest29);
 #endif /* defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) */
 }
 

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -96,27 +96,31 @@ typedef struct ThreadsAffinityType_ {
 extern ThreadsAffinityType thread_affinity[MAX_CPU_SET];
 #endif
 
+void TopologyDestroy(void);
+
 char *AffinityGetYamlPath(ThreadsAffinityType *taf);
-void AffinitySetupLoadFromConfig(void);
-ThreadsAffinityType *GetOrAllocAffinityTypeForIfaceOfName(
-        const char *name, const char *interface_name);
-ThreadsAffinityType *GetAffinityTypeForNameAndIface(const char *name, const char *interface_name);
-ThreadsAffinityType *FindAffinityByInterface(
+void AffinityLoadFromConfig(void);
+
+ThreadsAffinityType *AffinityTypeGetOrCreateByIfaceOrCpuset(
+        const char *affinity_set_name, const char *interface_name);
+ThreadsAffinityType *AffinityTypeGetByIfaceOrCpuset(
+        const char *affinity_set_name, const char *interface_name);
+ThreadsAffinityType *AffinityTypeGetChildTypeByIface(
         ThreadsAffinityType *parent, const char *interface_name);
 
-void TopologyDestroy(void);
 uint16_t AffinityGetNextCPU(ThreadVars *tv, ThreadsAffinityType *taf);
-uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf);
+uint16_t AffinityGetAffinedCPUNum(ThreadsAffinityType *taf);
 #ifdef HAVE_DPDK
-uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2);
-void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf);
+bool AffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2);
+void AffinityCpusSubtract(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf);
 #endif /* HAVE_DPDK */
 
-int BuildCpusetWithCallback(
+int AffinityBuildCpusetWithCallback(
         const char *name, SCConfNode *node, void (*Callback)(int i, void *data), void *data);
 
 #ifdef UNITTESTS
-void ThreadingAffinityRegisterTests(void);
+void AffinityRegisterTests(void);
+void AffinityReset(void);
 #endif
 
 #endif /* SURICATA_UTIL_AFFINITY_H */

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -99,7 +99,7 @@ extern ThreadsAffinityType thread_affinity[MAX_CPU_SET];
 void TopologyDestroy(void);
 
 char *AffinityGetYamlPath(ThreadsAffinityType *taf);
-void AffinityLoadFromConfig(void);
+int AffinityLoadFromConfig(void);
 
 ThreadsAffinityType *AffinityTypeGetOrCreateByIfaceOrCpuset(
         const char *affinity_set_name, const char *interface_name);

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -186,7 +186,7 @@ int LiveGetDeviceCountWithoutAssignedThreading(void)
     LiveDevice *pd;
 
     TAILQ_FOREACH (pd, &live_devices, next) {
-        if (GetAffinityTypeForNameAndIface("worker-cpu-set", pd->dev) == NULL) {
+        if (AffinityTypeGetByIfaceOrCpuset("worker-cpu-set", pd->dev) == NULL) {
             i++;
         }
     }

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -362,6 +362,8 @@ int LiveDeviceListClean(void)
         SCFree(pd);
     }
 
+    // re-initialize the list head
+    TAILQ_INIT(&live_devices);
     SCReturnInt(TM_ECODE_OK);
 }
 
@@ -444,8 +446,10 @@ static int g_livedev_array_size = 0;
 
 static void LiveDeviceFreeArray(void)
 {
-    if (g_livedev_array)
+    if (g_livedev_array) {
         SCFree(g_livedev_array);
+        g_livedev_array = NULL;
+    }
     g_livedev_array_size = 0;
 }
 
@@ -519,6 +523,9 @@ void LiveDeviceFinalize(void)
         SCFree(ld);
     }
     LiveDeviceFinalizeBuildArray();
+
+    // re-initialize the list head
+    TAILQ_INIT(&pre_live_devices);
 }
 
 static void LiveDevExtensionFree(void *x)

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -992,7 +992,8 @@ void EBPFBuildCPUSet(SCConfNode *node, char *iface)
                         BPF_ANY);
         return;
     }
-    if (BuildCpusetWithCallback("xdp-cpu-redirect", node, EBPFRedirectMapAddCPU, iface) < 0) {
+    if (AffinityBuildCpusetWithCallback("xdp-cpu-redirect", node, EBPFRedirectMapAddCPU, iface) <
+            0) {
         SCLogWarning("Failed to parse XDP CPU redirect configuration");
         return;
     }

--- a/src/util-unittest.c
+++ b/src/util-unittest.c
@@ -188,7 +188,7 @@ void UtListTests(const char *regex_arg)
 uint32_t UtRunTests(const char *regex_arg)
 {
     UtTest *ut;
-    uint32_t good = 0, bad = 0, matchcnt = 0;
+    uint32_t good = 0, skip = 0, bad = 0, matchcnt = 0;
     int ret = 0, rcomp = 0;
 
     StreamTcpInitMemuse();
@@ -225,22 +225,28 @@ uint32_t UtRunTests(const char *regex_arg)
                     ret = 0;
                 }
 
-                printf("%s\n", ret ? "pass" : "FAILED");
-
-                if (!ret) {
+                if (ret == 1) {
+                    good++;
+                    printf("pass\n");
+                } else if (ret == 2) {
+                    skip++;
+                    printf("skip\n");
+                } else {
+                    printf("FAILED\n");
                     if (unittests_fatal == 1) {
                         fprintf(stderr, "ERROR: unittest failed.\n");
                         exit(EXIT_FAILURE);
                     }
                     bad++;
-                } else {
-                    good++;
                 }
             }
         }
         if(matchcnt > 0){
             printf("==== TEST RESULTS ====\n");
             printf("PASSED: %" PRIu32 "\n", good);
+            if (skip > 0) {
+                printf("SKIPPED: %" PRIu32 "\n", skip);
+            }
             printf("FAILED: %" PRIu32 "\n", bad);
             printf("======================\n");
         } else {

--- a/src/util-unittest.h
+++ b/src/util-unittest.h
@@ -106,6 +106,18 @@ extern int unittests_fatal;
         return 1; \
     } while (0)
 
+/**
+ * \brief Skip the test.
+ *
+ * Used to skip the tests that cannot be run in the current environment.
+ * The aim is to keep this at 0.
+ */
+#define SKIP(reason)                                                                               \
+    do {                                                                                           \
+        SCLogInfo("Test skipped: %s", reason);                                                     \
+        return 2;                                                                                  \
+    } while (0)
+
 #endif
 
 #endif /* SURICATA_UTIL_UNITTEST_H */


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata/pull/15366

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6927

The PR is adding unit tests tailored to verify CPU threading logic and the automatic calculation of the mempool cache of the interface. Tests are skipped if the minimal CPU requirements (CPU count) on the executing machine are not met.

Describe changes:
v13.3:
-rebased

v13.2:
- new tests DPDKRunmodeSetThreads7 and 8
- YAMLs in DPDKRunmodeSetThreads tests deindented and switched to the `threading` format (switching from a list to nodes)
- minor fixes

v12.7:
- added more error propagations -- from lower level functions to higher ones (instead of just silent accepts/fatal errors)
- addressed Copilot's remarks about e.g. cpu_set overflow
- dropped/replaced the cleanup callback structure, replaced by error handling in an if-call (below: int ret = AffinityLoadFromConfig();)
- if a unit test returns anything except 1 or 2, it fails by default
- added ThreadingAffinityTest28 and ThreadingAffinityTest29

v12.1 (Victor-greened in v11.4):
- Copilot review comments addressed
- limited the addition of the number of Github CI builds to 1, to one Fedora build only
- the triage of not firing the function warning (unused function) in https://github.com/OISF/suricata/pull/14589#issuecomment-3940995485
- rebased

v11.4:
- reword "skip affinity" commit - explains there is no real behavior change, just the check was moved elsewhere - explain in https://github.com/OISF/suricata/pull/14150#discussion_r2680231654
- added have_dpdk guard where reminded
- rebased

v11.3:
- limit AffinityCPUConfigIsCompatible to Linux only (to exclude Darwin) as it does not contain CPU_EQUAL API
- Change SKIP_INCOMPATIBLE_ENVIRONMENT macro to accept an array of deinit callbacks to not leak memory when skipping tests
- rebased

v11.2:
- rebased
- util-affinity tests are now skipped
- minor follow-up adjustments in the dpdk unittests, cleaning LiveDevList on the Init as it crashed tests when the previous test failed.

v10.1:
- rebased

v2 (v10):

- rebased

v1 - PR splitted to sub-PRs:

- new unit tests
- skip directive for unit tests for incompatible environments
