### PR TITLE
Http2 ip6 host port 8778 v2

### DIFF
--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -581,15 +581,13 @@ fn http2_normalize_host(ve: Http2Header) -> Http2Header {
         Http2Header::Single(v) => v,
         Http2Header::Multiple(v) => v.as_slice(),
     };
-    let (start, end) = match vs.iter().position(|&x| x == b'@') {
-        Some(i) => match &vs[i + 1..].iter().position(|&x| x == b':') {
-            Some(j) => (i + 1, i + 1 + j),
-            None => (i + 1, vs.len()),
-        },
-        None => match vs.iter().position(|&x| x == b':') {
-            Some(i) => (0, i),
-            None => (0, vs.len()),
-        },
+    let start = match vs.iter().position(|&x| x == b'@') {
+        Some(i) => i + 1,
+        None => 0,
+    };
+    let end = match &vs[start..].iter().position(|&x| x == b':') {
+        Some(j) => start + j,
+        None => vs.len(),
     };
     return match ve {
         Http2Header::Single(v) => {

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -585,8 +585,18 @@ fn http2_normalize_host(ve: Http2Header) -> Http2Header {
         Some(i) => i + 1,
         None => 0,
     };
-    let end = match &vs[start..].iter().position(|&x| x == b':') {
-        Some(j) => start + j,
+    let end = match &vs[start..]
+        .iter()
+        .rev()
+        .position(|&x| x == b':' || x == b']')
+    {
+        Some(j) => {
+            if vs[vs.len() - 1 - j] == b']' {
+                vs.len()
+            } else {
+                vs.len() - 1 - j
+            }
+        }
         None => vs.len(),
     };
     return match ve {
@@ -1082,6 +1092,16 @@ mod tests {
         let buf4 = "user:pass@localhost:123".as_bytes();
         let r4 = http2_normalize_host(Http2Header::Single(buf4));
         assert_eq!(r4, Http2Header::Single("localhost".as_bytes()));
+
+        let buf5 = "[2001:db8::5]:443".as_bytes();
+        let r5 = http2_normalize_host(Http2Header::Single(buf5));
+        assert_eq!(r5, Http2Header::Single("[2001:db8::5]".as_bytes()));
+        let buf6 = "[2001:db8::5]".as_bytes();
+        let r6 = http2_normalize_host(Http2Header::Single(buf6));
+        assert_eq!(r6, Http2Header::Single("[2001:db8::5]".as_bytes()));
+        let buf7 = "user@[2001:db8::5]".as_bytes();
+        let r7 = http2_normalize_host(Http2Header::Single(buf7));
+        assert_eq!(r7, Http2Header::Single("[2001:db8::5]".as_bytes()));
     }
 
     #[test]


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8778

Describe changes:
- http2: parse ipv6 address correctlty for normalizing host

No SV test, just unit test as it just changes the one parsing function already having unit tests

#16126 after AI review fix