### PR TITLE
nfs: optionally parse nfs3 read attr-follows

### DIFF
--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -390,7 +390,8 @@ pub fn parse_nfs3_request_write(i: &[u8], complete: bool) -> IResult<&[u8], Nfs3
 pub fn parse_nfs3_reply_read(i: &[u8], complete: bool) -> IResult<&[u8], NfsReplyRead<'_>> {
     let (i, status) = be_u32(i)?;
     let (i, attr_follows) = verify(be_u32, |&v| v <= 1)(i)?;
-    let (i, attr_blob) = take(84_usize)(i)?; // fixed size?
+    let (i, attr_blob_opt) = cond(attr_follows == 1, take(84_usize))(i)?;
+    let attr_blob = attr_blob_opt.unwrap_or(&[]);
     let (i, count) = be_u32(i)?;
     let (i, eof) = verify(be_u32, |&v| v <= 1)(i)?;
     let (i, data_len) = verify(be_u32, |&v| v <= count)(i)?;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8750

Describe changes:
- nfs: optionally parse nfs3 read attr-follows

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3309

Was already staged in gitlab, making it public since it is low severity