### PR TITLE
logging: prevent double-free multi-threaded logging v1.1

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -983,16 +983,19 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCMutexDestroy(&lf_ctx->fp_mutex);
     }
 
-    if (lf_ctx->prefix != NULL) {
-        SCFree(lf_ctx->prefix);
-        lf_ctx->prefix_len = 0;
+    if (lf_ctx->parent == NULL) {
+        if (lf_ctx->prefix != NULL) {
+            SCFree(lf_ctx->prefix);
+            lf_ctx->prefix_len = 0;
+        }
+
+        if (lf_ctx->sensor_name != NULL) {
+            SCFree(lf_ctx->sensor_name);
+        }
     }
 
     if(lf_ctx->filename != NULL)
         SCFree(lf_ctx->filename);
-
-    if (lf_ctx->sensor_name)
-        SCFree(lf_ctx->sensor_name);
 
     if (!lf_ctx->threaded) {
         OutputUnregisterFileRotationFlag(&lf_ctx->rotation_flag);


### PR DESCRIPTION
Follow-up of the pre-approved #16057 (got blocked by SV tests)

When multithreaded output was enabled, all threads freed shallow-copy of sensor and prefix names.

This commit adds a guard so that only the parent frees the allocated buffers.

Ticket: https://redmine.openinfosecfoundation.org/issues/8861


SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3330
SU_REPO=
SU_BRANCH=

Describe changes:
v1.1:
- rebased
