### PR TITLE
plugin: migrate to nDPI 6.0 API

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -39,6 +39,11 @@ env:
   # Update this whenever we fix clippy issues due to a newer version of Rust.
   RUST_VERSION_KNOWN: "1.98.0"
 
+  # Version of nDPI the nDPI plugin is built against. The plugin targets the
+  # nDPI 6.0 API; releases older than that expose a different API and will
+  # not build.
+  NDPI_VERSION: "6.0"
+
 jobs:
 
   prepare-deps:
@@ -788,16 +793,16 @@ jobs:
 
       - name: Build and install nDPI
         run: |
-          curl -OL https://github.com/ntop/nDPI/archive/refs/tags/4.14.tar.gz
-          tar xvf 4.14.tar.gz
-          cd nDPI-4.14
+          curl -OL https://github.com/ntop/nDPI/archive/refs/tags/${{ env.NDPI_VERSION }}.tar.gz
+          tar xvf ${{ env.NDPI_VERSION }}.tar.gz
+          cd nDPI-${{ env.NDPI_VERSION }}
           ./autogen.sh
           ./configure
           make -j ${{ env.CPUS }}
 
       - run: tar zxvf suricata-*.tar.gz --strip-components=1
       - name: ./configure
-        run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-ndpi --with-ndpi=$(pwd)/nDPI-4.14 --enable-debug --enable-qa-simulation
+        run: CFLAGS="${DEFAULT_CFLAGS}" CPPFLAGS="-DUSE_GLOBAL_CONTEXT" ./configure --enable-ndpi --with-ndpi=$(pwd)/nDPI-${{ env.NDPI_VERSION }} --enable-debug --enable-qa-simulation
       - run: make -j ${{ env.CPUS }}
       - run: make install
       - run: make install-conf

--- a/doc/userguide/plugins/ndpi.rst
+++ b/doc/userguide/plugins/ndpi.rst
@@ -6,6 +6,9 @@ nDPI
 Installation
 ************
 
+This plugin requires nDPI 6.0 or later: earlier releases expose a
+different API and will not build.
+
 Before using nDPI, Suricata must be built with nDPI support, for
 example:
 
@@ -25,6 +28,37 @@ building Suricata with nDPI support.
 
 For more information on nDPI, see
 https://www.ntop.org/products/deep-packet-inspection/ndpi/.
+
+Configuration
+*************
+
+Starting with nDPI 6.0, the library has to be told under which license it
+is being used, as some of its dissectors are dual-licensed by ntop. The
+plugin exposes this through the optional ``ndpi`` section:
+
+.. code-block:: yaml
+
+  ndpi:
+    license: not-for-profit
+
+Accepted values:
+
+``not-for-profit``
+  Not-for-profit use. Every dissector is enabled. This is the default when
+  the option is absent.
+
+``for-profit``
+  For-profit use without a license agreement with ntop. nDPI refuses to load
+  its dual-licensed dissectors, which currently include DHCP, DNS, QUIC and
+  TLS, so rules matching on those protocols will never fire. The plugin logs
+  a warning at startup when this value is selected.
+
+``for-profit-dual``
+  For-profit use with a license agreement signed with ntop covering the
+  dual-licensed components. Every dissector is enabled.
+
+See https://www.ntop.org/announcing-ndpi-dual-license-change/ for the
+licensing terms themselves.
 
 Keywords
 ********

--- a/plugins/ndpi/ndpi.c
+++ b/plugins/ndpi/ndpi.c
@@ -22,6 +22,7 @@
 #include "suricata-common.h"
 #include "suricata-plugin.h"
 
+#include "conf.h"
 #include "detect-engine-helper.h"
 #include "detect-parse.h"
 #include "flow.h"
@@ -38,6 +39,8 @@ static SCThreadStorageId thread_storage_id = { .id = -1 };
 static SCFlowStorageId flow_storage_id = { .id = -1 };
 static int ndpi_protocol_keyword_id = -1;
 static int ndpi_risk_keyword_id = -1;
