### PR TITLE
detect/dcerpc: match zero-flag version 0 binds - v2

### DIFF
--- a/doc/userguide/rules/dcerpc-keywords.rst
+++ b/doc/userguide/rules/dcerpc-keywords.rst
@@ -9,9 +9,11 @@ of DCERPC packets over UDP, TCP and SMB.
 dcerpc.iface
 ------------
 
-Match on the value of the interface UUID in a DCERPC header. If `any_frag` option
-is given, the match shall be done on all fragments. If it's not, the match shall
-only happen on the first fragment.
+Match on the interface UUID of a DCERPC request, as negotiated by the BIND and
+accepted by the BIND_ACK. By default only requests with the ``PFC_FIRST_FRAG``
+flag set match, i.e. unfragmented requests and first fragments. With the
+``any_frag`` option all fragments match. The fragment flags of the BIND are
+not considered.
 
 The format of the keyword::
 

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -47,6 +47,12 @@ Major Changes
   suricata.yaml is now 1 MiB instead of 0/unlimited.
 - LLMNR protocol parser, logger and sticky buffers are implemented.
 
+Detection Changes
+~~~~~~~~~~~~~~~~~
+- Without ``any_frag``, ``dcerpc.iface`` now requires ``PFC_FIRST_FRAG`` on
+  the request PDU instead of on the BIND PDU, matching Snort. See ticket
+  `#8577 <https://redmine.openinfosecfoundation.org/issues/8577>`_.
+
 Logging Changes
 ~~~~~~~~~~~~~~~
 - The format of IKEv1 proposal attributes has been changed to handle

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -38,9 +38,6 @@ pub static mut DCERPC_MAX_STUB_SIZE: u32 = 1048576;
 
 // Constant DCERPC UDP Header length
 pub const DCERPC_HDR_LEN: u16 = 16;
-// FIRST flag set on the packet
-pub const DCERPC_UUID_ENTRY_FLAG_FF: u16 = 0x0001;
-
 // Flag bits in connection-oriented PDU header
 
 // Value to indicate first fragment
