### PR TITLE
doc: expand bitmask note in byte_test table

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -519,7 +519,7 @@ Format::
 +----------------+------------------------------------------------------------------------------+
 | [dce]		 | Allow the DCE module to determine the byte order 				|
 +----------------+------------------------------------------------------------------------------+
-| [bitmask]	 | Applies the AND operator on the bytes converted				|
+| [bitmask] <value> | The AND operator will be applied to the extracted value. The result will be right shifted by the number of bits equal to the number of trailing zeros in the mask. |
 +----------------+------------------------------------------------------------------------------+
 
 


### PR DESCRIPTION
Make the bitmask row in the byte_test options table consistent
with byte_math and byte_jump by including the right-shift
behavior description.

Ticket: https://redmine.openinfosecfoundation.org/issues/6694

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/main/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/main/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
Link to ticket: https://redmine.openinfosecfoundation.org/issues/6694

Describe changes:
- Expanded the `[bitmask]` row in the `byte_test` options table so it includes the right-shift behavior, matching the style used by `byte_math` and `byte_jump`.