+static struct ndpi_global_context *ndpi_g_ctx;
+static enum ndpi_license_type ndpi_license_type = NDPI_LICENSE_NOT_FOR_PROFIT_LGPL;
 
 struct NdpiThreadContext {
     struct ndpi_detection_module_struct *ndpi;
@@ -81,6 +84,79 @@ static inline struct NdpiFlowContext *NdpiGetFlowContext(const Flow *f)
     return SCFlowGetStorageById(f, flow_storage_id);
 }
 
+/**
+ * Since nDPI 6.0 the caller has to declare under which license the library is
+ * used. Dual-licensed dissectors (DHCP, DNS, QUIC and TLS) are not loaded when
+ * NDPI_LICENSE_FOR_PROFIT_LGPL is selected, so the not-for-profit case is the
+ * default and the choice is left to the user through "ndpi.license".
+ *
+ * Resolved once at plugin init, while Suricata is still single threaded.
+ */
+static enum ndpi_license_type NdpiResolveLicenseType(void)
+{
+    const char *license = NULL;
+
+    if (SCConfGet("ndpi.license", &license) != 1 || license == NULL)
+        return NDPI_LICENSE_NOT_FOR_PROFIT_LGPL;
+
+    if (strcmp(license, "not-for-profit") == 0)
+        return NDPI_LICENSE_NOT_FOR_PROFIT_LGPL;
+
+    if (strcmp(license, "for-profit") == 0) {
+        SCLogWarning("nDPI license set to \"for-profit\": the DHCP, DNS, QUIC and TLS "
+                     "dissectors are dual-licensed and will not be loaded");
+        return NDPI_LICENSE_FOR_PROFIT_LGPL;
+    }
+
+    if (strcmp(license, "for-profit-dual") == 0)
+        return NDPI_LICENSE_FOR_PROFIT_DUAL_LICENSE;
+
+    SCLogWarning("unknown nDPI license \"%s\", using \"not-for-profit\"", license);
+    return NDPI_LICENSE_NOT_FOR_PROFIT_LGPL;
+}
+
+/* nDPI keeps its cross-flow correlations in LRU caches that are private to a
+ * detection module unless they are made global, and it only accepts these
+ * settings when a global context is in use. Suricata spreads the flows of a
+ * single host over all its workers, so without sharing them the DNS, STUN and
+ * TLS correlations never leave the thread that saw the first flow. */
+static const char *ndpi_shared_lru_caches[] = {
+    "lru.ookla.scope",
+    "lru.bittorrent.scope",
+    "lru.stun.scope",
+    "lru.tls_cert.scope",
+    "lru.mining.scope",
+    "lru.msteams.scope",
+    "lru.fpc_dns.scope",
+    "lru.signal.scope",
+};
+
+/**
+ * Allocate and finalize a detection module. Worker modules attach to the
+ * global context to share their caches; the throwaway modules used while
+ * parsing rules do not, as they only resolve names.
+ */
+static struct ndpi_detection_module_struct *NdpiModuleNew(bool shared_caches)
+{
+    struct ndpi_detection_module_struct *ndpi =
+            ndpi_init_detection_module(shared_caches ? ndpi_g_ctx : NULL, ndpi_license_type);
+    if (ndpi == NULL)
+        return NULL;
+
+    if (shared_caches && ndpi_g_ctx != NULL) {
+        for (size_t i = 0; i < sizeof(ndpi_shared_lru_caches) / sizeof(ndpi_shared_lru_caches[0]);
+                i++) {
+            if (ndpi_set_config(ndpi, NULL, ndpi_shared_lru_caches[i], "1") != NDPI_CFG_OK) {
+                SCLogWarning("Failed to share the nDPI \"%s\" cache between threads",
+                        ndpi_shared_lru_caches[i]);
+            }
+        }
+    }
+
+    ndpi_finalize_initialization(ndpi);
+    return ndpi;
+}
+
 static void ThreadStorageFree(void *ptr)
 {
     SCLogDebug("Free'ing nDPI thread storage");
@@ -97,6 +173,8 @@ static void FlowStorageFree(void *ptr)
     struct NdpiFlowContext *ctx = ptr;
     if (ctx == NULL)
         return;
+    /* ndpi_flow_free() is the counterpart of ndpi_flow_malloc() and frees the
+     * flow internals as well */
     if (ctx->ndpi_flow != NULL)
         ndpi_flow_free(ctx->ndpi_flow);
     SCFree(ctx);
@@ -160,27 +238,43 @@ static void OnFlowUpdate(ThreadVars *tv, Flow *f, Packet *p, void *_data)
 
     if (!flowctx->detection_completed && ip_ptr != NULL && ip_len > 0) {
         uint64_t time_ms = ((uint64_t)p->ts.secs) * 1000 + p->ts.usecs / 1000;
+        struct ndpi_flow_input_info input_info;
 
         SCLogDebug("Performing nDPI detection...");
 
+        /* Suricata already knows the direction of the packet, so telling nDPI
+         * spares it from guessing, which matters on asymmetric and midstream
+         * traffic. The beginning of the flow is reported as unknown: the flow
+         * accessors expose no reliable "handshake was seen" flag. */
+        memset(&input_info, 0, sizeof(input_info));
+        input_info.seen_flow_beginning = NDPI_FLOW_BEGINNING_UNKNOWN;
+        if (PKT_IS_TOSERVER(p))
+            input_info.in_pkt_dir = NDPI_IN_PKT_DIR_C_TO_S;
+        else if (PKT_IS_TOCLIENT(p))
+            input_info.in_pkt_dir = NDPI_IN_PKT_DIR_S_TO_C;
+        else
+            input_info.in_pkt_dir = NDPI_IN_PKT_DIR_UNKNOWN;
+
         flowctx->detected_l7_protocol = ndpi_detection_process_packet(
-                threadctx->ndpi, flowctx->ndpi_flow, ip_ptr, ip_len, time_ms, NULL);
+                threadctx->ndpi, flowctx->ndpi_flow, ip_ptr, ip_len, time_ms, &input_info);
 
-        if (ndpi_is_protocol_detected(flowctx->detected_l7_protocol) != 0) {
-            if (!ndpi_is_proto_unknown(flowctx->detected_l7_protocol.proto)) {
-                if (!ndpi_extra_dissection_possible(threadctx->ndpi, flowctx->ndpi_flow))
-                    flowctx->detection_completed = true;
-            }
-        } else {
-            uint16_t max_num_pkts = (flow_proto == IPPROTO_UDP) ? 8 : 24;
+        const uint16_t max_num_pkts = (flow_proto == IPPROTO_UDP) ? 8 : 24;
+        const bool enough_packets =
+                (SCFlowGetToServerPacketCount(f) + SCFlowGetToClientPacketCount(f)) > max_num_pkts;
 
-            if ((SCFlowGetToServerPacketCount(f) + SCFlowGetToClientPacketCount(f)) >
-                    max_num_pkts) {
-                uint8_t proto_guessed;
+        /* NDPI_STATE_CLASSIFIED only means the library has enough information
+         * to report a protocol, not that it is done with the flow: several
+         * dissectors keep extra_packets_func set to observe more packets after
+         * that point. Stopping earlier would silently cut those heuristics off,
+         * so we stop once the library itself is done or the packet cap fires. */
+        if ((flowctx->detected_l7_protocol.state == NDPI_STATE_CLASSIFIED &&
+                    flowctx->ndpi_flow->extra_packets_func == NULL) ||
+                enough_packets) {
+            flowctx->detection_completed = true;
 
+            if (flowctx->detected_l7_protocol.state != NDPI_STATE_CLASSIFIED) {
                 flowctx->detected_l7_protocol =
-                        ndpi_detection_giveup(threadctx->ndpi, flowctx->ndpi_flow, &proto_guessed);
-                flowctx->detection_completed = true;
+                        ndpi_detection_giveup(threadctx->ndpi, flowctx->ndpi_flow);
             }
         }
 
@@ -209,14 +303,10 @@ static void OnThreadInit(ThreadVars *tv, void *_data)
     if (context == NULL) {
         FatalError("Failed to allocate nDPI thread context");
     }
-    context->ndpi = ndpi_init_detection_module(NULL);
+    context->ndpi = NdpiModuleNew(true);
     if (context->ndpi == NULL) {
         FatalError("Failed to initialize nDPI detection module");
     }
-    NDPI_PROTOCOL_BITMASK protos;
-    NDPI_BITMASK_SET_ALL(protos);
-    ndpi_set_protocol_detection_bitmask2(context->ndpi, &protos);
-    ndpi_finalize_initialization(context->ndpi);
     SCThreadSetStorageById(tv, thread_storage_id, context);
 }
 
@@ -272,16 +362,11 @@ static DetectnDPIProtocolData *DetectnDPIProtocolParse(const char *arg, bool neg
     struct ndpi_detection_module_struct *ndpi_struct;
     ndpi_master_app_protocol l7_protocol;
     char *l7_protocol_name = (char *)arg;
-    NDPI_PROTOCOL_BITMASK all;
 
     /* convert protocol name (string) to ID */
-    ndpi_struct = ndpi_init_detection_module(NULL);
+    ndpi_struct = NdpiModuleNew(false);
     if (unlikely(ndpi_struct == NULL))
         return NULL;
-
-    NDPI_BITMASK_SET_ALL(all);
-    ndpi_set_protocol_detection_bitmask2(ndpi_struct, &all);
-    ndpi_finalize_initialization(ndpi_struct);
 
     l7_protocol = ndpi_get_protocol_by_name(ndpi_struct, l7_protocol_name);
     ndpi_exit_detection_module(ndpi_struct);
@@ -399,20 +484,10 @@ static int DetectnDPIRiskPacketMatch(
 static DetectnDPIRiskData *DetectnDPIRiskParse(const char *arg, bool negate)
 {
     DetectnDPIRiskData *data;
-    struct ndpi_detection_module_struct *ndpi_struct;
     ndpi_risk risk_mask;
-    NDPI_PROTOCOL_BITMASK all;
 
-    /* convert list of risk names (string) to mask */
-    ndpi_struct = ndpi_init_detection_module(NULL);
-    if (unlikely(ndpi_struct == NULL))
-        return NULL;
-
-    NDPI_BITMASK_SET_ALL(all);
-    ndpi_set_protocol_detection_bitmask2(ndpi_struct, &all);
-    ndpi_finalize_initialization(ndpi_struct);
-    ndpi_exit_detection_module(ndpi_struct);
-
+    /* convert list of risk names (string) to mask: ndpi_code2risk() needs no
+     * detection module, so none is created here */
     if (isdigit(arg[0]))
         risk_mask = atoll(arg);
     else {
@@ -571,6 +646,17 @@ static void NdpInitRiskKeyword(void)
 static void NdpiInit(void)
 {
     SCLogDebug("Initializing nDPI plugin");
+
+    ndpi_license_type = NdpiResolveLicenseType();
+
+    /* The global context is what lets the per-thread detection modules share
+     * their LRU caches; nDPI rejects the "lru.*.scope" settings without it.
+     * SCPlugin has no deinit hook, so it lives until the process exits. */
+    ndpi_g_ctx = ndpi_global_init();
+    if (ndpi_g_ctx == NULL) {
+        SCLogWarning("Failed to initialize the nDPI global context: "
+                     "per-thread caches will not be shared");
+    }
 
     /* Register thread storage. */
     thread_storage_id = SCThreadStorageRegister("ndpi", ThreadStorageFree);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -85,6 +85,22 @@ plugins:
   @ndpi_comment@- @prefix@/lib/@PACKAGE_NAME@/ndpi.so
 # - /path/to/plugin.so
 
+# nDPI plugin settings, only used when the nDPI plugin is loaded above.
+ndpi:
+  # nDPI 6.0 and later require the embedding application to declare under
+  # which license the library is used:
+  #
+  #   not-for-profit  : not-for-profit use; every dissector is enabled.
+  #                     This is the default.
+  #   for-profit      : for-profit use without a license agreement with ntop.
+  #                     The dual-licensed dissectors (DHCP, DNS, QUIC and TLS)
+  #                     are NOT loaded by nDPI, so rules matching on those
+  #                     protocols will never fire.
+  #   for-profit-dual : for-profit use with a license agreement signed with
+  #                     ntop for the dual-licensed components.
+  #
+  #license: not-for-profit
+
 # Configure the type of alert (and other) logging you would like.
 outputs:
   # a line based alerts log similar to Snort's fast.log


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/master/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/master/etc/schema.json)) to reflect all logging changes
      (including schema descriptions) — *not applicable: the EVE `ndpi` object is produced by `ndpi_dpi2json()` and its contents are unchanged*
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Describe changes:
- port `plugins/ndpi/ndpi.c` to the nDPI 6.0 API, which the plugin currently does not build against
- give the per-thread detection modules a shared global context so nDPI's cross-flow LRU caches work across worker threads
- pass the packet direction Suricata already knows to nDPI instead of letting it guess
- add an `ndpi.license` configuration option, required by nDPI 6.0, with documentation

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=

---

## Background

The plugin currently targets the nDPI 4.14 API. nDPI 5.0 removed several of the
calls it uses, so building against any nDPI newer than 4.14 fails, and nDPI 6.0
changed one more signature on top of that. Reports of this:

- ntop/nDPI#3072 — Suricata 8 + nDPI 5.0 build failure
- ntop/nDPI#3091 — related plugin loading report
- https://forum.suricata.io/t/question-about-ndpi-5-0/6151

nDPI documents these removals under "Important API Changes" in its changelog and
bumps its major version and soname for them, so this is an expected migration
rather than a regression on either side. This PR performs it.

## What breaks without this PR

Compiling `plugins/ndpi/ndpi.c` against nDPI 6.0 headers fails on:

| Symbol used by the plugin | State in nDPI 6.0 | Removed in |
|---|---|---|
| `NDPI_PROTOCOL_BITMASK` | removed, replaced by a runtime-sized `ndpi_bitmask` | 5.0 |
| `NDPI_BITMASK_SET_ALL` | removed | 5.0 |
| `ndpi_set_protocol_detection_bitmask2()` | removed; all protocols are enabled by default | 5.0 |
| `ndpi_extra_dissection_possible()` | removed, no public replacement | 5.0 |
| `ndpi_detection_giveup()` | signature changed from 3 to 2 arguments | 5.0 |
| `ndpi_init_detection_module()` | signature changed from 1 to 2 arguments (`enum ndpi_license_type` added) | 6.0 |

## Changes in detail

### 1. API port

`OnThreadInit()` and the two keyword parsers now build their detection modules
through a single `NdpiModuleNew()` helper. The protocol bitmask dance is gone,
since nDPI enables every protocol by default.

`OnFlowUpdate()` replaces `ndpi_extra_dissection_possible()` with the criterion
nDPI's own `example/reader_util.c` uses in 6.0:

```c
if ((flowctx->detected_l7_protocol.state == NDPI_STATE_CLASSIFIED &&
            flowctx->ndpi_flow->extra_packets_func == NULL) ||
        enough_packets) {
```

This is behaviour-preserving: in 4.14 `ndpi_extra_dissection_possible()` was
literally `return flow->extra_packets_func != NULL`. The 8-packet (UDP) and
24-packet (TCP) safety caps are unchanged. `ndpi_detection_giveup()` loses its
third argument; the "was guessed" flag now lives in `flow->protocol_was_guessed`.

`DetectnDPIRiskParse()` used to create, finalize and immediately destroy a
detection module without ever using it — `ndpi_code2risk()` needs no module.
That is now removed, so parsing a ruleset with many `ndpi-risk` rules no longer
performs a full nDPI initialization per rule.

### 2. Shared LRU caches across worker threads

Each worker gets its own detection module, which means each worker also gets its
own copy of the LRU caches nDPI uses to correlate flows — STUN, TLS
certificates, FPC/DNS, MS Teams, Signal, BitTorrent, Ookla and mining. Suricata
distributes the flows of one host across all workers, so a DNS flow handled by
worker A never informs the TLS flow handled by worker B, and the correlations
those caches exist for are lost.

nDPI accepts `lru.<cache>.scope=1` to make a cache global, but only when the
modules share an `ndpi_global_context`. The plugin now creates one in
`NdpiInit()` and enables the eight cache scopes on every worker module. A
failure to set one is logged and non-fatal.

`SCPlugin` has no deinit hook, so the global context lives until the process
exits. Happy to add a teardown callback in a follow-up if the plugin API grows
one.

### 3. Packet direction

`ndpi_detection_process_packet()` was called with a NULL `input_info`, leaving
nDPI to work out the direction of each packet on its own even though Suricata
already knows it. The plugin now fills `in_pkt_dir` from `PKT_IS_TOSERVER()` /
`PKT_IS_TOCLIENT()`.

`seen_flow_beginning` is deliberately left at `NDPI_FLOW_BEGINNING_UNKNOWN`: the
flow accessors available to plugins expose no reliable "the handshake was seen"
flag, and telling nDPI something wrong is worse than telling it nothing.

### 4. `ndpi.license` configuration option

nDPI 6.0 requires the embedding application to declare under which license it
uses the library. This is not cosmetic: with `NDPI_LICENSE_FOR_PROFIT_LGPL`,
nDPI refuses to load its dual-licensed dissectors, which today are **DHCP, DNS,
QUIC and TLS**, and rules matching those protocols silently never fire.

The plugin exposes this as an optional top-level section, following the
`napatech:` convention:

```yaml
ndpi:
  license: not-for-profit   # or for-profit, for-profit-dual
```

The value is resolved once in `NdpiInit()`, while Suricata is still single
threaded. `for-profit` logs a warning naming the dissectors that will be
missing. **The default is `not-for-profit`**, so the plugin keeps working out of
the box — see the open question below.

### 5. Keeping Suricata's version out of nDPI's macro pollution

`SC_PACKAGE_VERSION` is `#define SC_PACKAGE_VERSION PACKAGE_VERSION` and expands
lazily. `ndpi_api.h` pulls in nDPI's own `ndpi_config.h`, which redefines the
autoconf `PACKAGE_*` macros, so by the time `PluginRegistration` is reached the
plugin reports nDPI's version as the Suricata version it was built against:

```
Initializing plugin ndpi; ... built from 6.0.0
```

The value is now captured into a `static const char[]` before `ndpi_api.h` is
included. Only the log line is affected today — the hard check uses
`SC_API_VERSION`, which is a `static const uint64_t` and immune — but the same
mechanism could reach a real check later.

## Testing done

Built against nDPI 6.0 (tag `6.0`, in-tree build) and Suricata `9.0.0-dev`,
`./configure --enable-ndpi --with-ndpi=<path> CPPFLAGS="-DUSE_GLOBAL_CONTEXT"`.

The plugin loads and registers:

```
Notice: plugin: Loading plugin /usr/local/lib/suricata/ndpi.so
Notice: plugin: Initializing plugin ndpi; author=Luca Deri; license=GPLv3
```

Replaying `443-chrome.pcap` from nDPI's own corpus
(`tests/cfgs/default/pcap/`) with

```
alert tcp any any -> any any (msg:"nDPI TLS"; requires:keyword ndpi-protocol; ndpi-protocol:TLS; sid:1;)
```

alerts, and the EVE record carries the expected metadata:

```json
"ndpi": {
  "confidence": { "6": "DPI" },
  "proto": "TLS",
  "proto_id": "91",
  "proto_by_ip": "Github",
  "proto_by_ip_id": 203,
  "encrypted": 1,
  "breed": "Safe",
  "category_id": 5,
  "category": "Web"
}
```

`ndpi-protocol:QUIC` on the QUIC captures of the same corpus was used to confirm
the dual-licensed dissectors load under the default license mode.
