### PR TITLE
detect/reference: set key on the unknown-key path

### DIFF
--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -161,14 +161,7 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
     } else {
 
         SCRConfReference *lookup_ref_conf = SCRConfGetReference(key, de_ctx);
-        if (lookup_ref_conf != NULL) {
-            ref->key = SCStrdup(lookup_ref_conf->url);
-            if (ref->key == NULL) {
-                goto error;
-            }
-            /* already bound checked to be REFERENCE_SYSTEM_NAME_MAX or less */
-            ref->key_len = (uint16_t)strlen(ref->key);
-        } else {
+        if (lookup_ref_conf == NULL) {
             if (SigMatchStrictEnabled(DETECT_REFERENCE)) {
                 SCLogError("unknown reference key \"%s\"", key);
                 goto error;
@@ -185,6 +178,13 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
             if (lookup_ref_conf == NULL)
                 goto error;
         }
+
+        ref->key = SCStrdup(lookup_ref_conf->url);
+        if (ref->key == NULL) {
+            goto error;
+        }
+        /* already bound checked to be REFERENCE_CONTENT_NAME_MAX or less */
+        ref->key_len = (uint16_t)strlen(ref->key);
     }
 
     /* make a copy so we can free pcre's substring */
@@ -340,6 +340,13 @@ static int DetectReferenceParseTest03(void)
                                    "(msg:\"invalid ref\"; "
                                    "reference:unknownkey,001-2010; sid:2;)");
     FAIL_IF_NULL(s);
+    FAIL_IF_NULL(s->references);
+    /* an unregistered key resolves through the synthetic config entry */
+    FAIL_IF_NULL(s->references->key);
+    FAIL_IF(strcmp(s->references->key, "undefined") != 0);
+    FAIL_IF(s->references->key_len != strlen("undefined"));
+    FAIL_IF_NULL(s->references->reference);
+    FAIL_IF(strcmp(s->references->reference, "001-2010") != 0);
     DetectEngineCtxFree(de_ctx);
     PASS;
 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2024 Open Information Security Foundation
+/* Copyright (C) 2013-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -187,8 +187,14 @@ static void AlertJsonReference(const PacketAlert *pa, SCJsonBuilder *jb)
          */
         const size_t size_needed = kv->key_len + kv->reference_len + 3;
         DEBUG_VALIDATE_BUG_ON(size_needed > DETECT_MAX_RULE_SIZE);
+        /* DetectReferenceParse() is the only producer and sets both alongside
+         * their lengths. Trip a debug build if a future one does not, and keep
+         * a release build off the undefined behavior of "%s" with NULL. */
+        DEBUG_VALIDATE_BUG_ON(kv->key == NULL || kv->reference == NULL);
+        const char *key = kv->key ? kv->key : "";
+        const char *reference = kv->reference ? kv->reference : "";
         char kv_store[size_needed];
-        snprintf(kv_store, size_needed, "%s%s", kv->key, kv->reference);
+        snprintf(kv_store, size_needed, "%s%s", key, reference);
         SCJbAppendString(jb, kv_store);
         kv = kv->next;
     }


### PR DESCRIPTION
Prevent NULL dereference when generating alert if the rule has a reference keyword that is not defined in reference.config.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/8849

Describe changes:
- detect/reference: assign ref->key when a rule's reference key is not  in reference.config. 
- detect/reference: extend DetectReferenceParseTest03(). 
- output/alert: substitute an empty string for a NULL key or reference 

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3338
SU_REPO=
SU_BRANCH=
