### PR TITLE
Backport 8.0.x: FW policy updates plus sensor name double free v1

### DIFF
--- a/doc/userguide/firewall/firewall-design.rst
+++ b/doc/userguide/firewall/firewall-design.rst
@@ -122,6 +122,14 @@ alert
 action in firewall rules. The effect will be the creation of an alert event when the
 firewall rule matches.
 
+config
+~~~~~~
+
+``config`` is a primary firewall action used to apply the setting of the ``config``
+rule keyword when the rule matches, see :doc:`../rules/config`.
+The ``config`` action does not issue a verdict for the packet or the flow, so the
+other tables are still evaluated. It is not available as a secondary action.
+
 Multi action rules
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1980,6 +1980,56 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
 
 #include "app-layer-parser.h"
 
+/**
+ * \brief Render a resolved firewall default policy as "<action>:<scope>".
+ *
+ * \retval true \p out holds the rendered policy
+ * \retval false the policy could not be rendered
+ */
+static bool FirewallPolicyToString(
+        const struct DetectFirewallPolicy *p, char *out, const size_t out_size)
+{
+    const char *as = ActionScopeToString(p->action_scope);
+    DEBUG_VALIDATE_BUG_ON(as == NULL);
+    if (as == NULL)
+        return false;
+    if (p->action & ACTION_REJECT_ANY) {
+        if (p->action & ACTION_REJECT_DST) {
+            snprintf(out, out_size, "rejectdst:%s", as);
+        } else if (p->action & ACTION_REJECT_BOTH) {
+            snprintf(out, out_size, "rejectboth:%s", as);
+        } else {
+            snprintf(out, out_size, "rejectsrc:%s", as);
+        }
+    } else if (p->action & ACTION_DROP) {
+        snprintf(out, out_size, "drop:%s", as);
+    } else if (p->action & ACTION_ACCEPT) {
+        snprintf(out, out_size, "accept:%s", as);
+    } else {
+        DEBUG_VALIDATE_BUG_ON(1);
+        return false;
+    }
+    if (p->action & ACTION_PASS) {
+        if (p->action_scope == ACTION_SCOPE_FLOW || p->action_scope == ACTION_SCOPE_PACKET) {
+            if (strlcat(out, ",pass:", out_size) >= out_size ||
+                    strlcat(out, as, out_size) >= out_size) {
+                DEBUG_VALIDATE_BUG_ON(1);
+                return false;
+            }
+        } else {
+            DEBUG_VALIDATE_BUG_ON(1);
+            return false;
+        }
+    }
+    if (p->action & ACTION_ALERT) {
+        if (strlcat(out, ",alert", out_size) >= out_size) {
+            DEBUG_VALIDATE_BUG_ON(1);
+            return false;
+        }
+    }
+    return true;
+}
+
 static void AddPolicy(const DetectEngineCtx *de_ctx, RuleAnalyzer *ctx, const AppProto a,
         const uint8_t state, const uint8_t direction)
 {
@@ -1991,32 +2041,8 @@ static void AddPolicy(const DetectEngineCtx *de_ctx, RuleAnalyzer *ctx, const Ap
     } else {
         p = &fw_policies->app[a].tc[state];
     }
-    const char *as = ActionScopeToString(p->action_scope);
-    DEBUG_VALIDATE_BUG_ON(as == NULL);
-    if (as == NULL)
+    if (!FirewallPolicyToString(p, policy_string, sizeof(policy_string)))
         return;
-    if (p->action & ACTION_REJECT_ANY) {
-        if (p->action & ACTION_REJECT_DST) {
-            snprintf(policy_string, sizeof(policy_string), "rejectdst:%s", as);
-        } else if (p->action & ACTION_REJECT_BOTH) {
-            snprintf(policy_string, sizeof(policy_string), "rejectboth:%s", as);
-        } else {
-            snprintf(policy_string, sizeof(policy_string), "rejectsrc:%s", as);
-        }
-    } else if (p->action & ACTION_DROP) {
-        snprintf(policy_string, sizeof(policy_string), "drop:%s", as);
-    } else if (p->action & ACTION_ACCEPT) {
-        snprintf(policy_string, sizeof(policy_string), "accept:%s", as);
-    } else {
-        DEBUG_VALIDATE_BUG_ON(1);
-    }
-    if (p->action & ACTION_PASS) {
-        if (p->action_scope == ACTION_SCOPE_FLOW) {
-            strlcat(policy_string, ",pass:flow", sizeof(policy_string));
-        } else {
-            DEBUG_VALIDATE_BUG_ON(1);
-        }
-    }
     SCJbSetString(ctx->js, "policy", policy_string);
 }
 
