### PR TITLE
DPDK rte_flow dynamic bypass v5

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -82,6 +82,7 @@ jobs:
       # flags handling.
       - run: |
           scan-build-22 --status-bugs --exclude "$(pwd)/rust/" \
+                --exclude /usr/include/dpdk \
                 -o scan-build-report/ \
                 -enable-checker core.BitwiseShift \
                 -enable-checker core.CallAndMessage \

--- a/configure.ac
+++ b/configure.ac
@@ -2454,10 +2454,10 @@ return 0;
 # get MAJOR_MINOR version for embedding in configuration file.
     MAJOR_MINOR=`expr "${PACKAGE_VERSION}" : "\([[0-9]]\+\.[[0-9]]\+\).*"`
 
-if test "${enable_ebpf}" = "yes" || test "${enable_unittests}" = "yes"; then
+if test "${enable_ebpf}" = "yes" || test "${enable_unittests}" = "yes" ||  test "${enable_dpdk}" = "yes"; then
   AC_DEFINE([CAPTURE_OFFLOAD_MANAGER], [1],[Building flow bypass manager code])
 fi
-if test "${enable_ebpf}" = "yes" || test "${enable_nfqueue}" = "yes" || test "${enable_pfring}" = "yes" || test "${enable_napatech}" = "yes"  || test "${enable_unittests}" = "yes"; then
+if test "${enable_ebpf}" = "yes" || test "${enable_nfqueue}" = "yes" || test "${enable_pfring}" = "yes" || test "${enable_napatech}" = "yes"  || test "${enable_unittests}" = "yes" || test "${enable_dpdk}" = "yes"; then
   AC_DEFINE([CAPTURE_OFFLOAD], [1],[Building flow capture bypass code])
 fi
 

--- a/doc/userguide/capture-hardware/dpdk.rst
+++ b/doc/userguide/capture-hardware/dpdk.rst
@@ -239,3 +239,50 @@ Encapsulation stripping
 Suricata supports stripping the hardware-offloaded encapsulation stripping on
 the supported NICs. Currently, VLAN encapsulation stripping is supported.
 VLAN encapsulation stripping can be enabled with `vlan-strip-offload`.
+
+Dynamic bypass
+--------------
+
+Suricata in IDS mode supports hardware accelerated flow bypass directly in the NIC.
+The capabilities of the bypass, such as how many flows can be bypassed in the hardware before 
+switching to software bypass, depend on the underlying hardware and the Poll Mode Driver.
+
+The DPDK hardware bypass can be enabled/disabled in the suricata.yaml file, via the ``capture-bypass`` option.
+The ``dpdk.bypass-info-mp-size`` option sets the number of flows that can be bypassed at once.
+The ``dpdk.bypass-ring-size`` option sets the size of the ring used for flows which are waiting to be bypassed. 
+In a case the ring is full, Suricata does not try to bypass incoming flow via hardware, but uses only software bypass.
+The ``dpdk.bypass-ring-dequeue-burst-size`` option sets the number of flows that can be dequeued from the ring at once
+in the loop where the hardware loops are created.
+By default, this number is set to the maximum capabilities of the NIC in use, which can be in order of millions of flows.
+The ``auto`` option also sets this value to maximum.
+As the memory for bypassed flows is preallocated, in the case the expected number of bypassed flows is not high,
+it is possible to save memory by lowering this value, although it is recommended to set 
+the number to a power of 2 for efficiency reasons.
+
+The global bypass statistics are gathered in eve.json (in the flow section) and stats.log (flow_bypassed.*).
+The statistics about behaviour of the bypass, such as failed ring enqueues or average ring occupancy, 
+are gathered in eve.json ( stats.log (capture.dpdk.*)
+
+Limitations:
+
+* Mellanox NICs with the mlx5_core PMD are currently the only supported NICs for this feature.
+
+* Mellanox NICs support offload of around 2 million flows at once, after the limit is reached, 
+  Suricata switches to software bypass. Although the NIC can handle more than 4 million hardware rules,
+  we need 2 rules for each direction of the flow.
+
+* The feature can be used on multiple interfaces at the same time, but only if the interfaces are on the same NIC.
+  The capacity of the bypassed flows is shared across the interfaces.
+
+Below is an example configuration with bypass enabled and the capacity of bypassed flows set to maximum: 
+::
+
+  ...
+  dpdk:
+      eal-params:
+        proc-type: primary
+
+      capture-bypass: yes
+      bypass-info-mp-size: auto 
+      bypass-ring-size: auto
+      bypass-ring-dequeue-burst-size: auto

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6908,6 +6908,25 @@
                                 }
                             }
                         },
