### PR TITLE
firewall: add firewall.policies.accept-arp option

### DIFF
--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -356,3 +356,25 @@ Example for DNS::
             # Accept all responses.
             response-started: ["accept:tx"]
 
+
+ARP handling in bridge mode
+---------------------------
+
+When running Suricata in bridge mode with a default deny policy, ARP packets are dropped by the
+default ``packet.filter`` policy. In Suricata 8.0.x ARP detection is not available, so ARP
+rules cannot be created. A global option can be used to automatically accept ARP packets
+without requiring an explicit firewall rule for ARP.
+
+The option is::
+
+    firewall:
+      policies:
+        accept-arp: yes
+
+When ``accept-arp`` is enabled, ARP packets are accepted regardless of the default packet
+filter policy. The default is ``no`` to preserve the existing deny-by-default behaviour.
+
+This is a minimal, non-intrusive backport for the 8.0.x stable branch. In the main branch ARP
+detection is available and ARP can be accepted via explicit rules, e.g.:
+
+    accept:packet arp:all any any -> any any (sid:1;)

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -4091,6 +4091,21 @@ int DetectFirewallLoadDefaultPolicies(DetectEngineCtx *de_ctx)
         }
     }
 
+    /* parse firewall.policies.accept-arp config option */
+    char accept_arp_key[128];
+    int accept_arp = 0;
+    if (strlen(de_ctx->config_prefix) > 0) {
+        snprintf(accept_arp_key, sizeof(accept_arp_key), "%s.firewall.policies.accept-arp",
+                de_ctx->config_prefix);
+    } else {
+        snprintf(accept_arp_key, sizeof(accept_arp_key), "firewall.policies.accept-arp");
+    }
+    if (SCConfGetBool(accept_arp_key, &accept_arp) == 1) {
+        de_ctx->fw_accept_arp = accept_arp ? true : false;
+    } else {
+        de_ctx->fw_accept_arp = false;
+    }
+
     return 0;
 }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -685,6 +685,12 @@ static uint8_t DetectRunApplyPacketPolicy(const DetectEngineCtx *de_ctx,
         const bool final)
 {
     DEBUG_VALIDATE_BUG_ON(de_ctx->fw_policies == NULL);
+    /* Accept ARP packets if configured, overriding default drop policy */
+    if (de_ctx->fw_accept_arp && PacketIsARP(p)) {
+        SCLogDebug("packet %" PRIu64 ": accept ARP per config fw_accept_arp", p->pcap_cnt);
+        p->action |= ACTION_ACCEPT;
+        return p->action;
+    }
     const struct DetectFirewallPolicy *pol = &de_ctx->fw_policies->pkt[policy];
     if (pol->action & ACTION_DROP) {
         SCLogDebug(

--- a/src/detect.h
+++ b/src/detect.h
@@ -1015,6 +1015,9 @@ typedef struct DetectEngineCtx_ {
     /* force app-layer tx finding for alerts with signatures not having app-layer keywords */
     bool guess_applayer;
 
+    /** accept ARP packets in firewall mode when default policy would drop */
+    bool fw_accept_arp;
+
     /* registration id for per thread ctx for the filemagic/file.magic keywords */
     int filemagic_thread_ctx_id;
 


### PR DESCRIPTION
Add a minimal, non-intrusive config option firewall.policies.accept-arp to allow ARP packets to be accepted in firewall mode without requiring ARP detection rules. Default is false to preserve current behavior.

Ticket: #8314.
https://redmine.openinfosecfoundation.org/issues/8314

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3303