### PR TITLE
fw: tighten pre-flow hook scopes and apply flow scope to packet drop v1

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -112,6 +112,7 @@ typedef struct SignatureParser_ {
 /** Valid action scopes per firewall hook class. */
 enum DetectFirewallPolicyClass {
     DETECT_FIREWALL_POLICY_CLASS_PACKET,
+    DETECT_FIREWALL_POLICY_CLASS_PACKET_PRE_FLOW,
     DETECT_FIREWALL_POLICY_CLASS_APP
 };
 
@@ -119,6 +120,10 @@ static const uint8_t fw_packet_hook_scopes[] = {
     ACTION_SCOPE_PACKET,
     ACTION_SCOPE_HOOK,
     ACTION_SCOPE_FLOW,
+};
+static const uint8_t fw_packet_pre_flow_hook_scopes[] = {
+    ACTION_SCOPE_PACKET,
+    ACTION_SCOPE_HOOK,
 };
 static const uint8_t fw_app_hook_scopes[] = {
     ACTION_SCOPE_FLOW,
@@ -4215,6 +4220,10 @@ static bool FirewallScopeValidForClass(uint8_t scope, enum DetectFirewallPolicyC
             set = fw_packet_hook_scopes;
             n = ARRAY_SIZE(fw_packet_hook_scopes);
             break;
+        case DETECT_FIREWALL_POLICY_CLASS_PACKET_PRE_FLOW:
+            set = fw_packet_pre_flow_hook_scopes;
+            n = ARRAY_SIZE(fw_packet_pre_flow_hook_scopes);
+            break;
         case DETECT_FIREWALL_POLICY_CLASS_APP:
             set = fw_app_hook_scopes;
             n = ARRAY_SIZE(fw_app_hook_scopes);
@@ -4242,6 +4251,10 @@ static void FirewallScopeHintForClass(
         case DETECT_FIREWALL_POLICY_CLASS_PACKET:
             set = fw_packet_hook_scopes;
             n = ARRAY_SIZE(fw_packet_hook_scopes);
+            break;
+        case DETECT_FIREWALL_POLICY_CLASS_PACKET_PRE_FLOW:
+            set = fw_packet_pre_flow_hook_scopes;
+            n = ARRAY_SIZE(fw_packet_pre_flow_hook_scopes);
             break;
         case DETECT_FIREWALL_POLICY_CLASS_APP:
             set = fw_app_hook_scopes;
@@ -4460,8 +4473,11 @@ static int DetectFirewallLoadPacketPolicy(struct DetectFirewallPolicies *fw_poli
     /* <prefix>.default-policy */
     FirewallPolicyChainAdd(&chain, "%s.default-policy", prefix);
 
+    const enum DetectFirewallPolicyClass pol_class =
+            (id == DETECT_FIREWALL_POLICY_PRE_FLOW) ? DETECT_FIREWALL_POLICY_CLASS_PACKET_PRE_FLOW
+                                                    : DETECT_FIREWALL_POLICY_CLASS_PACKET;
     struct DetectFirewallPolicy *pol = &fw_policies->pkt[id]; // built-in default
-    int r = ResolveFirewallPolicy(pol, DETECT_FIREWALL_POLICY_CLASS_PACKET, &chain);
+    int r = ResolveFirewallPolicy(pol, pol_class, &chain);
     if (r < 0) {
         return -1;
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -710,6 +710,10 @@ static uint8_t DetectRunApplyPacketPolicy(const DetectEngineCtx *de_ctx,
         SCLogDebug("packet %" PRIu64 ": drop PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY",
                 PcapPacketCntGet(p));
         PacketDrop(p, pol->action, PKT_DROP_REASON_FW_DEFAULT_PACKET_POLICY);
+        if (p->flow && pol->action_scope == ACTION_SCOPE_FLOW) {
+            p->flow->flags |= FLOW_ACTION_DROP | FLOW_ACTION_BY_FIREWALL;
+            SCLogDebug("packet %" PRIu64 ": drop scope flow", PcapPacketCntGet(p));
+        }
     } else if (pol->action & ACTION_ACCEPT) {
         SCLogDebug("packet %" PRIu64 ": accept", PcapPacketCntGet(p));
         if (pol->action_scope == ACTION_SCOPE_PACKET) {


### PR DESCRIPTION
The commits cover these Redmine tickets:
- https://redmine.openinfosecfoundation.org/issues/8967
- https://redmine.openinfosecfoundation.org/issues/8969

Describe changes:
- flow scope got excluded from pre-flow hook (as flow object is not available when hook is evaluated)
- flow policy is applied when a packet's default policy is hit

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3327