### PR TITLE
detect/analyzer: fix swapped output file pointers

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -193,7 +193,7 @@ void EngineAnalysisFP(const DetectEngineCtx *de_ctx, const Signature *s, const c
         }
     }
 
-    FILE *fp = de_ctx->ea->rule_engine_analysis_fp;
+    FILE *fp = de_ctx->ea->fp_engine_analysis_fp;
     fprintf(fp, "== Sid: %u ==\n", s->id);
     fprintf(fp, "%s\n", line);
 
@@ -446,7 +446,10 @@ static int SetupRuleAnalyzer(DetectEngineCtx *de_ctx)
 
 static void CleanupFPAnalyzer(DetectEngineCtx *de_ctx)
 {
-    FILE *fp = de_ctx->ea->rule_engine_analysis_fp;
+    FILE *fp = de_ctx->ea->fp_engine_analysis_fp;
+    if (fp == NULL) {
+        return;
+    }
     fprintf(fp, "============\n"
                 "Summary:\n============\n");
 
@@ -462,15 +465,15 @@ static void CleanupFPAnalyzer(DetectEngineCtx *de_ctx)
                 (float)((double)f->tot / (float)f->cnt));
     }
 
-    fclose(de_ctx->ea->rule_engine_analysis_fp);
-    de_ctx->ea->rule_engine_analysis_fp = NULL;
+    fclose(de_ctx->ea->fp_engine_analysis_fp);
+    de_ctx->ea->fp_engine_analysis_fp = NULL;
 }
 
 static void CleanupRuleAnalyzer(DetectEngineCtx *de_ctx)
 {
-    if (de_ctx->ea->fp_engine_analysis_fp != NULL) {
-        fclose(de_ctx->ea->fp_engine_analysis_fp);
-        de_ctx->ea->fp_engine_analysis_fp = NULL;
+    if (de_ctx->ea->rule_engine_analysis_fp != NULL) {
+        fclose(de_ctx->ea->rule_engine_analysis_fp);
+        de_ctx->ea->rule_engine_analysis_fp = NULL;
     }
     if (de_ctx->ea->percent_re != NULL) {
         pcre2_code_free(de_ctx->ea->percent_re);


### PR DESCRIPTION
EngineAnalysisFP(), CleanupFPAnalyzer(), and CleanupRuleAnalyzer() were writing to and closing the wrong FILE* pointers. Fast pattern output was written to rules_analysis.txt instead of rules_fast_pattern.txt, leaving the latter effectively empty.

Restore the behavior from before c8615bcd4, which inadvertently swapped the pointers.

Bug: [9007](https://redmine.openinfosecfoundation.org/issues/9007)

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [X] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [X] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [X] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket:  https://redmine.openinfosecfoundation.org/issues/9007

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
