### PR TITLE
counters: add STATS_TYPE_RATE for time-derivative counters 6410 v1

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -57,6 +57,7 @@ enum StatsType {
     STATS_TYPE_MAXIMUM = 3,
     STATS_TYPE_FUNC = 4,
     STATS_TYPE_DERIVE_DIV = 5,
+    STATS_TYPE_RATE = 6,
 };
 
 /**
@@ -590,6 +591,9 @@ static void *StatsWakeupThread(void *arg)
 static void StatsReleaseCounter(StatsCounter *pc)
 {
     if (pc != NULL) {
+        if (pc->type == STATS_TYPE_RATE && pc->rate_state != NULL) {
+            SCFree(pc->rate_state);
+        }
         SCFree(pc);
     }
 }
@@ -683,6 +687,15 @@ static uint16_t StatsRegisterQualifiedCounter(const char *name, StatsPublicThrea
     pc->Func = Func;
     pc->did1 = did1;
     pc->did2 = did2;
+
+    if (type_q == STATS_TYPE_RATE) {
+        pc->rate_state = SCCalloc(1, sizeof(StatsRateState));
+        if (pc->rate_state == NULL) {
+            SCFree(pc);
+            return 0;
+        }
+    /* prev_ts.tv_sec == 0 signals "first tick, no baseline yet" */
+    }
 
     /* we now add the counter to the list */
     if (prev == NULL)
@@ -807,6 +820,9 @@ static int StatsOutput(ThreadVars *tv)
                     thread_table[pc->gid].value = thread_table_from_private[pc->did1].v;
                     thread_table[pc->gid].updates = thread_table_from_private[pc->did2].v;
                     break;
+                case STATS_TYPE_RATE:
+                    /* Value computed in phase 4 from aggregated stats_table.stats[]. */
+                    break;
                 default:
                     SCLogDebug("Counter %s (%u:%u) value %" PRIu64, pc->name, pc->id, pc->gid,
                             thread_table_from_private[i].v);
@@ -822,6 +838,9 @@ static int StatsOutput(ThreadVars *tv)
             /* thread only sets type if it has a counter
              * of this type. */
             if (e->type == 0)
+                continue;
+
+            if (e->type == STATS_TYPE_RATE)
                 continue;
 
             switch (e->type) {
@@ -847,6 +866,9 @@ static int StatsOutput(ThreadVars *tv)
             /* thread only sets type if it has a counter
              * of this type. */
             if (e->type == 0)
+                continue;
+
+            if (e->type == STATS_TYPE_RATE)
                 continue;
 
             uint32_t offset = (thread * stats_table.nstats) + c;
@@ -899,6 +921,67 @@ static int StatsOutput(ThreadVars *tv)
                 table[x].value += m->value;
                 break;
         }
+    }
+
+    /* Sample once per tick; used for all rate counters. */
+    struct timespec now_ts;
+    clock_gettime(CLOCK_MONOTONIC, &now_ts);
+
+    /* Phase 4: compute rate counters from the fully aggregated stats_table.
+    * Rate counters live on global_counter_ctx and read the aggregated
+    * source value from stats_table.stats[source_gid]. */
+    for (StatsCounter *pc = stats_ctx->global_counter_ctx.head;
+            pc != NULL; pc = pc->next) {
+        if (pc->type != STATS_TYPE_RATE)
+            continue;
+
+        StatsRateState *st = pc->rate_state;
+        if (st == NULL) {
+            /* should not happen; allocated at registration */
+            continue;
+        }
+
+        uint64_t current_value = table[pc->source_gid].value;
+
+        table[pc->gid].tm_name = "Total";
+
+        /* First tick: seed baseline and output 0. tv_sec == 0 is a safe
+        * sentinel because CLOCK_MONOTONIC counts from boot; by the time
+        * stats output runs, many seconds have passed. */
+        if (st->prev_ts.tv_sec == 0) {
+            st->prev_value = current_value;
+            st->prev_ts = now_ts;
+            table[pc->gid].value = 0;
+            continue;
+        }
+
+        /* Elapsed time in nanoseconds. */
+        int64_t elapsed_ns =
+                (int64_t)(now_ts.tv_sec  - st->prev_ts.tv_sec)  * 1000000000LL +
+                (int64_t)(now_ts.tv_nsec - st->prev_ts.tv_nsec);
+        if (elapsed_ns <= 0) {
+            /* Clock anomaly; skip this tick, keep baseline. */
+            table[pc->gid].value = 0;
+            continue;
+        }
+
+        /* Defensive: if source counter decreased (reset), don't underflow.
+        * Re-baseline and output 0 this tick. */
+        if (current_value < st->prev_value) {
+            st->prev_value = current_value;
+            st->prev_ts = now_ts;
+            table[pc->gid].value = 0;
+            continue;
+        }
+
+        uint64_t delta = current_value - st->prev_value;
+        /* Multiply before divide to preserve integer precision. */
+        uint64_t rate = (delta * 1000000000ULL) / (uint64_t)elapsed_ns;
+
+        table[pc->gid].value = rate;
+
+        st->prev_value = current_value;
+        st->prev_ts = now_ts;
     }
 
     /* invoke logger(s) */

