### PR TITLE
fw: validate scope inheritance in policies and rules + pass&config action updates v3

### DIFF
--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -122,6 +122,14 @@ alert
 action in firewall rules. The effect will be the creation of an alert event when the
 firewall rule matches.
 
+config
+~~~~~~
+
+``config`` is a primary firewall action used to apply the setting of the ``config``
+rule keyword when the rule matches, see :doc:`../rules/config`.
+The ``config`` action does not issue a verdict for the packet or the flow, so the
+other tables are still evaluated. It is not available as a secondary action.
+
 Multi action rules
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1822,6 +1822,10 @@ static int SigParseActionDo(const char *action_in, const int idx, const bool fw_
                        "rules");
             return -1;
         }
+        if (idx > 0 && (flags & ACTION_PASS) && !(*action_out & ACTION_ACCEPT)) {
+            SCLogError("'pass' is only supported as a secondary action for 'accept'");
+            return -1;
+        }
     }
 
     /* parse scope, if any */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -4213,6 +4213,11 @@ static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *p
             return -1;
         idx++;
     }
+
+    if (action & ACTION_CONFIG) {
+        SCLogError("%s: 'config' is not a valid default policy action", policy_name);
+        return -1;
+    }
     pol->action = action;
     pol->action_scope = action_scope;
     return 1;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1873,6 +1873,14 @@ static int SigParseActionDo(const char *action_in, const int idx, const bool fw_
             return -1;
         }
         *scope_out = scope_flags;
+    } else if (*scope_out != 0 && (flags & ACTION_PASS)) {
+        /* No scope given, this action inherits the scope set by the preceding
+         * actions of a multi-action rule. */
+        if (*scope_out != ACTION_SCOPE_PACKET && *scope_out != ACTION_SCOPE_FLOW) {
+            SCLogError("invalid action scope '%s' in action '%s': only 'packet' and 'flow' allowed",
+                    ActionScopeToString((enum ActionScope) * scope_out), action_in);
+            return -1;
+        }
     }
 
     /* require explicit action scope for fw rules */


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata/pull/16132

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8954

Describe changes:
v3:
- `config` action disallowed to be used in policies
- document `config` action in the FW overview action enumeration 

v2:
- validate `pass` only is used next to `accept` primary action

v1:
- validate `pass` only inherits packet and flow scopes

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3331