@@ -190,6 +187,8 @@ pub struct DCERPCTransaction {
     pub ctxid: u16,
     pub opnum: u16,
     pub first_request_seen: u8,
+    /// A request PDU with PFC_FIRST_FRAG set was seen for this transaction.
+    pub req_first_frag: bool,
     pub min_version: u8,
     pub call_id: u32, // ID to match any request-response pair
     pub frag_cnt_ts: u16,
@@ -257,7 +256,6 @@ pub struct DCERPCUuidEntry {
     pub uuid: Vec<u8>,
     pub version: u16,
     pub versionminor: u16,
-    pub flags: u16,
     pub call_id: u32,
     pub acked: bool,
 }
@@ -538,12 +536,6 @@ impl DCERPCState {
                 uuidentry.ctxid = ctxitem.ctxid;
                 uuidentry.version = ctxitem.version;
                 uuidentry.versionminor = ctxitem.versionminor;
-                let pfcflags = hdr.pfc_flags;
-                // Store the first frag flag in the uuid as pfc_flags will
-                // be overwritten by new packets
-                if pfcflags & PFC_FIRST_FRAG > 0 {
-                    uuidentry.flags |= DCERPC_UUID_ENTRY_FLAG_FF;
-                }
                 for uuid in self.interface_uuids.iter_mut() {
                     if uuid.ctxid == uuidentry.ctxid {
                         *uuid = uuidentry;
@@ -765,6 +757,7 @@ impl DCERPCState {
                         tx.ctxid = request.ctxid;
                         tx.opnum = request.opnum;
                         tx.first_request_seen = request.first_request_seen;
+                        tx.req_first_frag |= hdr.pfc_flags & PFC_FIRST_FRAG != 0;
                     }
                     None => {
                         let mut tx = self.create_tx(hdr);
@@ -772,6 +765,7 @@ impl DCERPCState {
                         tx.ctxid = request.ctxid;
                         tx.opnum = request.opnum;
                         tx.first_request_seen = request.first_request_seen;
+                        tx.req_first_frag = hdr.pfc_flags & PFC_FIRST_FRAG != 0;
                         self.transactions.push_back(tx);
                     }
                 }

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -17,7 +17,6 @@
 
 use super::dcerpc::{
     DCERPCState, DCERPCTransaction, ALPROTO_DCERPC, DCERPC_TYPE_REQUEST, DCERPC_TYPE_RESPONSE,
-    DCERPC_UUID_ENTRY_FLAG_FF,
 };
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{detect_match_uint, detect_parse_uint, DetectUintData};
@@ -80,13 +79,14 @@ pub(crate) enum DCEOpnumData {
 fn match_backuuid(
     tx: &DCERPCTransaction, state: &mut DCERPCState, if_data: &mut DCEIfaceData,
 ) -> c_int {
+    // if any_frag is not enabled, we need to match only if the request was
+    // a first fragment (or not fragmented), like Snort's dce_iface
+    if if_data.any_frag == 0 && !tx.req_first_frag {
+        SCLogDebug!("any frag not enabled");
+        return 0;
+    }
     if !state.interface_uuids.is_empty() {
         for uuidentry in &state.interface_uuids {
-            // if any_frag is not enabled, we need to match only against the first fragment
-            if if_data.any_frag == 0 && (uuidentry.flags & DCERPC_UUID_ENTRY_FLAG_FF == 0) {
-                SCLogDebug!("any frag not enabled");
-                continue;
-            }
             // if the uuid has been rejected(uuidentry->result == 1), we skip to the next uuid
             if !uuidentry.acked || uuidentry.result != 0 {
                 SCLogDebug!("Skipping to next UUID");


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8578
Ticket: https://redmine.openinfosecfoundation.org/issues/8577

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3333

Previous PR: https://github.com/OISF/suricata/pull/16073
- See for discussion; intentionally left open as it is a different variation.

Chart, based on the chart from the ticket...

| #  | Scenario                                                               | Suricata     | Snort        | This PR      |
|----|------------------------------------------------------------------------|--------------|--------------|--------------|
| 1  | BIND `pfc_flags=0`, request 0x03 (ticket pcap)                         | no match     | match        | match        |
| 2  | BIND with only `PFC_LAST_FRAG`, request 0x03                           | no match     | match        | match        |
| 3  | BIND `pfc_flags=0` with `rpc_vers_minor=1`                             | no match     | no match[^1] | match        |
| 4  | Request `pfc_flags=0`, BIND normal                                     | match        | no match     | no match     |
| 5  | Request with only `PFC_LAST_FRAG` (first fragment missed)              | match        | no match     | no match     |
| 6  | Fragmented request 0x01 + 0x02                                         | match        | match        | match        |
| 7  | Request with only `PFC_LAST_FRAG`, rule **with** `any_frag`            | match        | match        | match        |
| 8  | Request `pfc_flags=0`, rule **with** `any_frag`                        | match        | match        | match        |
| 9  | `flow:to_client` rule, response lacks `PFC_FIRST_FRAG`, request normal | match        | no match     | match[^2]    |
| 10 | Request seen before BIND_ACK (context pending)                         | no match     | match[^3]    | no match[^2] |
| 11 | Context rejected in BIND_ACK (`result != 0`)                           | no match     | no match     | no match     |
| 12 | Over SMB: request 0x03                                                 | match        | match        | match        |
| 13 | Over SMB: middle-fragment-only request, rule **with** `any_frag`       | no match[^4] | match        | no match[^4] |

[^1]: Snort drops connection-oriented PDUs with `rpc_vers_minor != 0` as malformed, so no context is ever established. This PR matches because the BIND flags are simply not consulted.
[^2]: Known remaining divergence from Snort, left for follow-up: response PDU flags are not tracked (the request's `PFC_FIRST_FRAG` decides for both directions), and Suricata still requires the context to be accepted in a BIND_ACK.
[^3]: Snort deliberately accepts pending (not yet acknowledged) contexts to defeat a request-before-BIND_ACK evasion.
[^4]: Suricata's SMB DCERPC code only creates a request transaction from a first fragment, so there is nothing to match against. Unchanged by this PR.

Rows 1–5 are the ones this PR changes; 1–3 are the ticket (BIND flags no longer considered), 4–5 give `any_frag` its Snort meaning (paired with 7–8, which are unchanged). Rows 9–10 and 13 are the follow-ups.
