### PR TITLE
fw: validate scope inheritance in policies and rules v2

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1822,6 +1822,10 @@ static int SigParseActionDo(const char *action_in, const int idx, const bool fw_
                        "rules");
             return -1;
         }
+        if (idx > 0 && (flags & ACTION_PASS) && !(*action_out & ACTION_ACCEPT)) {
+            SCLogError("'pass' is only supported as a secondary action for 'accept'");
+            return -1;
+        }
     }
 
     /* parse scope, if any */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1873,6 +1873,14 @@ static int SigParseActionDo(const char *action_in, const int idx, const bool fw_
             return -1;
         }
         *scope_out = scope_flags;
+    } else if (*scope_out != 0 && (flags & ACTION_PASS)) {
+        /* No scope given, this action inherits the scope set by the preceding
+         * actions of a multi-action rule. */
+        if (*scope_out != ACTION_SCOPE_PACKET && *scope_out != ACTION_SCOPE_FLOW) {
+            SCLogError("invalid action scope '%s' in action '%s': only 'packet' and 'flow' allowed",
+                    ActionScopeToString((enum ActionScope) * scope_out), action_in);
+            return -1;
+        }
     }
 
     /* require explicit action scope for fw rules */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/8954

Describe changes:
v2:
- validate `pass` only is used next to `accept` primary action

v1:
- validate `pass` only inherits packet and flow scopes

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3329