### PR TITLE
doc: document valid nbytes ranges for byte_math

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -590,8 +590,9 @@ Format::
 
 
 +-----------------------+-----------------------------------------------------------------------+
-| <num of bytes>        | The number of bytes selected from the packet                          |
-|                       | or the name of a byte_extract variable.                               |
+| <num of bytes>        | The number of bytes selected from the packet or the name of a         |
+|                       | byte_extract variable.                                                |
+|                       | Valid values: 1-10 when the ``string`` option is used, 1-4 otherwise. |
 +-----------------------+-----------------------------------------------------------------------+
 | <offset>              | Number of bytes into the payload                                      |
 +-----------------------+-----------------------------------------------------------------------+


### PR DESCRIPTION
Suricata enforces 1-10 bytes when the string option is used and 1-4 bytes otherwise (DetectByteMathValidateNbytesOnly).

Ticket: https://redmine.openinfosecfoundation.org/issues/8236

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8236
Describe changes:
- Documented the valid ranges for the `bytes` parameter of `byte_math`
- 1–10 when the `string` option is used
- 1–4 otherwise
- Matches the enforcement in DetectByteMathValidateNbytesOnly

### Provide values to any of the below to override the defaults.
- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=