### PR TITLE
ftp: log completion code when the response message is empty

### DIFF
--- a/rust/src/ftp/response.rs
+++ b/rust/src/ftp/response.rs
@@ -41,12 +41,20 @@ fn parse_response_line(input: &str) -> Option<FTPResponseLine> {
         return None;
     }
 
-    // Try to split off the 3-digit FTP status code
-    let (code_str, response_str) = match response_line.split_once(' ') {
-        Some((prefix, rest)) if prefix.len() == 3 && prefix.chars().all(|c| c.is_ascii_digit()) => {
-            (prefix, rest)
+    let is_code = |s: &str| s.len() == 3 && s.chars().all(|c| c.is_ascii_digit());
+
+    /* A response may carry no message at all ("221 \r\n"); the trim_end above
+     * then leaves a bare code with no separator left to split on. */
+    let response_contains_only_code = is_code(response_line);
+
+    let (code_str, response_str) = if response_contains_only_code {
+        (response_line, "")
+    } else {
+        // Try to split off the 3-digit FTP status code
+        match response_line.split_once(' ') {
+            Some((prefix, rest)) if is_code(prefix) => (prefix, rest),
+            _ => ("", response_line),
         }
-        _ => ("", response_line),
     };
 
     let code_bytes = code_str.as_bytes().to_vec();


### PR DESCRIPTION
A response line carrying a code but no message, such as "221 \r\n" sent by some servers in reply to QUIT, was logged with no completion_code, and with the code itself in the reply field:

    {"command": "QUIT", "reply": ["221"], "reply_received": "yes"}

parse_response_line split caused problems on no response message and prevented good logging of completion code

Ticket: #8966

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8966

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