+                        "dpdk": {
+                            "type": "object",
+                            "description": "Statistics for DPDK capture module",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ierrors": {
+                                    "type": "integer",
+                                    "description": "Total number of erroneous received packets. "
+                                },
+                                "imissed": {
+                                    "type": "integer",
+                                    "description": "Total of Rx packets dropped by the HW, because there are no available buffers (i.e. Rx queues are full)."
+                                },
+                                "no_mbufs": {
+                                    "type": "integer",
+                                    "description": "Total number of Rx mbuf allocation failures. "
+                                }
+                            }
+                        },
                         "errors": {
                             "type": "integer",
                             "description": "Number of Suricata errors reported while reading capture module"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6913,6 +6913,46 @@
                             "description": "Statistics for DPDK capture module",
                             "additionalProperties": false,
                             "properties": {
+                                "bypass_flow_error": {
+                                    "type": "integer",
+                                    "description": "Number of errors creating rte_flow bypass rules"
+                                },
+                                "bypass_mempool_get_error": {
+                                    "type": "integer",
+                                    "description": "Number of errors getting bypass mempool entries"
+                                },
+                                "bypass_mempool_info_get_error": {
+                                    "type": "integer",
+                                    "description": "Number of errors getting bypass_info mempool entries"
+                                },
+                                "bypass_query_errors": {
+                                    "type": "integer",
+                                    "description": "Number of errors querying rte_flow bypass rule stats"
+                                },
+                                "bypass_ring_avg": {
+                                    "type": "integer",
+                                    "description": "Average occupancy of the bypass ring"
+                                },
+                                "bypass_ring_dequeue_success": {
+                                    "type": "integer",
+                                    "description": "Number of successful bypass ring dequeues"
+                                },
+                                "bypass_ring_enqueue_error": {
+                                    "type": "integer",
+                                    "description": "Number of errors enqueuing to bypass ring"
+                                },
+                                "bypass_ring_max": {
+                                    "type": "integer",
+                                    "description": "Maximum occupancy of the bypass ring"
+                                },
+                                "bypass_rte_rules_error": {
+                                    "type": "integer",
+                                    "description": "Number of errors in rte_flow bypass rule operations"
+                                },
+                                "bypass_rules_max": {
+                                    "type": "integer",
+                                    "description": "Maximum number of active bypass rte_flow rules"
+                                },
                                 "ierrors": {
                                     "type": "integer",
                                     "description": "Total number of erroneous received packets. "
@@ -6924,6 +6964,10 @@
                                 "no_mbufs": {
                                     "type": "integer",
                                     "description": "Total number of Rx mbuf allocation failures. "
+                                },
+                                "rte_rules_created": {
+                                    "type": "integer",
+                                    "description": "Total number of rte_flow bypass rules created"
                                 }
                             }
                         },

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -484,6 +484,8 @@ noinst_HEADERS = \
 	util-dpdk-mlx5.h \
 	util-dpdk-rss.h \
 	util-dpdk.h \
+	util-dpdk-rte-flow.h \
+	util-dpdk-rte-flow-structs.h \
 	util-ebpf.h \
 	util-enum.h \
 	util-error.h \
@@ -1044,6 +1046,7 @@ libsuricata_c_a_SOURCES = \
 	util-dpdk-mlx5.c \
 	util-dpdk-rss.c \
 	util-dpdk.c \
+	util-dpdk-rte-flow.c \
 	util-ebpf.c \
 	util-enum.c \
 	util-error.c \

--- a/src/flow-bypass.c
+++ b/src/flow-bypass.c
@@ -26,12 +26,14 @@
 #include "flow.h"
 #include "flow-bypass.h"
 #include "flow-private.h"
+#include "util-byte.h"
 #include "util-ebpf.h"
 #include "runmodes.h"
 
 #ifdef CAPTURE_OFFLOAD_MANAGER
 
-#define FLOW_BYPASS_DELAY       10
+#define FLOW_BYPASS_DELAY 100000
+#define FLOW_BYPASS_SLEEP 0.1
 
 #ifndef TIMEVAL_TO_TIMESPEC
 #define TIMEVAL_TO_TIMESPEC(tv, ts) {                               \
@@ -44,6 +46,7 @@ typedef struct BypassedFlowManagerThreadData_ {
     StatsCounterId flow_bypassed_cnt_clo;
     StatsCounterId flow_bypassed_pkts;
     StatsCounterId flow_bypassed_bytes;
+    int flow_bypass_delay;
 } BypassedFlowManagerThreadData;
 
 #define BYPASSFUNCMAX   4
@@ -64,6 +67,39 @@ typedef struct BypassedUpdateFuncItem_ {
 
 int g_bypassed_update_max_index = 0;
 BypassedUpdateFuncItem updatefunclist[BYPASSFUNCMAX];
+
+/**
+ * \brief Get configuration for the BypassedFlowManager.
+ *
+ * \param root_node 'flow.bypass' node in suricata.yaml
+ * \param str 'delay' or 'sleep'
+ * \param def default value for the configuration
+ * \param[out] cfg_ret value as found in suricata.yaml or default value if not found
+ * \return int 0 if config found, negative value on error
+ */
+static int BypassedFlowManagerGetConf(
+        SCConfNode *root_node, const char *cfg_str, int def, int *cfg_ret)
+{
+    SCEnter();
+
+    int cfg = 0;
+    const char *entry_str = NULL;
+    int ret = SCConfGetChildValue(root_node, cfg_str, &entry_str);
+    /* Set to default if value is "auto" or missing */
+    if (ret != 1 || strcmp(entry_str, "auto") == 0) {
+        cfg = def;
+    } else {
+        if (StringParseInt32(&cfg, 10, 0, entry_str) < 0) {
+            SCLogError("flow.bypass.%s is not set to 'auto' and contains non-numerical characters "
+                       "- \"%s\"",
+                    cfg_str, entry_str);
+            SCReturnInt(-EINVAL);
+        }
+    }
+    SCLogConfig("FlowBypassedManager %s set to %d", cfg_str, cfg);
+    *cfg_ret = cfg;
+    SCReturnInt(0);
+}
 
 static TmEcode BypassedFlowManager(ThreadVars *th_v, void *thread_data)
 {
@@ -119,13 +155,13 @@ static TmEcode BypassedFlowManager(ThreadVars *th_v, void *thread_data)
             StatsSyncCounters(&th_v->stats);
             return TM_ECODE_OK;
         }
-        for (i = 0; i < FLOW_BYPASS_DELAY * 100; i++) {
+        for (i = 0; i < ftd->flow_bypass_delay; i++) {
             if (TmThreadsCheckFlag(th_v, THV_KILL)) {
                 StatsSyncCounters(&th_v->stats);
                 return TM_ECODE_OK;
             }
             StatsSyncCountersIfSignalled(&th_v->stats);
-            SleepMsec(10);
+            SleepMsec(FLOW_BYPASS_SLEEP);
         }
     }
     return TM_ECODE_OK;
@@ -142,6 +178,8 @@ static TmEcode BypassedFlowManagerThreadInit(ThreadVars *t, const void *initdata
     ftd->flow_bypassed_cnt_clo = StatsRegisterCounter("flow_bypassed.closed", &t->stats);
     ftd->flow_bypassed_pkts = StatsRegisterCounter("flow_bypassed.pkts", &t->stats);
     ftd->flow_bypassed_bytes = StatsRegisterCounter("flow_bypassed.bytes", &t->stats);
+    SCConfNode *root_node = SCConfGetNode("flow.bypass");
+    BypassedFlowManagerGetConf(root_node, "delay", FLOW_BYPASS_DELAY, &ftd->flow_bypass_delay);
 
     return TM_ECODE_OK;
 }

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -1055,7 +1055,7 @@ Flow *FlowGetExistingFlowFromFlowId(uint64_t flow_id)
  *  \param hash Value of the flow hash
  *  \retval f *LOCKED* flow or NULL
  */
-static Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash)
+Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash)
 {
     /* get our hash bucket and lock it */
     FlowBucket *fb = &flow_hash[hash % flow_config.hash_size];

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -836,6 +836,12 @@ static inline bool FlowIsTimedOut(
         const FlowThreadId ftid, const Flow *f, const SCTime_t pktts, const bool emerg)
 {
     SCTime_t timesout_at;
+#ifdef CAPTURE_OFFLOAD
+    /* FlowManager handles timeout of capture-bypassed flows, as only it has the necessary means to
+     * check the flow activity properly (BypassUpdate() callback) */
+    if (f->flow_state == FLOW_STATE_CAPTURE_BYPASSED)
+        return false;
+#endif /* CAPTURE_OFFLOAD */
     if (emerg) {
         extern FlowProtoTimeout flow_timeouts_emerg[FLOW_PROTO_MAX];
         timesout_at = SCTIME_ADD_SECS(f->lastts,

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -80,7 +80,7 @@ typedef struct FlowBucket_ {
 /* prototypes */
 
 Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *tctx, Packet *, Flow **);
-
+Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash);
 Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t hash);
 Flow *FlowGetExistingFlowFromFlowId(uint64_t flow_id);
 uint32_t FlowKeyGetHash(FlowKey *flow_key);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -357,7 +357,12 @@ static void FlowManagerHashRowTimeout(FlowManagerTimeoutThread *td, Flow *f, SCT
          * be modified when we have both the flow and hash row lock */
 
         /* timeout logic goes here */
-        if (!FlowManagerFlowTimeout(f, ts, next_ts, emergency)) {
+        bool bypass_shutdown = false;
+#ifdef CAPTURE_OFFLOAD
+        bypass_shutdown = (f->flow_state == FLOW_STATE_CAPTURE_BYPASSED) &&
+                          (SC_ATOMIC_GET(flow_flags) & FLOW_SHUTDOWN);
+#endif
+        if (!bypass_shutdown && !FlowManagerFlowTimeout(f, ts, next_ts, emergency)) {
             FLOWLOCK_UNLOCK(f);
             counters->flows_notimeout++;
 
@@ -448,21 +453,25 @@ static uint32_t FlowTimeoutHash(FlowManagerTimeoutThread *td, SCTime_t ts, const
 #endif
 
     const uint32_t ts_secs = (uint32_t)SCTIME_SECS(ts);
+    const bool shutdown = (SC_ATOMIC_GET(flow_flags) & FLOW_SHUTDOWN);
     for (uint32_t idx = hash_min; idx < hash_max; idx+=BITS) {
         TYPE check_bits = 0;
         const uint32_t check = MIN(BITS, (hash_max - idx));
-        for (uint32_t i = 0; i < check; i++) {
-            FlowBucket *fb = &flow_hash[idx+i];
-            check_bits |= (TYPE)(SC_ATOMIC_LOAD_EXPLICIT(
-                                         fb->next_ts, SC_ATOMIC_MEMORY_ORDER_RELAXED) <= ts_secs)
-                          << (TYPE)i;
+        if (!shutdown) {
+            for (uint32_t i = 0; i < check; i++) {
+                FlowBucket *fb = &flow_hash[idx + i];
+                check_bits |= (TYPE)(SC_ATOMIC_LOAD_EXPLICIT(fb->next_ts,
+                                             SC_ATOMIC_MEMORY_ORDER_RELAXED) <= ts_secs)
+                              << (TYPE)i;
+            }
+            if (check_bits == 0)
+                continue;
         }
-        if (check_bits == 0)
-            continue;
-
         for (uint32_t i = 0; i < check; i++) {
             FlowBucket *fb = &flow_hash[idx+i];
-            if ((check_bits & ((TYPE)1 << (TYPE)i)) != 0 && SC_ATOMIC_GET(fb->next_ts) <= ts_secs) {
+            if (((check_bits & ((TYPE)1 << (TYPE)i)) != 0 &&
+                        SC_ATOMIC_GET(fb->next_ts) <= ts_secs) ||
+                    shutdown) {
                 FBLOCK_LOCK(fb);
                 Flow *evicted = NULL;
                 if (fb->evicted != NULL || fb->head != NULL) {
@@ -972,6 +981,13 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         }
 
         if (TmThreadsCheckFlag(th_v, THV_KILL)) {
+            SC_ATOMIC_OR(flow_flags, FLOW_SHUTDOWN);
+#ifdef CAPTURE_OFFLOAD
+            /* Pass through all flows to gather counters from bypassed flows */
+            FlowTimeoutCounters counters = { 0 };
+            FlowTimeoutHash(&ftd->timeout, ts, ftd->min, ftd->max, &counters);
+            FlowCountersUpdate(th_v, ftd, &counters);
+#endif /* CAPTURE_OFFLOAD */
             StatsSyncCounters(&th_v->stats);
             break;
         }

--- a/src/flow-private.h
+++ b/src/flow-private.h
@@ -35,6 +35,9 @@
  *  flows for new flows and/or it's memcap limit it reached. In this state the
  *  flow engine with evaluate flows with lower timeout settings. */
 #define FLOW_EMERGENCY   0x01
+/** FlowManager is in shutdown stage. This results in a final pass of all
+ *  flows in the flow table, during which statistics from flows are collected. */
+#define FLOW_SHUTDOWN 0x02
 
 /* Flow Time out values */
 #define FLOW_DEFAULT_NEW_TIMEOUT 30

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -47,6 +47,7 @@
 #include "util-dpdk-ice.h"
 #include "util-dpdk-ixgbe.h"
 #include "util-dpdk-rss.h"
+#include "util-dpdk-rte-flow.h"
 #include "util-time.h"
 #include "util-conf.h"
 #include "suricata.h"
@@ -105,6 +106,8 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
         const struct rte_eth_conf *port_conf);
 static int DeviceValidateOutIfaceConfig(DPDKIfaceConfig *iconf);
 static int DeviceConfigureIPS(DPDKIfaceConfig *iconf);
+static int DeviceConfigureDynamicBypass(
+        DPDKIfaceConfig *iconf, const struct rte_eth_dev_info *dev_info);
 static int DeviceConfigure(DPDKIfaceConfig *iconf);
 static void *ParseDpdkConfigAndConfigureDevice(const char *iface);
 static void DPDKDerefConfig(void *conf);
@@ -143,6 +146,7 @@ DPDKIfaceConfigAttributes dpdk_yaml = {
     .tx_descriptors = "tx-descriptors",
     .copy_mode = "copy-mode",
     .copy_iface = "copy-iface",
+    .capture_bypass = "capture-bypass",
 };
 
 /**
@@ -325,8 +329,14 @@ static void DPDKDerefConfig(void *conf)
     DPDKIfaceConfig *iconf = (DPDKIfaceConfig *)conf;
 
     if (SC_ATOMIC_SUB(iconf->ref, 1) == 1) {
+        if (iconf->dpdk_dev_resources != NULL &&
+                iconf->dpdk_dev_resources->rte_flow_bypass_data != NULL) {
+            if (iconf->dpdk_dev_resources->rte_flow_bypass_data->bypass_mp != NULL) {
+                rte_mempool_free(iconf->dpdk_dev_resources->rte_flow_bypass_data->bypass_mp);
+                iconf->dpdk_dev_resources->rte_flow_bypass_data->bypass_mp = NULL;
+            }
+        }
         DPDKDeviceResourcesDeinit(&iconf->dpdk_dev_resources);
-        iconf->RteRulesFree(&iconf->drop_filter);
         SCFree(iconf);
     }
     SCReturn;
@@ -1047,6 +1057,11 @@ static int ConfigLoad(DPDKIfaceConfig *iconf, const char *iface)
     if (retval < 0)
         SCReturnInt(retval);
 
+    /* Global flag dpdk.capture-bypass is set to each interface */
+    retval = ConfigSetCaptureBypass(iconf);
+    if (retval < 0)
+        SCReturnInt(retval);
+
     SCReturnInt(0);
 }
 
@@ -1469,7 +1484,7 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
     if (retval < 0) {
         goto cleanup;
     }
-
+    iconf->dpdk_dev_resources->port_id = iconf->port_id;
     // +4 for VLAN header
     uint16_t mtu_size = iconf->mtu + RTE_ETHER_CRC_LEN + RTE_ETHER_HDR_LEN + 4;
     uint16_t mbuf_size = ROUNDUP(mtu_size, 1024) + RTE_PKTMBUF_HEADROOM;
@@ -1630,6 +1645,26 @@ static int DeviceConfigureIPS(DPDKIfaceConfig *iconf)
     SCReturnInt(0);
 }
 
+static int DeviceConfigureDynamicBypass(
+        DPDKIfaceConfig *iconf, const struct rte_eth_dev_info *dev_info)
+{
+    SCEnter();
+    int retval = 0;
+    if (!(iconf->capture_bypass_enabled)) {
+        SCReturnInt(retval);
+    }
+    const char *driver_name = dev_info->driver_name;
+    if (strcmp(driver_name, "mlx5_pci") == 0) {
+        retval = RteBypassInit(iconf, driver_name);
+    } else {
+        SCLogWarning("%s: rte_flow capture bypass is not supported for driver %s", iconf->iface,
+                driver_name);
+    }
+
+    if (retval == 0)
+        SCLogConfig("%s rte_flow capture bypass enabled", iconf->iface);
+    SCReturnInt(retval);
+}
 /**
  * Function verifies changes in e.g. device info after configuration has
  * happened. Sometimes (e.g. DPDK Bond PMD with Intel NICs i40e/ixgbe) change
@@ -1807,6 +1842,10 @@ static int DeviceConfigure(DPDKIfaceConfig *iconf)
         SCReturnInt(retval);
     }
 
+    retval = DeviceConfigureDynamicBypass(iconf, &dev_info);
+    if (retval < 0) {
+        SCReturnInt(retval);
+    }
     SCReturnInt(0);
 }
 

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -146,20 +146,6 @@ DPDKIfaceConfigAttributes dpdk_yaml = {
 };
 
 /**
- * \brief Input is a number of which we want to find the greatest divisor up to max_num (inclusive).
- * The divisor is returned.
- */
-static uint32_t GreatestDivisorUpTo(uint32_t num, uint32_t max_num)
-{
-    for (uint32_t i = max_num; i >= 2; i--) {
-        if (num % i == 0) {
-            return i;
-        }
-    }
-    return 1;
-}
-
-/**
  * \brief Input is a number of which we want to find the greatest power of 2 up to num. The power of
  * 2 is returned or 0 if no valid power of 2 is found.
  */
@@ -634,15 +620,6 @@ static int ConfigSetMempoolSize(
     }
 
     SCReturnInt(0);
-}
-
-static uint32_t MempoolCacheSizeCalculate(uint32_t mp_sz)
-{
-    // It is advised to have mempool cache size lower or equal to:
-    //   RTE_MEMPOOL_CACHE_MAX_SIZE (by default 512) and "mempool-size / 1.5"
-    // and at the same time "mempool-size modulo cache_size == 0".
-    uint32_t max_cache_size = MIN(RTE_MEMPOOL_CACHE_MAX_SIZE, (uint32_t)(mp_sz / 1.5));
-    return GreatestDivisorUpTo(mp_sz, max_cache_size);
 }
 
 static int ConfigSetMempoolCacheSize(DPDKIfaceConfig *iconf, const char *entry_str)

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -339,7 +339,8 @@ static void DPDKDerefConfig(void *conf)
     DPDKIfaceConfig *iconf = (DPDKIfaceConfig *)conf;
 
     if (SC_ATOMIC_SUB(iconf->ref, 1) == 1) {
-        DPDKDeviceResourcesDeinit(&iconf->pkt_mempools);
+        DPDKDeviceResourcesDeinit(&iconf->dpdk_dev_resources);
+        iconf->RteRulesFree(&iconf->drop_filter);
         SCFree(iconf);
     }
     SCReturn;
@@ -1487,7 +1488,7 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
     struct rte_eth_rxconf rxq_conf;
     struct rte_eth_txconf txq_conf;
 
-    retval = DPDKDeviceResourcesInit(&(iconf->pkt_mempools), iconf->nb_rx_queues);
+    retval = DPDKDeviceResourcesInit(&(iconf->dpdk_dev_resources), iconf->nb_rx_queues);
     if (retval < 0) {
         goto cleanup;
     }
@@ -1503,9 +1504,9 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
     for (int i = 0; i < iconf->nb_rx_queues; i++) {
         char mempool_name[64];
         snprintf(mempool_name, sizeof(mempool_name), "mp_%d_%.20s", i, iconf->iface);
-        iconf->pkt_mempools->pkt_mp[i] = rte_pktmbuf_pool_create(mempool_name,
+        iconf->dpdk_dev_resources->pkt_mp[i] = rte_pktmbuf_pool_create(mempool_name,
                 iconf->queue_mempool_size, q_mp_cache_sz, 0, mbuf_size, (int)iconf->socket_id);
-        if (iconf->pkt_mempools->pkt_mp[i] == NULL) {
+        if (iconf->dpdk_dev_resources->pkt_mp[i] == NULL) {
             retval = -rte_errno;
             SCLogError("%s: rte_pktmbuf_pool_create failed with code %d (mempool: %s) - %s",
                     iconf->iface, rte_errno, mempool_name, rte_strerror(rte_errno));
@@ -1529,7 +1530,8 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
                 rxq_conf.rx_free_thresh, rxq_conf.rx_drop_en);
 
         retval = rte_eth_rx_queue_setup(iconf->port_id, queue_id, iconf->nb_rx_desc,
-                (unsigned int)iconf->socket_id, &rxq_conf, iconf->pkt_mempools->pkt_mp[queue_id]);
+                (unsigned int)iconf->socket_id, &rxq_conf,
+                iconf->dpdk_dev_resources->pkt_mp[queue_id]);
         if (retval < 0) {
             SCLogError("%s: failed to setup RX queue %u: %s", iconf->iface, queue_id,
                     rte_strerror(-retval));
@@ -1560,7 +1562,7 @@ static int DeviceConfigureQueues(DPDKIfaceConfig *iconf, const struct rte_eth_de
     SCReturnInt(0);
 
 cleanup:
-    DPDKDeviceResourcesDeinit(&iconf->pkt_mempools);
+    DPDKDeviceResourcesDeinit(&iconf->dpdk_dev_resources);
     SCReturnInt(retval);
 }
 
@@ -1877,8 +1879,8 @@ static void *ParseDpdkConfigAndConfigureDevice(const char *iface)
     if (ldev_instance == NULL) {
         FatalError("Device %s is not registered as a live device", iface);
     }
-    ldev_instance->dpdk_vars = iconf->pkt_mempools;
-    iconf->pkt_mempools = NULL;
+    ldev_instance->dpdk_vars = iconf->dpdk_dev_resources;
+    iconf->dpdk_dev_resources = NULL;
     return iconf;
 }
 

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -40,6 +40,7 @@ typedef struct DPDKIfaceConfigAttributes_ {
     const char *tx_descriptors;
     const char *copy_mode;
     const char *copy_iface;
+    const char *capture_bypass;
 } DPDKIfaceConfigAttributes;
 
 int RunModeIdsDpdkWorkers(void);

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -42,6 +42,7 @@
 #include "tmqh-packetpool.h"
 #include "util-privs.h"
 #include "util-device-private.h"
+#include "util-dpdk-rte-flow.h"
 #include "action-globals.h"
 
 #ifndef HAVE_DPDK
@@ -122,6 +123,28 @@ typedef struct DPDKThreadVars_ {
     StatsCounterId capture_dpdk_rx_no_mbufs;
     StatsCounterId capture_dpdk_ierrors;
     StatsCounterId capture_dpdk_tx_errs;
+    /* bypass.rules.* : individual rte_flow hardware rules */
+    StatsCounterId capture_dpdk_rte_bypass_rules_created;
+    StatsCounterId capture_dpdk_rte_bypass_rules_error;
+    StatsCounterMaxId capture_dpdk_rte_bypass_rules_max;
+    /* bypass.ring.* : bypass ring enqueue/dequeue of flow keys and ring occupancy tracking (max,
+     * average and a helper calculation counter) */
+    StatsCounterId capture_dpdk_rte_bypass_ring_enqueue_success;
+    StatsCounterId capture_dpdk_rte_bypass_ring_enqueue_error_ring_full;
+    StatsCounterId capture_dpdk_rte_bypass_ring_dequeue_success;
+    StatsCounterId capture_dpdk_rte_bypass_ring_max;
+    StatsCounterAvgId capture_dpdk_rte_bypass_ring_occupancy_avg;
+    /* bypass.flows.* — Suricata flows bypass succeeded/failed for */
+    StatsCounterId capture_dpdk_rte_bypass_flows_bypass_success;
+    StatsCounterId capture_dpdk_rte_bypass_flows_bypass_error;
+    /* bypass.flow_lookup_error — flow-hash lookup failure during rule creation */
+    StatsCounterId capture_dpdk_rte_bypass_flow_lookup_error;
+    /* bypass.mempool.* — bypass mempool allocation failures */
+    StatsCounterId capture_dpdk_rte_bypass_mempool_key_get_error;
+    StatsCounterId capture_dpdk_rte_bypass_mempool_info_get_error;
+    /* bypass.query_error — rte_flow_query() failures */
+    StatsCounterId capture_dpdk_rte_bypass_query_error;
+    bool capture_bypass_enabled;
     unsigned int flags;
     uint16_t threads;
     /* for IPS */
@@ -190,7 +213,8 @@ static inline void DPDKFreeMbufArray(
     }
 }
 
-static void DevicePostStartPMDSpecificActions(DPDKThreadVars *ptv, const char *driver_name)
+static void DevicePostStartPMDSpecificActions(
+        DPDKThreadVars *ptv, DPDKIfaceConfig *dpdk_config, const char *driver_name)
 {
     if (strcmp(driver_name, "net_bonding") == 0)
         driver_name = BondingDeviceDriverGet(ptv->port_id);
@@ -200,8 +224,10 @@ static void DevicePostStartPMDSpecificActions(DPDKThreadVars *ptv, const char *d
         ixgbeDeviceSetRSS(ptv->port_id, ptv->threads, ptv->livedev->dev);
     else if (strcmp(driver_name, "net_ice") == 0)
         iceDeviceSetRSS(ptv->port_id, ptv->threads, ptv->livedev->dev);
-    else if (strcmp(driver_name, "mlx5_pci") == 0)
-        mlx5DeviceSetRSS(ptv->port_id, ptv->threads, ptv->livedev->dev);
+    else if (strcmp(driver_name, "mlx5_pci") == 0) {
+        mlx5DevicePostStartActions(
+                ptv->port_id, ptv->threads, ptv->livedev->dev, dpdk_config->capture_bypass_enabled);
+    }
 }
 
 static void DevicePreClosePMDSpecificActions(DPDKThreadVars *ptv, const char *driver_name)
@@ -302,6 +328,49 @@ static inline void DPDKDumpCounters(DPDKThreadVars *ptv)
         StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_tx_errs, eth_stats.oerrors);
         SC_ATOMIC_SET(
                 ptv->livedev->drop, eth_stats.imissed + eth_stats.ierrors + eth_stats.rx_nombuf);
+        if (ptv->capture_bypass_enabled) {
+            RteFlowBypassData *rte_flow_bypass_data = ptv->livedev->dpdk_vars->rte_flow_bypass_data;
+            StatsCounterMaxUpdateI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_rules_max,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_rules_active));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_rules_created,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_rules_created));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_rules_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_rules_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_ring_enqueue_success,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_ring_enqueue_success));
+            StatsCounterSetI64(&ptv->tv->stats,
+                    ptv->capture_dpdk_rte_bypass_ring_enqueue_error_ring_full,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_ring_enqueue_error_ring_full));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_ring_dequeue_success,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_ring_dequeue_success));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_ring_max,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_ring_max));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_flows_bypass_success,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_flows_bypass_success));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_flows_bypass_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_flows_bypass_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_flow_lookup_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_flow_lookup_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_mempool_key_get_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_mempool_key_get_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_mempool_info_get_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_mempool_info_get_error));
+            StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_rte_bypass_query_error,
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_query_error));
+            /* We calculate the average ring occupancy as a sum of ring occupancies throughout
+             * multiple measurements divided by the number of measurements. We then pass this result
+             * StatsCounterAvgAddI64() */
+            uint32_t ring_occupancy =
+                    SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_ring_occupancy);
+            uint32_t ring_ops = SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_ring_ops);
+            if (ring_ops > 0) {
+                uint32_t tmp_avg_occupancy = ring_occupancy / ring_ops;
+                StatsCounterAvgAddI64(&ptv->tv->stats,
+                        ptv->capture_dpdk_rte_bypass_ring_occupancy_avg, tmp_avg_occupancy);
+                SC_ATOMIC_SUB(rte_flow_bypass_data->rte_bypass_ring_occupancy, ring_occupancy);
+                SC_ATOMIC_SUB(rte_flow_bypass_data->rte_bypass_ring_ops, ring_ops);
+            }
+        }
     } else {
         StatsCounterSetI64(&ptv->tv->stats, ptv->capture_dpdk_packets, ptv->pkts);
     }
