### PR TITLE
 doc: standardize Symantec SSL Visibility heading

### DIFF
--- a/doc/userguide/3rd-party-integration/symantec-sslv.rst
+++ b/doc/userguide/3rd-party-integration/symantec-sslv.rst
@@ -1,5 +1,5 @@
 Symantec SSL Visibility (BlueCoat)
-==================================
+##################################
 
 As Suricata itself cannot decrypt SSL/TLS traffic, some organizations use
 a decryption product to handle this. This document will offer some advice


### PR DESCRIPTION
Describe changes:

* Standardize the Symantec SSL Visibility (BlueCoat) page title to follow the User Guide heading convention.
* Documentation-only change for Redmine issue 7396.