--- a/src/counters.c
+++ b/src/counters.c
@@ -854,8 +854,6 @@ static int StatsOutput(ThreadVars *tv)
 
     /* max_id > 0 is guaranteed at this point. */
     const uint16_t max_id = counters_global_id;
-    if (max_id == 0)
-        return -1;
 
     /** temporary local table to merge the per thread counters,
      *  especially needed for the average counters */
@@ -1162,6 +1160,9 @@ void StatsInit(void)
     }
 
     StatsPublicThreadContextInit(&stats_ctx->global_counter_ctx);
+
+    StatsRegisterRateCounter("stats.pps", "decoder.pkts");
+    StatsRegisterRateCounter("stats.bps", "decoder.bytes");
 }
 
 void StatsSetupPostConfigPreOutput(void)

--- a/src/counters.c
+++ b/src/counters.c
@@ -86,6 +86,25 @@ typedef struct StatsGlobalContext_ {
     StatsPublicThreadContext global_counter_ctx;
 } StatsGlobalContext;
 
+/* Queue of rate counters awaiting registration. Populated by
+ * StatsRegisterRateCounter during startup, drained on first StatsOutput
+ * tick once counters_id_hash is populated with all source counters.
+ * Note: Accessed only during single-threaded init and from StatsMgmtThread,
+ * so no locking needed. */
+typedef struct PendingRateCounter_ {
+    const char *name;
+    const char *source_name;
+    struct PendingRateCounter_ *next;
+} PendingRateCounter;
+
+static PendingRateCounter *pending_rate_counters = NULL;
+
+/** Moved here so it can be used by StatsFlushPendingRateCounters */
+typedef struct CountersIdType_ {
+    uint16_t id;
+    const char *string;
+} CountersIdType;
+
 static void *stats_thread_data = NULL;
 static StatsGlobalContext *stats_ctx = NULL;
 static time_t stats_start_time;
@@ -357,6 +376,16 @@ static void StatsReleaseCtx(void)
         SCLogDebug("Counter module has been disabled");
         return;
     }
+
+    /* Drain any pending rate-counter registrations that never got flushed
+    * (e.g. shutdown before first output tick). */
+    PendingRateCounter *p = pending_rate_counters;
+    while (p != NULL) {
+        PendingRateCounter *next = p->next;
+        SCFree(p);
+        p = next;
+    }
+    pending_rate_counters = NULL;
 
     StatsThreadStore *sts = NULL;
     StatsThreadStore *temp = NULL;