@@ -428,6 +497,8 @@ static inline Packet *PacketInitFromMbuf(DPDKThreadVars *ptv, struct rte_mbuf *m
     p->ts = TimeGet();
     p->dpdk_v.mbuf = mbuf;
     p->ReleasePacket = DPDKReleasePacket;
+    if (ptv->capture_bypass_enabled)
+        p->BypassPacketsFlow = RteFlowBypassCallback;
     p->dpdk_v.copy_mode = ptv->copy_mode;
     p->dpdk_v.out_port_id = ptv->out_port_id;
     p->dpdk_v.out_queue_id = ptv->queue_id;
@@ -543,6 +614,27 @@ static void HandleShutdown(DPDKThreadVars *ptv)
         // If Suricata runs in peered mode, the peer threads might still want to send
         // packets to our port. Instead, we know, that we are done with the peered port, so
         // we stop it. The peered threads will stop our port.
+        if (ptv->capture_bypass_enabled) {
+            if (SC_ATOMIC_GET(
+                        ptv->livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_rules_active) !=
+                    0) {
+                SCLogInfo("Waiting for all bypass rte_flow rules to be removed");
+                while (SC_ATOMIC_GET(ptv->livedev->dpdk_vars->rte_flow_bypass_data
+                                             ->rte_bypass_rules_active) != 0) {
+                    rte_delay_us(10000);
+                }
+            }
+            struct rte_flow_error err = { 0 };
+            int retval = rte_flow_flush(ptv->port_id, &err);
+            if (retval != 0) {
+                SCLogError("%s: unable to flush rte_flow rules: %s Flush error msg: %s",
+                        ptv->livedev->dev, rte_strerror(-retval), err.message);
+            }
+        }
+
+        DPDKDumpCounters(ptv);
+        struct rte_flow_error err = { 0 };
+        rte_flow_flush(ptv->port_id, &err);
         if (ptv->copy_mode == DPDK_COPY_MODE_TAP || ptv->copy_mode == DPDK_COPY_MODE_IPS) {
             rte_eth_dev_stop(ptv->out_port_id);
         } else {
@@ -656,7 +748,41 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
     ptv->capture_dpdk_imissed = StatsRegisterCounter("capture.dpdk.imissed", &ptv->tv->stats);
     ptv->capture_dpdk_rx_no_mbufs = StatsRegisterCounter("capture.dpdk.no_mbufs", &ptv->tv->stats);
     ptv->capture_dpdk_ierrors = StatsRegisterCounter("capture.dpdk.ierrors", &ptv->tv->stats);
-
+    /* bypass.rules.* — individual rte_flow hardware rules on the NIC */
+    ptv->capture_dpdk_rte_bypass_rules_created =
+            StatsRegisterCounter("capture.dpdk.bypass.rules.created", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_rules_error =
+            StatsRegisterCounter("capture.dpdk.bypass.rules.error", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_rules_max =
+            StatsRegisterMaxCounter("capture.dpdk.bypass.rules.active_max", &ptv->tv->stats);
+    /* bypass.ring.* — bypass ring enqueue/dequeue of flow keys and occupation tracking */
+    ptv->capture_dpdk_rte_bypass_ring_enqueue_success =
+            StatsRegisterCounter("capture.dpdk.bypass.ring.enqueue_success", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_ring_enqueue_error_ring_full =
+            StatsRegisterCounter("capture.dpdk.bypass.ring.enqueue_error", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_ring_dequeue_success =
+            StatsRegisterCounter("capture.dpdk.bypass.ring.dequeue_success", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_ring_max =
+            StatsRegisterCounter("capture.dpdk.bypass.ring.occupancy_max", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_ring_occupancy_avg =
+            StatsRegisterAvgCounter("capture.dpdk.bypass.ring.occupancy_avg", &ptv->tv->stats);
+    /* bypass.flows.* — Suricata flows bypass succeeded/failed for */
+    ptv->capture_dpdk_rte_bypass_flows_bypass_success =
+            StatsRegisterCounter("capture.dpdk.bypass.flows.success", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_flows_bypass_error =
+            StatsRegisterCounter("capture.dpdk.bypass.flows.error", &ptv->tv->stats);
+    /* bypass.flow_lookup_error — flow-hash lookup failure during rule creation */
+    ptv->capture_dpdk_rte_bypass_flow_lookup_error =
+            StatsRegisterCounter("capture.dpdk.bypass.flow_lookup_error", &ptv->tv->stats);
+    /* bypass.mempool.* — bypass mempool allocation failures */
+    ptv->capture_dpdk_rte_bypass_mempool_key_get_error =
+            StatsRegisterCounter("capture.dpdk.bypass.mempool.key_get_error", &ptv->tv->stats);
+    ptv->capture_dpdk_rte_bypass_mempool_info_get_error =
+            StatsRegisterCounter("capture.dpdk.bypass.mempool.info_get_error", &ptv->tv->stats);
+    /* bypass.query_error — rte_flow_query() failures */
+    ptv->capture_dpdk_rte_bypass_query_error =
+            StatsRegisterCounter("capture.dpdk.bypass.query_error", &ptv->tv->stats);
+    ptv->capture_bypass_enabled = dpdk_config->capture_bypass_enabled;
     ptv->copy_mode = dpdk_config->copy_mode;
     ptv->checksum_mode = dpdk_config->checksum_mode;
 
@@ -735,7 +861,7 @@ static TmEcode ReceiveDPDKThreadInit(ThreadVars *tv, const void *initdata, void 
         }
 
         // some PMDs requires additional actions only after the device has started
-        DevicePostStartPMDSpecificActions(ptv, dev_info.driver_name);
+        DevicePostStartPMDSpecificActions(ptv, dpdk_config, dev_info.driver_name);
 
         uint16_t inconsistent_numa_cnt = SC_ATOMIC_GET(dpdk_config->inconsistent_numa_cnt);
         if (inconsistent_numa_cnt > 0 && ptv->port_socket_id != SOCKET_ID_ANY) {

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -76,6 +76,7 @@ typedef struct DPDKIfaceConfig_ {
     bool mempool_cache_size_auto; // auto cache size based on mempool size
     DPDKDeviceResources *dpdk_dev_resources;
     uint16_t linkup_timeout; // in seconds how long to wait for link to come up
+    bool capture_bypass_enabled;
     SC_ATOMIC_DECLARE(uint16_t, ref);
     /* threads bind queue id one by one */
     SC_ATOMIC_DECLARE(uint16_t, queue_id);

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -74,7 +74,7 @@ typedef struct DPDKIfaceConfig_ {
     uint32_t queue_mempool_size;
     uint32_t mempool_cache_size;
     bool mempool_cache_size_auto; // auto cache size based on mempool size
-    DPDKDeviceResources *pkt_mempools;
+    DPDKDeviceResources *dpdk_dev_resources;
     uint16_t linkup_timeout; // in seconds how long to wait for link to come up
     SC_ATOMIC_DECLARE(uint16_t, ref);
     /* threads bind queue id one by one */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2877,6 +2877,11 @@ int PostConfLoadedSetup(SCInstance *suri)
         LiveDevRegisterExtension();
     }
 #endif
+#ifdef HAVE_DPDK
+    if (suri->run_mode == RUNMODE_DPDK) {
+        LiveDevRegisterExtension();
+    }
+#endif
     RegisterFlowBypassInfo();
 
     MacSetRegisterFlowStorage();

--- a/src/util-device-private.h
+++ b/src/util-device-private.h
@@ -24,7 +24,7 @@
 #include "util-device.h"
 #include "queue.h"
 #include "util-storage.h"
-#include "util-dpdk-common.h"
+#include "util-dpdk.h"
 
 #define MAX_DEVNAME 10
 

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -344,6 +344,18 @@ int LiveDeviceListClean(void)
     }
     TAILQ_FOREACH_SAFE(pd, &live_devices, next, tpd) {
         if (live_devices_stats) {
+#ifdef CAPTURE_OFFLOAD
+            SCLogNotice("%s: packets: %" PRIu64 ", bypassed: %" PRIu64 ", drops: %" PRIu64
+                        " (%.2f%%), invalid chksum: %" PRIu64,
+                    pd->dev, SC_ATOMIC_GET(pd->pkts) + SC_ATOMIC_GET(pd->bypassed),
+                    SC_ATOMIC_GET(pd->bypassed), SC_ATOMIC_GET(pd->drop),
+                    SC_ATOMIC_GET(pd->pkts) > 0
+                            ? 100 * ((double)SC_ATOMIC_GET(pd->drop)) /
+                                      ((double)SC_ATOMIC_GET(pd->pkts) +
+                                              (double)SC_ATOMIC_GET(pd->bypassed))
+                            : 0,
+                    SC_ATOMIC_GET(pd->invalid_checksums));
+#else
             SCLogNotice("%s: packets: %" PRIu64 ", drops: %" PRIu64
                         " (%.2f%%), invalid chksum: %" PRIu64,
                     pd->dev, SC_ATOMIC_GET(pd->pkts), SC_ATOMIC_GET(pd->drop),
@@ -351,6 +363,7 @@ int LiveDeviceListClean(void)
                                                           (double)SC_ATOMIC_GET(pd->pkts)
                                                 : 0,
                     SC_ATOMIC_GET(pd->invalid_checksums));
+#endif
         }
 
         RestoreIfaceOffloading(pd);

--- a/src/util-dpdk-common.c
+++ b/src/util-dpdk-common.c
@@ -27,43 +27,27 @@
 
 #ifdef HAVE_DPDK
 
-int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt)
+/**
+ * \brief Input is a number of which we want to find the greatest divisor up to max_num (inclusive).
+ * The divisor is returned.
+ */
+static int GreatestDivisorUpTo(uint32_t num, uint32_t max_num)
 {
-    SCEnter();
-    *dpdk_vars = SCCalloc(1, sizeof(*dpdk_vars[0]));
-    if (*dpdk_vars == NULL) {
-        SCLogError("failed to allocate memory for packet mempools structure");
-        SCReturnInt(-ENOMEM);
+    for (int i = max_num; i >= 2; i--) {
+        if (num % i == 0) {
+            return i;
+        }
     }
-
-    (*dpdk_vars)->pkt_mp = SCCalloc(mp_cnt, sizeof((*dpdk_vars)->pkt_mp[0]));
-    if ((*dpdk_vars)->pkt_mp == NULL) {
-        SCLogError("failed to allocate memory for packet mempools");
-        SCReturnInt(-ENOMEM);
-    }
-    (*dpdk_vars)->pkt_mp_capa = mp_cnt;
-    (*dpdk_vars)->pkt_mp_cnt = 0;
-
-    SCReturnInt(0);
+    return 1;
 }
 
-void DPDKDeviceResourcesDeinit(DPDKDeviceResources **dpdk_vars)
+uint32_t MempoolCacheSizeCalculate(uint32_t mp_sz)
 {
-    if ((*dpdk_vars) != NULL) {
-        if ((*dpdk_vars)->pkt_mp != NULL) {
-            for (int j = 0; j < (*dpdk_vars)->pkt_mp_capa; j++) {
-                if ((*dpdk_vars)->pkt_mp[j] != NULL) {
-                    rte_mempool_free((*dpdk_vars)->pkt_mp[j]);
-                }
-            }
-            SCFree((*dpdk_vars)->pkt_mp);
-            (*dpdk_vars)->pkt_mp_capa = 0;
-            (*dpdk_vars)->pkt_mp_cnt = 0;
-            (*dpdk_vars)->pkt_mp = NULL;
-        }
-        SCFree(*dpdk_vars);
-        *dpdk_vars = NULL;
-    }
+    // It is advised to have mempool cache size lower or equal to:
+    //   RTE_MEMPOOL_CACHE_MAX_SIZE (by default 512) and "mempool-size / 1.5"
+    // and at the same time "mempool-size modulo cache_size == 0".
+    uint32_t max_cache_size = MIN(RTE_MEMPOOL_CACHE_MAX_SIZE, mp_sz / 1.5);
+    return GreatestDivisorUpTo(mp_sz, max_cache_size);
 }
 
 #endif /* HAVE_DPDK */

--- a/src/util-dpdk-common.h
+++ b/src/util-dpdk-common.h
@@ -118,14 +118,7 @@
 #define RTE_ETH_LINK_MAX_STR_LEN 40
 #endif
 
-typedef struct {
-    struct rte_mempool **pkt_mp;
-    uint16_t pkt_mp_cnt;
-    uint16_t pkt_mp_capa;
-} DPDKDeviceResources;
-
-int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt);
-void DPDKDeviceResourcesDeinit(DPDKDeviceResources **dpdk_vars);
+uint32_t MempoolCacheSizeCalculate(uint32_t mp_sz);
 
 #endif /* HAVE_DPDK */
 

--- a/src/util-dpdk-ixgbe.c
+++ b/src/util-dpdk-ixgbe.c
@@ -62,7 +62,7 @@ int ixgbeDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
     struct rte_flow_action_rss rss_action_conf =
             DPDKInitRSSAction(rss_conf, nb_rx_queues, queues, RTE_ETH_HASH_FUNCTION_DEFAULT, true);
 
-    int retval = DPDKCreateRSSFlowGeneric(port_id, port_name, rss_action_conf);
+    int retval = DPDKCreateRSSFlowGeneric(port_id, port_name, rss_action_conf, RTE_DEFAULT_GROUP);
     if (retval != 0) {
         retval = rte_flow_flush(port_id, &flush_error);
         if (retval != 0) {

--- a/src/util-dpdk-mlx5.c
+++ b/src/util-dpdk-mlx5.c
@@ -35,12 +35,28 @@
 #include "util-dpdk-bonding.h"
 #include "util-dpdk-mlx5.h"
 #include "util-dpdk-rss.h"
+#include "util-dpdk-rte-flow.h"
 
 #ifdef HAVE_DPDK
 
 #define MLX5_RSS_HKEY_LEN 40
 
-int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
+static int mlx5DeviceSetRSS(int, uint16_t, char *, uint16_t);
+
+int mlx5DevicePostStartActions(
+        int port_id, uint16_t nb_rx_queues, char *port_name, bool capture_bypass_enabled)
+{
+    int retval = 0;
+    if (capture_bypass_enabled) {
+        RteFlowCreateJumpRule(port_id);
+        retval = mlx5DeviceSetRSS(port_id, nb_rx_queues, port_name, RTE_JUMP_GROUP);
+    } else {
+        retval = mlx5DeviceSetRSS(port_id, nb_rx_queues, port_name, RTE_DEFAULT_GROUP);
+    }
+    return retval;
+}
+
+static int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name, uint16_t group)
 {
     uint16_t queues[RTE_MAX_QUEUES_PER_PORT];
     struct rte_flow_error flush_error = { 0 };
@@ -57,7 +73,7 @@ int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
     struct rte_flow_action_rss rss_action_conf =
             DPDKInitRSSAction(rss_conf, nb_rx_queues, queues, RTE_ETH_HASH_FUNCTION_TOEPLITZ, true);
 
-    int retval = DPDKCreateRSSFlowGeneric(port_id, port_name, rss_action_conf);
+    int retval = DPDKCreateRSSFlowGeneric(port_id, port_name, rss_action_conf, group);
     if (retval != 0) {
         retval = rte_flow_flush(port_id, &flush_error);
         if (retval != 0) {

--- a/src/util-dpdk-mlx5.h
+++ b/src/util-dpdk-mlx5.h
@@ -28,7 +28,10 @@
 
 #ifdef HAVE_DPDK
 
-int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
+#define MLX5_RTE_FLOW_RULES_CAPACITY 4194304
+
+int mlx5DevicePostStartActions(
+        int port_id, uint16_t nb_rx_queues, char *port_name, bool capture_bypass_enabled);
 
 #endif /* HAVE_DPDK */
 

--- a/src/util-dpdk-rss.c
+++ b/src/util-dpdk-rss.c
@@ -91,10 +91,11 @@ struct rte_flow_action_rss DPDKInitRSSAction(struct rte_eth_rss_conf rss_conf, i
  * \param port_id The port identifier of the Ethernet device
  * \param port_name The port name of the Ethernet device
  * \param rss_conf RSS configuration
+ * \param group rte_flow group to create the rule in
  * \return int 0 on success, a negative errno value otherwise
  */
 int DPDKCreateRSSFlowGeneric(
-        int port_id, const char *port_name, struct rte_flow_action_rss rss_conf)
+        int port_id, const char *port_name, struct rte_flow_action_rss rss_conf, uint32_t group)
 {
     struct rte_flow_attr attr = { 0 };
     struct rte_flow_action action[] = { { 0 }, { 0 } };
@@ -104,6 +105,9 @@ int DPDKCreateRSSFlowGeneric(
     rss_conf.types = RTE_ETH_RSS_IPV4 | RTE_ETH_RSS_IPV6;
 
     attr.ingress = 1;
+    attr.priority = 1;
+    attr.group = group;
+
     action[0].type = RTE_FLOW_ACTION_TYPE_RSS;
     action[0].conf = &rss_conf;
     action[1].type = RTE_FLOW_ACTION_TYPE_END;

--- a/src/util-dpdk-rss.h
+++ b/src/util-dpdk-rss.h
@@ -37,7 +37,7 @@ extern uint8_t RSS_HKEY[];
 struct rte_flow_action_rss DPDKInitRSSAction(struct rte_eth_rss_conf rss_conf, int nb_rx_queues,
         uint16_t *queues, enum rte_eth_hash_function func, bool set_key);
 int DPDKCreateRSSFlowGeneric(
-        int port_id, const char *port_name, struct rte_flow_action_rss rss_conf);
+        int port_id, const char *port_name, struct rte_flow_action_rss rss_conf, uint32_t group);
 int DPDKSetRSSFlowQueues(int port_id, const char *port_name, struct rte_flow_action_rss rss_conf);
 int DPDKCreateRSSFlow(int port_id, const char *port_name, struct rte_flow_action_rss rss_conf,
         uint64_t rss_type, struct rte_flow_item *pattern);

--- a/src/util-dpdk-rte-flow-structs.h
+++ b/src/util-dpdk-rte-flow-structs.h
@@ -1,0 +1,74 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  \defgroup dpdk DPDK rte_flow rules util functions
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util structures
+ *
+ */
+
+#ifndef SURICATA_RTE_FLOW_STRUCTS_H
+#define SURICATA_RTE_FLOW_STRUCTS_H
+
+#ifdef HAVE_DPDK
+#include "suricata-common.h"
+#include "util-dpdk-common.h"
+
+typedef struct RteFlowRuleStorage_ {
+    uint32_t rule_cnt;
+    uint32_t rule_size;
+    char **rules;
+    struct rte_flow **rule_handlers;
+} RteFlowRuleStorage;
+
+typedef struct RteFlowBypassData_ {
+    struct rte_mempool *bypass_info_mp;
+    struct rte_mempool *bypass_mp;
+    struct rte_ring *bypass_ring;
+    uint32_t rte_ring_dequeue_burst_size;
+    uint32_t rte_bypass_rule_capacity;
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_rules_created);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_rules_error);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_rules_active);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_ring_enqueue_success);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_ring_enqueue_error_ring_full);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_ring_dequeue_success);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_ring_max);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_ring_occupancy);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_ring_ops);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_flows_bypass_success);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_flows_bypass_error);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_flow_lookup_error);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_mempool_key_get_error);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_mempool_info_get_error);
+    SC_ATOMIC_DECLARE(uint32_t, rte_bypass_query_error);
+} RteFlowBypassData;
+
+#endif /* HAVE_DPDK */
+#endif /* SURICATA_RTE_FLOW_STRUCTS_H */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.c
+++ b/src/util-dpdk-rte-flow.c
@@ -1,0 +1,879 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  \defgroup dpdk DPDK rte_flow rules util functions
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
+ */
+
+#include "decode.h"
+#include "flow-bypass.h"
+#include "flow-hash.h"
+#include "flow-storage.h"
+#include "flow-callbacks.h"
+#include "runmode-dpdk.h"
+#include "util-byte.h"
+#include "util-debug.h"
+#include "util-dpdk.h"
+#include "util-dpdk-ice.h"
+#include "util-dpdk-mlx5.h"
+#include "util-dpdk-rte-flow.h"
+#include "util-device-private.h"
+#include "flow-private.h"
+#include "flow.h"
+#include "runmodes.h"
+#include "tm-threads.h"
+#include "suricata.h"
+
+#ifdef HAVE_DPDK
+
+#define COUNT_ACTION_ID 1
+
+#define RTE_BYPASS_RING_NAME                       "rte_bypass_ring"
+#define RTE_BYPASS_MEMPOOL_NAME                    "rte_bypass_mempool"
+#define RTE_BYPASS_INFO_MEMPOOL_NAME               "rte_bypass_info_mempool"
+#define RTE_BYPASS_RING_SIZE_DEFAULT               16384
+#define RTE_BYPASS_RING_DEQUEUE_BURST_SIZE_DEFAULT 16383
+
+static int RteFlowBypassGetBypassInfoMPSize(const char *, uint32_t *);
+int RteFlowBypassLoadConf(const char *, uint32_t *, uint32_t *, uint32_t *);
+static int RteFlowBypassGetNodeInt(SCConfNode *, uint32_t *, const char *, uint32_t);
+static int RteFlowBypassRuleCreate(
+        RteFlowBypassData *, struct rte_flow_item *, int, struct rte_flow **);
+static void RteFlowHandleEmergency(ThreadVars *, Flow *, void *);
+static void RteFlowBiRuleDestroy(uint16_t, struct rte_flow *, struct rte_flow *);
+static int RteFlowUpdateStats(FlowBypassInfo *, LiveDevice *, struct rte_flow *, struct rte_flow *);
+static int RteFlowSetFlowBypassInfo(Flow *, struct rte_flow *, struct rte_flow *, int);
+static uint32_t DeviceDecideRteFlowRulesCapacity(const char *);
+
+typedef struct RteFlowHandlerToFlow_ {
+    struct rte_flow *src_handler;
+    struct rte_flow *dst_handler;
+    uint16_t livedev_id;
+} RteFlowHandlerToFlow;
+
+/**
+ * \brief Create a jump rule in the rte_flow default group to the group for bypass rules.
+ *  In some NICs, the default group has less capacity and higher rule insertion latency.
+ *
+ * \param port_id port id of the device to create the rule on
+ * \return int 0 on success, negative value on error
+ */
+int RteFlowCreateJumpRule(uint16_t port_id)
+{
+    struct rte_flow_error flow_error = { 0 };
+    struct rte_flow_attr attr = { 0 };
+    struct rte_flow_item pattern[] = { { 0 } };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+
+    attr.ingress = 1;
+    attr.priority = 0;
+    attr.group = RTE_DEFAULT_GROUP;
+
+    pattern[0].type = RTE_FLOW_ITEM_TYPE_END;
+
+    struct rte_flow_action_jump jump = {
+        .group = RTE_JUMP_GROUP,
+    };
+
+    action[0].type = RTE_FLOW_ACTION_TYPE_JUMP;
+    action[0].conf = &jump;
+
+    struct rte_flow *flow_handler = rte_flow_create(port_id, &attr, pattern, action, &flow_error);
+    if (flow_handler == NULL) {
+        FatalError("Error when creating rte_flow jump rule: %s", flow_error.message);
+        SCReturnInt(-1);
+    }
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Decide what is the maximal capacity of dynamic bypass rte_flow rules the device can
+ * handle.
+ *
+ * \param driver_name name of the driver
+ * \return uint32_t count of rte_flow bypass rules the device can utilize
+ */
+static uint32_t DeviceDecideRteFlowRulesCapacity(const char *driver_name)
+{
+    uint32_t retval = 0;
+    if (strcmp(driver_name, "mlx5_pci") == 0)
+        retval = MLX5_RTE_FLOW_RULES_CAPACITY;
+    return retval;
+}
+
+/**
+ * \brief Retrieve dpdk.capture-bypass and set it to all interfaces.
+ *
+ * Get dpdk.capture-bypass flag for enabling rte_flow bypass.
+ * Set this global flag to each interface.
+ * Default setting is disabled.
+ *
+ * \param iconf configuration of the interface
+ * \return 1 if key found, 0 if not
+ */
+int ConfigSetCaptureBypass(DPDKIfaceConfig *iconf)
+{
+    SCEnter();
+    int entry_bool = 0;
+    int retval = SCConfGetBool("dpdk.capture-bypass", &entry_bool);
+    if (retval != 1) {
+        iconf->capture_bypass_enabled = false;
+    } else {
+        iconf->capture_bypass_enabled = entry_bool;
+        retval = entry_bool;
+    }
+    SCReturnInt(retval);
+}
+
+/**
+ * \brief Get bypass-info mempool size from suricata.yaml.
+ *
+ * \param driver_name name of the driver
+ * \param[out] bypass_info_mp_size size of the mempool from config or maximum capacity of rte_flow
+ * rules the device can handle.
+ * \return 0 on success, negative value on error
+ */
+static int RteFlowBypassGetBypassInfoMPSize(const char *driver_name, uint32_t *bypass_info_mp_size)
+{
+    SCEnter();
+    SCConfNode *dpdk_root = SCConfGetNode("dpdk");
+
+    uint32_t capa = DeviceDecideRteFlowRulesCapacity(driver_name);
+    if (capa < 2) {
+        SCLogWarning("rte_flow capture bypass is not supported for driver %s", driver_name);
+        SCReturnInt(-1);
+    }
+    /* We want to have a mempool of size (2^n)-1. Half the capacity of the card is enough, each
+     * mempool object holds info about 2 rules */
+    uint32_t max_sz = capa / 2 - 1;
+    uint32_t sz = 0;
+
+    const char *entry_str = NULL;
+    int ret = SCConfGetChildValue(dpdk_root, "bypass-info-mp-size", &entry_str);
+    /* Set to maximum if value is "auto" or missing */
+    if (ret != 1 || strcmp(entry_str, "auto") == 0) {
+        sz = max_sz;
+    } else {
+        if (StringParseUint32(&sz, 10, 0, entry_str) < 0) {
+            SCLogError("bypass-info-mp-size contains non-numerical characters - \"%s\"", entry_str);
+            SCReturnInt(-EINVAL);
+        }
+    }
+
+    if (sz > max_sz) {
+        SCLogConfig("bypass-info-mp-size too big (%d), setting it to driver (%s) maximum: %d", sz,
+                driver_name, max_sz);
+        sz = max_sz;
+    } else {
+        SCLogConfig("bypass-info-mp-size set to %d", sz);
+    }
+    *bypass_info_mp_size = sz;
+    SCReturnInt(0);
+}
+
+static int RteFlowBypassGetNodeInt(
+        SCConfNode *root_node, uint32_t *cfg_ret, const char *cfg_str, uint32_t def)
+{
+    SCEnter();
+    uint32_t cfg_curr = 0;
+    const char *entry_str = NULL;
+    int ret = SCConfGetChildValue(root_node, cfg_str, &entry_str);
+    /* Set to default if value is "auto" or missing */
+    if (ret != 1 || strcmp(entry_str, "auto") == 0) {
+        cfg_curr = def;
+    } else {
+        if (StringParseUint32(&cfg_curr, 10, 0, entry_str) < 0) {
+            SCLogError("configuration for %s is not set to auto and contains non-numerical "
+                       "characters - \"%s\"",
+                    cfg_str, entry_str);
+            SCReturnInt(-EINVAL);
+        }
+    }
+    if (cfg_curr <= 0) {
+        SCLogError(
+                "configuration for %s is set to %d, but must be greater than 0", cfg_str, cfg_curr);
+        SCReturnInt(-EINVAL);
+    }
+    SCLogConfig("%s set to %d", cfg_str, cfg_curr);
+    *cfg_ret = cfg_curr;
+    SCReturnInt(0);
+}
+
+int RteFlowBypassLoadConf(const char *driver_name, uint32_t *bypass_ring_size,
+        uint32_t *bypass_ring_dequeue_burst_size, uint32_t *bypass_info_mempool_size)
+{
+    SCConfNode *dpdk_root = SCConfGetNode("dpdk");
+    int retval = 0;
+    retval += RteFlowBypassGetNodeInt(
+            dpdk_root, bypass_ring_size, "bypass-ring-size", RTE_BYPASS_RING_SIZE_DEFAULT);
+    retval += RteFlowBypassGetNodeInt(dpdk_root, bypass_ring_dequeue_burst_size,
+            "bypass-ring-dequeue-burst-size", RTE_BYPASS_RING_DEQUEUE_BURST_SIZE_DEFAULT);
+    retval += RteFlowBypassGetBypassInfoMPSize(driver_name, bypass_info_mempool_size);
+    SCReturnInt(retval);
+}
+/**
+ * \brief Enable and register functions for BypassManager,
+ *        initialize rte_ring data structure and store in global
+ *        variable
+ *
+ * \param iconf configuration of the interface
+ * \param driver_name name of the driver
+ * \return int 0 on success, negative value on error
+ */
+int RteBypassInit(DPDKIfaceConfig *iconf, const char *driver_name)
+{
+    SCEnter();
+    static RteFlowBypassData *rte_flow_bypass_data = NULL;
+    char *port_name = iconf->iface;
+    LiveDevice *livedev = LiveGetDevice(port_name);
+    LiveDevUseBypass(livedev);
+    int retval = 0;
+
+    /* We do not init the bypass data if the variable is already set */
+    if (rte_flow_bypass_data != NULL) {
+        iconf->dpdk_dev_resources->rte_flow_bypass_data = rte_flow_bypass_data;
+        SCReturnInt(retval);
+    }
+
+    RunModeEnablesBypassManager();
+    rte_flow_bypass_data = SCCalloc(1, sizeof(RteFlowBypassData));
+    if (rte_flow_bypass_data == NULL) {
+        SCLogError("%s: Memory allocation for RteFlowBypassData failed", port_name);
+        SCReturnInt(-ENOMEM);
+    }
+
+    uint32_t bypass_info_mp_size, bypass_ring_size;
+    retval = RteFlowBypassLoadConf(driver_name, &bypass_ring_size,
+            &rte_flow_bypass_data->rte_ring_dequeue_burst_size, &bypass_info_mp_size);
+    if (retval < 0) {
+        goto cleanup;
+    }
+
+    struct rte_ring *bypass_ring =
+            rte_ring_create(RTE_BYPASS_RING_NAME, bypass_ring_size, rte_socket_id(), RING_F_SC_DEQ);
+    if (bypass_ring == NULL) {
+        SCLogError("%s: rte_ring_create failed with (ring: %s): %s", port_name,
+                RTE_BYPASS_RING_NAME, rte_strerror(rte_errno));
+        retval = -1;
+        goto cleanup;
+    }
+    rte_flow_bypass_data->bypass_ring = bypass_ring;
+
+    uint32_t bypass_mp_size = (bypass_ring_size * 2) - 1;
+    struct rte_mempool *bypass_mp = rte_mempool_create(RTE_BYPASS_MEMPOOL_NAME, bypass_mp_size,
+            sizeof(FlowKey), MempoolCacheSizeCalculate(bypass_mp_size), 0, NULL, NULL, NULL, NULL,
+            rte_socket_id(), 0);
+    if (bypass_mp == NULL) {
+        SCLogError("%s: rte_mempool_create failed (mempool: %s): %s", port_name,
+                RTE_BYPASS_MEMPOOL_NAME, rte_strerror(rte_errno));
+        retval = -1;
+        goto cleanup;
+    }
+    rte_flow_bypass_data->bypass_mp = bypass_mp;
+
+    struct rte_mempool *bypass_info_mp =
+            rte_mempool_create(RTE_BYPASS_INFO_MEMPOOL_NAME, bypass_info_mp_size,
+                    sizeof(RteFlowHandlerToFlow), MempoolCacheSizeCalculate(bypass_info_mp_size), 0,
+                    NULL, NULL, NULL, NULL, rte_socket_id(), 0);
+    if (bypass_info_mp == NULL) {
+        SCLogError("%s: rte_mempool_create failed (mempool: %s): %s", port_name,
+                RTE_BYPASS_INFO_MEMPOOL_NAME, rte_strerror(rte_errno));
+        retval = -1;
+        goto cleanup;
+    }
+    rte_flow_bypass_data->bypass_info_mp = bypass_info_mp;
+
+    BypassedFlowManagerRegisterCheckFunc(RteFlowBypassRuleLoad, NULL, (void *)rte_flow_bypass_data);
+
+    rte_flow_bypass_data->rte_bypass_rule_capacity = DeviceDecideRteFlowRulesCapacity(driver_name);
+
+    /* Destroys rte_flow rules of bypassed flows evicted during emergency mode */
+    SCFlowRegisterFinishCallback(RteFlowHandleEmergency, NULL);
+
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_rules_active);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_rules_created);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_rules_error);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_ring_enqueue_success);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_ring_enqueue_error_ring_full);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_ring_dequeue_success);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_ring_max);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_ring_occupancy);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_ring_ops);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_flows_bypass_success);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_flows_bypass_error);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_flow_lookup_error);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_mempool_key_get_error);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_mempool_info_get_error);
+    SC_ATOMIC_INIT(rte_flow_bypass_data->rte_bypass_query_error);
+
+    iconf->dpdk_dev_resources->rte_flow_bypass_data = rte_flow_bypass_data;
+
+    SCReturnInt(retval);
+
+cleanup:
+    SCFree(rte_flow_bypass_data);
+    SCReturnInt(retval);
+}
+
+/**
+ * \brief Decides whether the rte_flow rule is active and collects statistics for the flow.
+ *        If the rule is not active, it should be removed from the table.
+ *
+ * \param fc FlowBypassInfo of the flow to check
+ * \param livedev LiveDevice the flow belongs to
+ * \param src_rule_handler rte_flow rule handler for specific flow in one direction
+ * \param dst_rule_handler rte_flow rule handler for specific flow in other direction
+ * \param flow flow to be possibly removed from the table
+ * \return int 1 if the rte_flow rule is active, 0 if it should be removed
+ */
+static int RteFlowUpdateStats(FlowBypassInfo *fc, LiveDevice *livedev,
+        struct rte_flow *src_rule_handler, struct rte_flow *dst_rule_handler)
+{
+    SCEnter();
+    struct rte_flow_query_count query_count = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+    struct rte_flow_error flow_error = { 0 };
+    uint32_t counter_id = COUNT_ACTION_ID;
+    uint64_t src_packets = 0, src_bytes = 0, dst_packets = 0, dst_bytes = 0;
+
+    query_count.reset = 1;
+    action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+    action[0].conf = &counter_id;
+    action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+    uint16_t port_id = livedev->dpdk_vars->port_id;
+    int retval = rte_flow_query(
+            port_id, src_rule_handler, &(action[0]), (void *)&query_count, &flow_error);
+    if (retval != 0) {
+        SCLogError("rte_flow dynamic bypass: count query error %s errmsg: %s",
+                rte_strerror(-retval), flow_error.message);
+        SC_ATOMIC_ADD(livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_query_error, 1);
+    } else {
+        src_packets = query_count.hits;
+        src_bytes = query_count.bytes;
+    }
+
+    memset(&query_count, 0, sizeof(struct rte_flow_query_count));
+    query_count.reset = 1;
+    retval = rte_flow_query(
+            port_id, dst_rule_handler, &(action[0]), (void *)&query_count, &flow_error);
+    if (retval != 0) {
+        SCLogError("rte_flow dynamic bypass: count query error %s errmsg: %s",
+                rte_strerror(-retval), flow_error.message);
+        SC_ATOMIC_ADD(livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_query_error, 1);
+    } else {
+        dst_packets = query_count.hits;
+        dst_bytes = query_count.bytes;
+    }
+
+    /* Proceed only if there are new filtered packets in the flow */
+    if (src_packets || dst_packets) {
+        fc->tosrcpktcnt += src_packets;
+        fc->tosrcbytecnt += src_bytes;
+        fc->todstpktcnt += dst_packets;
+        fc->todstbytecnt += dst_bytes;
+        SCReturnInt(1);
+    }
+    SCReturnInt(0);
+}
+
+/**
+ * \brief Create rte_flow drop rule for dynamic bypass
+ *
+ * \param items array of pattern items
+ * \param port_id identifier of a port
+ * \param flow_handler rte_flow rule handler
+ * \return int 0 on success, negative value on error
+ */
+static int RteFlowBypassRuleCreate(RteFlowBypassData *rte_flow_bypass_data,
+        struct rte_flow_item *items, int port_id, struct rte_flow **flow_handler)
+{
+    struct rte_flow_error flow_error = { 0 };
+    struct rte_flow_attr attr = { 0 };
+    struct rte_flow_action action[] = { { 0 }, { 0 }, { 0 } };
+
+    attr.ingress = 1;
+    attr.priority = 0;
+    attr.group = RTE_JUMP_GROUP;
+
+    uint32_t counter_id = COUNT_ACTION_ID;
+
+    action[0].type = RTE_FLOW_ACTION_TYPE_COUNT;
+    action[0].conf = &counter_id;
+    action[1].type = RTE_FLOW_ACTION_TYPE_DROP;
+    action[2].type = RTE_FLOW_ACTION_TYPE_END;
+
+    int retval = rte_flow_validate(port_id, &attr, items, action, &flow_error);
+    if (retval != 0) {
+        goto rule_failed;
+    }
+
+    *flow_handler = rte_flow_create(port_id, &attr, items, action, &flow_error);
+    if (*flow_handler == NULL) {
+        retval = -1;
+        goto rule_failed;
+    }
+    SCReturnInt(retval);
+
+rule_failed:
+    SCLogError("rte_flow dynamic bypass: create rte_flow rule error %s errmsg: %s",
+            rte_strerror(-retval), flow_error.message);
+    SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_rules_error, 1);
+    SCReturnInt(retval);
+}
+
+static void RteFlowHandleEmergency(ThreadVars *tv, Flow *f, void *data)
+{
+    if (f->flow_state != FLOW_STATE_CAPTURE_BYPASSED &&
+            (f->flow_end_flags & FLOW_END_FLAG_EMERGENCY) == 0) {
+        return;
+    }
+    FlowBypassInfo *fc = SCFlowGetStorageById(f, GetFlowBypassInfoID());
+    if (fc == NULL)
+        return;
+    RteFlowHandlerToFlow *flow_handler_info = (RteFlowHandlerToFlow *)fc->bypass_data;
+    if (flow_handler_info == NULL)
+        return;
+    if (flow_handler_info->src_handler != NULL && flow_handler_info->dst_handler != NULL) {
+        LiveDevice *livedev = LiveDeviceGetById(f->livedev_id);
+        RteFlowBiRuleDestroy(livedev->dpdk_vars->port_id, flow_handler_info->src_handler,
+                flow_handler_info->dst_handler);
+        flow_handler_info->src_handler = NULL;
+        flow_handler_info->dst_handler = NULL;
+        SC_ATOMIC_SUB(livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_rules_active, 2);
+    }
+}
+
+/**
+ * \brief Destroy rte_flow rules for both directions of a flow
+ *
+ * \param port_id identifier of a port
+ * \param src_handler handler of rte_flow rule
+ * \param dst_handler handler of rte_flow rule
+ */
+static void RteFlowBiRuleDestroy(
+        uint16_t port_id, struct rte_flow *src_handler, struct rte_flow *dst_handler)
+{
+    int retval = 0;
+    struct rte_flow_error flow_error = { 0 };
+    if (src_handler != NULL) {
+        retval = rte_flow_destroy(port_id, src_handler, &flow_error);
+        if (retval != 0) {
+            SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                    rte_strerror(-retval), flow_error.message);
+        }
+    }
+
+    if (dst_handler != NULL) {
+        retval = rte_flow_destroy(port_id, dst_handler, &flow_error);
+        if (retval != 0) {
+            SCLogError("rte_flow dynamic bypass: destroy rte_flow rule error %s errmsg: %s",
+                    rte_strerror(-retval), flow_error.message);
+        }
+    }
+}
+
+/**
+ * \brief Poll flow data from rte_flow_ring structure and create rte_flow bypass rule to bypass flow
+ *        from both directions
+ *
+ * \param th_v thread vars
+ * \param bypassstats bypass stats
+ * \param curtime time
+ * \param data table of flows and rte_flow rule handlers
+ * \return int number of successfully created rte_flow rules
+ */
+int RteFlowBypassRuleLoad(
+        ThreadVars *th_v, struct flows_stats *bypassstats, struct timespec *curtime, void *data)
+{
+    SCEnter();
+    RteFlowBypassData *rte_flow_bypass_data = (RteFlowBypassData *)data;
+    struct rte_ring *bypass_ring = rte_flow_bypass_data->bypass_ring;
+    struct rte_mempool *bypass_mp = rte_flow_bypass_data->bypass_mp;
+    struct rte_flow_item items[] = { { 0 }, { 0 }, { 0 }, { 0 }, { 0 } };
+    uint16_t L2_INDEX = 0, L3_INDEX = 1, L4_INDEX = 2, END_INDEX = 3;
+    uint16_t ring_dequeue_num = rte_flow_bypass_data->rte_ring_dequeue_burst_size;
+    uint32_t success_count = 0;
+    FlowKey *ring_data[ring_dequeue_num];
+
+    memset(ring_data, 0, sizeof(ring_data));
+    /* Initialize the reusable part of rte_flow rules */
+    items[L2_INDEX].type = RTE_FLOW_ITEM_TYPE_ETH;
+    items[END_INDEX].type = RTE_FLOW_ITEM_TYPE_END;
+
+    /* Bypass ring statistics, avg occupancy is calculated in DumpCounters().
+       We exclude cycles where the ring is empty from the average*/
+    unsigned int bypass_ring_curr = rte_ring_count(bypass_ring);
+    if (bypass_ring_curr > SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_ring_max))
+        SC_ATOMIC_SET(rte_flow_bypass_data->rte_bypass_ring_max, bypass_ring_curr);
+    SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_ring_occupancy, bypass_ring_curr);
+    if (bypass_ring_curr > 0)
+        SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_ring_ops, 1);
+
+    uint32_t to_bypass_packets =
+            rte_ring_dequeue_burst(bypass_ring, (void **)ring_data, ring_dequeue_num, NULL);
+    /* rte_ring_dequeue_burst() returns the number of dequeued objects (>= 0);
+     * it does not return a negative error code, so there is no dequeue error
+     * to count. The success counter tracks every successfully dequeued
+     * flow key. */
+    SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_ring_dequeue_success, to_bypass_packets);
+    for (uint32_t i = 0; i < to_bypass_packets; i++) {
+        if (unlikely(suricata_ctl_flags != 0)) {
+            /* Empty mempool of remaining unutilized entries */
+            for (uint32_t j = i; j < to_bypass_packets; j++) {
+                rte_mempool_put(bypass_mp, ring_data[j]);
+            }
+            SCReturnInt(success_count);
+        }
+        struct rte_flow_item_ipv4 ipv4_spec = { 0 }, ipv4_mask = { 0 };
+        struct rte_flow_item_ipv6 ipv6_spec = { 0 }, ipv6_mask = { 0 };
+        struct rte_flow_item_tcp tcp_spec = { 0 }, tcp_mask = { 0 };
+        struct rte_flow_item_udp udp_spec = { 0 }, udp_mask = { 0 };
+        void *ip_spec = NULL, *ip_mask = NULL, *l4_spec = NULL, *l4_mask = NULL;
+
+        FlowKey *flow_key = ring_data[i];
+        uint16_t port_id = LiveDeviceGetById(flow_key->livedev_id)->dpdk_vars->port_id;
+        uint32_t flow_hash = FlowKeyGetHash(flow_key);
+        Flow *flow = FlowGetExistingFlowFromHash(flow_key, flow_hash);
+        rte_mempool_put(bypass_mp, flow_key);
+
+        /* If the flow has already ended (lookup failed) or the NIC's rte_flow
+         * rule capacity is exhausted, we cannot install bypass rules. */
+        if (flow == NULL || SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_rules_active) + 2 >=
+                                    rte_flow_bypass_data->rte_bypass_rule_capacity) {
+            if (flow == NULL) {
+                /* Flow expired before we could create its bypass rule */
+                SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_flow_lookup_error, 1);
+            } else {
+                /* NIC rule capacity exhausted, fall back to local bypass */
+                SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_flows_bypass_error, 1);
+                FlowUpdateState(flow, FLOW_STATE_LOCAL_BYPASSED);
+                FLOWLOCK_UNLOCK(flow);
+            }
+            continue;
+        }
+
+        /* Create rte_flow rule for original direction */
+        if (FLOW_IS_IPV4(flow)) {
+            SCLogDebug("Add an IPv4 rte_flow bypass rule");
+            ipv4_spec.hdr.src_addr = flow->src.address.address_un_data32[0];
+            ipv4_mask.hdr.src_addr = 0xFFFFFFFF;
+            ipv4_spec.hdr.dst_addr = flow->dst.address.address_un_data32[0];
+            ipv4_mask.hdr.dst_addr = 0xFFFFFFFF;
+            ip_spec = &ipv4_spec;
+            ip_mask = &ipv4_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV4;
+        } else {
+#if RTE_VERSION >= RTE_VERSION_NUM(24, 0, 0, 0)
+            SCLogDebug("Add an IPv6 rte_flow bypass rule");
+            memcpy(ipv6_spec.hdr.src_addr.a, flow->src.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.src_addr.a, 0xFF, 16);
+            memcpy(ipv6_spec.hdr.dst_addr.a, flow->dst.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.dst_addr.a, 0xFF, 16);
+#else
+            SCLogDebug("Add an IPv6 rte_flow bypass rule");
+            memcpy(ipv6_spec.hdr.src_addr, flow->src.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.src_addr, 0xFF, 16);
+            memcpy(ipv6_spec.hdr.dst_addr, flow->dst.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.dst_addr, 0xFF, 16);
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(24, 0, 0, 0) */
+            ip_spec = &ipv6_spec;
+            ip_mask = &ipv6_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV6;
+        }
+
+        if (flow->proto == IPPROTO_TCP) {
+            tcp_spec.hdr.src_port = htons(flow->sp);
+            tcp_mask.hdr.src_port = 0xFFFF;
+            tcp_spec.hdr.dst_port = htons(flow->dp);
+            tcp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &tcp_spec;
+            l4_mask = &tcp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_TCP;
+        } else {
+            udp_spec.hdr.src_port = htons(flow->sp);
+            udp_mask.hdr.src_port = 0xFFFF;
+            udp_spec.hdr.dst_port = htons(flow->dp);
+            udp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &udp_spec;
+            l4_mask = &udp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_UDP;
+        }
+
+        items[L3_INDEX].spec = ip_spec;
+        items[L3_INDEX].mask = ip_mask;
+        items[L4_INDEX].spec = l4_spec;
+        items[L4_INDEX].mask = l4_mask;
+
+        struct rte_flow *src_rule_handler = NULL;
+        int retval =
+                RteFlowBypassRuleCreate(rte_flow_bypass_data, items, port_id, &src_rule_handler);
+
+        /* Create rte_flow rule for the opposite direction */
+        if (FLOW_IS_IPV4(flow)) {
+            SCLogDebug("Add an IPv4 rte_flow bypass rule in other direction");
+            ipv4_spec.hdr.src_addr = flow->dst.address.address_un_data32[0];
+            ipv4_mask.hdr.src_addr = 0xFFFFFFFF;
+            ipv4_spec.hdr.dst_addr = flow->src.address.address_un_data32[0];
+            ipv4_mask.hdr.dst_addr = 0xFFFFFFFF;
+            ip_spec = &ipv4_spec;
+            ip_mask = &ipv4_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV4;
+        } else {
+            SCLogDebug("Add an IPv6 rte_flow bypass rule");
+#if RTE_VERSION >= RTE_VERSION_NUM(24, 0, 0, 0)
+            memcpy(ipv6_spec.hdr.src_addr.a, flow->dst.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.src_addr.a, 0xFF, 16);
+            memcpy(ipv6_spec.hdr.dst_addr.a, flow->src.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.dst_addr.a, 0xFF, 16);
+#else
+            memcpy(ipv6_spec.hdr.src_addr, flow->dst.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.src_addr, 0xFF, 16);
+            memcpy(ipv6_spec.hdr.dst_addr, flow->src.address.address_un_data8, 16);
+            memset(ipv6_mask.hdr.dst_addr, 0xFF, 16);
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(24, 0, 0, 0) */
+            ip_spec = &ipv6_spec;
+            ip_mask = &ipv6_mask;
+            items[L3_INDEX].type = RTE_FLOW_ITEM_TYPE_IPV6;
+        }
+
+        if (flow->proto == IPPROTO_TCP) {
+            tcp_spec.hdr.src_port = htons(flow->dp);
+            tcp_mask.hdr.src_port = 0xFFFF;
+            tcp_spec.hdr.dst_port = htons(flow->sp);
+            tcp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &tcp_spec;
+            l4_mask = &tcp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_TCP;
+        } else {
+            udp_spec.hdr.src_port = htons(flow->dp);
+            udp_mask.hdr.src_port = 0xFFFF;
+            udp_spec.hdr.dst_port = htons(flow->sp);
+            udp_mask.hdr.dst_port = 0xFFFF;
+            l4_spec = &udp_spec;
+            l4_mask = &udp_mask;
+            items[L4_INDEX].type = RTE_FLOW_ITEM_TYPE_UDP;
+        }
+
+        items[L3_INDEX].spec = ip_spec;
+        items[L3_INDEX].mask = ip_mask;
+        items[L4_INDEX].spec = l4_spec;
+        items[L4_INDEX].mask = l4_mask;
+
+        struct rte_flow *dst_rule_handler = NULL;
+        retval += RteFlowBypassRuleCreate(rte_flow_bypass_data, items, port_id, &dst_rule_handler);
+
+        /* If either rule creation failed, destroy both rules (the one that may
+         * have succeeded and the one that failed) and fall back to local
+         * bypass for this flow. */
+        if (retval != 0) {
+            RteFlowBiRuleDestroy(port_id, src_rule_handler, dst_rule_handler);
+            SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_flows_bypass_error, 1);
+            FlowUpdateState(flow, FLOW_STATE_LOCAL_BYPASSED);
+            FLOWLOCK_UNLOCK(flow);
+            continue;
+        }
+
+        int inet_family = FLOW_IS_IPV4(flow) ? AF_INET : AF_INET6;
+
+        retval = RteFlowSetFlowBypassInfo(flow, src_rule_handler, dst_rule_handler, inet_family);
+        if (retval == 0) {
+            success_count++;
+            /* 2 rte_flow rules (src + dst) installed for this flow */
+            SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_rules_active, 2);
+            SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_rules_created, 2);
+            SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_flows_bypass_success, 1);
+        } else {
+            SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_flows_bypass_error, 1);
+        }
+        FLOWLOCK_UNLOCK(flow);
+    }
+    SCReturnInt(success_count);
+}
+
+bool RteBypassUpdate(Flow *flow, void *data, time_t tsec)
+{
+    RteFlowHandlerToFlow *flow_handler_info = (RteFlowHandlerToFlow *)data;
+    if (flow_handler_info == NULL) {
+        /* Data already freed */
+        return false;
+    }
+    FlowBypassInfo *fc = SCFlowGetStorageById(flow, GetFlowBypassInfoID());
+    if (fc == NULL) {
+        /* Data already freed */
+        return false;
+    }
+    if (flow_handler_info->src_handler == NULL || flow_handler_info->dst_handler == NULL) {
+        /* Rules already deleted */
+        return false;
+    }
+    LiveDevice *livedev = LiveDeviceGetById(flow->livedev_id);
+    bool activity = RteFlowUpdateStats(
+            fc, livedev, flow_handler_info->src_handler, flow_handler_info->dst_handler);
+
+    if (activity)
+        flow->lastts = SCTIME_FROM_SECS(tsec);
+
+    /* At shutdown, we only get the counters. We delete the rules with rte_flow_flush later */
+    if (unlikely(suricata_ctl_flags != 0)) {
+        flow_handler_info->src_handler = NULL;
+        flow_handler_info->dst_handler = NULL;
+        SC_ATOMIC_SUB(livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_rules_active, 2);
+        return activity;
+    }
+
+    if (!activity) {
+        if (flow_handler_info->src_handler != NULL && flow_handler_info->dst_handler != NULL) {
+            RteFlowBiRuleDestroy(livedev->dpdk_vars->port_id, flow_handler_info->src_handler,
+                    flow_handler_info->dst_handler);
+            flow_handler_info->src_handler = NULL;
+            flow_handler_info->dst_handler = NULL;
+            SC_ATOMIC_SUB(livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_rules_active, 2);
+        }
+    }
+    SCReturnBool(activity);
+}
+
+void RteBypassFree(void *data)
+{
+    RteFlowHandlerToFlow *flow_handler_info = (RteFlowHandlerToFlow *)data;
+    if (flow_handler_info == NULL) {
+        return;
+    }
+    LiveDevice *livedev = LiveDeviceGetById(flow_handler_info->livedev_id);
+    if (livedev && livedev->dpdk_vars && livedev->dpdk_vars->rte_flow_bypass_data) {
+        rte_mempool_put(
+                livedev->dpdk_vars->rte_flow_bypass_data->bypass_info_mp, flow_handler_info);
+    }
+}
+
+static int RteFlowSetFlowBypassInfo(
+        Flow *flow, struct rte_flow *src_handler, struct rte_flow *dst_handler, int family)
+{
+    FlowBypassInfo *fc = SCFlowGetStorageById(flow, GetFlowBypassInfoID());
+    LiveDevice *livedev = LiveDeviceGetById(flow->livedev_id);
+    if (fc) {
+        if (fc->bypass_data != NULL) {
+            SCReturnInt(0);
+        }
+        RteFlowHandlerToFlow *flow_handler_info;
+        if (rte_mempool_get(livedev->dpdk_vars->rte_flow_bypass_data->bypass_info_mp,
+                    (void **)&flow_handler_info) < 0) {
+            SC_ATOMIC_ADD(
+                    livedev->dpdk_vars->rte_flow_bypass_data->rte_bypass_mempool_info_get_error, 1);
+            /* Mempool capacity has been reached, switch to local bypass */
+            goto bypass_fail;
+        }
+        flow_handler_info->src_handler = src_handler;
+        flow_handler_info->dst_handler = dst_handler;
+        flow_handler_info->livedev_id = livedev->id;
+        fc->bypass_data = flow_handler_info;
+        fc->BypassUpdate = RteBypassUpdate;
+        fc->BypassFree = RteBypassFree;
+        LiveDevAddBypassStats(livedev, 1, family);
+        LiveDevAddBypassSuccess(livedev, 1, family);
+        SCReturnInt(0);
+    }
+
+bypass_fail:;
+    RteFlowBiRuleDestroy(livedev->dpdk_vars->port_id, src_handler, dst_handler);
+    LiveDevAddBypassFail(livedev, 1, family);
+    FlowUpdateState(flow, FLOW_STATE_LOCAL_BYPASSED);
+    SCReturnInt(-ENOMEM);
+}
+
+int RteFlowBypassCallback(Packet *p)
+{
+    if (p == NULL || p->flow == NULL) {
+        SCReturnInt(0);
+    }
+
+    /* Only bypass TCP and UDP */
+    if (!(PacketIsTCP(p) || PacketIsUDP(p))) {
+        SCReturnInt(0);
+    }
+
+    FlowKey *flow_key = NULL;
+    LiveDevice *livedev = LiveDeviceGetById(p->livedev_id);
+    RteFlowBypassData *rte_flow_bypass_data = livedev->dpdk_vars->rte_flow_bypass_data;
+
+    /* The tested rte_flow rule capacity of the device has been exhausted, new rules will be added
+     * after bypassed flows time out and the existing rules are deleted */
+    if (SC_ATOMIC_GET(rte_flow_bypass_data->rte_bypass_rules_active) + 2 >=
+            rte_flow_bypass_data->rte_bypass_rule_capacity) {
+        SCReturnInt(0);
+    }
+
+    if (rte_mempool_get(rte_flow_bypass_data->bypass_mp, (void **)&flow_key) < 0) {
+        SCLogError("Memory allocation for rte_flow bypass data failed");
+        SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_mempool_key_get_error, 1);
+        SCReturnInt(0);
+    }
+    memset(flow_key, 0, sizeof(FlowKey));
+    if (PacketIsIPv4(p)) {
+        flow_key->src.family = AF_INET;
+        flow_key->src.address.address_un_data32[0] = (GET_IPV4_SRC_ADDR_U32(p));
+        flow_key->dst.family = AF_INET;
+        flow_key->dst.address.address_un_data32[0] = (GET_IPV4_DST_ADDR_U32(p));
+    } else if (PacketIsIPv6(p)) {
+        flow_key->src.family = AF_INET6;
+        memcpy(flow_key->src.address.address_un_data8, GET_IPV6_SRC_ADDR(p), 16 * sizeof(uint8_t));
+        flow_key->dst.family = AF_INET6;
+        memcpy(flow_key->dst.address.address_un_data8, GET_IPV6_DST_ADDR(p), 16 * sizeof(uint8_t));
+    }
+    if (p->proto == IPPROTO_TCP) {
+        flow_key->proto = IPPROTO_TCP;
+    } else {
+        flow_key->proto = IPPROTO_UDP;
+    }
+    flow_key->sp = p->sp;
+    flow_key->dp = p->dp;
+    flow_key->livedev_id = p->livedev_id;
+    flow_key->vlan_id[0] = p->vlan_id[0];
+    flow_key->vlan_id[1] = p->vlan_id[1];
+    flow_key->vlan_id[2] = p->vlan_id[2];
+    flow_key->recursion_level = 0;
+
+    int retval = rte_ring_mp_enqueue(rte_flow_bypass_data->bypass_ring, flow_key);
+    /* If ring is full, continue with local bypass. Also, if Suricata shuts down, do not increase
+     * counters */
+    if (retval < 0) {
+        rte_mempool_put(rte_flow_bypass_data->bypass_mp, flow_key);
+        SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_ring_enqueue_error_ring_full, 1);
+    } else {
+        SC_ATOMIC_ADD(rte_flow_bypass_data->rte_bypass_ring_enqueue_success, 1);
+    }
+    retval = retval == 0 ? 1 : 0;
+    SCReturnInt(retval);
+}
+
+#endif /* HAVE_DPDK */
+
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.h
+++ b/src/util-dpdk-rte-flow.h
@@ -1,0 +1,59 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *  \defgroup dpdk DPDK rte_flow rules util functions
+ *
+ *  @{
+ */
+
+/**
+ * \file
+ *
+ * \author Adam Kiripolsky <adam.kiripolsky@cesnet.cz>
+ *
+ * DPDK rte_flow rules util functions
+ *
+ */
+
+#ifndef SURICATA_RTE_FLOW_RULES_H
+#define SURICATA_RTE_FLOW_RULES_H
+
+#ifdef HAVE_DPDK
+
+#include "conf.h"
+#include "util-dpdk-common.h"
+
+typedef struct RteFlowRuleStorage_ {
+    uint32_t rule_cnt;
+    uint32_t rule_size;
+    char **rules;
+    struct rte_flow **rule_handlers;
+} RteFlowRuleStorage;
+
+void RteFlowRuleStorageFree(RteFlowRuleStorage *rule_storage);
+int ConfigLoadRteFlowRules(
+        SCConfNode *if_root, const char *drop_filter_str, RteFlowRuleStorage *rule_storage);
+int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name);
+uint64_t RteFlowFilteredPacketsQuery(
+        struct rte_flow **rules, uint32_t rule_count, const char *device_name, int port_id);
+
+#endif /* HAVE_DPDK */
+#endif /* SURICATA_RTE_FLOW_RULES_H */
+/**
+ * @}
+ */

