### PR TITLE
pgsql: truly disable by default - v1

### DIFF
--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -32,8 +32,8 @@ use std::collections::VecDeque;
 use std::ffi::CString;
 use suricata_sys::sys::{
     AppLayerParserState, AppProto, SCAppLayerParserConfParserEnabled,
-    SCAppLayerParserSetStreamDepth, SCAppLayerParserStateIssetFlag,
-    SCAppLayerProtoDetectConfProtoDetectionEnabled, SCAppLayerRequestProtocolTLSUpgrade,
+    SCAppLayerParserRegisterLogger, SCAppLayerParserSetStreamDepth, SCAppLayerParserStateIssetFlag,
+    SCAppLayerProtoDetectConfProtoDetectionEnabledDefault, SCAppLayerRequestProtocolTLSUpgrade,
 };
 
 const PGSQL_CONFIG_DEFAULT_STREAM_DEPTH: u32 = 0;
@@ -964,12 +964,18 @@ pub unsafe extern "C" fn SCRegisterPgsqlParser() {
 
     let ip_proto_str = CString::new("tcp").unwrap();
 
-    if SCAppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+    if SCAppLayerProtoDetectConfProtoDetectionEnabledDefault(
+        ip_proto_str.as_ptr(),
+        parser.name,
+        false,
+    ) != 0
+    {
         let alproto = applayer_register_protocol_detection(&parser, 1);
         ALPROTO_PGSQL = alproto;
         if SCAppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
             let _ = AppLayerRegisterParser(&parser, alproto);
         }
+        SCAppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_PGSQL);
         SCLogDebug!("Rust pgsql parser registered.");
         let retval = conf_get("app-layer.protocols.pgsql.stream-depth");
         if let Some(val) = retval {
@@ -991,7 +997,7 @@ pub unsafe extern "C" fn SCRegisterPgsqlParser() {
             }
         }
     } else {
-        SCLogDebug!("Protocol detector and parser disabled for PGSQL.");
+        SCLogDebug!("Protocol detection and parser disabled for PGSQL.");
     }
 }
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -989,11 +989,11 @@ app-layer:
       #encryption-handling: track-only
 
     pgsql:
-      enabled: no
+      #enabled: no
       # Stream reassembly size for PostgreSQL. By default, track it completely.
-      stream-depth: 0
-      # Maximum number of live PostgreSQL transactions per flow
-      # max-tx: 1024
+       # stream-depth: 0
+       # Maximum number of live PostgreSQL transactions per flow
+       # max-tx: 1024
     dcerpc:
       enabled: yes
       # Maximum number of live DCERPC transactions per flow


### PR DESCRIPTION
While the pgsql parser is disabled if its setting is present in the yaml config file, it is actually enabled if truly defaulted, that is, if not present in the settings.

Actually disable pgsql parsing and logging if not present in the suricata.yaml config.

Bug: #8349

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

https://redmine.openinfosecfoundation.org/issues/8349

Describe changes:
- Use registration function that doesn't register pgsql app-proto by default. This means that the behavior with no configuration present or the default config set should be the same, for `pgsql`, truly making it disabled by default
This means that if the protocol isn't explicitly enabled for detection a pgsql rule will throw an error, and that logging has to be explicitly enabled, too.

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3351