### PR TITLE
unix-socket: close socket and remove socket file on shutdown v2

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -93,6 +93,7 @@ typedef struct UnixCommand_ {
     int socket;
     struct sockaddr_un client_addr;
     int select_max;
+    char sockettarget[PATH_MAX];
     TAILQ_HEAD(, Command_) commands;
     TAILQ_HEAD(, Task_) tasks;
     TAILQ_HEAD(, UnixClient_) clients;
@@ -133,6 +134,10 @@ static int UnixNew(UnixCommand * this)
         strlcpy(sockettarget, SOCKET_TARGET, sizeof(sockettarget));
         check_dir = 1;
     }
+
+    /* Remember the socket path so it can be removed again on shutdown */
+    strlcpy(this->sockettarget, sockettarget, sizeof(this->sockettarget));
+
     SCLogInfo("unix socket '%s'", sockettarget);
 
     if (check_dir) {
@@ -1171,6 +1176,25 @@ static TmEcode UnixManager(ThreadVars *th_v, void *thread_data)
                 close(item->fd);
                 SCFree(item);
             }
+
+            /* Close the socket and remove the socket file.
+             * The cleanup is done in the shutdown path of UnixManager(),
+             * which is reached uniformly whether shutdown is triggered by
+             * a fatal error or a signal (e.g. SIGTERM) via THV_KILL. This
+             * also applies for a clean shutdown via 'suricatasc -c shutdown'.
+             * Guarded by command.socket so this only runs once. */
+            if (command.socket != -1) {
+                close(command.socket);
+                command.socket = -1;
+                if (unlink(command.sockettarget) != 0 && errno != ENOENT) {
+                    SCLogWarning("unable to remove unix socket file %s: %s", command.sockettarget,
+                            strerror(errno));
+                } else {
+                    SCLogDebug("unix socket file '%s' removed", command.sockettarget);
+                }
+                SCLogInfo("unix socket '%s' closed", command.sockettarget);
+            }
+
             StatsSyncCounters(&th_v->stats);
             break;
         }


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made -> not needed
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes -> not needed
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8799

Describe changes:
- Preserve socket path (`sockettarget`) in struct `UnixCommand_`, because this is needed on shutdown to close the socket
- The cleanup is now done in the shutdown path of UnixManager(), which is reached uniformly whether shutdown is triggered by a fatal error or a signal (e.g. SIGTERM) via THV_KILL. This also applies for a clean shutdown via 'suricatasc shutdown'.
- Implement a logic to close the command socket on Suricata shutdown and set `command.socket = -1` to mark it uninitialized.
- unlink the socket target file to remove the remaining socket file
- Ensure that the closing procedure is executed only once
- Created by the aid of AI, but I fully understand the changes and tested it myself
- Compiled Suricata in a Docker Container and it cleans up the socket on `suricatasc -c 'shutdown'` as well as on `kill -TERM $(pidof suricata)`.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
  - I did a first try in suricata-verify, but I suppose this can be a rather complex task. As far as I understand till now, suricata-verify uses the shutdown socket command to stop suricata after each test, so we have to find a workaround to test the removal of the socket file on shutdown as well as on SIGTERM. If you agree, I will try to do an approach, but independently of this MR here.
- Leave unused overrides blank or remove.

Thanks for your feedback and the review!
Regards,
Andreas

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3346