### PR TITLE
affinity: handle NULL set name from --set affinity path

### DIFF
--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -291,6 +291,9 @@ static int BuildCpuset(const char *name, SCConfNode *node, cpu_set_t *cpu)
  */
 static const char *GetAffinitySetName(const char *val)
 {
+    if (val == NULL) {
+        return NULL;
+    }
     if (strcmp(val, "decode-cpu-set") == 0 || strcmp(val, "stream-cpu-set") == 0 ||
             strcmp(val, "reject-cpu-set") == 0 || strcmp(val, "output-cpu-set") == 0) {
         return NULL;


### PR DESCRIPTION
Setting a cpu-affinity path with --set, like

  --set threading.cpu-affinity.worker-cpu-set.threads=28

creates an intermediate node under cpu-affinity whose val is NULL.

With a legacy list format cpu-affinity, AffinitySetupLoadFromConfig() red the set name from the node val and passed it to GetAffinitySetName(), which then dereferenced the NULL pointer.

Address it by simply checking for the NULL.

Ticket: #6735.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3310