--- a/src/util-dpdk-rte-flow.h
+++ b/src/util-dpdk-rte-flow.h
@@ -36,21 +36,19 @@
 #ifdef HAVE_DPDK
 
 #include "conf.h"
+#include "flow-bypass.h"
+#include "flow-hash.h"
 #include "util-dpdk-common.h"
+#include "util-dpdk-rte-flow-structs.h"
 
-typedef struct RteFlowRuleStorage_ {
-    uint32_t rule_cnt;
-    uint32_t rule_size;
-    char **rules;
-    struct rte_flow **rule_handlers;
-} RteFlowRuleStorage;
-
-void RteFlowRuleStorageFree(RteFlowRuleStorage *rule_storage);
-int ConfigLoadRteFlowRules(
-        SCConfNode *if_root, const char *drop_filter_str, RteFlowRuleStorage *rule_storage);
-int RteFlowRulesCreate(uint16_t port_id, RteFlowRuleStorage *rule_storage, const char *driver_name);
-uint64_t RteFlowFilteredPacketsQuery(
-        struct rte_flow **rules, uint32_t rule_count, const char *device_name, int port_id);
+int ConfigSetCaptureBypass(DPDKIfaceConfig *);
+int RteBypassInit(DPDKIfaceConfig *iconf, const char *driver_name);
+int RteFlowCreateJumpRule(uint16_t port_id);
+int RteFlowBypassCallback(Packet *);
+int RteFlowBypassRuleLoad(
+        ThreadVars *th_v, struct flows_stats *bypassstats, struct timespec *curtime, void *data);
+bool RteBypassUpdate(Flow *flow, void *data, time_t tsec);
+void RteBypassFree(void *data);
 
 #endif /* HAVE_DPDK */
 #endif /* SURICATA_RTE_FLOW_RULES_H */