@@ -707,6 +736,78 @@ static uint16_t StatsRegisterQualifiedCounter(const char *name, StatsPublicThrea
 }
 
 /**
+ * \brief Flush pending rate-counter registrations.
+ *
+ * Called once, on the first StatsOutput tick, BEFORE
+ * StatsThreadRegister("Global", ...) runs. counters_id_hash is
+ * expected to already exist and contain the source counters; this
+ * is guaranteed because worker threads register their counters
+ * during startup, well before the first mgmt tick.
+ *
+ * Rate counters whose source is not found are logged and skipped.
+ */
+static void StatsFlushPendingRateCounters(void)
+{
+    /* If no worker ever registered, the hash doesn't exist yet.
+     * In that case there are no source counters, so nothing to
+     * flush against; skip and let the queue drain to warnings. */
+    if (stats_ctx->counters_id_hash == NULL) {
+        PendingRateCounter *p = pending_rate_counters;
+        while (p != NULL) {
+            PendingRateCounter *next = p->next;
+            SCLogWarning("rate counter '%s': no counters registered, cannot resolve source '%s'",
+                    p->name, p->source_name);
+            SCFree(p);
+            p = next;
+        }
+        pending_rate_counters = NULL;
+        return;
+    }
+
+    PendingRateCounter *p = pending_rate_counters;
+    while (p != NULL) {
+        PendingRateCounter *next = p->next;
+
+        /* Resolve source name to gid via the shared global hash. */
+        CountersIdType lookup = { 0, p->source_name };
+        CountersIdType *found = HashTableLookup(stats_ctx->counters_id_hash,
+                                                &lookup, sizeof(lookup));
+        if (found == NULL) {
+            SCLogWarning("rate counter '%s': source '%s' not registered, skipping",
+                    p->name, p->source_name);
+            SCFree(p);
+            p = next;
+            continue;
+        }
+        uint16_t source_gid = found->id;
+
+        /* Append the rate counter to global_counter_ctx.head. gid is
+         * assigned later by StatsThreadRegister("Global", ...). */
+        uint16_t local_id = StatsRegisterQualifiedCounter(
+                p->name, &stats_ctx->global_counter_ctx,
+                STATS_TYPE_RATE, NULL, NULL, NULL);
+        if (local_id == 0) {
+            SCLogWarning("rate counter '%s': registration failed", p->name);
+            SCFree(p);
+            p = next;
+            continue;
+        }
+
+        /* Locate the freshly appended counter and stash source_gid on it. */
+        for (StatsCounter *c = stats_ctx->global_counter_ctx.head; c != NULL; c = c->next) {
+            if (c->id == local_id && c->type == STATS_TYPE_RATE) {
+                c->source_gid = source_gid;
+                break;
+            }
+        }
+
+        SCFree(p);
+        p = next;
+    }
+    pending_rate_counters = NULL;
+}
+
+/**
  * \brief The output interface for the Stats API
  */
 static int StatsOutput(ThreadVars *tv)
@@ -714,14 +815,23 @@ static int StatsOutput(ThreadVars *tv)
     const StatsThreadStore *sts = NULL;
     void *td = stats_thread_data;
 