@@ -2070,7 +2096,11 @@ int FirewallAnalyzer(const DetectEngineCtx *de_ctx)
 
     SCJbOpenObject(ctx.js, "tables");
     SCJbOpenObject(ctx.js, "packet:filter");
-    SCJbSetString(ctx.js, "policy", "drop:packet");
+    char pkt_policy[64] = "";
+    if (FirewallPolicyToString(&de_ctx->fw_policies->pkt[DETECT_FIREWALL_POLICY_PACKET_FILTER],
+                pkt_policy, sizeof(pkt_policy))) {
+        SCJbSetString(ctx.js, "policy", pkt_policy);
+    }
     SCJbOpenArray(ctx.js, "rules");
     uint32_t accept_rules = 0;
     uint32_t last_sid = 0;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1702,6 +1702,14 @@ static int SigParseActionDo(const char *action_in, const int idx, const bool fw_
             return -1;
         }
         *scope_out = scope_flags;
+    } else if (*scope_out != 0 && (flags & ACTION_PASS)) {
+        /* No scope given, this action inherits the scope set by the preceding
+         * actions of a multi-action rule. */
+        if (*scope_out != ACTION_SCOPE_PACKET && *scope_out != ACTION_SCOPE_FLOW) {
+            SCLogError("invalid action scope '%s' in action '%s': only 'packet' and 'flow' allowed",
+                    ActionScopeToString((enum ActionScope) * scope_out), action_in);
+            return -1;
+        }
     }
 
     /* require explicit action scope for fw rules */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1651,6 +1651,10 @@ static int SigParseActionDo(const char *action_in, const int idx, const bool fw_
                        "rules");
             return -1;
         }
+        if (idx > 0 && (flags & ACTION_PASS) && !(*action_out & ACTION_ACCEPT)) {
+            SCLogError("'pass' is only supported as a secondary action for 'accept'");
+            return -1;
+        }
     }
 
     /* parse scope, if any */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -3954,6 +3954,11 @@ static int DoParsePolicy(const char *policy_name, struct DetectFirewallPolicy *p
             return -1;
         idx++;
     }
+
+    if (action & ACTION_CONFIG) {
+        SCLogError("%s: 'config' is not a valid default policy action", policy_name);
+        return -1;
+    }
     pol->action = action;
     pol->action_scope = action_scope;
     return 1;

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -967,16 +967,19 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCMutexDestroy(&lf_ctx->fp_mutex);
     }
 
-    if (lf_ctx->prefix != NULL) {
-        SCFree(lf_ctx->prefix);
-        lf_ctx->prefix_len = 0;
+    if (lf_ctx->parent == NULL) {
+        if (lf_ctx->prefix != NULL) {
+            SCFree(lf_ctx->prefix);
+            lf_ctx->prefix_len = 0;
+        }
+
+        if (lf_ctx->sensor_name != NULL) {
+            SCFree(lf_ctx->sensor_name);
+        }
     }
 
     if(lf_ctx->filename != NULL)
         SCFree(lf_ctx->filename);
-
-    if (lf_ctx->sensor_name)
-        SCFree(lf_ctx->sensor_name);
 
     if (!lf_ctx->threaded) {
         OutputUnregisterFileRotationFlag(&lf_ctx->rotation_flag);


### PR DESCRIPTION
Links to tickets:

- https://redmine.openinfosecfoundation.org/issues/8952
- https://redmine.openinfosecfoundation.org/issues/8955
- https://redmine.openinfosecfoundation.org/issues/9018

Describe changes:
- pretty much clean backports except for "[fw: respect configured policies in the rule analysis output](https://github.com/OISF/suricata/commit/aee2eb2ba8a2fff28b91a1f097cbf6dfe13d9556)" where small adjustments (because of substates) had to be made

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/3359