--- a/src/util-dpdk.c
+++ b/src/util-dpdk.c
@@ -27,6 +27,47 @@
 #include "util-debug.h"
 #include "util-device-private.h"
 
+int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt)
+{
+    SCEnter();
+    *dpdk_vars = SCCalloc(1, sizeof(*dpdk_vars[0]));
+    if (*dpdk_vars == NULL) {
+        SCLogError("failed to allocate memory for packet mempools structure");
+        SCReturnInt(-ENOMEM);
+    }
+
+    (*dpdk_vars)->pkt_mp = SCCalloc(mp_cnt, sizeof((*dpdk_vars)->pkt_mp[0]));
+    if ((*dpdk_vars)->pkt_mp == NULL) {
+        SCLogError("failed to allocate memory for packet mempools");
+        SCReturnInt(-ENOMEM);
+    }
+    (*dpdk_vars)->pkt_mp_capa = mp_cnt;
+    (*dpdk_vars)->pkt_mp_cnt = 0;
+
+    SCReturnInt(0);
+}
+
+void DPDKDeviceResourcesDeinit(DPDKDeviceResources **dpdk_vars)
+{
+#ifdef HAVE_DPDK
+    if ((*dpdk_vars) != NULL) {
+        if ((*dpdk_vars)->pkt_mp != NULL) {
+            for (int j = 0; j < (*dpdk_vars)->pkt_mp_capa; j++) {
+                if ((*dpdk_vars)->pkt_mp[j] != NULL) {
+                    rte_mempool_free((*dpdk_vars)->pkt_mp[j]);
+                }
+            }
+            SCFree((*dpdk_vars)->pkt_mp);
+            (*dpdk_vars)->pkt_mp_capa = 0;
+            (*dpdk_vars)->pkt_mp_cnt = 0;
+            (*dpdk_vars)->pkt_mp = NULL;
+        }
+        SCFree(*dpdk_vars);
+        *dpdk_vars = NULL;
+    }
+#endif /* HAVE_DPDK */
+}
+
 void DPDKCleanupEAL(void)
 {
 #ifdef HAVE_DPDK

--- a/src/util-dpdk.c
+++ b/src/util-dpdk.c
@@ -102,6 +102,11 @@ void DPDKFreeDevice(LiveDevice *ldev)
     (void)ldev; // avoid warnings of unused variable
 #ifdef HAVE_DPDK
     if (SCRunmodeGet() == RUNMODE_DPDK) {
+        if (ldev->dpdk_vars->rte_flow_bypass_data != NULL &&
+                ldev->dpdk_vars->rte_flow_bypass_data->bypass_mp != NULL) {
+            rte_mempool_free(ldev->dpdk_vars->rte_flow_bypass_data->bypass_mp);
+            ldev->dpdk_vars->rte_flow_bypass_data->bypass_mp = NULL;
+        }
         SCLogDebug("%s: releasing packet mempools", ldev->dev);
         DPDKDeviceResourcesDeinit(&ldev->dpdk_vars);
     }

--- a/src/util-dpdk.h
+++ b/src/util-dpdk.h
@@ -26,6 +26,20 @@
 
 #include "util-dpdk-common.h"
 #include "util-device.h"
+#include "util-dpdk-rte-flow.h"
+
+typedef struct {
+    struct rte_mempool **pkt_mp;
+    uint16_t pkt_mp_cnt;
+    uint16_t pkt_mp_capa;
+#ifdef HAVE_DPDK
+    RteFlowRuleStorage *drop_filter;
+#endif /* HAVE_DPDK */
+    uint16_t port_id;
+} DPDKDeviceResources;
+
+int DPDKDeviceResourcesInit(DPDKDeviceResources **dpdk_vars, uint16_t mp_cnt);
+void DPDKDeviceResourcesDeinit(DPDKDeviceResources **dpdk_vars);
 
 void DPDKCleanupEAL(void);
 

--- a/src/util-dpdk.h
+++ b/src/util-dpdk.h
@@ -26,14 +26,17 @@
 
 #include "util-dpdk-common.h"
 #include "util-device.h"
-#include "util-dpdk-rte-flow.h"
+#include "util-dpdk-rte-flow-structs.h"
+
+#define RTE_DEFAULT_GROUP 0
+#define RTE_JUMP_GROUP    1
 
 typedef struct {
     struct rte_mempool **pkt_mp;
     uint16_t pkt_mp_cnt;
     uint16_t pkt_mp_capa;
 #ifdef HAVE_DPDK
-    RteFlowRuleStorage *drop_filter;
+    RteFlowBypassData *rte_flow_bypass_data;
 #endif /* HAVE_DPDK */
     uint16_t port_id;
 } DPDKDeviceResources;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -811,6 +811,18 @@ dpdk:
     proc-type: primary
 
   # DPDK capture support
+  # Toggle support of hardware accelerated flow bypass.
+  capture-bypass: no
+  # The following bypass.* features are only applicable when
+  # 'capture-bypass' is enabled.
+
+  # Configures how many flows the NIC can offload at once.
+  # bypass-info-mp-size: auto
+  # Sets how many flows can wait for HW offload at once. Needs to be a power of 2.
+  # bypass-ring-size: auto
+  # Defines how many flows are dequeued from bypass-ring at once. 
+  # Needs to be less than bypass-ring-size.
+  # bypass-ring-dequeue-burst-size: auto
   # RX queues (and TX queues in IPS mode) are assigned to cores in 1:1 ratio
   interfaces:
     - interface: 0000:3b:00.0 # PCIe address of the NIC port

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1598,6 +1598,10 @@ flow:
   #rate-tracking:
   #  bytes: 1GiB
   #  interval: 10 # seconds is the only supported unit for interval so far
+  # Configures how many iterations of sleep (100 microseconds) will Bypass Manager 
+  # perform, if capture bypass is enabled
+  #bypass:
+  # delay: auto
 
 # This option controls the use of VLAN ids in the flow (and defrag)
 # hashing. Normally this should be enabled, but in some (broken)


### PR DESCRIPTION
# DPDK dynamic bypass with rte_flow rules

This feature brings capture offload into the DPDK Suricata
runmode. The offload is based on the DPDK's rte_flow hardware rules,
which can filter traffic directly in the NIC. 
 
 The bypass utilizes the BypassManager thread and API for 
creating bypass rules and the FlowManager for collecting statistics and destroying 
rules.

## Related branches
These commits assure the proper working of the bypass implementation, but they originate in different branches, that have not been merged yet.
- commit https://github.com/OISF/suricata/commit/3fbe1728cc444c6f620920cd9f985493a1b8f8db from branch https://github.com/OISF/suricata/pull/15774
- commit https://github.com/OISF/suricata/commit/6bcb23241f5f0b351f2d6d158a4d7a63d349612e from branch https://github.com/OISF/suricata/pull/15773

## Changes
- rebased to main
- change PR from draft to regular PR
- fixed ci: exclude DPDK files from scan-build analysis

Link to ticket: [#7871](https://redmine.openinfosecfoundation.org/issues/7871)
Previous PR: https://github.com/OISF/suricata/pull/15877