-    if (counters_global_id == 0)
+    if (counters_global_id == 0 && pending_rate_counters == NULL)
         return -1;
 
     if (stats_table.nstats == 0) {
+        /* Flush deferred rate-counter registrations FIRST, so they end up
+        * in global_counter_ctx.head before StatsThreadRegister sizes
+        * pc_array and copy_of_private for that context. */
+        StatsFlushPendingRateCounters();
+
         StatsThreadRegister("Global", &stats_ctx->global_counter_ctx);
 
-        uint32_t nstats = counters_global_id;
+        if (counters_global_id == 0) {
+            /* No counters at all; nothing to output. */
+            return -1;
+        }
 
+        uint32_t nstats = counters_global_id;
         stats_table.nstats = nstats;
         stats_table.stats = SCCalloc(stats_table.nstats, sizeof(StatsRecord));
         if (stats_table.stats == NULL) {
@@ -742,6 +852,7 @@ static int StatsOutput(ThreadVars *tv)
         stats_table.start_time = stats_start_time;
     }
 
+    /* max_id > 0 is guaranteed at this point. */
     const uint16_t max_id = counters_global_id;
     if (max_id == 0)
         return -1;
@@ -1218,10 +1329,51 @@ StatsCounterDeriveId StatsRegisterDeriveDivCounter(
     return s;
 }
 
-typedef struct CountersIdType_ {
-    uint16_t id;
-    const char *string;
-} CountersIdType;
+/**
+ * \brief Registers a rate counter: value = delta(source_counter) / delta(time)
+ *
+ * Rate counters are attached to the global counter context and computed
+ * by the stats management thread once per output tick. The source counter
+ * must exist by the time the first output tick runs, but does NOT need to
+ * exist at the time of this call. Actual registration is deferred until
+ * the first StatsOutput invocation.
+ *
+ * \param name         Name of this rate counter (e.g. "stats.pps")
+ * \param source_name  Name of the counter to derive the rate from (e.g. "decoder.pkts")
+ *
+ * Both strings must have process lifetime (string literals are fine).
+ *
+ * \retval StatsCounterRateId with id=0 always at this point; the real id is
+ *         assigned during deferred registration. Callers should not rely on
+ *         the returned id for anything other than API symmetry.
+ */
+StatsCounterRateId StatsRegisterRateCounter(const char *name, const char *source_name)
+{
+    StatsCounterRateId s = { .id = 0 };
+#if defined(UNITTESTS) || defined(FUZZ)
+    if (stats_ctx == NULL)
+        return s;
+#else
+    BUG_ON(stats_ctx == NULL);
+#endif
+
+    if (name == NULL || source_name == NULL) {
+        SCLogError("rate counter registration: name and source_name required");
+        return s;
+    }
+
+    PendingRateCounter *p = SCCalloc(1, sizeof(*p));
+    if (p == NULL) {
+        SCLogError("rate counter registration: alloc failed");
+        return s;
+    }
+    p->name = name;
+    p->source_name = source_name;
+    p->next = pending_rate_counters;
+    pending_rate_counters = p;
+
+    return s;
+}
 
 static uint32_t CountersIdHashFunc(HashTable *ht, void *data, uint16_t datalen)
 {

--- a/src/counters.h
+++ b/src/counters.h
@@ -26,6 +26,7 @@
 #define SURICATA_COUNTERS_H
 
 #include "threads.h"
+#include <time.h>
 
 typedef struct StatsCounterId {
     uint16_t id;
@@ -49,6 +50,19 @@ typedef struct StatsCounterDeriveId {
     uint16_t id;
 } StatsCounterDeriveId;
 
+/* rate counters are counters that compute value from a
+ * source counter and a time delta at output time.*/
+typedef struct StatsCounterRateId {
+    uint16_t id;
+} StatsCounterRateId;
+
+/* rate counter need to keep track of the prev value of the source
+ * counter, and the prev timespec. */
+typedef struct StatsRateState_ {
+    uint64_t prev_value;
+    struct timespec prev_ts;/**< CLOCK_MONOTONIC */
+} StatsRateState;
+
 /**
  * \brief Container to hold the counter variable
  */
@@ -69,6 +83,13 @@ typedef struct StatsCounter_ {
     /* when using type STATS_TYPE_FUNC this function is called once
      * to get the counter value, regardless of how many threads there are. */
     uint64_t (*Func)(void);
+
+    /* global id for the source counter */
+    uint16_t source_gid;
+
+    /* for STATS_TYPE_RATE this struct stores both prev counter
+     * value and prev timestamp. */
+    StatsRateState *rate_state;
 
     /* name of the counter */
     const char *name;

--- a/src/counters.h
+++ b/src/counters.h
@@ -170,6 +170,7 @@ StatsCounterId StatsRegisterCounter(const char *, StatsThreadContext *);
 StatsCounterAvgId StatsRegisterAvgCounter(const char *, StatsThreadContext *);
 StatsCounterMaxId StatsRegisterMaxCounter(const char *, StatsThreadContext *);
 StatsCounterGlobalId StatsRegisterGlobalCounter(const char *cname, uint64_t (*Func)(void));
+StatsCounterRateId StatsRegisterRateCounter(const char *name, const char *source_name);
 
 StatsCounterDeriveId StatsRegisterDeriveDivCounter(
         const char *cname, const char *dname1, const char *dname2, StatsThreadContext *);


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6410

# counters: add `STATS_TYPE_RATE` for per-second counters

Adds a new counter type for time-derivative values, plus two counters built on it:

- `stats.pps`: packets per second, derived from `decoder.pkts`
- `stats.bps`: bytes per second, derived from `decoder.bytes`

The stats management thread computes the value once per tick. Every existing output path (stats.log, EVE, unix socket) picks them up with no changes.

## Why a new counter type
Rate is a stats concept, not an output format. The alternatives all put the logic in the wrong place:

- **In the JSON logger**: every other logger would have to redo the same delta/timestamp bookkeeping.
- **In the mgmt thread, writing into a `NORMAL` counter**: there's no private context on the global side, and it introduces a one-tick lag between compute and publish.
- **Reuse `STATS_TYPE_FUNC`**: its callback takes no arguments, so prev-value and prev-timestamp end up in file statics, and two rate counters sharing a tick have to coordinate through globals.

`STATS_TYPE_RATE` matches the shape of the existing `STATS_TYPE_DERIVE_DIV` (a counter whose value is computed at output time from another counter), with per-counter state (`StatsRateState`) attached to the `StatsCounter` itself. Adding another rate counter later is one registration line.

## Why `global_counter_ctx`
Rate is engine-wide, not per-worker. Putting it on a worker context would either average averages under uneven load (wrong) or force workers to share a counter (kills the lock-free hot path). `global_counter_ctx` already exists for exactly this case.

## Why deferred registration
Rate counters need their source counter's `gid`, which only exists after `StatsThreadRegister` runs and populates `counters_id_hash`. That hash doesn't exist yet at `StatsInit` time, and the source counter hasn't been registered by any worker either; so registering with other counters would fail.

Registering the counter early and resolving `source_gid` lazily at output time doesn't work either: the counter has to be in `global_counter_ctx.head` **before** `StatsThreadSetupPublic` sizes `pc_array` and `copy_of_private`, otherwise those arrays get resized later, which cascades into resizing `stats_table.stats`. That allocation path is fragile and out of scope here.

The fix: `StatsRegisterRateCounter` just enqueues the request. `StatsFlushPendingRateCounters` drains the queue at one specific moment; the first `StatsOutput` tick, right before `StatsThreadRegister("Global", ...)`. At that point workers have registered, the hash is populated, and the global head is still empty. Sources resolve, rate counters get appended, and the Global-thread register that follows sizes every downstream array correctly on the first allocation. No reallocations, no changes to `stats_table` sizing.

Side benefit: typos in source names fail loudly on the first tick with a warning, and the counter is skipped rather than producing garbage.

## Smaller decisions

- **`CLOCK_MONOTONIC`** instead of `gettimeofday`. Wall-clock jumps from NTP or admin changes would show up as spikes or dropouts in a long-running sensor.
- **First tick emits 0**, not "missing" — unambiguous for downstream consumers. Sentinel is `prev_ts.tv_sec == 0`, safe because `CLOCK_MONOTONIC` is non-zero by the time stats output runs.
- **Integer `(delta * 1e9) / elapsed_ns`**, multiply before divide. Overflow headroom is huge; floating point would cost more and vary tick-to-tick for no benefit.
- **Re-baseline if the source counter decreases.** Shouldn't happen with 64-bit counters, but the guard is one comparison and prevents a future reset mechanism or aggregation bug from producing an astronomical spike.

## Out of scope

No EMA smoothing, no per-thread breakdown, no rate-of-a-rate, no public API for reading rate values from application code, no yaml configuration. Each is a separate conversation.

## Open questions / things to flag

- **Where to register `stats.pps` and `stats.bps`.** Currently in `StatsInit`. The decoder is arguably a more natural home since the source counters live there.
- **`bps` naming.** Here it means *bytes* per second, but `bps` more commonly means *bits* per second. Open to `stats.Bps` or a rename.
- **Timestamp source.** Rate uses its own `CLOCK_MONOTONIC` sample taken inside `StatsOutput`, while the packet/byte counts it reads reflect the state as of the last tick boundary (`stats_tts`). The rate is mathematically accurate against real elapsed time but slightly inconsistent with how the source counters are sampled. Happy to switch to the `stats_tts` interval instead if reviewers prefer consistency over precision.
- Code comments are intentionally verbose to make review easier; can be trimmed in v2.

## Tests
Manual smoke test against a live capture works. Unit tests still to add inside the existing `#ifdef UNITTESTS` block: flush ordering, first-tick sentinel, steady-state math, source-decrease re-baseline.

### Provide values to any of the below to override the defaults.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
